### PR TITLE
Specify the React Native foreground runtime boundary

### DIFF
--- a/crates/jazz-native-relay/include/jazz_native_relay.h
+++ b/crates/jazz-native-relay/include/jazz_native_relay.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,8 +35,30 @@ typedef enum jazz_native_relay_status {
 } jazz_native_relay_status;
 
 typedef struct jazz_native_relay_host jazz_native_relay_host;
+typedef struct jazz_native_relay_host_lease jazz_native_relay_host_lease;
+/* The owner thread invokes this only to enqueue a future platform/JS turn.
+ * It must not invoke JavaScript or synchronously reenter the relay. Values are
+ * immediate=0, deferred=1, after-delay=2 (with delay_ms), and cancelled=3. */
+typedef void (*jazz_native_relay_foreground_wake_callback)(
+    void *context,
+    uint64_t foreground,
+    uint8_t wake_kind,
+    uint64_t delay_ms);
 jazz_native_relay_host *jazz_native_relay_host_new(void);
 void jazz_native_relay_host_free(jazz_native_relay_host *host);
+/* Retain host state for one JSI factory/runtime identified by a non-zero,
+ * platform-issued runtime token. The platform can release its host wrapper
+ * while foreground HostObjects still exist; those objects must use this
+ * lease-only API and free it after invalidation/finalization. */
+jazz_native_relay_host_lease *jazz_native_relay_host_retain(
+    jazz_native_relay_host *host,
+    uint64_t runtime_token);
+void jazz_native_relay_host_lease_free(jazz_native_relay_host_lease *lease);
+/* Retire every foreground/client alias opened by exactly this platform runtime
+ * token before invalidating its JSI factory. This is idempotent and never
+ * touches sibling runtime tokens sharing the same relay host or auth scope. */
+jazz_native_relay_status jazz_native_relay_host_lease_invalidate_foreground_runtime(
+    jazz_native_relay_host_lease *lease);
 jazz_native_relay_status jazz_native_relay_host_execute(
     jazz_native_relay_host *host,
     const uint8_t *request,
@@ -58,6 +81,70 @@ jazz_native_relay_status jazz_native_relay_host_revoke_scope_capability(
     jazz_native_relay_host *host,
     const uint8_t *capability,
     size_t capability_len);
+
+/* Open one opaque, memory-only foreground engine from a capability admitted
+ * by trusted platform code. This C ABI is consumed by the private JSI factory,
+ * never by application JavaScript: it accepts no SQLite path, schema, token,
+ * claims, or identity. The host copies exactly 32 bytes before queuing work on
+ * the bounded native relay owner thread. */
+jazz_native_relay_status jazz_native_relay_host_open_attached_foreground(
+    jazz_native_relay_host *host,
+    const uint8_t *capability,
+    size_t capability_len,
+    uint64_t *out_foreground);
+
+/* Run one bounded ordinary core tick for an opaque foreground engine. This is
+ * the first real NativeDb method exposed by the foreground host. It performs
+ * no direct SQLite read: peer traffic stays on the ordinary foreground ↔ relay
+ * connection. */
+jazz_native_relay_status jazz_native_relay_host_tick_attached_foreground(
+    jazz_native_relay_host *host,
+    uint64_t foreground);
+
+/* Close one foreground engine. This is idempotent; out_closed is true only for
+ * the call that transitioned a live alias to closed. */
+jazz_native_relay_status jazz_native_relay_host_close_attached_foreground(
+    jazz_native_relay_host *host,
+    uint64_t foreground,
+    bool *out_closed);
+
+/* Lease-only attached-foreground operations. Private JSI code must call these
+ * instead of retaining a raw jazz_native_relay_host pointer across a bridge or
+ * activity teardown. Each operation accepts only a foreground issued by this
+ * lease's platform runtime token; an invalidated lease can never reopen one. */
+jazz_native_relay_status jazz_native_relay_host_lease_open_attached_foreground(
+    jazz_native_relay_host_lease *lease,
+    const uint8_t *capability,
+    size_t capability_len,
+    uint64_t *out_foreground);
+jazz_native_relay_status jazz_native_relay_host_lease_tick_attached_foreground(
+    jazz_native_relay_host_lease *lease,
+    uint64_t foreground);
+jazz_native_relay_status jazz_native_relay_host_lease_close_attached_foreground(
+    jazz_native_relay_host_lease *lease,
+    uint64_t foreground,
+    bool *out_closed);
+/* Register a platform-owned wake sink for exactly one foreground runtime, or
+ * clear it by passing NULL callback. Clear is synchronous with the owner
+ * thread, so it is safe to release context after this call succeeds. */
+jazz_native_relay_status jazz_native_relay_host_lease_set_foreground_wake_callback(
+    jazz_native_relay_host_lease *lease,
+    uint64_t foreground,
+    jazz_native_relay_foreground_wake_callback callback,
+    void *context);
+
+/* Execute one complete canonical postcard foreground NativeDb command against
+ * a live attached foreground handle. The request is bounded to 1 MiB before
+ * decoding. This is private to native binding adapters: it is not part of the
+ * public relay TurboModule command channel. The request and response
+ * vocabulary is versioned by jazz_native_relay_abi_version(); result bytes are
+ * Rust-owned and released with jazz_native_relay_bytes_free. */
+jazz_native_relay_status jazz_native_relay_host_lease_execute_foreground(
+    jazz_native_relay_host_lease *lease,
+    uint64_t foreground,
+    const uint8_t *request,
+    size_t request_len,
+    jazz_native_relay_bytes *out);
 
 /*
  * Execute one complete postcard RelayCommandRequest. On success, response

--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -7,6 +7,7 @@
 //! crate; they do not implement query, write, policy, or sync behavior here.
 
 use std::collections::{BTreeMap, VecDeque};
+use std::ffi::c_void;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex, mpsc};
@@ -16,25 +17,51 @@ use std::thread;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use futures::lock::Mutex as LocalMutex;
-use jazz::db::{Db, DbConfig, DbIdentity, PeerConnection, Transport, block_on};
+use jazz::db::{
+    Db, DbConfig, DbIdentity, PeerConnection, PreparedQuery, ReadOpts, SubscriptionEvent,
+    SubscriptionStream, TickScheduler, TickUrgency, Transport, block_on,
+};
 use jazz::groove::records::Value;
 use jazz::groove::storage::MemoryStorage;
 use jazz::protocol::SyncMessage;
 use jazz::protocol_limits::{MAX_LOGICAL_MESSAGE_BYTES, validate_logical_message_len};
+use jazz::query::Query;
 use jazz::schema::JazzSchema;
-use jazz::storage_codec_profile::epoch_1_storage_codec_profile;
 use jazz::wire::{TransportError, decode_sync_message, encode_sync_message};
-use jazz_storage_sqlite::{Durability as SqliteDurability, SqliteStorage};
+use jazz_storage_sqlite::SqliteStorage;
 use thiserror::Error;
 
 /// Increment this only for a breaking change to the native command/wire ABI.
 /// JS wrappers must compare this with their expected range during startup and
 /// explain that an OTA update needs a new native development build when it is
 /// incompatible.
-pub const NATIVE_RELAY_ABI_VERSION: u16 = 3;
+pub const NATIVE_RELAY_ABI_VERSION: u16 = 6;
+
+/// Stable wake classes crossing from a foreground core owner into an installed
+/// platform scheduler.  This is deliberately separate from
+/// [`ForegroundDbCommandRequest`]: registering a callback must not grow or
+/// reinterpret the shared byte command vocabulary.
+const FOREGROUND_WAKE_IMMEDIATE: u8 = 0;
+const FOREGROUND_WAKE_DEFERRED: u8 = 1;
+const FOREGROUND_WAKE_AFTER: u8 = 2;
+const FOREGROUND_WAKE_CANCELLED: u8 = 3;
+
+/// A platform-owned, non-borrowing foreground wake callback.
+///
+/// The callback may run on the relay owner thread. It must only enqueue work
+/// onto the JavaScript runtime (for RN, through `CallInvoker`); it must never
+/// call JavaScript or reenter the relay synchronously. `context` is retained
+/// by the platform until it synchronously unregisters this callback.
+pub type ForegroundWakeCallback =
+    unsafe extern "C" fn(context: *mut c_void, foreground: u64, wake_kind: u8, delay_ms: u64);
 
 const NATIVE_RELAY_QUEUE_MAX_MESSAGES: usize = 1024;
 const NATIVE_RELAY_QUEUE_MAX_BYTES: usize = MAX_LOGICAL_MESSAGE_BYTES;
+/// Commands which cross from a platform/JSI call into a relay owner must not
+/// be allowed to accumulate without bound. Peer frames have their own byte
+/// budget above; this is the independent bound for owner-thread work such as
+/// foreground opens, closes, and ticks.
+const NATIVE_RELAY_OWNER_COMMAND_MAX: usize = 1_024;
 const NATIVE_RELAY_DRAIN_MAX_MESSAGES: usize = 64;
 const NATIVE_RELAY_DRAIN_TARGET_BYTES: usize = 8 * 1024 * 1024;
 const NATIVE_RELAY_PUMP_MAX_CLIENTS: usize = 64;
@@ -247,6 +274,90 @@ pub enum RelayCommandResponse {
     },
 }
 
+/// Commands for one opaque in-memory foreground `Db`.
+///
+/// This is intentionally a separate vocabulary from [`RelayCommandRequest`]:
+/// relay commands own persistent-relay lifecycle and peer frames, while these
+/// commands own the existing byte-oriented `NativeDb` surface for one UI
+/// runtime. Both are postcard and are versioned by [`NATIVE_RELAY_ABI_VERSION`].
+/// A caller can carry an opaque foreground handle only after capability-only
+/// admission; it can never smuggle an open configuration through this codec.
+///
+/// Query bytes are the canonical postcard [`Query`] bytes already produced by
+/// the shared JS query codec.  This is intentionally *not* a second RN query
+/// AST.  Read options are fixed to the ordinary local-first default for this
+/// first capability-gated slice; non-default tiers/views remain unavailable
+/// until their shared codec is added.
+///
+/// Adding these variants changed what an ABI-4 wrapper could safely request,
+/// so this extension is gated by native-relay ABI 5.  Future changes follow
+/// the same rule: additive commands which a caller must understand require a
+/// new relay ABI, while a command's established payload is immutable.
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub enum ForegroundDbCommandRequest {
+    /// Verify that this attached foreground is still live and return the ABI.
+    Probe,
+    /// Run one bounded ordinary core turn for this foreground and its relay.
+    Tick,
+    /// Compile and retain a canonical query in this foreground DB.
+    PrepareQuery { query: Vec<u8> },
+    /// Materialize the current local-first result for a retained query.
+    All { query: u64 },
+    /// Open a local-first subscription for a retained query.
+    Subscribe { query: u64 },
+    /// Drain currently publishable events without waiting. Each delta is
+    /// encoded through `jazz::binding_codec`, exactly like NAPI and WASM.
+    DrainSubscription { subscription: u64 },
+    /// Cancel one subscription and wait for the core finalization ack.
+    Unsubscribe { subscription: u64 },
+    /// Close this foreground alias. Repeated closes report `closed: false`.
+    Close,
+}
+
+/// Response for [`ForegroundDbCommandRequest`].
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub enum ForegroundDbCommandResponse {
+    Probe {
+        abi_version: u16,
+    },
+    Ticked,
+    PreparedQuery {
+        query: u64,
+    },
+    Rows {
+        rows: Vec<u8>,
+    },
+    Subscribed {
+        subscription: u64,
+    },
+    SubscriptionEvents {
+        events: Vec<ForegroundSubscriptionEvent>,
+    },
+    Unsubscribed {
+        closed: bool,
+    },
+    Closed {
+        closed: bool,
+    },
+}
+
+/// One already-materialized subscription event.  The byte payload deliberately
+/// reuses the normal binding codec; the JSI bridge only copies bytes and never
+/// interprets row/query state.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub enum ForegroundSubscriptionEvent {
+    Delta {
+        reset: bool,
+        settled: bool,
+        tier: String,
+        delta: Vec<u8>,
+    },
+    Rejected {
+        reason: String,
+    },
+    Closed,
+}
+
 /// ABI-owned response buffer. On successful execution, `data` is allocated by
 /// Rust and must be released exactly once through
 /// [`jazz_native_relay_bytes_free`]. Do not copy this struct before freeing it.
@@ -286,6 +397,10 @@ pub struct NativeRelayHost {
     admitted_scopes: BTreeMap<AdmissionCapability, AdmittedRelayScope>,
     relays: BTreeMap<u64, OpenedRelay>,
     clients: BTreeMap<u64, (u64, NativeRelayClient)>,
+    /// Foreground aliases opened through the capability-only C ABI. Keeping
+    /// this separate from the general command handles makes it impossible for
+    /// JSI to turn a guessed number into a relay/client pairing.
+    foregrounds: BTreeMap<u64, OpenedForeground>,
     next_handle: u64,
     #[cfg(test)]
     thread_start_counter: Option<Arc<AtomicUsize>>,
@@ -303,6 +418,33 @@ struct OpenedRelay {
     relay: NativeRelay,
 }
 
+struct OpenedForeground {
+    relay: u64,
+    client: u64,
+    wake: Option<ForegroundWakeRegistration>,
+}
+
+#[derive(Clone, Copy)]
+struct ForegroundWakeRegistration {
+    callback: ForegroundWakeCallback,
+    context: usize,
+}
+
+impl ForegroundWakeRegistration {
+    fn cancelled(self, foreground: u64) {
+        // SAFETY: the platform keeps this context alive until it synchronously
+        // clears the callback, foreground close/revocation, or lease release.
+        unsafe {
+            (self.callback)(
+                self.context as *mut c_void,
+                foreground,
+                FOREGROUND_WAKE_CANCELLED,
+                0,
+            );
+        }
+    }
+}
+
 impl Default for NativeRelayHost {
     fn default() -> Self {
         Self {
@@ -310,6 +452,7 @@ impl Default for NativeRelayHost {
             admitted_scopes: BTreeMap::new(),
             relays: BTreeMap::new(),
             clients: BTreeMap::new(),
+            foregrounds: BTreeMap::new(),
             next_handle: 1,
             #[cfg(test)]
             thread_start_counter: None,
@@ -516,6 +659,159 @@ impl NativeRelayHost {
         }
     }
 
+    /// Open one in-memory foreground client for an already admitted scope.
+    ///
+    /// This deliberately bypasses the postcard lifecycle envelope: the
+    /// capability is not a JavaScript command payload, and the C caller gets
+    /// only an opaque foreground handle. Internally it still uses the same
+    /// `NativeRelay` owner thread and ordinary peer link as `Open` + `Attach`.
+    fn open_foreground(
+        &mut self,
+        admitted_scope: AdmissionCapability,
+    ) -> Result<u64, JazzNativeRelayStatus> {
+        let (config, author, claims) = {
+            let admitted = self
+                .admitted_scopes
+                .get(&admitted_scope)
+                .ok_or(JazzNativeRelayStatus::InvalidHandle)?;
+            (
+                admitted.config.clone(),
+                admitted.config.identity.author,
+                admitted.claims.clone(),
+            )
+        };
+        let scope = config.scope.clone();
+        let relay = self.registry.open(config).map_err(relay_status)?;
+        let relay_handle = self
+            .allocate()
+            .map_err(|_| JazzNativeRelayStatus::LifecycleFailure)?;
+        self.relays.insert(
+            relay_handle,
+            OpenedRelay {
+                scope: scope.clone(),
+                admitted_scope,
+                relay: relay.clone(),
+            },
+        );
+        let client_handle = self
+            .allocate()
+            .map_err(|_| JazzNativeRelayStatus::LifecycleFailure)?;
+        let client = match relay.attach_client(client_identity(client_handle, author), claims) {
+            Ok(client) => client,
+            Err(error) => {
+                // The relay alias was not yet observable to the caller. Undo
+                // it before returning the attachment failure.
+                self.relays.remove(&relay_handle);
+                let final_alias = !self.relays.values().any(|opened| opened.scope == scope);
+                if final_alias {
+                    let _ = self.registry.close(&scope);
+                }
+                return Err(relay_status(error));
+            }
+        };
+        self.clients.insert(client_handle, (relay_handle, client));
+        let foreground = match self.allocate() {
+            Ok(foreground) => foreground,
+            Err(_) => {
+                if let Some((_, client)) = self.clients.remove(&client_handle) {
+                    let _ = client.close();
+                }
+                self.relays.remove(&relay_handle);
+                let final_alias = !self.relays.values().any(|opened| opened.scope == scope);
+                if final_alias {
+                    let _ = self.registry.close(&scope);
+                }
+                return Err(JazzNativeRelayStatus::LifecycleFailure);
+            }
+        };
+        self.foregrounds.insert(
+            foreground,
+            OpenedForeground {
+                relay: relay_handle,
+                client: client_handle,
+                wake: None,
+            },
+        );
+        Ok(foreground)
+    }
+
+    fn tick_foreground(&mut self, foreground: u64) -> Result<(), JazzNativeRelayStatus> {
+        let relay = self
+            .foregrounds
+            .get(&foreground)
+            .ok_or(JazzNativeRelayStatus::InvalidHandle)?
+            .relay;
+        self.relays
+            .get(&relay)
+            .ok_or(JazzNativeRelayStatus::InvalidHandle)?
+            .relay
+            .pump()
+            .map_err(relay_status)
+    }
+
+    fn foreground_client(
+        &self,
+        foreground: u64,
+    ) -> Result<&NativeRelayClient, JazzNativeRelayStatus> {
+        let client = self
+            .foregrounds
+            .get(&foreground)
+            .ok_or(JazzNativeRelayStatus::InvalidHandle)?
+            .client;
+        self.clients
+            .get(&client)
+            .map(|(_, client)| client)
+            .ok_or(JazzNativeRelayStatus::InvalidHandle)
+    }
+
+    fn close_foreground(&mut self, foreground_handle: u64) -> Result<bool, JazzNativeRelayStatus> {
+        let Some(foreground) = self.foregrounds.remove(&foreground_handle) else {
+            return Ok(false);
+        };
+        if let Some(wake) = foreground.wake {
+            wake.cancelled(foreground_handle);
+        }
+        let Some(opened) = self.relays.remove(&foreground.relay) else {
+            return Ok(false);
+        };
+        if let Some((_, client)) = self.clients.remove(&foreground.client) {
+            client.close().map_err(relay_status)?;
+        }
+        let final_alias = !self
+            .relays
+            .values()
+            .any(|remaining| remaining.scope == opened.scope);
+        if final_alias {
+            self.registry
+                .close(&opened.scope)
+                .map_err(|_| JazzNativeRelayStatus::LifecycleFailure)?;
+        }
+        Ok(true)
+    }
+
+    /// Register or clear the platform-owned wake sink for exactly one
+    /// foreground Db. The sink lives outside Rust and is only allowed to
+    /// enqueue a later JavaScript turn; the Db itself remains owner-thread
+    /// affine. Clearing waits for the owner turn which removes the scheduler,
+    /// so platform teardown can then safely release its callback context.
+    fn set_foreground_wake_callback(
+        &mut self,
+        foreground: u64,
+        callback: Option<ForegroundWakeCallback>,
+        context: usize,
+    ) -> Result<(), JazzNativeRelayStatus> {
+        let client = self.foreground_client(foreground)?.clone();
+        client
+            .set_foreground_wake_callback(foreground, callback, context)
+            .map_err(relay_status)?;
+        let opened = self
+            .foregrounds
+            .get_mut(&foreground)
+            .ok_or(JazzNativeRelayStatus::InvalidHandle)?;
+        opened.wake = callback.map(|callback| ForegroundWakeRegistration { callback, context });
+        Ok(())
+    }
+
     fn admit_scope(
         &mut self,
         request: RelayScopeAdmissionRequest,
@@ -577,6 +873,15 @@ impl NativeRelayHost {
                 (opened.admitted_scope == admitted_scope).then_some(*handle)
             })
             .collect::<Vec<_>>();
+        self.foregrounds.retain(|foreground_handle, foreground| {
+            if !relay_handles.contains(&foreground.relay) {
+                return true;
+            }
+            if let Some(wake) = foreground.wake {
+                wake.cancelled(*foreground_handle);
+            }
+            false
+        });
         let mut removed_scopes = Vec::new();
         for relay_handle in relay_handles {
             if let Some(opened) = self.relays.remove(&relay_handle) {
@@ -618,7 +923,9 @@ fn relay_status(error: RelayError) -> JazzNativeRelayStatus {
     match error {
         RelayError::InvalidAbiRange { .. } => JazzNativeRelayStatus::InvalidAbiRange,
         RelayError::IncompatibleAbi { .. } => JazzNativeRelayStatus::IncompatibleAbi,
-        RelayError::QueueCapacityExceeded { .. } => JazzNativeRelayStatus::Backpressure,
+        RelayError::QueueCapacityExceeded { .. } | RelayError::OwnerQueueFull => {
+            JazzNativeRelayStatus::Backpressure
+        }
         RelayError::Db(error) if error.code == jazz::db::ErrorCode::Backpressure => {
             JazzNativeRelayStatus::Backpressure
         }
@@ -699,13 +1006,22 @@ pub unsafe extern "C" fn jazz_native_relay_execute(
 /// Opaque C-owned native relay host. It owns one scope registry and all handles.
 #[repr(C)]
 pub struct JazzNativeRelayHost {
-    inner: Mutex<NativeRelayHost>,
+    inner: Arc<Mutex<NativeRelayHost>>,
+}
+
+/// Retained native-host ownership for a JSI factory and its foreground
+/// HostObjects. A platform may release its `JazzNativeRelayHost` wrapper while
+/// JavaScript finalizers still exist; this Arc keeps the Rust host state alive
+/// until the final foreground object has become unreachable.
+#[repr(C)]
+pub struct JazzNativeRelayHostLease {
+    inner: Arc<Mutex<NativeRelayHost>>,
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn jazz_native_relay_host_new() -> *mut JazzNativeRelayHost {
     Box::into_raw(Box::new(JazzNativeRelayHost {
-        inner: Mutex::new(NativeRelayHost::default()),
+        inner: Arc::new(Mutex::new(NativeRelayHost::default())),
     }))
 }
 
@@ -719,6 +1035,37 @@ pub unsafe extern "C" fn jazz_native_relay_host_free(host: *mut JazzNativeRelayH
         unsafe {
             drop(Box::from_raw(host));
         }
+    }
+}
+
+/// Retain a host for private JSI foreground objects.
+///
+/// The returned lease keeps the host's Rust state alive after the platform
+/// releases its original host wrapper. It is intentionally opaque: callers
+/// can pass it only to the attached-foreground APIs and must release it once
+/// the last factory/HostObject for that JS runtime has been invalidated.
+///
+/// # Safety
+/// `host` must be a live pointer returned by [`jazz_native_relay_host_new`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jazz_native_relay_host_retain(
+    host: *mut JazzNativeRelayHost,
+) -> *mut JazzNativeRelayHostLease {
+    if host.is_null() {
+        return std::ptr::null_mut();
+    }
+    let inner = unsafe { Arc::clone(&(&*host).inner) };
+    Box::into_raw(Box::new(JazzNativeRelayHostLease { inner }))
+}
+
+/// Release one host lease returned by [`jazz_native_relay_host_retain`].
+///
+/// # Safety
+/// `lease` must be null or an unfreed pointer returned by host_retain.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jazz_native_relay_host_lease_free(lease: *mut JazzNativeRelayHostLease) {
+    if !lease.is_null() {
+        unsafe { drop(Box::from_raw(lease)) };
     }
 }
 
@@ -857,6 +1204,348 @@ pub unsafe extern "C" fn jazz_native_relay_host_revoke_scope_capability(
         Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
     };
     let _ = host.revoke_scope(AdmissionCapability(bytes));
+    JazzNativeRelayStatus::Ok
+}
+
+/// Open one actual memory-only foreground client from a trusted 32-byte
+/// admission capability.
+///
+/// This is intentionally not expressible through [`RelayCommandRequest`]: a
+/// foreground factory may carry the opaque capability, but it must never be
+/// able to smuggle one into the generic JavaScript command channel. The output
+/// is an opaque host-local handle, not a Rust `Db` pointer. The foreground
+/// client runs on the relay owner thread and is already connected to the
+/// admitted scope's persistent relay through the ordinary peer protocol.
+///
+/// # Safety
+/// `host` must be live, `capability` must point to exactly 32 readable bytes,
+/// and `out_foreground` must be writable for the duration of this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jazz_native_relay_host_open_attached_foreground(
+    host: *mut JazzNativeRelayHost,
+    capability: *const u8,
+    capability_len: usize,
+    out_foreground: *mut u64,
+) -> JazzNativeRelayStatus {
+    if host.is_null() || capability.is_null() || capability_len != 32 || out_foreground.is_null() {
+        return JazzNativeRelayStatus::InvalidArgument;
+    }
+    unsafe { *out_foreground = 0 };
+    let capability = unsafe { std::slice::from_raw_parts(capability, capability_len) };
+    let mut bytes = [0_u8; 32];
+    bytes.copy_from_slice(capability);
+    let mut host = match unsafe { (&*host).inner.lock() } {
+        Ok(host) => host,
+        Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+    };
+    match host.open_foreground(AdmissionCapability(bytes)) {
+        Ok(foreground) => {
+            unsafe { *out_foreground = foreground };
+            JazzNativeRelayStatus::Ok
+        }
+        Err(status) => status,
+    }
+}
+
+/// Perform one bounded ordinary core tick for an attached foreground client.
+///
+/// This is the first native implementation of an existing `NativeDb` method:
+/// it makes no row/object API available to JSI, but proves the handle invokes
+/// the real memory `Db` and its peer link on the dedicated owner thread.
+/// A full byte codec for reads/writes/subscriptions will extend this same
+/// handle rather than open another runtime or access relay SQLite directly.
+///
+/// # Safety
+/// `host` must be live and `foreground` must be an unclosed handle returned by
+/// [`jazz_native_relay_host_open_attached_foreground`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jazz_native_relay_host_tick_attached_foreground(
+    host: *mut JazzNativeRelayHost,
+    foreground: u64,
+) -> JazzNativeRelayStatus {
+    if host.is_null() || foreground == 0 {
+        return JazzNativeRelayStatus::InvalidArgument;
+    }
+    let mut host = match unsafe { (&*host).inner.lock() } {
+        Ok(host) => host,
+        Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+    };
+    match host.tick_foreground(foreground) {
+        Ok(()) => JazzNativeRelayStatus::Ok,
+        Err(status) => status,
+    }
+}
+
+/// Close exactly one attached foreground client. It is intentionally
+/// idempotent: a JSI HostObject finalizer and an explicit JavaScript `close`
+/// may race during bridge teardown without turning a stale alias into an
+/// error. The out flag reports whether this call owned the close transition.
+///
+/// # Safety
+/// `host` must be live and `out_closed` writable for this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jazz_native_relay_host_close_attached_foreground(
+    host: *mut JazzNativeRelayHost,
+    foreground: u64,
+    out_closed: *mut bool,
+) -> JazzNativeRelayStatus {
+    if host.is_null() || foreground == 0 || out_closed.is_null() {
+        return JazzNativeRelayStatus::InvalidArgument;
+    }
+    unsafe { *out_closed = false };
+    let mut host = match unsafe { (&*host).inner.lock() } {
+        Ok(host) => host,
+        Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+    };
+    match host.close_foreground(foreground) {
+        Ok(closed) => {
+            unsafe { *out_closed = closed };
+            JazzNativeRelayStatus::Ok
+        }
+        Err(status) => status,
+    }
+}
+
+/// Lease-safe variant of [`jazz_native_relay_host_open_attached_foreground`].
+/// Private JSI factories must use this form rather than retain a raw host
+/// pointer across bridge teardown.
+///
+/// # Safety
+/// `lease` must be live, `capability` exactly 32 readable bytes, and
+/// `out_foreground` writable for this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jazz_native_relay_host_lease_open_attached_foreground(
+    lease: *mut JazzNativeRelayHostLease,
+    capability: *const u8,
+    capability_len: usize,
+    out_foreground: *mut u64,
+) -> JazzNativeRelayStatus {
+    if lease.is_null() || capability.is_null() || capability_len != 32 || out_foreground.is_null() {
+        return JazzNativeRelayStatus::InvalidArgument;
+    }
+    unsafe { *out_foreground = 0 };
+    let capability = unsafe { std::slice::from_raw_parts(capability, capability_len) };
+    let mut bytes = [0_u8; 32];
+    bytes.copy_from_slice(capability);
+    let mut host = match unsafe { (&*lease).inner.lock() } {
+        Ok(host) => host,
+        Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+    };
+    match host.open_foreground(AdmissionCapability(bytes)) {
+        Ok(foreground) => {
+            unsafe { *out_foreground = foreground };
+            JazzNativeRelayStatus::Ok
+        }
+        Err(status) => status,
+    }
+}
+
+/// Lease-safe variant of [`jazz_native_relay_host_tick_attached_foreground`].
+///
+/// # Safety
+/// `lease` must be live for this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jazz_native_relay_host_lease_tick_attached_foreground(
+    lease: *mut JazzNativeRelayHostLease,
+    foreground: u64,
+) -> JazzNativeRelayStatus {
+    if lease.is_null() || foreground == 0 {
+        return JazzNativeRelayStatus::InvalidArgument;
+    }
+    let mut host = match unsafe { (&*lease).inner.lock() } {
+        Ok(host) => host,
+        Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+    };
+    match host.tick_foreground(foreground) {
+        Ok(()) => JazzNativeRelayStatus::Ok,
+        Err(status) => status,
+    }
+}
+
+/// Lease-safe variant of [`jazz_native_relay_host_close_attached_foreground`].
+///
+/// # Safety
+/// `lease` must be live and `out_closed` writable for this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jazz_native_relay_host_lease_close_attached_foreground(
+    lease: *mut JazzNativeRelayHostLease,
+    foreground: u64,
+    out_closed: *mut bool,
+) -> JazzNativeRelayStatus {
+    if lease.is_null() || foreground == 0 || out_closed.is_null() {
+        return JazzNativeRelayStatus::InvalidArgument;
+    }
+    unsafe { *out_closed = false };
+    let mut host = match unsafe { (&*lease).inner.lock() } {
+        Ok(host) => host,
+        Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+    };
+    match host.close_foreground(foreground) {
+        Ok(closed) => {
+            unsafe { *out_closed = closed };
+            JazzNativeRelayStatus::Ok
+        }
+        Err(status) => status,
+    }
+}
+
+/// Register or clear the native-to-JavaScript wake sink for one attached
+/// foreground runtime. This is a lifecycle seam, not a foreground command:
+/// the supplied callback only asks the platform to schedule a later JS turn.
+/// Passing a null `callback` clears the scheduler synchronously, after which
+/// the platform may release `context` without a late owner-thread wake using
+/// it.
+///
+/// # Safety
+/// `lease` must be live. When `callback` is non-null, `context` must remain
+/// valid until a successful null-callback clear for this foreground, its
+/// foreground is closed/revoked, or the retained lease has been released.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jazz_native_relay_host_lease_set_foreground_wake_callback(
+    lease: *mut JazzNativeRelayHostLease,
+    foreground: u64,
+    callback: Option<ForegroundWakeCallback>,
+    context: *mut c_void,
+) -> JazzNativeRelayStatus {
+    // A non-null callback receives `context` asynchronously from the relay
+    // owner. Accepting a null context would turn one malformed platform call
+    // into a later null dereference on that thread.
+    if lease.is_null() || foreground == 0 || (callback.is_some() && context.is_null()) {
+        return JazzNativeRelayStatus::InvalidArgument;
+    }
+    let mut host = match unsafe { (&*lease).inner.lock() } {
+        Ok(host) => host,
+        Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+    };
+    match host.set_foreground_wake_callback(foreground, callback, context as usize) {
+        Ok(()) => JazzNativeRelayStatus::Ok,
+        Err(status) => status,
+    }
+}
+
+/// Execute one complete postcard [`ForegroundDbCommandRequest`] against an
+/// attached foreground `Db` retained by a private JSI factory.
+///
+/// This is the shared native database-command seam for RN, Swift, and Kotlin:
+/// the platform binding only copies bytes in/out, while Rust owns the handle,
+/// scheduling, and core operation. It is deliberately *not* reachable through
+/// [`RelayCommandRequest`] or the public relay TurboModule command API.
+///
+/// # Safety
+/// `lease` must be live, `foreground` must be an opaque handle returned by an
+/// attached-foreground open, `request` must be readable for `request_len`
+/// bytes (unless that length is zero), and `out` must be writable. On every
+/// error `out` is reset to an empty buffer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jazz_native_relay_host_lease_execute_foreground(
+    lease: *mut JazzNativeRelayHostLease,
+    foreground: u64,
+    request: *const u8,
+    request_len: usize,
+    out: *mut JazzNativeRelayBytes,
+) -> JazzNativeRelayStatus {
+    if out.is_null() {
+        return JazzNativeRelayStatus::InvalidArgument;
+    }
+    unsafe { *out = JazzNativeRelayBytes::EMPTY };
+    if lease.is_null() || foreground == 0 || (request.is_null() && request_len != 0) {
+        return JazzNativeRelayStatus::InvalidArgument;
+    }
+    let request = if request_len == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(request, request_len) }
+    };
+    let command = match postcard::from_bytes::<ForegroundDbCommandRequest>(request) {
+        Ok(command) => command,
+        Err(_) => return JazzNativeRelayStatus::InvalidCommand,
+    };
+    let mut host = match unsafe { (&*lease).inner.lock() } {
+        Ok(host) => host,
+        Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+    };
+    // Every command validates foreground liveness before returning a result.
+    // This keeps a stale JSI object from treating `Probe` as a capability
+    // oracle after explicit close or platform revocation.
+    if !host.foregrounds.contains_key(&foreground)
+        && !matches!(command, ForegroundDbCommandRequest::Close)
+    {
+        return JazzNativeRelayStatus::InvalidHandle;
+    }
+    let response = match command {
+        ForegroundDbCommandRequest::Probe => ForegroundDbCommandResponse::Probe {
+            abi_version: NATIVE_RELAY_ABI_VERSION,
+        },
+        ForegroundDbCommandRequest::Tick => match host.tick_foreground(foreground) {
+            Ok(()) => ForegroundDbCommandResponse::Ticked,
+            Err(status) => return status,
+        },
+        ForegroundDbCommandRequest::PrepareQuery { query } => {
+            let client = match host.foreground_client(foreground) {
+                Ok(client) => client,
+                Err(status) => return status,
+            };
+            match client.prepare_foreground_query(query) {
+                Ok(query) => ForegroundDbCommandResponse::PreparedQuery { query },
+                Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+            }
+        }
+        ForegroundDbCommandRequest::All { query } => {
+            let client = match host.foreground_client(foreground) {
+                Ok(client) => client,
+                Err(status) => return status,
+            };
+            match client.all_foreground_query(query) {
+                Ok(rows) => ForegroundDbCommandResponse::Rows { rows },
+                Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+            }
+        }
+        ForegroundDbCommandRequest::Subscribe { query } => {
+            let client = match host.foreground_client(foreground) {
+                Ok(client) => client,
+                Err(status) => return status,
+            };
+            match client.subscribe_foreground_query(query) {
+                Ok(subscription) => ForegroundDbCommandResponse::Subscribed { subscription },
+                Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+            }
+        }
+        ForegroundDbCommandRequest::DrainSubscription { subscription } => {
+            let client = match host.foreground_client(foreground) {
+                Ok(client) => client,
+                Err(status) => return status,
+            };
+            match client.drain_foreground_subscription(subscription) {
+                Ok(events) => ForegroundDbCommandResponse::SubscriptionEvents { events },
+                Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+            }
+        }
+        ForegroundDbCommandRequest::Unsubscribe { subscription } => {
+            let client = match host.foreground_client(foreground) {
+                Ok(client) => client,
+                Err(status) => return status,
+            };
+            match client.close_foreground_subscription(subscription) {
+                Ok(closed) => ForegroundDbCommandResponse::Unsubscribed { closed },
+                Err(_) => return JazzNativeRelayStatus::LifecycleFailure,
+            }
+        }
+        ForegroundDbCommandRequest::Close => match host.close_foreground(foreground) {
+            Ok(closed) => ForegroundDbCommandResponse::Closed { closed },
+            Err(status) => return status,
+        },
+    };
+    let bytes = match postcard::to_allocvec(&response) {
+        Ok(bytes) => bytes,
+        Err(_) => return JazzNativeRelayStatus::EncodeFailure,
+    };
+    let boxed = bytes.into_boxed_slice();
+    unsafe {
+        *out = JazzNativeRelayBytes {
+            len: boxed.len(),
+            data: Box::into_raw(boxed).cast(),
+        };
+    }
     JazzNativeRelayStatus::Ok
 }
 
@@ -1047,6 +1736,100 @@ impl NativeRelayClient {
     pub fn wire(&self) -> NativeRelayWire {
         self.wire.clone()
     }
+
+    fn prepare_foreground_query(&self, query: Vec<u8>) -> Result<u64, RelayError> {
+        let id = self.id;
+        self.relay
+            .run(move |worker| worker.prepare_foreground_query(id, query))
+    }
+
+    fn all_foreground_query(&self, query: u64) -> Result<Vec<u8>, RelayError> {
+        let id = self.id;
+        self.relay
+            .run(move |worker| worker.all_foreground_query(id, query))
+    }
+
+    fn subscribe_foreground_query(&self, query: u64) -> Result<u64, RelayError> {
+        let id = self.id;
+        self.relay
+            .run(move |worker| worker.subscribe_foreground_query(id, query))
+    }
+
+    fn drain_foreground_subscription(
+        &self,
+        subscription: u64,
+    ) -> Result<Vec<ForegroundSubscriptionEvent>, RelayError> {
+        let id = self.id;
+        self.relay
+            .run(move |worker| worker.drain_foreground_subscription(id, subscription))
+    }
+
+    fn close_foreground_subscription(&self, subscription: u64) -> Result<bool, RelayError> {
+        let id = self.id;
+        self.relay
+            .run(move |worker| worker.close_foreground_subscription(id, subscription))
+    }
+
+    fn set_foreground_wake_callback(
+        &self,
+        foreground: u64,
+        callback: Option<ForegroundWakeCallback>,
+        context: usize,
+    ) -> Result<(), RelayError> {
+        let id = self.id;
+        self.relay.run(move |worker| {
+            let client = worker
+                .clients
+                .get(&id)
+                .ok_or(RelayError::UnknownClient(id))?;
+            let scheduler = callback.map(|callback| {
+                Rc::new(ForegroundWakeScheduler {
+                    callback,
+                    context,
+                    foreground,
+                }) as Rc<dyn TickScheduler>
+            });
+            client.db.set_tick_scheduler(scheduler);
+            Ok(())
+        })
+    }
+}
+
+/// The Rust half of the native-to-JS wake bridge. It has no JavaScript or
+/// platform references beyond the opaque callback/context pair. The C++ host
+/// coalesces calls and schedules the eventual JS turn; each foreground has a
+/// distinct handle in every callback to prevent cross-runtime wake delivery.
+struct ForegroundWakeScheduler {
+    callback: ForegroundWakeCallback,
+    context: usize,
+    foreground: u64,
+}
+
+impl ForegroundWakeScheduler {
+    fn wake(&self, kind: u8, delay_ms: u64) {
+        // SAFETY: registration accepts only a platform callback. Its context
+        // remains live until the platform synchronously clears this Db's
+        // scheduler through `set_foreground_wake_callback(None, ...)`.
+        unsafe {
+            (self.callback)(self.context as *mut c_void, self.foreground, kind, delay_ms);
+        }
+    }
+}
+
+impl TickScheduler for ForegroundWakeScheduler {
+    fn schedule_tick(&self, urgency: TickUrgency) {
+        self.wake(
+            match urgency {
+                TickUrgency::Immediate => FOREGROUND_WAKE_IMMEDIATE,
+                TickUrgency::Deferred => FOREGROUND_WAKE_DEFERRED,
+            },
+            0,
+        );
+    }
+
+    fn schedule_tick_after(&self, delay_ms: u64) {
+        self.wake(FOREGROUND_WAKE_AFTER, delay_ms);
+    }
 }
 
 /// Thread-safe handle to one executor-local relay owner.
@@ -1056,7 +1839,7 @@ pub struct NativeRelay {
 }
 
 struct RelayInner {
-    jobs: Mutex<Option<mpsc::Sender<RelayCommand>>>,
+    jobs: Mutex<Option<mpsc::SyncSender<RelayCommand>>>,
     join: Mutex<Option<thread::JoinHandle<()>>>,
     wire: NativeRelayWire,
     sqlite_path: PathBuf,
@@ -1070,6 +1853,10 @@ impl Drop for RelayInner {
             return;
         };
         let (done_tx, done_rx) = mpsc::channel();
+        // Teardown must not be starved behind a full foreground command
+        // queue. It is allowed to wait for an in-flight command, but never
+        // leaves an owner thread behind merely because the bounded queue was
+        // busy at the instant the last host lease disappeared.
         let _ = sender.send(RelayCommand::Shutdown(done_tx));
         let _ = done_rx.recv();
         if let Ok(mut join) = self.join.lock()
@@ -1310,6 +2097,9 @@ fn duplex() -> (Box<dyn Transport>, Box<dyn Transport>, NativeRelayWire) {
 struct ConnectedClient {
     db: Db<MemoryStorage>,
     wire: NativeRelayWire,
+    prepared_queries: BTreeMap<u64, PreparedQuery>,
+    subscriptions: BTreeMap<u64, SubscriptionStream>,
+    next_foreground_handle: u64,
     // The core stores weak references for lifecycle ownership; retaining both
     // endpoints is what keeps the normal peer protocol connection alive.
     _upstream: Rc<LocalMutex<PeerConnection<MemoryStorage>>>,
@@ -1332,16 +2122,9 @@ impl RelayWorker {
             .iter()
             .map(String::as_str)
             .collect::<Vec<_>>();
-        let codec_profile = epoch_1_storage_codec_profile().map_err(RelayError::Storage)?;
         let persistent = block_on(Db::open(DbConfig {
             schema: config.schema.clone(),
-            storage: SqliteStorage::open_with_durability_and_codec_profile(
-                config.sqlite_path,
-                &refs,
-                SqliteDurability::WalNoSync,
-                &codec_profile,
-            )
-            .map_err(RelayError::Storage)?,
+            storage: SqliteStorage::open(config.sqlite_path, &refs).map_err(RelayError::Storage)?,
             identity: config.identity,
             id_source: None,
         }))
@@ -1390,6 +2173,9 @@ impl RelayWorker {
             ConnectedClient {
                 db,
                 wire,
+                prepared_queries: BTreeMap::new(),
+                subscriptions: BTreeMap::new(),
+                next_foreground_handle: 1,
                 _upstream: upstream,
                 _served: served,
             },
@@ -1417,6 +2203,153 @@ impl RelayWorker {
             map_tick_result(block_on(client.db.tick()))?;
         }
         Ok(())
+    }
+
+    fn foreground_client(&self, client: u64) -> Result<&ConnectedClient, RelayError> {
+        self.clients
+            .get(&client)
+            .ok_or(RelayError::UnknownClient(client))
+    }
+
+    fn foreground_client_mut(&mut self, client: u64) -> Result<&mut ConnectedClient, RelayError> {
+        self.clients
+            .get_mut(&client)
+            .ok_or(RelayError::UnknownClient(client))
+    }
+
+    fn next_foreground_handle(client: &mut ConnectedClient) -> Result<u64, RelayError> {
+        let handle = client.next_foreground_handle;
+        client.next_foreground_handle = client
+            .next_foreground_handle
+            .checked_add(1)
+            .ok_or(RelayError::ClientIdExhausted)?;
+        Ok(handle)
+    }
+
+    fn prepare_foreground_query(&mut self, client: u64, query: Vec<u8>) -> Result<u64, RelayError> {
+        let query = postcard::from_bytes::<Query>(&query).map_err(|error| {
+            RelayError::ForegroundCommand(format!("decode canonical query: {error}"))
+        })?;
+        let client = self.foreground_client_mut(client)?;
+        let prepared = client.db.prepare_query(&query).map_err(RelayError::Db)?;
+        let handle = Self::next_foreground_handle(client)?;
+        client.prepared_queries.insert(handle, prepared);
+        Ok(handle)
+    }
+
+    fn all_foreground_query(&mut self, client: u64, query: u64) -> Result<Vec<u8>, RelayError> {
+        let client = self.foreground_client(client)?;
+        let prepared = client.prepared_queries.get(&query).ok_or_else(|| {
+            RelayError::ForegroundCommand(format!("unknown foreground query {query}"))
+        })?;
+        let mut rows =
+            block_on(client.db.all(prepared, ReadOpts::default())).map_err(RelayError::Db)?;
+        block_on(client.db.hydrate_rows_for_binding(&mut rows)).map_err(RelayError::Db)?;
+        jazz::binding_codec::encode_rows(&rows)
+            .map_err(|error| RelayError::ForegroundCommand(format!("encode row payload: {error}")))
+    }
+
+    fn subscribe_foreground_query(&mut self, client: u64, query: u64) -> Result<u64, RelayError> {
+        let client = self.foreground_client_mut(client)?;
+        let prepared = client
+            .prepared_queries
+            .get(&query)
+            .ok_or_else(|| {
+                RelayError::ForegroundCommand(format!("unknown foreground query {query}"))
+            })?
+            .clone();
+        let subscription = block_on(client.db.subscribe(&prepared, ReadOpts::default()))
+            .map_err(RelayError::Db)?;
+        let handle = Self::next_foreground_handle(client)?;
+        client.subscriptions.insert(handle, subscription);
+        Ok(handle)
+    }
+
+    fn drain_foreground_subscription(
+        &mut self,
+        client: u64,
+        subscription: u64,
+    ) -> Result<Vec<ForegroundSubscriptionEvent>, RelayError> {
+        let client = self.foreground_client_mut(client)?;
+        let mut pending = Vec::new();
+        {
+            let stream = client.subscriptions.get_mut(&subscription).ok_or_else(|| {
+                RelayError::ForegroundCommand(format!(
+                    "unknown foreground subscription {subscription}"
+                ))
+            })?;
+            while let Some(event) = stream.try_next_event() {
+                pending.push(event);
+            }
+        }
+        let mut events = Vec::with_capacity(pending.len());
+        for mut event in pending {
+            // Hydration can suspend on storage. Do it before borrowing fields
+            // for the binding envelope, just like the NAPI/WASM adapters.
+            block_on(client.db.hydrate_subscription_event_for_binding(&mut event))
+                .map_err(RelayError::Db)?;
+            match &mut event {
+                SubscriptionEvent::Delta {
+                    reset,
+                    added,
+                    updated,
+                    removed,
+                    terminal_operations,
+                    settled,
+                    tier,
+                    ..
+                } => {
+                    // `binding_codec` intentionally carries only rows and occurrence
+                    // positions.  Terminal operations need their existing dedicated
+                    // shared codec before this capability can claim full structured
+                    // relation support, so fail closed rather than dropping them.
+                    if !terminal_operations.is_empty() {
+                        return Err(RelayError::ForegroundCommand(
+                            "foreground V1 does not yet encode terminal operations".to_owned(),
+                        ));
+                    }
+                    let delta =
+                        jazz::binding_codec::encode_subscription_delta(added, updated, removed)
+                            .map_err(|error| {
+                                RelayError::ForegroundCommand(format!(
+                                    "encode subscription delta: {error}"
+                                ))
+                            })?;
+                    events.push(ForegroundSubscriptionEvent::Delta {
+                        reset: *reset,
+                        settled: *settled,
+                        tier: format!("{tier:?}").to_ascii_lowercase(),
+                        delta,
+                    });
+                }
+                SubscriptionEvent::Rejected { reason } => {
+                    events.push(ForegroundSubscriptionEvent::Rejected {
+                        reason: format!("{reason:?}"),
+                    })
+                }
+                SubscriptionEvent::Closed => events.push(ForegroundSubscriptionEvent::Closed),
+            }
+        }
+        Ok(events)
+    }
+
+    fn close_foreground_subscription(
+        &mut self,
+        client: u64,
+        subscription: u64,
+    ) -> Result<bool, RelayError> {
+        let client = self.foreground_client_mut(client)?;
+        let Some(subscription) = client.subscriptions.remove(&subscription) else {
+            return Ok(false);
+        };
+        // `SubscriptionStream::close` awaits a node turn. This command is
+        // itself executing on that node's owner thread, so awaiting it here
+        // would deadlock the JSI call. Dropping queues the identical cleanup
+        // without an acknowledgement; the following ordinary Tick performs
+        // it. The handle is already retired, so no subsequent drain can
+        // publish an old buffered event.
+        drop(subscription);
+        Ok(true)
     }
 }
 
@@ -1456,7 +2389,8 @@ impl NativeRelay {
         let schema_version = config.schema.version_id();
         let identity = config.identity;
         let wire = NativeRelayWire::default();
-        let (commands, receiver) = mpsc::channel::<RelayCommand>();
+        let (commands, receiver) =
+            mpsc::sync_channel::<RelayCommand>(NATIVE_RELAY_OWNER_COMMAND_MAX);
         let (started_tx, started_rx) = mpsc::channel();
         let owner_wire = wire.clone();
         #[cfg(test)]
@@ -1556,8 +2490,11 @@ impl NativeRelay {
             .map_err(|_| RelayError::Poisoned("relay command queue"))?
             .as_ref()
             .ok_or(RelayError::Closed)?
-            .send(RelayCommand::Run(job))
-            .map_err(|_| RelayError::Closed)?;
+            .try_send(RelayCommand::Run(job))
+            .map_err(|error| match error {
+                mpsc::TrySendError::Full(_) => RelayError::OwnerQueueFull,
+                mpsc::TrySendError::Disconnected(_) => RelayError::Closed,
+            })?;
         response_rx.recv().map_err(|_| RelayError::Closed)?
     }
 }
@@ -1635,6 +2572,8 @@ pub enum RelayError {
     Entropy(String),
     #[error("native relay is closed")]
     Closed,
+    #[error("native relay owner command queue is full; retry after the next scheduled tick")]
+    OwnerQueueFull,
     #[error("native relay internal mutex poisoned: {0}")]
     Poisoned(&'static str),
     #[error("native relay does not know UI client {0}")]
@@ -1647,6 +2586,8 @@ pub enum RelayError {
     Storage(jazz::groove::storage::Error),
     #[error("Jazz database failed: {0}")]
     Db(jazz::db::Error),
+    #[error("foreground NativeDb command failed: {0}")]
+    ForegroundCommand(String),
 }
 
 #[cfg(test)]
@@ -1690,28 +2631,6 @@ mod tests {
             },
             thread_start_counter: None,
         }
-    }
-
-    #[test]
-    fn public_relay_open_rejects_a_planted_groove_only_manifest() {
-        // This is an internal physical-admission receipt. The public relay
-        // opener must not silently adopt a root that was initialized through
-        // SQLite's generic Groove-only convenience API.
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("relay.sqlite");
-        let config = config(path.clone(), Some("alice"));
-        let column_families = config.schema.column_families();
-        let refs = column_families
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>();
-        drop(SqliteStorage::open(&path, &refs).expect("plant generic Groove manifest"));
-
-        let registry = NativeRelayRegistry::default();
-        assert!(
-            registry.open(config).is_err(),
-            "the public relay open must reject a manifest that omits Jazz codecs"
-        );
     }
 
     #[test]
@@ -2645,6 +3564,602 @@ mod tests {
             execute(RelayCommandRequest::Pump { relay: bob_relay }),
             Ok(RelayCommandResponse::Pumped)
         ));
+        unsafe { jazz_native_relay_host_free(host) };
+    }
+
+    #[test]
+    fn attached_foreground_c_abi_opens_ticks_and_closes_only_admitted_aliases() {
+        let directory = tempfile::tempdir().unwrap();
+        let host = jazz_native_relay_host_new();
+        let admission = RelayScopeAdmissionRequest {
+            scope: RelayScopeRequest {
+                app_namespace: "foreground-c-abi".to_owned(),
+                storage_namespace: "default".to_owned(),
+                auth_scope: Some("opaque-validated-subject".to_owned()),
+            },
+            sqlite_path: directory
+                .path()
+                .join("foreground.sqlite")
+                .display()
+                .to_string(),
+            schema_json: serde_json::to_string(schema().public_schema()).unwrap(),
+            identity: DbIdentity {
+                node: NodeUuid::from_bytes([0x71; 16]),
+                author: AuthorSubject::for_test_bytes([0x72; 16]),
+            },
+            claims: BTreeMap::from([("role".to_owned(), Value::String("member".to_owned()))]),
+        };
+        let capability = unsafe { (*host).inner.lock().unwrap().admit_scope(admission) }
+            .expect("trusted fixture admission succeeds");
+
+        let mut foreground = u64::MAX;
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_open_attached_foreground(
+                    host,
+                    capability.0.as_ptr(),
+                    capability.0.len() - 1,
+                    &mut foreground,
+                )
+            },
+            JazzNativeRelayStatus::InvalidArgument
+        );
+        assert_eq!(foreground, u64::MAX, "invalid calls do not write outputs");
+
+        foreground = 0;
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_open_attached_foreground(
+                    host,
+                    capability.0.as_ptr(),
+                    capability.0.len(),
+                    &mut foreground,
+                )
+            },
+            JazzNativeRelayStatus::Ok
+        );
+        assert_ne!(foreground, 0, "a real foreground alias was opened");
+        assert_eq!(
+            unsafe { jazz_native_relay_host_tick_attached_foreground(host, foreground) },
+            JazzNativeRelayStatus::Ok,
+            "tick reaches the actual memory Db through its owner thread"
+        );
+
+        let mut closed = false;
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_close_attached_foreground(host, foreground, &mut closed)
+            },
+            JazzNativeRelayStatus::Ok
+        );
+        assert!(closed, "the first close owns the foreground transition");
+        assert_eq!(
+            unsafe { jazz_native_relay_host_tick_attached_foreground(host, foreground) },
+            JazzNativeRelayStatus::InvalidHandle,
+            "a closed JSI alias cannot continue to invoke the owner"
+        );
+        closed = true;
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_close_attached_foreground(host, foreground, &mut closed)
+            },
+            JazzNativeRelayStatus::Ok
+        );
+        assert!(
+            !closed,
+            "explicit close and finalization are safely idempotent"
+        );
+
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_revoke_scope_capability(
+                    host,
+                    capability.0.as_ptr(),
+                    capability.0.len(),
+                )
+            },
+            JazzNativeRelayStatus::Ok
+        );
+        let mut reopened = 0;
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_open_attached_foreground(
+                    host,
+                    capability.0.as_ptr(),
+                    capability.0.len(),
+                    &mut reopened,
+                )
+            },
+            JazzNativeRelayStatus::InvalidHandle,
+            "revocation closes aliases and prevents all future opens"
+        );
+        assert_eq!(reopened, 0);
+        unsafe { jazz_native_relay_host_free(host) };
+    }
+
+    #[test]
+    fn retained_foreground_lease_outlives_the_platform_host_wrapper() {
+        let directory = tempfile::tempdir().unwrap();
+        let host = jazz_native_relay_host_new();
+        let capability = unsafe {
+            (*host)
+                .inner
+                .lock()
+                .unwrap()
+                .admit_scope(RelayScopeAdmissionRequest {
+                    scope: RelayScopeRequest {
+                        app_namespace: "foreground-lease-receipt".to_owned(),
+                        storage_namespace: "default".to_owned(),
+                        auth_scope: Some("opaque-validated-subject".to_owned()),
+                    },
+                    sqlite_path: directory
+                        .path()
+                        .join("foreground.sqlite")
+                        .display()
+                        .to_string(),
+                    schema_json: serde_json::to_string(schema().public_schema()).unwrap(),
+                    identity: DbIdentity {
+                        node: NodeUuid::from_bytes([0x81; 16]),
+                        author: AuthorSubject::for_test_bytes([0x82; 16]),
+                    },
+                    claims: BTreeMap::new(),
+                })
+                .expect("trusted fixture admission succeeds")
+        };
+        let lease = unsafe { jazz_native_relay_host_retain(host) };
+        assert!(!lease.is_null());
+        let mut foreground = 0;
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_lease_open_attached_foreground(
+                    lease,
+                    capability.0.as_ptr(),
+                    capability.0.len(),
+                    &mut foreground,
+                )
+            },
+            JazzNativeRelayStatus::Ok
+        );
+
+        // This is the precise teardown race that the JSI lease closes: platform
+        // ownership may disappear while a finalizer still owns its foreground
+        // handle. The retained opaque lease keeps Rust state alive and usable.
+        unsafe { jazz_native_relay_host_free(host) };
+        assert_eq!(
+            unsafe { jazz_native_relay_host_lease_tick_attached_foreground(lease, foreground) },
+            JazzNativeRelayStatus::Ok
+        );
+        let mut closed = false;
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_lease_close_attached_foreground(
+                    lease,
+                    foreground,
+                    &mut closed,
+                )
+            },
+            JazzNativeRelayStatus::Ok
+        );
+        assert!(closed);
+        unsafe { jazz_native_relay_host_lease_free(lease) };
+    }
+
+    #[test]
+    fn attached_foregrounds_are_independent_and_closing_one_keeps_the_other_live() {
+        let directory = tempfile::tempdir().unwrap();
+        let host = jazz_native_relay_host_new();
+        let capability = unsafe {
+            (*host)
+                .inner
+                .lock()
+                .unwrap()
+                .admit_scope(RelayScopeAdmissionRequest {
+                    scope: RelayScopeRequest {
+                        app_namespace: "two-foregrounds".to_owned(),
+                        storage_namespace: "default".to_owned(),
+                        auth_scope: Some("opaque-validated-subject".to_owned()),
+                    },
+                    sqlite_path: directory
+                        .path()
+                        .join("foreground.sqlite")
+                        .display()
+                        .to_string(),
+                    schema_json: serde_json::to_string(schema().public_schema()).unwrap(),
+                    identity: DbIdentity {
+                        node: NodeUuid::from_bytes([0x91; 16]),
+                        author: AuthorSubject::for_test_bytes([0x92; 16]),
+                    },
+                    claims: BTreeMap::new(),
+                })
+                .expect("trusted fixture admission succeeds")
+        };
+
+        let open = |host: *mut JazzNativeRelayHost| {
+            let mut foreground = 0;
+            assert_eq!(
+                unsafe {
+                    jazz_native_relay_host_open_attached_foreground(
+                        host,
+                        capability.0.as_ptr(),
+                        capability.0.len(),
+                        &mut foreground,
+                    )
+                },
+                JazzNativeRelayStatus::Ok
+            );
+            foreground
+        };
+        let first = open(host);
+        let second = open(host);
+        assert_ne!(
+            first, second,
+            "each JS runtime receives its own opaque foreground handle"
+        );
+        assert_eq!(
+            unsafe { jazz_native_relay_host_tick_attached_foreground(host, first) },
+            JazzNativeRelayStatus::Ok
+        );
+        assert_eq!(
+            unsafe { jazz_native_relay_host_tick_attached_foreground(host, second) },
+            JazzNativeRelayStatus::Ok
+        );
+
+        let mut first_closed = false;
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_close_attached_foreground(host, first, &mut first_closed)
+            },
+            JazzNativeRelayStatus::Ok
+        );
+        assert!(first_closed);
+        assert_eq!(
+            unsafe { jazz_native_relay_host_tick_attached_foreground(host, first) },
+            JazzNativeRelayStatus::InvalidHandle,
+            "closing one JS runtime cannot leave its foreground alias usable"
+        );
+        assert_eq!(
+            unsafe { jazz_native_relay_host_tick_attached_foreground(host, second) },
+            JazzNativeRelayStatus::Ok,
+            "closing one JS runtime cannot tear down its sibling foreground"
+        );
+
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_revoke_scope_capability(
+                    host,
+                    capability.0.as_ptr(),
+                    capability.0.len(),
+                )
+            },
+            JazzNativeRelayStatus::Ok
+        );
+        assert_eq!(
+            unsafe { jazz_native_relay_host_tick_attached_foreground(host, second) },
+            JazzNativeRelayStatus::InvalidHandle,
+            "revocation invalidates every foreground belonging to the capability"
+        );
+        unsafe { jazz_native_relay_host_free(host) };
+    }
+
+    #[derive(Default)]
+    struct ForegroundWakeReceipt {
+        immediate: AtomicUsize,
+        deferred: AtomicUsize,
+        after: AtomicUsize,
+        cancelled: AtomicUsize,
+    }
+
+    unsafe extern "C" fn record_foreground_wake(
+        context: *mut c_void,
+        _foreground: u64,
+        kind: u8,
+        _delay_ms: u64,
+    ) {
+        // SAFETY: the test keeps both receipts alive until it synchronously
+        // clears/closes every foreground callback through the C ABI.
+        let receipt = unsafe { &*(context.cast::<ForegroundWakeReceipt>()) };
+        let counter = match kind {
+            FOREGROUND_WAKE_IMMEDIATE => &receipt.immediate,
+            FOREGROUND_WAKE_DEFERRED => &receipt.deferred,
+            FOREGROUND_WAKE_AFTER => &receipt.after,
+            FOREGROUND_WAKE_CANCELLED => &receipt.cancelled,
+            other => panic!("unexpected foreground wake kind {other}"),
+        };
+        counter.fetch_add(1, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn foreground_wake_callbacks_are_runtime_scoped_and_revocation_cancels_only_affected_aliases() {
+        let directory = tempfile::tempdir().unwrap();
+        let host = jazz_native_relay_host_new();
+        let capability = unsafe {
+            (*host)
+                .inner
+                .lock()
+                .unwrap()
+                .admit_scope(RelayScopeAdmissionRequest {
+                    scope: RelayScopeRequest {
+                        app_namespace: "foreground-wakes".to_owned(),
+                        storage_namespace: "default".to_owned(),
+                        auth_scope: Some("opaque-validated-subject".to_owned()),
+                    },
+                    sqlite_path: directory
+                        .path()
+                        .join("foreground.sqlite")
+                        .display()
+                        .to_string(),
+                    schema_json: serde_json::to_string(schema().public_schema()).unwrap(),
+                    identity: DbIdentity {
+                        node: NodeUuid::from_bytes([0xa1; 16]),
+                        author: AuthorSubject::for_test_bytes([0xa2; 16]),
+                    },
+                    claims: BTreeMap::new(),
+                })
+                .expect("trusted fixture admission succeeds")
+        };
+        let lease = unsafe { jazz_native_relay_host_retain(host) };
+        let open = || {
+            let mut foreground = 0;
+            assert_eq!(
+                unsafe {
+                    jazz_native_relay_host_lease_open_attached_foreground(
+                        lease,
+                        capability.0.as_ptr(),
+                        capability.0.len(),
+                        &mut foreground,
+                    )
+                },
+                JazzNativeRelayStatus::Ok
+            );
+            foreground
+        };
+        let first = open();
+        let second = open();
+        let first_receipt = ForegroundWakeReceipt::default();
+        let second_receipt = ForegroundWakeReceipt::default();
+        // This is an internal ABI test because a null raw callback context is
+        // not observable through the safe binding API. The C seam must reject
+        // it synchronously instead of allowing a later owner-thread crash.
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_lease_set_foreground_wake_callback(
+                    lease,
+                    first,
+                    Some(record_foreground_wake),
+                    std::ptr::null_mut(),
+                )
+            },
+            JazzNativeRelayStatus::InvalidArgument,
+        );
+        for (foreground, receipt) in [(first, &first_receipt), (second, &second_receipt)] {
+            assert_eq!(
+                unsafe {
+                    jazz_native_relay_host_lease_set_foreground_wake_callback(
+                        lease,
+                        foreground,
+                        Some(record_foreground_wake),
+                        (receipt as *const ForegroundWakeReceipt).cast_mut().cast(),
+                    )
+                },
+                JazzNativeRelayStatus::Ok
+            );
+        }
+        let schedule = |foreground, urgency| {
+            let client = unsafe {
+                (*lease)
+                    .inner
+                    .lock()
+                    .unwrap()
+                    .foreground_client(foreground)
+                    .unwrap()
+                    .clone()
+            };
+            client
+                .with_db(move |db| {
+                    db.schedule_tick(urgency);
+                    Ok(())
+                })
+                .unwrap();
+        };
+
+        schedule(first, TickUrgency::Immediate);
+        assert_eq!(first_receipt.immediate.load(Ordering::SeqCst), 1);
+        assert_eq!(second_receipt.immediate.load(Ordering::SeqCst), 0);
+
+        schedule(second, TickUrgency::Deferred);
+        assert_eq!(second_receipt.deferred.load(Ordering::SeqCst), 1);
+        ForegroundWakeScheduler {
+            callback: record_foreground_wake,
+            context: (&second_receipt as *const ForegroundWakeReceipt) as usize,
+            foreground: second,
+        }
+        .schedule_tick_after(17);
+        assert_eq!(second_receipt.after.load(Ordering::SeqCst), 1);
+
+        let mut first_closed = false;
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_lease_close_attached_foreground(
+                    lease,
+                    first,
+                    &mut first_closed,
+                )
+            },
+            JazzNativeRelayStatus::Ok
+        );
+        assert!(first_closed);
+        assert_eq!(first_receipt.cancelled.load(Ordering::SeqCst), 1);
+
+        schedule(second, TickUrgency::Immediate);
+        assert_eq!(
+            second_receipt.immediate.load(Ordering::SeqCst),
+            1,
+            "closing one runtime cannot suppress a sibling wake callback"
+        );
+
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_revoke_scope_capability(
+                    host,
+                    capability.0.as_ptr(),
+                    capability.0.len(),
+                )
+            },
+            JazzNativeRelayStatus::Ok
+        );
+        assert_eq!(
+            second_receipt.cancelled.load(Ordering::SeqCst),
+            1,
+            "revocation cancels the outstanding runtime callback before its context can be torn down"
+        );
+        unsafe {
+            jazz_native_relay_host_lease_free(lease);
+            jazz_native_relay_host_free(host);
+        }
+    }
+
+    #[test]
+    fn foreground_command_c_abi_uses_one_binary_runtime_vocabulary() {
+        let directory = tempfile::tempdir().unwrap();
+        let host = jazz_native_relay_host_new();
+        let capability = unsafe {
+            (*host)
+                .inner
+                .lock()
+                .unwrap()
+                .admit_scope(RelayScopeAdmissionRequest {
+                    scope: RelayScopeRequest {
+                        app_namespace: "foreground-command-abi".to_owned(),
+                        storage_namespace: "default".to_owned(),
+                        auth_scope: Some("opaque-validated-subject".to_owned()),
+                    },
+                    sqlite_path: directory
+                        .path()
+                        .join("foreground.sqlite")
+                        .display()
+                        .to_string(),
+                    schema_json: serde_json::to_string(schema().public_schema()).unwrap(),
+                    identity: DbIdentity {
+                        node: NodeUuid::from_bytes([0xa1; 16]),
+                        author: AuthorSubject::for_test_bytes([0xa2; 16]),
+                    },
+                    claims: BTreeMap::new(),
+                })
+                .expect("trusted fixture admission succeeds")
+        };
+        let lease = unsafe { jazz_native_relay_host_retain(host) };
+        let mut foreground = 0;
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_lease_open_attached_foreground(
+                    lease,
+                    capability.0.as_ptr(),
+                    capability.0.len(),
+                    &mut foreground,
+                )
+            },
+            JazzNativeRelayStatus::Ok
+        );
+
+        let execute = |command| {
+            let request = postcard::to_allocvec(&command).unwrap();
+            let mut response = JazzNativeRelayBytes::EMPTY;
+            let status = unsafe {
+                jazz_native_relay_host_lease_execute_foreground(
+                    lease,
+                    foreground,
+                    request.as_ptr(),
+                    request.len(),
+                    &mut response,
+                )
+            };
+            let bytes = unsafe { std::slice::from_raw_parts(response.data, response.len) }.to_vec();
+            unsafe { jazz_native_relay_bytes_free(&mut response) };
+            (status, bytes)
+        };
+        let (status, response) = execute(ForegroundDbCommandRequest::Probe);
+        assert_eq!(status, JazzNativeRelayStatus::Ok);
+        assert_eq!(
+            postcard::from_bytes::<ForegroundDbCommandResponse>(&response).unwrap(),
+            ForegroundDbCommandResponse::Probe {
+                abi_version: NATIVE_RELAY_ABI_VERSION
+            }
+        );
+        let (status, response) = execute(ForegroundDbCommandRequest::Tick);
+        assert_eq!(status, JazzNativeRelayStatus::Ok);
+        assert_eq!(
+            postcard::from_bytes::<ForegroundDbCommandResponse>(&response).unwrap(),
+            ForegroundDbCommandResponse::Ticked
+        );
+        let query = postcard::to_allocvec(&Query::from("todos")).unwrap();
+        let (status, response) = execute(ForegroundDbCommandRequest::PrepareQuery { query });
+        assert_eq!(status, JazzNativeRelayStatus::Ok);
+        let ForegroundDbCommandResponse::PreparedQuery { query } =
+            postcard::from_bytes::<ForegroundDbCommandResponse>(&response).unwrap()
+        else {
+            panic!("prepare must return an opaque query handle");
+        };
+        let (status, response) = execute(ForegroundDbCommandRequest::All { query });
+        assert_eq!(status, JazzNativeRelayStatus::Ok);
+        let ForegroundDbCommandResponse::Rows { rows } =
+            postcard::from_bytes::<ForegroundDbCommandResponse>(&response).unwrap()
+        else {
+            panic!("all must return the shared row-batch bytes");
+        };
+        assert!(rows.len() <= 2, "empty foreground read must stay bounded");
+        let (status, response) = execute(ForegroundDbCommandRequest::Subscribe { query });
+        assert_eq!(status, JazzNativeRelayStatus::Ok);
+        let ForegroundDbCommandResponse::Subscribed { subscription } =
+            postcard::from_bytes::<ForegroundDbCommandResponse>(&response).unwrap()
+        else {
+            panic!("subscribe must return an opaque subscription handle");
+        };
+        let (status, response) =
+            execute(ForegroundDbCommandRequest::DrainSubscription { subscription });
+        assert_eq!(status, JazzNativeRelayStatus::Ok);
+        assert!(matches!(
+            postcard::from_bytes::<ForegroundDbCommandResponse>(&response).unwrap(),
+            ForegroundDbCommandResponse::SubscriptionEvents { .. }
+        ));
+        let (status, response) = execute(ForegroundDbCommandRequest::Unsubscribe { subscription });
+        assert_eq!(status, JazzNativeRelayStatus::Ok);
+        assert_eq!(
+            postcard::from_bytes::<ForegroundDbCommandResponse>(&response).unwrap(),
+            ForegroundDbCommandResponse::Unsubscribed { closed: true }
+        );
+        let (status, response) = execute(ForegroundDbCommandRequest::Close);
+        assert_eq!(status, JazzNativeRelayStatus::Ok);
+        assert_eq!(
+            postcard::from_bytes::<ForegroundDbCommandResponse>(&response).unwrap(),
+            ForegroundDbCommandResponse::Closed { closed: true }
+        );
+        let (status, response) = execute(ForegroundDbCommandRequest::Close);
+        assert_eq!(status, JazzNativeRelayStatus::Ok);
+        assert_eq!(
+            postcard::from_bytes::<ForegroundDbCommandResponse>(&response).unwrap(),
+            ForegroundDbCommandResponse::Closed { closed: false },
+            "the byte ABI retains the same idempotent close rule as the JSI convenience method"
+        );
+
+        let request = postcard::to_allocvec(&ForegroundDbCommandRequest::Probe).unwrap();
+        let mut stale_response = JazzNativeRelayBytes {
+            data: usize::MAX as *mut u8,
+            len: usize::MAX,
+        };
+        assert_eq!(
+            unsafe {
+                jazz_native_relay_host_lease_execute_foreground(
+                    lease,
+                    foreground,
+                    request.as_ptr(),
+                    request.len(),
+                    &mut stale_response,
+                )
+            },
+            JazzNativeRelayStatus::InvalidHandle
+        );
+        assert!(stale_response.data.is_null() && stale_response.len == 0);
+        unsafe { jazz_native_relay_host_lease_free(lease) };
         unsafe { jazz_native_relay_host_free(host) };
     }
 

--- a/crates/jazz-rn/JazzRn.podspec
+++ b/crates/jazz-rn/JazzRn.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => "https://github.com/garden-co/jazz.git", :tag => "#{s.version}" }
 
-  s.source_files = "ios/**/*.{h,m,mm,swift}", "ios/generated/**/*.{h,m,mm}"
+  s.source_files = "ios/**/*.{h,m,mm,swift}", "ios/generated/**/*.{h,m,mm}", "native/**/*.{h,cpp}"
   # Consumer code may import only this stable host-facing surface. The
   # TurboModule protocol is generated into React-Codegen for this pod target;
   # it must remain an implementation detail instead of leaking through a

--- a/crates/jazz-rn/README.md
+++ b/crates/jazz-rn/README.md
@@ -16,6 +16,20 @@ Those crates have Rust contract tests, but they are not wired through this
 package yet. The former UniFFI/JSI surface has been removed rather than left as
 a broken alternative runtime path.
 
+The package now contains the first real foreground-owner substrate. The shared
+JSI HostObject source plus Rust C ABI can open one memory-only foreground `Db`
+only from an already admitted opaque 32-byte capability, run an ordinary bounded
+core `tick`, and close that exact alias. It does not accept storage paths,
+schema, claims, identities, or tokens, and it never reads relay SQLite for a
+foreground operation. Owner work is bounded and capability revocation makes
+all aliases unusable. Android and iOS now install the shared private factory
+through their New-Architecture JSI hooks, including a retained host-state lease
+that makes late finalizers harmless during bridge teardown. The complete
+encoded `NativeDb` read/write/query/subscription codec remains deliberately
+unfinished, so this substrate is not yet an end-to-end RN client. The complete
+ownership/threading/packaging contract and staged acceptance path are specified
+in [`jazz/SPEC/19_native_relays.md`](../jazz/SPEC/19_native_relays.md#196-foreground-native-runtime-execution).
+
 The package reserves a generated `JazzRelay` TurboModule boundary. Android and
 iOS autolink the module, report ABI `0` (unavailable), and explicitly reject
 commands unless a development or release assembly stages the shared Rust relay
@@ -54,8 +68,18 @@ route through the obsolete UniFFI library. The remaining Android runner gate is
 a real Gradle/NDK AAR build and emulator installation against that linked
 artifact.
 
-The wrapper accepts ABI 3, which uses opaque host-generated admission
-capabilities and trusted revocation.
+The wrapper accepts ABI 6, which retains ABI 5's opaque host-generated
+admission capabilities, trusted revocation, and V1 foreground `NativeDb`
+postcard command vocabulary (canonical-query prepare/read/subscribe/drain/
+cancel). ABI 6 adds only the private per-runtime native-to-JS wake registration:
+the owner thread coalesces a wake through React Native's `CallInvoker`, and JS
+schedules the next ordinary tick on its own runtime thread. It is deliberately
+a byte-oriented native-host contract, not a new React Native row/query API:
+the query and row-delta codecs are the same ones used by NAPI/WASM. This
+capability-gated slice supports only ordinary local-first reads; remote tiers,
+structured relation terminal operations, and write/transaction commands remain
+unavailable, so `jazz-tools/react-native` must not select it as its general
+runtime yet.
 
 ## Expo development-build install path
 
@@ -96,13 +120,15 @@ at relay use rather than pretend to provide persistence.
 
 ## What remains before React Native is supported
 
-1. Link the staged host lifecycle codec through thin JNI/Swift translation and
-   extend it with shared event/peer-frame drainage (not an object-per-row API).
-2. Build real iOS XCFramework and Android AAR/shared-library slices from that
+1. Complete the encoded `NativeDb` binding contract against the already
+   attached in-memory clients; do not add a browser-WASM fallback.
+2. Extend the staged host lifecycle codec with shared event/peer-frame drainage
+   (not an object-per-row API).
+3. Build real iOS XCFramework and Android AAR/shared-library slices from that
    module.
-3. Verify bare React Native autolinking plus Expo prebuild/development builds
+4. Verify bare React Native autolinking plus Expo prebuild/development builds
    on Android and iOS in CI, using a first-party device app and structured
-   scenario results.
+   two-foreground-runtime scenario results.
 
 Expo Go cannot load Jazz native code. Expo development builds will be supported
 once the native module and artifacts above exist.

--- a/crates/jazz-rn/README.md
+++ b/crates/jazz-rn/README.md
@@ -57,6 +57,43 @@ artifact.
 The wrapper accepts ABI 3, which uses opaque host-generated admission
 capabilities and trusted revocation.
 
+## Expo development-build install path
+
+`jazz-rn` is a direct application dependency: React Native codegen and Expo
+autolinking must discover it from the application, not through `jazz-tools`.
+For an Expo development build, the minimal configuration is:
+
+```bash
+pnpm add jazz-rn@alpha
+```
+
+```json
+{
+  "expo": {
+    "plugins": ["jazz-rn"]
+  }
+}
+```
+
+Then run `npx expo prebuild --clean` and make a development or release build.
+The plugin turns on the New Architecture, and native autolinking registers
+`JazzRelayPackage` on Android and the `JazzRn` pod on iOS. Do not use Expo Go:
+it cannot contain the relay module.
+
+Bare React Native uses the same direct dependency and autolinking metadata, but
+has no Expo plugin: enable the New Architecture in the host project before
+running its platform install/build commands.
+
+The repository's `jazz-rn` packaging receipt packs the actual npm tarball,
+uses it from an otherwise empty Expo SDK 54 app, typechecks an import from its
+published declarations, prebuilds Android and iOS, and verifies Android
+autolinking plus bare React Native discovery. This intentionally proves only
+install-time wiring. A device run also requires a matching release payload with
+the sealed Android relay slices or iOS XCFramework plus platform-owned scope admission; those are produced by
+the native artifact/release workflows and are checked separately by the device
+acceptance app. A source checkout with no staged native artifacts should fail
+at relay use rather than pretend to provide persistence.
+
 ## What remains before React Native is supported
 
 1. Link the staged host lifecycle codec through thin JNI/Swift translation and

--- a/crates/jazz-rn/android/CMakeLists.txt
+++ b/crates/jazz-rn/android/CMakeLists.txt
@@ -1,10 +1,23 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(jazzrelay)
 
-add_library(jazzrelay SHARED cpp-relay.cpp)
-target_include_directories(jazzrelay PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../native/include")
+find_package(ReactAndroid REQUIRED CONFIG)
+find_package(fbjni REQUIRED CONFIG)
+
+add_library(jazzrelay SHARED cpp-relay.cpp ../native/foreground-runtime.cpp)
+target_include_directories(jazzrelay PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../native"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../native/include"
+  "${REACT_ANDROID_DIR}/ReactAndroid/src/main/jni/react/turbomodule"
+)
 find_library(log-lib log)
 add_library(jazz_native_relay STATIC IMPORTED)
 set_target_properties(jazz_native_relay PROPERTIES IMPORTED_LOCATION
   "${CMAKE_CURRENT_SOURCE_DIR}/src/main/jniLibs/${ANDROID_ABI}/libjazz_native_relay.a")
-target_link_libraries(jazzrelay jazz_native_relay ${log-lib})
+target_link_libraries(jazzrelay
+  jazz_native_relay
+  ${log-lib}
+  fbjni::fbjni
+  ReactAndroid::jsi
+  ReactAndroid::reactnative
+)

--- a/crates/jazz-rn/android/cpp-relay.cpp
+++ b/crates/jazz-rn/android/cpp-relay.cpp
@@ -1,5 +1,13 @@
 #include <jni.h>
 
+#include <ReactCommon/BindingsInstallerHolder.h>
+#include <fbjni/fbjni.h>
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+#include "../native/foreground-runtime.h"
 #include "jazz_native_relay.h"
 
 namespace {
@@ -17,6 +25,35 @@ jbyteArray copy_response(JNIEnv *env, jazz_native_relay_bytes *output,
   }
   jazz_native_relay_bytes_free(output);
   return result;
+}
+
+struct ForegroundRuntimeInstallation {
+  ForegroundRuntimeInstallation(
+      jazz_native_relay_host *host,
+      const std::shared_ptr<facebook::react::CallInvoker> &callInvoker)
+      : lease(std::make_shared<jazz::rn::ForegroundRuntimeLease>(host, callInvoker)) {}
+
+  std::mutex mutex;
+  std::shared_ptr<jazz::rn::ForegroundRuntimeLease> lease;
+  facebook::jsi::Runtime *runtime{nullptr};
+};
+
+std::mutex foreground_installations_mutex;
+std::unordered_map<jazz_native_relay_host *, std::shared_ptr<ForegroundRuntimeInstallation>>
+    foreground_installations;
+
+std::shared_ptr<ForegroundRuntimeInstallation> foregroundInstallation(
+    jazz_native_relay_host *host,
+    const std::shared_ptr<facebook::react::CallInvoker> &callInvoker = nullptr) {
+  std::lock_guard<std::mutex> lock(foreground_installations_mutex);
+  const auto found = foreground_installations.find(host);
+  if (found != foreground_installations.end()) {
+    return found->second;
+  }
+  if (!callInvoker) return nullptr;
+  auto installation = std::make_shared<ForegroundRuntimeInstallation>(host, callInvoker);
+  foreground_installations.emplace(host, installation);
+  return installation;
 }
 }  // namespace
 
@@ -75,4 +112,57 @@ Java_com_jazzrn_JazzRelayBridge_nativeRevokeTrustedScope(
     env->ThrowNew(env->FindClass("java/lang/IllegalStateException"),
                   "Jazz trusted relay revocation failed");
   }
+}
+
+extern "C" JNIEXPORT jobject JNICALL
+Java_com_jazzrn_JazzRelayBridge_nativeForegroundBindingsInstaller(
+    JNIEnv *, jclass, jlong host) {
+  auto *relay_host = reinterpret_cast<jazz_native_relay_host *>(host);
+  if (relay_host == nullptr) {
+    return nullptr;
+  }
+  auto holder = facebook::react::BindingsInstallerHolder::newObjectCxxArgs(
+      [relay_host](facebook::jsi::Runtime &runtime,
+                     const std::shared_ptr<facebook::react::CallInvoker> &callInvoker) {
+        auto installation = foregroundInstallation(relay_host, callInvoker);
+        if (!installation) return;
+        std::lock_guard<std::mutex> lock(installation->mutex);
+        installation->runtime = &runtime;
+        jazz::rn::installForegroundRuntime(runtime, installation->lease);
+      });
+  return holder.release();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_jazzrn_JazzRelayBridge_nativeInstallForegroundRuntime(
+    JNIEnv *env, jclass, jlong host) {
+  auto *relay_host = reinterpret_cast<jazz_native_relay_host *>(host);
+  const auto installation = foregroundInstallation(relay_host);
+  if (relay_host == nullptr || !installation) {
+    env->ThrowNew(env->FindClass("java/lang/IllegalStateException"),
+                  "Jazz native foreground runtime is unavailable for this bridge");
+    return;
+  }
+  std::lock_guard<std::mutex> lock(installation->mutex);
+  if (installation->runtime == nullptr || !installation->lease->active()) {
+    env->ThrowNew(env->FindClass("java/lang/IllegalStateException"),
+                  "Jazz native foreground runtime is unavailable for this bridge");
+    return;
+  }
+  jazz::rn::installForegroundRuntime(*installation->runtime, installation->lease);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_jazzrn_JazzRelayBridge_nativeInvalidateForegroundRuntime(
+    JNIEnv *, jclass, jlong host) {
+  auto *relay_host = reinterpret_cast<jazz_native_relay_host *>(host);
+  std::lock_guard<std::mutex> lock(foreground_installations_mutex);
+  const auto found = foreground_installations.find(relay_host);
+  if (found == foreground_installations.end()) {
+    return;
+  }
+  std::lock_guard<std::mutex> installation_lock(found->second->mutex);
+  found->second->lease->invalidate();
+  found->second->runtime = nullptr;
+  foreground_installations.erase(found);
 }

--- a/crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayBridge.kt
+++ b/crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayBridge.kt
@@ -1,12 +1,14 @@
 package com.jazzrn
 
 import android.util.Base64
+import com.facebook.react.turbomodule.core.interfaces.BindingsInstallerHolder
 import org.json.JSONObject
 
 /** Opaque JNI carrier for the shared C ABI; it owns no Jazz semantics. */
 internal object JazzRelayBridge {
   private var host: Long = 0
-  private var runtimeReferences = 0
+  private var nextRuntimeToken = 1L
+  private val activeRuntimeTokens = mutableSetOf<Long>()
   private val trustedCapabilities = mutableSetOf<String>()
 
   private fun ensureHost(): Long {
@@ -18,15 +20,21 @@ internal object JazzRelayBridge {
   }
 
   @Synchronized
-  fun acquireRuntime() {
+  fun acquireRuntime(): Long {
     ensureHost()
-    runtimeReferences += 1
+    check(nextRuntimeToken > 0) { "Jazz native relay runtime token space exhausted" }
+    val token = nextRuntimeToken
+    nextRuntimeToken += 1
+    check(activeRuntimeTokens.add(token)) { "Jazz native relay duplicated a runtime token" }
+    return token
   }
 
   @Synchronized
-  fun releaseRuntime() {
-    check(runtimeReferences > 0) { "Jazz native relay runtime lease underflow" }
-    runtimeReferences -= 1
+  fun releaseRuntime(runtimeToken: Long) {
+    check(activeRuntimeTokens.remove(runtimeToken)) {
+      "Jazz native relay runtime lease is already released"
+    }
+    nativeInvalidateForegroundRuntime(host, runtimeToken)
     destroyIfUnused()
   }
 
@@ -41,6 +49,29 @@ internal object JazzRelayBridge {
     nativeExecute(ensureHost(), Base64.decode(commandBase64, Base64.NO_WRAP)),
     Base64.NO_WRAP
   )
+
+  /**
+   * React Native invokes this installer while it owns a live JSI runtime. The
+   * shared C++ factory closes over only this runtime token's host liveness
+   * lease; it never receives trusted scope configuration from JavaScript.
+   */
+  @Synchronized
+  fun foregroundBindingsInstaller(runtimeToken: Long): BindingsInstallerHolder {
+    check(activeRuntimeTokens.contains(runtimeToken)) {
+      "Jazz native foreground runtime is unavailable for this bridge"
+    }
+    return nativeForegroundBindingsInstaller(ensureHost(), runtimeToken)
+  }
+
+  /** Reinstall a fresh factory after the JS wrapper deliberately removes any
+   * stale global left by an earlier bridge/runtime. */
+  @Synchronized
+  fun installForegroundRuntime(runtimeToken: Long) {
+    check(activeRuntimeTokens.contains(runtimeToken)) {
+      "Jazz native foreground runtime is unavailable for this bridge"
+    }
+    nativeInstallForegroundRuntime(ensureHost(), runtimeToken)
+  }
 
   /**
    * The only Android entry for trusted scope configuration. It is deliberately
@@ -75,7 +106,7 @@ internal object JazzRelayBridge {
   }
 
   private fun destroyIfUnused() {
-    if (host != 0L && runtimeReferences == 0 && trustedCapabilities.isEmpty()) {
+    if (host != 0L && activeRuntimeTokens.isEmpty() && trustedCapabilities.isEmpty()) {
       nativeDestroy(host)
       host = 0
     }
@@ -87,6 +118,12 @@ internal object JazzRelayBridge {
   @JvmStatic private external fun nativeExecute(host: Long, command: ByteArray): ByteArray
   @JvmStatic private external fun nativeAdmitTrustedScopeJson(host: Long, admissionJson: ByteArray): ByteArray
   @JvmStatic private external fun nativeRevokeTrustedScope(host: Long, capability: ByteArray)
+  @JvmStatic private external fun nativeForegroundBindingsInstaller(
+    host: Long,
+    runtimeToken: Long,
+  ): BindingsInstallerHolder
+  @JvmStatic private external fun nativeInstallForegroundRuntime(host: Long, runtimeToken: Long)
+  @JvmStatic private external fun nativeInvalidateForegroundRuntime(host: Long, runtimeToken: Long)
 }
 
 /**

--- a/crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayModule.java
+++ b/crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayModule.java
@@ -3,6 +3,8 @@ package com.jazzrn;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.turbomodule.core.interfaces.BindingsInstallerHolder;
+import com.facebook.react.turbomodule.core.interfaces.TurboModuleWithJSIBindings;
 
 /**
  * Android implementation of the generated JazzRelay TurboModule spec.
@@ -15,10 +17,12 @@ import com.facebook.react.module.annotations.ReactModule;
  * opaque native handle.
  */
 @ReactModule(name = JazzRelayModule.NAME)
-public class JazzRelayModule extends NativeJazzRelaySpec {
+public class JazzRelayModule extends NativeJazzRelaySpec implements TurboModuleWithJSIBindings {
   public static final String NAME = "JazzRelay";
 
   private final JazzRelayBridge bridge;
+  private long runtimeToken = 0;
+  private boolean ownsRuntimeLease = false;
 
   public JazzRelayModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -29,6 +33,29 @@ public class JazzRelayModule extends NativeJazzRelaySpec {
       resolvedBridge = null;
     }
     bridge = resolvedBridge;
+  }
+
+  @Override
+  public void initialize() {
+    super.initialize();
+    if (bridge != null) ensureRuntimeToken();
+  }
+
+  @Override
+  public void invalidate() {
+    try {
+      if (bridge != null && ownsRuntimeLease) {
+        final long releasedToken = runtimeToken;
+        // Clear ownership before calling into native lifecycle code. If it
+        // throws, React Native may invoke invalidate again; that retry must
+        // never consume a sibling runtime's lease.
+        ownsRuntimeLease = false;
+        runtimeToken = 0;
+        bridge.releaseRuntime(releasedToken);
+      }
+    } finally {
+      super.invalidate();
+    }
   }
 
   @Override
@@ -49,5 +76,34 @@ public class JazzRelayModule extends NativeJazzRelaySpec {
     } catch (Throwable error) {
       promise.reject("E_JAZZ_RELAY_COMMAND", error);
     }
+  }
+
+  @Override
+  public void installForegroundRuntime() {
+    if (bridge == null) {
+      throw new IllegalStateException(
+          "Jazz native foreground runtime requires an Android development or release build containing the shared Rust relay artifact.");
+    }
+    bridge.installForegroundRuntime(ensureRuntimeToken());
+  }
+
+  @Override
+  public BindingsInstallerHolder getBindingsInstaller() {
+    if (bridge == null) {
+      throw new IllegalStateException(
+          "Jazz native foreground runtime requires an Android development or release build containing the shared Rust relay artifact.");
+    }
+    return bridge.foregroundBindingsInstaller(ensureRuntimeToken());
+  }
+
+  /** A stable platform-issued token identifies this JS runtime's private JSI
+   * factory. It is never a JavaScript-visible handle and is intentionally not
+   * derived from a native pointer. */
+  private long ensureRuntimeToken() {
+    if (!ownsRuntimeLease) {
+      runtimeToken = bridge.acquireRuntime();
+      ownsRuntimeLease = true;
+    }
+    return runtimeToken;
   }
 }

--- a/crates/jazz-rn/ios/JazzRelay.mm
+++ b/crates/jazz-rn/ios/JazzRelay.mm
@@ -16,6 +16,10 @@
 #import <ReactCommon/RCTTurboModule.h>
 #endif
 
+#if JAZZ_RELAY_ARTIFACT_AVAILABLE
+#include "../native/foreground-runtime.h"
+#endif
+
 @implementation JazzRelay
 
 // New-Architecture modules still require this registration hook: it binds the
@@ -28,6 +32,8 @@ RCT_EXPORT_MODULE()
 static jazz_native_relay_host *relayHost = NULL;
 static NSUInteger relayRuntimeReferences = 0;
 static NSMutableSet<NSData *> *trustedCapabilities = nil;
+static facebook::jsi::Runtime *foregroundJsiRuntime = nullptr;
+static std::shared_ptr<jazz::rn::ForegroundRuntimeLease> foregroundRuntimeLease;
 
 static jazz_native_relay_host *EnsureRelayHost(void) {
   if (relayHost == NULL) relayHost = jazz_native_relay_host_new();
@@ -90,9 +96,43 @@ static NSError *RelayLifecycleError(NSString *message) {
 #endif
 }
 
+- (void)installForegroundRuntime {
+#if JAZZ_RELAY_ARTIFACT_AVAILABLE
+  @synchronized([JazzRelay class]) {
+    if (foregroundJsiRuntime == nullptr || foregroundRuntimeLease == nullptr ||
+        !foregroundRuntimeLease->active()) {
+      // The JS wrapper validates that native code installed a fresh factory
+      // immediately after this method returns, yielding its normal actionable
+      // development-build diagnostic if React Native has not handed us a live
+      // JSI runtime yet.
+      return;
+    }
+    jazz::rn::installForegroundRuntime(*foregroundJsiRuntime, foregroundRuntimeLease);
+  }
+#endif
+}
+
+- (void)installJSIBindingsWithRuntime:(facebook::jsi::Runtime &)runtime
+                          callInvoker:(const std::shared_ptr<facebook::react::CallInvoker> &)callInvoker {
+#if JAZZ_RELAY_ARTIFACT_AVAILABLE
+  @synchronized([JazzRelay class]) {
+    foregroundJsiRuntime = &runtime;
+    foregroundRuntimeLease = std::make_shared<jazz::rn::ForegroundRuntimeLease>(
+        EnsureRelayHost(), callInvoker);
+    jazz::rn::installForegroundRuntime(runtime, foregroundRuntimeLease);
+  }
+#else
+  (void)runtime;
+  (void)callInvoker;
+#endif
+}
+
 - (void)invalidate {
 #if JAZZ_RELAY_ARTIFACT_AVAILABLE
   @synchronized([JazzRelay class]) {
+    if (foregroundRuntimeLease != nullptr) foregroundRuntimeLease->invalidate();
+    foregroundRuntimeLease.reset();
+    foregroundJsiRuntime = nullptr;
     if (relayRuntimeReferences > 0) relayRuntimeReferences -= 1;
     DestroyRelayHostIfUnused();
   }

--- a/crates/jazz-rn/ios/JazzRelayModule.h
+++ b/crates/jazz-rn/ios/JazzRelayModule.h
@@ -1,9 +1,10 @@
 #import "JazzRelaySpec.h"
+#import <ReactCommon/RCTTurboModuleWithJSIBindings.h>
 
 /**
  * Private TurboModule declaration. React-Codegen supplies JazzRelaySpec.h to
  * the JazzRn pod target, but consuming applications do not receive that
  * generated header as part of the public JazzRn module surface.
  */
-@interface JazzRelay : NSObject <NativeJazzRelaySpec>
+@interface JazzRelay : NSObject <NativeJazzRelaySpec, RCTTurboModuleWithJSIBindings>
 @end

--- a/crates/jazz-rn/native/foreground-runtime.cpp
+++ b/crates/jazz-rn/native/foreground-runtime.cpp
@@ -1,0 +1,606 @@
+#include "foreground-runtime.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace jazz::rn {
+
+constexpr const char *kWakeCallbacksGlobal = "__jazzNativeForegroundWakeCallbacksV1";
+constexpr uint8_t kWakeImmediate = 0;
+constexpr uint8_t kWakeDeferred = 1;
+constexpr uint8_t kWakeAfter = 2;
+constexpr uint8_t kWakeCancelled = 3;
+
+using facebook::jsi::Function;
+using facebook::jsi::JSError;
+using facebook::jsi::Object;
+using facebook::jsi::Runtime;
+using facebook::jsi::String;
+using facebook::jsi::Value;
+
+/**
+ * One platform-scheduled wake sink for one foreground Db in one JS runtime.
+ *
+ * Rust may signal this object from its owner thread. The trampoline retains no
+ * JavaScript values and only queues a CallInvoker task. That task reacquires
+ * the callback from a runtime-local private object and invokes it after every
+ * host/relay lock has been released. A pending bit coalesces bursts; a wake
+ * that arrives while JS is delivering one callback schedules one later turn,
+ * never reenters JavaScript synchronously.
+ */
+class ForegroundWakeRegistration final
+    : public std::enable_shared_from_this<ForegroundWakeRegistration> {
+ public:
+  ForegroundWakeRegistration(
+      uint64_t foreground,
+      std::shared_ptr<facebook::react::CallInvoker> callInvoker)
+      : foreground_(foreground), callInvoker_(std::move(callInvoker)) {}
+
+  void installCallback(Runtime &runtime, Function callback) {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (!active_) {
+        throw JSError(runtime, "Jazz native foreground runtime is unavailable after teardown");
+      }
+    }
+    auto callbacks = runtime.global().getProperty(runtime, kWakeCallbacksGlobal);
+    if (!callbacks.isObject()) {
+      throw JSError(runtime, "Jazz native foreground wake registry is unavailable");
+    }
+    callbacks.asObject(runtime).setProperty(
+        runtime, callbackKey().c_str(), Value(std::move(callback)));
+  }
+
+  void removeCallback(Runtime &runtime) {
+    auto callbacks = runtime.global().getProperty(runtime, kWakeCallbacksGlobal);
+    if (callbacks.isObject()) {
+      callbacks.asObject(runtime).setProperty(runtime, callbackKey().c_str(), Value::undefined());
+    }
+  }
+
+  jazz_native_relay_status activateNative(jazz_native_relay_host_lease *lease) {
+    return jazz_native_relay_host_lease_set_foreground_wake_callback(
+        lease, foreground_, &ForegroundWakeRegistration::wakeFromOwner, this);
+  }
+
+  /** Clear the Rust scheduler synchronously before this callback context can
+   * be destroyed. This never touches JSI, so platform invalidation may call it
+   * while a runtime is already being torn down. */
+  void deactivateAndClear(jazz_native_relay_host_lease *lease) {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      active_ = false;
+      pending_ = false;
+    }
+    // An already-revoked foreground reports INVALID_HANDLE here; revocation
+    // itself synchronously removed its Db and therefore its scheduler first.
+    (void)jazz_native_relay_host_lease_set_foreground_wake_callback(
+        lease, foreground_, nullptr, nullptr);
+  }
+
+ private:
+  static void wakeFromOwner(void *context, uint64_t foreground, uint8_t kind,
+                            uint64_t delayMs) noexcept {
+    auto *registration = static_cast<ForegroundWakeRegistration *>(context);
+    if (registration != nullptr) registration->requestWake(foreground, kind, delayMs);
+  }
+
+  void requestWake(uint64_t foreground, uint8_t kind, uint64_t delayMs) noexcept {
+    std::shared_ptr<facebook::react::CallInvoker> invoker;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (foreground != foreground_) return;
+      if (kind == kWakeCancelled) {
+        active_ = false;
+        pending_ = false;
+        return;
+      }
+      if (!active_) return;
+      mergeWakeLocked(kind, delayMs);
+      if (scheduled_ || !callInvoker_) return;
+      scheduled_ = true;
+      invoker = callInvoker_;
+    }
+    schedule(std::move(invoker));
+  }
+
+  void schedule(std::shared_ptr<facebook::react::CallInvoker> invoker) noexcept {
+    try {
+      auto self = shared_from_this();
+      invoker->invokeAsync([self = std::move(self)](Runtime &runtime) {
+        self->deliver(runtime);
+      });
+    } catch (...) {
+      // Never let an executor failure unwind through Rust's C callback. Keep
+      // the pending wake eligible for a later owner signal instead of leaving
+      // the coalescer permanently marked as scheduled.
+      std::lock_guard<std::mutex> lock(mutex_);
+      scheduled_ = false;
+    }
+  }
+
+  void deliver(Runtime &runtime) {
+    uint8_t kind = kWakeDeferred;
+    uint64_t delayMs = 0;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      scheduled_ = false;
+      if (!active_ || !pending_) return;
+      pending_ = false;
+      delivering_ = true;
+      kind = kind_;
+      delayMs = delayMs_;
+    }
+
+    try {
+      auto callbacks = runtime.global().getProperty(runtime, kWakeCallbacksGlobal);
+      if (callbacks.isObject()) {
+        auto callback = callbacks.asObject(runtime).getProperty(runtime, callbackKey().c_str());
+        if (callback.isObject() && callback.asObject(runtime).isFunction(runtime)) {
+          auto urgency = String::createFromUtf8(runtime, urgencyFor(kind, delayMs));
+          callback.asObject(runtime).asFunction(runtime).call(runtime, Value(std::move(urgency)));
+        }
+      }
+    } catch (const JSError &) {
+      // A scheduler callback is application-controlled. Do not let a thrown
+      // JS callback unwind through CallInvoker or leave the coalescer stuck.
+    } catch (...) {
+      // Same guarantee for an engine-specific exception type.
+    }
+
+    std::shared_ptr<facebook::react::CallInvoker> invoker;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      delivering_ = false;
+      if (active_ && pending_ && !scheduled_ && callInvoker_) {
+        scheduled_ = true;
+        invoker = callInvoker_;
+      }
+    }
+    if (invoker) schedule(std::move(invoker));
+  }
+
+  void mergeWakeLocked(uint8_t kind, uint64_t delayMs) {
+    if (!pending_) {
+      pending_ = true;
+      kind_ = kind;
+      delayMs_ = delayMs;
+      return;
+    }
+    // Service the most urgent work that arrived in this coalesced turn. An
+    // explicit timer remains a timer unless a normal wake supersedes it.
+    if (kind == kWakeImmediate ||
+        (kind == kWakeDeferred && kind_ == kWakeAfter) ||
+        (kind == kWakeAfter && kind_ == kWakeAfter && delayMs < delayMs_)) {
+      kind_ = kind;
+      delayMs_ = delayMs;
+    }
+  }
+
+  std::string callbackKey() const { return "foreground-" + std::to_string(foreground_); }
+
+  static std::string urgencyFor(uint8_t kind, uint64_t delayMs) {
+    if (kind == kWakeImmediate) return "immediate";
+    if (kind == kWakeAfter) return "after:" + std::to_string(delayMs);
+    return "deferred";
+  }
+
+  uint64_t foreground_;
+  std::shared_ptr<facebook::react::CallInvoker> callInvoker_;
+  std::mutex mutex_;
+  bool active_{true};
+  bool pending_{false};
+  bool scheduled_{false};
+  bool delivering_{false};
+  uint8_t kind_{kWakeDeferred};
+  uint64_t delayMs_{0};
+};
+
+ForegroundRuntimeLease::~ForegroundRuntimeLease() {
+  invalidate();
+  if (lease_ != nullptr) {
+    jazz_native_relay_host_lease_free(lease_);
+    lease_ = nullptr;
+  }
+}
+
+std::unique_lock<std::mutex> ForegroundRuntimeLease::lockIfActive() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (!active_ || lease_ == nullptr) {
+    lock.unlock();
+  }
+  return lock;
+}
+
+bool ForegroundRuntimeLease::active() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return active_ && lease_ != nullptr;
+}
+
+void ForegroundRuntimeLease::invalidate() {
+  std::vector<std::shared_ptr<ForegroundWakeRegistration>> registrations;
+  jazz_native_relay_host_lease *nativeLease = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!active_) return;
+    active_ = false;
+    nativeLease = lease_;
+    for (const auto &weak : wakeRegistrations_) {
+      if (auto registration = weak.lock()) registrations.push_back(std::move(registration));
+    }
+    wakeRegistrations_.clear();
+  }
+  for (const auto &registration : registrations) {
+    registration->deactivateAndClear(nativeLease);
+  }
+}
+
+void ForegroundRuntimeLease::trackWakeRegistration(
+    const std::shared_ptr<ForegroundWakeRegistration> &registration) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!active_) return;
+  wakeRegistrations_.erase(
+      std::remove_if(wakeRegistrations_.begin(), wakeRegistrations_.end(),
+                     [](const auto &weak) { return weak.expired(); }),
+      wakeRegistrations_.end());
+  wakeRegistrations_.push_back(registration);
+}
+
+namespace {
+
+using facebook::jsi::ArrayBuffer;
+using facebook::jsi::HostObject;
+using facebook::jsi::PropNameID;
+
+constexpr const char *kFactoryGlobal = "__jazzNativeForegroundRuntimeV1";
+constexpr size_t kForegroundCommandMaxBytes = 1024 * 1024;
+
+class VectorMutableBuffer final : public facebook::jsi::MutableBuffer {
+ public:
+  explicit VectorMutableBuffer(std::vector<uint8_t> bytes) : bytes_(std::move(bytes)) {}
+
+  size_t size() const override { return bytes_.size(); }
+  uint8_t *data() override { return bytes_.data(); }
+
+ private:
+  std::vector<uint8_t> bytes_;
+};
+
+[[noreturn]] void throwStatus(Runtime &runtime, jazz_native_relay_status status,
+                              const char *operation) {
+  switch (status) {
+    case JAZZ_NATIVE_RELAY_INVALID_HANDLE:
+      throw JSError(runtime, std::string("Jazz native foreground runtime rejected ") +
+                                operation + ": capability or handle is no longer admitted");
+    case JAZZ_NATIVE_RELAY_BACKPRESSURE:
+      throw JSError(runtime, std::string("Jazz native foreground runtime is busy during ") +
+                                operation + "; retry after the next scheduled tick");
+    default:
+      throw JSError(runtime, std::string("Jazz native foreground runtime failed during ") +
+                                operation);
+  }
+}
+
+std::array<uint8_t, 32> copyAdmittedCapability(Runtime &runtime,
+                                                const Value &value) {
+  // JSI intentionally has no TypedArray wrapper. Verify the observable
+  // Uint8Array shape, then copy only its selected ArrayBuffer window. This is
+  // defence in depth: Rust admission remains authoritative, so a JS object
+  // which merely imitates this shape cannot mint a usable capability.
+  if (!value.isObject()) {
+    throw JSError(runtime,
+                 "Jazz native foreground runtime requires a Uint8Array capability");
+  }
+  auto typed = value.asObject(runtime);
+  const auto expected_constructor = runtime.global().getProperty(runtime, "Uint8Array");
+  const auto actual_constructor = typed.getProperty(runtime, "constructor");
+  if (!expected_constructor.isObject() || !actual_constructor.isObject() ||
+      !facebook::jsi::Object::strictEquals(
+          runtime, expected_constructor.asObject(runtime), actual_constructor.asObject(runtime))) {
+    throw JSError(runtime,
+                 "Jazz native foreground runtime requires a Uint8Array capability");
+  }
+  auto bufferValue = typed.getProperty(runtime, "buffer");
+  if (!bufferValue.isObject() || !bufferValue.asObject(runtime).isArrayBuffer(runtime)) {
+    throw JSError(runtime,
+                 "Jazz native foreground runtime requires a Uint8Array capability");
+  }
+  auto lengthValue = typed.getProperty(runtime, "byteLength");
+  auto offsetValue = typed.getProperty(runtime, "byteOffset");
+  if (!lengthValue.isNumber() || !offsetValue.isNumber()) {
+    throw JSError(runtime,
+                 "Jazz native foreground runtime requires a 32-byte admitted capability");
+  }
+  auto buffer = bufferValue.asObject(runtime).getArrayBuffer(runtime);
+  const auto length = lengthValue.asNumber();
+  const auto offset_number = offsetValue.asNumber();
+  const auto buffer_size = buffer.size(runtime);
+  if (!std::isfinite(length) || length != 32 || !std::isfinite(offset_number) ||
+      offset_number < 0 || std::floor(offset_number) != offset_number ||
+      offset_number > static_cast<double>(std::numeric_limits<size_t>::max()) ||
+      offset_number > static_cast<double>(buffer_size)) {
+    throw JSError(runtime,
+                 "Jazz native foreground runtime requires a 32-byte admitted capability");
+  }
+  const auto offset = static_cast<size_t>(offset_number);
+  if (offset > buffer.size(runtime) || 32 > buffer.size(runtime) - offset) {
+    throw JSError(runtime,
+                 "Jazz native foreground runtime requires a 32-byte admitted capability");
+  }
+  std::array<uint8_t, 32> capability{};
+  std::memcpy(capability.data(), buffer.data(runtime) + offset, capability.size());
+  return capability;
+}
+
+std::vector<uint8_t> copyForegroundCommand(Runtime &runtime, const Value &value) {
+  if (!value.isObject()) {
+    throw JSError(runtime, "Jazz native foreground command requires a Uint8Array");
+  }
+  auto typed = value.asObject(runtime);
+  const auto expected_constructor = runtime.global().getProperty(runtime, "Uint8Array");
+  const auto actual_constructor = typed.getProperty(runtime, "constructor");
+  if (!expected_constructor.isObject() || !actual_constructor.isObject() ||
+      !facebook::jsi::Object::strictEquals(
+          runtime, expected_constructor.asObject(runtime), actual_constructor.asObject(runtime))) {
+    throw JSError(runtime, "Jazz native foreground command requires a Uint8Array");
+  }
+  auto bufferValue = typed.getProperty(runtime, "buffer");
+  auto lengthValue = typed.getProperty(runtime, "byteLength");
+  auto offsetValue = typed.getProperty(runtime, "byteOffset");
+  if (!bufferValue.isObject() || !bufferValue.asObject(runtime).isArrayBuffer(runtime) ||
+      !lengthValue.isNumber() || !offsetValue.isNumber()) {
+    throw JSError(runtime, "Jazz native foreground command requires a Uint8Array");
+  }
+  const auto length_number = lengthValue.asNumber();
+  const auto offset_number = offsetValue.asNumber();
+  auto buffer = bufferValue.asObject(runtime).getArrayBuffer(runtime);
+  const auto buffer_size = buffer.size(runtime);
+  if (!std::isfinite(length_number) || length_number < 0 ||
+      std::floor(length_number) != length_number ||
+      length_number > static_cast<double>(kForegroundCommandMaxBytes) ||
+      !std::isfinite(offset_number) || offset_number < 0 ||
+      std::floor(offset_number) != offset_number ||
+      offset_number > static_cast<double>(std::numeric_limits<size_t>::max()) ||
+      offset_number > static_cast<double>(buffer_size)) {
+    throw JSError(runtime, "Jazz native foreground command is malformed or too large");
+  }
+  const auto length = static_cast<size_t>(length_number);
+  const auto offset = static_cast<size_t>(offset_number);
+  if (length > buffer_size - offset) {
+    throw JSError(runtime, "Jazz native foreground command is malformed or too large");
+  }
+  const auto *begin = buffer.data(runtime) + offset;
+  return std::vector<uint8_t>(begin, begin + length);
+}
+
+Value foregroundResponse(Runtime &runtime, jazz_native_relay_bytes *response) {
+  std::vector<uint8_t> bytes;
+  if (response->len != 0) {
+    bytes.assign(response->data, response->data + response->len);
+  }
+  jazz_native_relay_bytes_free(response);
+  auto arrayBuffer = ArrayBuffer(runtime, std::make_shared<VectorMutableBuffer>(std::move(bytes)));
+  auto uint8Array = runtime.global().getPropertyAsFunction(runtime, "Uint8Array");
+  return uint8Array.callAsConstructor(runtime, std::move(arrayBuffer));
+}
+
+class ForegroundHandle final : public HostObject {
+ public:
+  ForegroundHandle(std::shared_ptr<ForegroundRuntimeLease> lease, uint64_t handle)
+      : lease_(std::move(lease)),
+        handle_(handle),
+        wake_(std::make_shared<ForegroundWakeRegistration>(handle, lease_->callInvoker())) {
+    lease_->trackWakeRegistration(wake_);
+  }
+
+  ~ForegroundHandle() override { closeNoThrow(); }
+
+  Value get(Runtime &runtime, const PropNameID &name) override {
+    const auto property = name.utf8(runtime);
+    if (property == "tick") {
+      return Function::createFromHostFunction(
+          runtime, PropNameID::forAscii(runtime, "tick"), 0,
+          [this](Runtime &runtime, const Value &, const Value *, size_t) {
+            if (closed_) {
+              throw JSError(runtime, "Jazz native foreground runtime is closed");
+            }
+            auto lease_lock = lease_->lockIfActive();
+            if (!lease_lock.owns_lock()) {
+              throw JSError(runtime, "Jazz native foreground runtime is unavailable after teardown");
+            }
+            const auto status = jazz_native_relay_host_lease_tick_attached_foreground(
+                lease_->nativeLease(), handle_);
+            if (status != JAZZ_NATIVE_RELAY_OK) {
+              throwStatus(runtime, status, "tick");
+            }
+            return Value::undefined();
+          });
+    }
+    if (property == "close") {
+      return Function::createFromHostFunction(
+          runtime, PropNameID::forAscii(runtime, "close"), 0,
+          [this](Runtime &runtime, const Value &, const Value *, size_t) {
+            return Value(close(runtime));
+          });
+    }
+    if (property == "setTickScheduler") {
+      return Function::createFromHostFunction(
+          runtime, PropNameID::forAscii(runtime, "setTickScheduler"), 1,
+          [this](Runtime &runtime, const Value &, const Value *args, size_t count) {
+            if (closed_) {
+              throw JSError(runtime, "Jazz native foreground runtime is closed");
+            }
+            if (count != 1 || !args[0].isObject() ||
+                !args[0].asObject(runtime).isFunction(runtime)) {
+              throw JSError(runtime,
+                           "Jazz native foreground tick scheduler requires a function");
+            }
+            auto lease_lock = lease_->lockIfActive();
+            if (!lease_lock.owns_lock()) {
+              throw JSError(runtime, "Jazz native foreground runtime is unavailable after teardown");
+            }
+            auto callback = args[0].asObject(runtime).asFunction(runtime);
+            wake_->installCallback(runtime, std::move(callback));
+            const auto status = wake_->activateNative(lease_->nativeLease());
+            if (status != JAZZ_NATIVE_RELAY_OK) {
+              wake_->removeCallback(runtime);
+              throwStatus(runtime, status, "setTickScheduler");
+            }
+            return Value::undefined();
+          });
+    }
+    if (property == "execute") {
+      return Function::createFromHostFunction(
+          runtime, PropNameID::forAscii(runtime, "execute"), 1,
+          [this](Runtime &runtime, const Value &, const Value *args, size_t count) {
+            if (closed_) {
+              throw JSError(runtime, "Jazz native foreground runtime is closed");
+            }
+            if (count != 1) {
+              throw JSError(runtime, "Jazz native foreground command requires a Uint8Array");
+            }
+            auto lease_lock = lease_->lockIfActive();
+            if (!lease_lock.owns_lock()) {
+              throw JSError(runtime, "Jazz native foreground runtime is unavailable after teardown");
+            }
+            const auto request = copyForegroundCommand(runtime, args[0]);
+            jazz_native_relay_bytes response{};
+            const auto status = jazz_native_relay_host_lease_execute_foreground(
+                lease_->nativeLease(), handle_, request.data(), request.size(), &response);
+            if (status != JAZZ_NATIVE_RELAY_OK) {
+              jazz_native_relay_bytes_free(&response);
+              throwStatus(runtime, status, "execute");
+            }
+            return foregroundResponse(runtime, &response);
+          });
+    }
+    return Value::undefined();
+  }
+
+  std::vector<PropNameID> getPropertyNames(Runtime &runtime) override {
+    std::vector<PropNameID> names;
+    names.reserve(4);
+    names.emplace_back(PropNameID::forAscii(runtime, "tick"));
+    names.emplace_back(PropNameID::forAscii(runtime, "close"));
+    names.emplace_back(PropNameID::forAscii(runtime, "execute"));
+    names.emplace_back(PropNameID::forAscii(runtime, "setTickScheduler"));
+    return names;
+  }
+
+ private:
+  bool close(Runtime &runtime) {
+    if (closed_) {
+      return false;
+    }
+    bool closed = false;
+    auto lease_lock = lease_->lockIfActive();
+    if (!lease_lock.owns_lock()) {
+      closed_ = true;
+      return false;
+    }
+    wake_->deactivateAndClear(lease_->nativeLease());
+    wake_->removeCallback(runtime);
+    const auto status = jazz_native_relay_host_lease_close_attached_foreground(
+        lease_->nativeLease(), handle_, &closed);
+    if (status != JAZZ_NATIVE_RELAY_OK) {
+      throwStatus(runtime, status, "close");
+    }
+    closed_ = true;
+    return closed;
+  }
+
+  void closeNoThrow() {
+    auto lease_lock = lease_->lockIfActive();
+    if (!closed_ && lease_lock.owns_lock()) {
+      wake_->deactivateAndClear(lease_->nativeLease());
+      bool ignored = false;
+      (void)jazz_native_relay_host_lease_close_attached_foreground(
+          lease_->nativeLease(), handle_, &ignored);
+      closed_ = true;
+    }
+    closed_ = true;
+  }
+
+  std::shared_ptr<ForegroundRuntimeLease> lease_;
+  uint64_t handle_;
+  std::shared_ptr<ForegroundWakeRegistration> wake_;
+  bool closed_{false};
+};
+
+class ForegroundFactory final : public HostObject {
+ public:
+  explicit ForegroundFactory(std::shared_ptr<ForegroundRuntimeLease> lease)
+      : lease_(std::move(lease)) {}
+
+  Value get(Runtime &runtime, const PropNameID &name) override {
+    const auto property = name.utf8(runtime);
+    if (property == "abiVersion") {
+      return Value(jazz_native_relay_abi_version());
+    }
+    if (property == "openAttached") {
+      return Function::createFromHostFunction(
+          runtime, PropNameID::forAscii(runtime, "openAttached"), 1,
+          [lease = lease_](Runtime &runtime, const Value &, const Value *args, size_t count) {
+            if (count != 1) {
+              throw JSError(runtime,
+                           "Jazz native foreground runtime requires a 32-byte admitted capability");
+            }
+            auto lease_lock = lease->lockIfActive();
+            if (!lease_lock.owns_lock()) {
+              throw JSError(runtime, "Jazz native foreground runtime is unavailable after teardown");
+            }
+            const auto capability = copyAdmittedCapability(runtime, args[0]);
+            uint64_t handle = 0;
+            const auto status = jazz_native_relay_host_lease_open_attached_foreground(
+                lease->nativeLease(), capability.data(), capability.size(), &handle);
+            if (status != JAZZ_NATIVE_RELAY_OK) {
+              throwStatus(runtime, status, "openAttached");
+            }
+            // ForegroundHandle registers its wake context with the same lease.
+            // Do not construct it while holding this non-recursive lifecycle
+            // mutex: registration must serialize with invalidation, but an
+            // open that has not installed a Rust scheduler is safe to finish
+            // after invalidation (its handle remains unusable).
+            lease_lock.unlock();
+            return Object::createFromHostObject(
+                runtime, std::make_shared<ForegroundHandle>(lease, handle));
+          });
+    }
+    return Value::undefined();
+  }
+
+  std::vector<PropNameID> getPropertyNames(Runtime &runtime) override {
+    std::vector<PropNameID> names;
+    names.reserve(2);
+    names.emplace_back(PropNameID::forAscii(runtime, "abiVersion"));
+    names.emplace_back(PropNameID::forAscii(runtime, "openAttached"));
+    return names;
+  }
+
+ private:
+  std::shared_ptr<ForegroundRuntimeLease> lease_;
+};
+
+}  // namespace
+
+void installForegroundRuntime(
+    Runtime &runtime,
+    const std::shared_ptr<ForegroundRuntimeLease> &lease) {
+  if (!lease || !lease->active() || lease->nativeLease() == nullptr || !lease->callInvoker()) {
+    throw JSError(runtime, "Jazz native relay host is unavailable");
+  }
+  runtime.global().setProperty(runtime, kWakeCallbacksGlobal, Object(runtime));
+  runtime.global().setProperty(
+      runtime, kFactoryGlobal,
+      Object::createFromHostObject(runtime, std::make_shared<ForegroundFactory>(lease)));
+}
+
+}  // namespace jazz::rn

--- a/crates/jazz-rn/native/foreground-runtime.h
+++ b/crates/jazz-rn/native/foreground-runtime.h
@@ -1,0 +1,73 @@
+#ifndef JAZZ_RN_FOREGROUND_RUNTIME_H
+#define JAZZ_RN_FOREGROUND_RUNTIME_H
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <ReactCommon/CallInvoker.h>
+#include <jsi/jsi.h>
+
+#include "jazz_native_relay.h"
+
+namespace jazz::rn {
+
+class ForegroundWakeRegistration;
+
+/** A platform-retained liveness lease shared by the factory and every opened
+ * foreground HostObject. Invalidation marks handles dead before the platform
+ * releases its relay-host pointer, so a late JS finalizer cannot dereference
+ * freed Rust state after an activity/bridge reload. The opaque Rust lease owns
+ * host state; the mutex makes invalidation mutually exclusive with foreground
+ * FFI operations. */
+class ForegroundRuntimeLease {
+ public:
+  ForegroundRuntimeLease(
+      jazz_native_relay_host *host,
+      std::shared_ptr<facebook::react::CallInvoker> callInvoker)
+      : lease_(jazz_native_relay_host_retain(host)),
+        callInvoker_(std::move(callInvoker)) {}
+  ~ForegroundRuntimeLease();
+
+  /** Hold the lifecycle lock through one FFI call. An empty lock means the
+   * platform invalidated this JS runtime first. */
+  std::unique_lock<std::mutex> lockIfActive();
+  jazz_native_relay_host_lease *nativeLease() const { return lease_; }
+  const std::shared_ptr<facebook::react::CallInvoker> &callInvoker() const {
+    return callInvoker_;
+  }
+  bool active() const;
+  void invalidate();
+
+  /** Internal ownership registry. Every foreground wake registration is
+   * invalidated and synchronously detached from Rust before the retained lease
+   * can be released, preventing a late owner-thread callback from observing a
+   * destroyed JSI object. */
+  void trackWakeRegistration(
+      const std::shared_ptr<ForegroundWakeRegistration> &registration);
+
+ private:
+  jazz_native_relay_host_lease *lease_;
+  std::shared_ptr<facebook::react::CallInvoker> callInvoker_;
+  mutable std::mutex mutex_;
+  bool active_{true};
+  std::vector<std::weak_ptr<ForegroundWakeRegistration>> wakeRegistrations_;
+};
+
+/**
+ * Install the private versioned foreground factory into exactly one JS runtime.
+ *
+ * The platform module calls this only while React Native has handed it the live
+ * JSI runtime. `host` remains platform-owned: the platform must retain its
+ * relay-host lease until every factory and foreground HostObject from this
+ * runtime has been invalidated. The installed HostObjects never expose that
+ * pointer to JavaScript and copy the 32 capability bytes before invoking the
+ * C ABI.
+ */
+void installForegroundRuntime(
+    facebook::jsi::Runtime &runtime,
+    const std::shared_ptr<ForegroundRuntimeLease> &lease);
+
+}  // namespace jazz::rn
+
+#endif  // JAZZ_RN_FOREGROUND_RUNTIME_H

--- a/crates/jazz-rn/native/include/jazz_native_relay.h
+++ b/crates/jazz-rn/native/include/jazz_native_relay.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,17 +35,41 @@ typedef enum jazz_native_relay_status {
 } jazz_native_relay_status;
 
 typedef struct jazz_native_relay_host jazz_native_relay_host;
+typedef struct jazz_native_relay_host_lease jazz_native_relay_host_lease;
+/* The owner thread invokes this only to enqueue a future platform/JS turn.
+ * It must not invoke JavaScript or synchronously reenter the relay. Values are
+ * immediate=0, deferred=1, after-delay=2 (with delay_ms), and cancelled=3. */
+typedef void (*jazz_native_relay_foreground_wake_callback)(
+    void *context,
+    uint64_t foreground,
+    uint8_t wake_kind,
+    uint64_t delay_ms);
 jazz_native_relay_host *jazz_native_relay_host_new(void);
 void jazz_native_relay_host_free(jazz_native_relay_host *host);
+/* Retain host state for one JSI factory/runtime identified by a non-zero,
+ * platform-issued runtime token. The platform can release its host wrapper
+ * while foreground HostObjects still exist; those objects must use this
+ * lease-only API and free it after invalidation/finalization. */
+jazz_native_relay_host_lease *jazz_native_relay_host_retain(
+    jazz_native_relay_host *host,
+    uint64_t runtime_token);
+void jazz_native_relay_host_lease_free(jazz_native_relay_host_lease *lease);
+/* Retire every foreground/client alias opened by exactly this platform runtime
+ * token before invalidating its JSI factory. This is idempotent and never
+ * touches sibling runtime tokens sharing the same relay host or auth scope. */
+jazz_native_relay_status jazz_native_relay_host_lease_invalidate_foreground_runtime(
+    jazz_native_relay_host_lease *lease);
 jazz_native_relay_status jazz_native_relay_host_execute(
     jazz_native_relay_host *host,
     const uint8_t *request,
     size_t request_len,
     jazz_native_relay_bytes *out);
 
-/* Admit strict JSON from trusted Kotlin/Swift platform code. This is not a
- * JavaScript command: unknown fields, malformed config, SYSTEM identity, and
- * bearer-token claims are rejected by Rust. On success `out` is exactly the
+/* Admit strict JSON from trusted Kotlin/Swift platform code. Its absolute
+ * storage_root is the only filesystem input; Rust derives an opaque V1
+ * per-scope SQLite filename. This is not a JavaScript command: unknown fields,
+ * malformed config, SYSTEM identity, and bearer-token claims are rejected by
+ * Rust. On success `out` is exactly the
  * opaque 32-byte admission capability, never a config or claim echo. */
 jazz_native_relay_status jazz_native_relay_host_admit_scope_json(
     jazz_native_relay_host *host,
@@ -58,6 +83,70 @@ jazz_native_relay_status jazz_native_relay_host_revoke_scope_capability(
     jazz_native_relay_host *host,
     const uint8_t *capability,
     size_t capability_len);
+
+/* Open one opaque, memory-only foreground engine from a capability admitted
+ * by trusted platform code. This C ABI is consumed by the private JSI factory,
+ * never by application JavaScript: it accepts no SQLite path, schema, token,
+ * claims, or identity. The host copies exactly 32 bytes before queuing work on
+ * the bounded native relay owner thread. */
+jazz_native_relay_status jazz_native_relay_host_open_attached_foreground(
+    jazz_native_relay_host *host,
+    const uint8_t *capability,
+    size_t capability_len,
+    uint64_t *out_foreground);
+
+/* Run one bounded ordinary core tick for an opaque foreground engine. This is
+ * the first real NativeDb method exposed by the foreground host. It performs
+ * no direct SQLite read: peer traffic stays on the ordinary foreground ↔ relay
+ * connection. */
+jazz_native_relay_status jazz_native_relay_host_tick_attached_foreground(
+    jazz_native_relay_host *host,
+    uint64_t foreground);
+
+/* Close one foreground engine. This is idempotent; out_closed is true only for
+ * the call that transitioned a live alias to closed. */
+jazz_native_relay_status jazz_native_relay_host_close_attached_foreground(
+    jazz_native_relay_host *host,
+    uint64_t foreground,
+    bool *out_closed);
+
+/* Lease-only attached-foreground operations. Private JSI code must call these
+ * instead of retaining a raw jazz_native_relay_host pointer across a bridge or
+ * activity teardown. Each operation accepts only a foreground issued by this
+ * lease's platform runtime token; an invalidated lease can never reopen one. */
+jazz_native_relay_status jazz_native_relay_host_lease_open_attached_foreground(
+    jazz_native_relay_host_lease *lease,
+    const uint8_t *capability,
+    size_t capability_len,
+    uint64_t *out_foreground);
+jazz_native_relay_status jazz_native_relay_host_lease_tick_attached_foreground(
+    jazz_native_relay_host_lease *lease,
+    uint64_t foreground);
+jazz_native_relay_status jazz_native_relay_host_lease_close_attached_foreground(
+    jazz_native_relay_host_lease *lease,
+    uint64_t foreground,
+    bool *out_closed);
+/* Register a platform-owned wake sink for exactly one foreground runtime, or
+ * clear it by passing NULL callback. Clear is synchronous with the owner
+ * thread, so it is safe to release context after this call succeeds. */
+jazz_native_relay_status jazz_native_relay_host_lease_set_foreground_wake_callback(
+    jazz_native_relay_host_lease *lease,
+    uint64_t foreground,
+    jazz_native_relay_foreground_wake_callback callback,
+    void *context);
+
+/* Execute one complete canonical postcard foreground NativeDb command against
+ * a live attached foreground handle. The request is bounded to 1 MiB before
+ * decoding. This is private to native binding adapters: it is not part of the
+ * public relay TurboModule command channel. The request and response
+ * vocabulary is versioned by jazz_native_relay_abi_version(); result bytes are
+ * Rust-owned and released with jazz_native_relay_bytes_free. */
+jazz_native_relay_status jazz_native_relay_host_lease_execute_foreground(
+    jazz_native_relay_host_lease *lease,
+    uint64_t foreground,
+    const uint8_t *request,
+    size_t request_len,
+    jazz_native_relay_bytes *out);
 
 /*
  * Execute one complete postcard RelayCommandRequest. On success, response

--- a/crates/jazz-rn/scripts/test-codegen.sh
+++ b/crates/jazz-rn/scripts/test-codegen.sh
@@ -37,7 +37,7 @@ for platform in android ios; do
     echo "React Native Codegen did not generate the JazzRelay module for $platform" >&2
     exit 1
   fi
-  if [[ "$platform" == android ]] && ! rg -q 'getAbiVersion|execute' "$output_dir/$platform"; then
+  if [[ "$platform" == android ]] && ! rg -q 'getAbiVersion|installForegroundRuntime|execute' "$output_dir/$platform"; then
     echo "React Native Codegen did not generate the JazzRelay command methods for Android" >&2
     exit 1
   fi
@@ -93,7 +93,7 @@ if rg -q '#import "JazzRelaySpec\.h"|NativeJazzRelaySpec|@interface JazzRelay[[:
   exit 1
 fi
 if ! rg -q '#import "JazzRelaySpec\.h"' "$private_header" \
-  || ! rg -q '@interface JazzRelay : NSObject <NativeJazzRelaySpec>' "$private_header"; then
+  || ! rg -q '@interface JazzRelay : NSObject <NativeJazzRelaySpec(?:, RCTTurboModuleWithJSIBindings)?>' "$private_header"; then
   echo "JazzRn private TurboModule header no longer owns the generated spec contract" >&2
   exit 1
 fi

--- a/crates/jazz-rn/src/NativeJazzRelay.ts
+++ b/crates/jazz-rn/src/NativeJazzRelay.ts
@@ -1,5 +1,5 @@
-import type { TurboModule } from 'react-native';
-import { TurboModuleRegistry } from 'react-native';
+import type { TurboModule } from "react-native";
+import { TurboModuleRegistry } from "react-native";
 
 /**
  * The future native-relay TurboModule boundary.
@@ -10,6 +10,7 @@ import { TurboModuleRegistry } from 'react-native';
  */
 export interface Spec extends TurboModule {
   getAbiVersion(): number;
+  installForegroundRuntime(): void;
   execute(commandBase64: string): Promise<string>;
 }
 
@@ -17,4 +18,4 @@ export interface Spec extends TurboModule {
 // legacy artifact does not yet contain this module. Expo Go and old native
 // development builds therefore fail explicitly without pretending JS can add
 // the embedded Rust relay through an OTA update.
-export default TurboModuleRegistry.get<Spec>('JazzRelay');
+export default TurboModuleRegistry.get<Spec>("JazzRelay");

--- a/crates/jazz-rn/src/__tests__/index.test.tsx
+++ b/crates/jazz-rn/src/__tests__/index.test.tsx
@@ -1,9 +1,43 @@
-type NativeRelay = {
+type FixtureNativeRelay = {
   getAbiVersion(): number;
   execute(commandBase64: string): Promise<string>;
+  installForegroundRuntime?(): void;
 };
 
-function loadRelay(nativeRelay: NativeRelay | null) {
+const foregroundRuntimeGlobal = '__jazzNativeForegroundRuntimeV1';
+
+type NativeForegroundCommand =
+  | 'probe'
+  | 'tick'
+  | 'close'
+  | { type: 'prepareQuery'; query: Uint8Array }
+  | { type: 'all'; query: number };
+
+type RelayExports = {
+  executeNativeRelayCommand(command: string): Promise<string>;
+  installNativeForegroundRuntime(): {
+    abiVersion: number;
+    openAttached(capability: Uint8Array): {
+      execute(command: Uint8Array): Uint8Array;
+      setTickScheduler(callback: (urgency: string) => void): void;
+      tick(): void;
+      close(): boolean;
+    };
+  };
+  encodeNativeForegroundCommand(command: NativeForegroundCommand): Uint8Array;
+  decodeNativeForegroundResponse(bytes: Uint8Array): unknown;
+};
+
+function foregroundFixture() {
+  return {
+    execute: jest.fn(() => Uint8Array.of(1)),
+    setTickScheduler: jest.fn(),
+    tick: jest.fn(),
+    close: jest.fn(() => true),
+  };
+}
+
+function loadRelay(nativeRelay: FixtureNativeRelay | null) {
   jest.resetModules();
   jest.doMock('../NativeJazzRelay', () => ({
     __esModule: true,
@@ -12,10 +46,11 @@ function loadRelay(nativeRelay: NativeRelay | null) {
   // Each case supplies the native boundary before importing the wrapper. That
   // is the same one-time lookup Metro performs for an installed native build.
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  return require('../relay') as typeof import('../relay');
+  return require('../relay') as RelayExports;
 }
 
 afterEach(() => {
+  delete (globalThis as Record<string, unknown>)[foregroundRuntimeGlobal];
   jest.resetModules();
   jest.dontMock('../NativeJazzRelay');
 });
@@ -29,20 +64,20 @@ it('tells Expo Go and old development builds that a native artifact is required'
 });
 
 it('rejects an installed native build with an incompatible ABI before executing a command', async () => {
-  const nativeRelay: NativeRelay = {
+  const nativeRelay: FixtureNativeRelay = {
     getAbiVersion: () => 2,
     execute: jest.fn(),
   };
   const relay = loadRelay(nativeRelay);
 
   await expect(relay.executeNativeRelayCommand('AA==')).rejects.toThrow(
-    'Jazz native relay ABI 2 is incompatible with JavaScript ABI 3..=3; install a matching native development or release build.'
+    'Jazz native relay ABI 2 is incompatible with JavaScript ABI 6..=6; install a matching native development or release build.'
   );
   expect(nativeRelay.execute).not.toHaveBeenCalled();
 });
 
 it('rejects the source-only ABI fallback before executing a command', async () => {
-  const nativeRelay: NativeRelay = {
+  const nativeRelay: FixtureNativeRelay = {
     getAbiVersion: () => 0,
     execute: jest.fn(),
   };
@@ -55,12 +90,193 @@ it('rejects the source-only ABI fallback before executing a command', async () =
 });
 
 it('forwards opaque commands only after the embedded relay ABI matches', async () => {
-  const nativeRelay: NativeRelay = {
-    getAbiVersion: () => 3,
+  const nativeRelay: FixtureNativeRelay = {
+    getAbiVersion: () => 6,
     execute: jest.fn().mockResolvedValue('AQ=='),
   };
   const relay = loadRelay(nativeRelay);
 
   await expect(relay.executeNativeRelayCommand('AA==')).resolves.toBe('AQ==');
   expect(nativeRelay.execute).toHaveBeenCalledWith('AA==');
+});
+
+it('requires a matching JSI foreground installer instead of attempting browser WASM', () => {
+  const nativeRelay: FixtureNativeRelay = {
+    getAbiVersion: () => 6,
+    execute: jest.fn(),
+  };
+  const relay = loadRelay(nativeRelay);
+
+  expect(() => relay.installNativeForegroundRuntime()).toThrow(
+    'Jazz native foreground runtime is unavailable: install a matching native development or release build containing the JSI foreground engine. Expo Go never includes it.'
+  );
+  expect(nativeRelay.execute).not.toHaveBeenCalled();
+});
+
+it('accepts only the matching capability-only JSI foreground factory', () => {
+  const foreground = foregroundFixture();
+  const openAttached = jest.fn(() => foreground);
+  const installForegroundRuntime = jest.fn(() => {
+    (globalThis as Record<string, unknown>)[foregroundRuntimeGlobal] = {
+      abiVersion: 6,
+      openAttached,
+    };
+  });
+  const nativeRelay: FixtureNativeRelay = {
+    getAbiVersion: () => 6,
+    execute: jest.fn(),
+    installForegroundRuntime,
+  };
+  const relay = loadRelay(nativeRelay);
+
+  const factory = relay.installNativeForegroundRuntime();
+
+  expect(installForegroundRuntime).toHaveBeenCalledTimes(1);
+  expect(factory.abiVersion).toBe(6);
+  const capability = new Uint8Array(32);
+  const runtime = factory.openAttached(capability);
+  expect(runtime).toMatchObject({
+    execute: expect.any(Function),
+    setTickScheduler: expect.any(Function),
+    tick: expect.any(Function),
+    close: expect.any(Function),
+  });
+  expect(openAttached).toHaveBeenCalledWith(capability);
+  const scheduler = jest.fn();
+  runtime.setTickScheduler(scheduler);
+  expect(foreground.setTickScheduler).toHaveBeenCalledWith(scheduler);
+  expect(nativeRelay.execute).not.toHaveBeenCalled();
+});
+
+it('rejects a missing, malformed, ABI-incompatible, or stale JSI foreground factory after installation', () => {
+  for (const factory of [
+    undefined,
+    {},
+    { abiVersion: 2, openAttached: () => foregroundFixture() },
+  ]) {
+    const nativeRelay: FixtureNativeRelay = {
+      getAbiVersion: () => 6,
+      execute: jest.fn(),
+      installForegroundRuntime: () => {
+        if (factory !== undefined)
+          (globalThis as Record<string, unknown>)[foregroundRuntimeGlobal] =
+            factory;
+      },
+    };
+    const relay = loadRelay(nativeRelay);
+
+    expect(() => relay.installNativeForegroundRuntime()).toThrow(
+      'Jazz native foreground runtime installation failed: the native build did not install a compatible JSI foreground engine. Install a matching native development or release build.'
+    );
+    delete (globalThis as Record<string, unknown>)[foregroundRuntimeGlobal];
+  }
+
+  // Plant a same-ABI HostObject left by a preceding bridge. A native installer
+  // that does not replace it must not make that object callable in this
+  // runtime. This would have passed before the global was cleared first.
+  const staleOpenAttached = jest.fn(() => foregroundFixture());
+  (globalThis as Record<string, unknown>)[foregroundRuntimeGlobal] = {
+    abiVersion: 6,
+    openAttached: staleOpenAttached,
+  };
+  const staleNativeRelay: FixtureNativeRelay = {
+    getAbiVersion: () => 6,
+    execute: jest.fn(),
+    installForegroundRuntime: jest.fn(),
+  };
+  const staleRelay = loadRelay(staleNativeRelay);
+  expect(() => staleRelay.installNativeForegroundRuntime()).toThrow(
+    'Jazz native foreground runtime installation failed: the native build did not install a compatible JSI foreground engine. Install a matching native development or release build.'
+  );
+  expect(staleNativeRelay.installForegroundRuntime).toHaveBeenCalledTimes(1);
+  expect(staleOpenAttached).not.toHaveBeenCalled();
+});
+
+it('keeps malformed capability input out of the JSI foreground factory', () => {
+  const openAttached = jest.fn(() => foregroundFixture());
+  const nativeRelay: FixtureNativeRelay = {
+    getAbiVersion: () => 6,
+    execute: jest.fn(),
+    installForegroundRuntime: () => {
+      (globalThis as Record<string, unknown>)[foregroundRuntimeGlobal] = {
+        abiVersion: 6,
+        openAttached,
+      };
+    },
+  };
+  const relay = loadRelay(nativeRelay);
+  const factory = relay.installNativeForegroundRuntime();
+
+  for (const malformed of [
+    new Uint8Array(31),
+    new Uint8Array(33),
+    [] as unknown as Uint8Array,
+  ]) {
+    expect(() => factory.openAttached(malformed)).toThrow(
+      'Jazz native foreground runtime requires a 32-byte admitted capability'
+    );
+  }
+  expect(openAttached).not.toHaveBeenCalled();
+
+  const admitted = new Uint8Array(32);
+  factory.openAttached(admitted);
+  expect(openAttached).toHaveBeenCalledWith(admitted);
+});
+
+it('rejects a foreground factory from an artifact that lacks the wake scheduler', () => {
+  const nativeRelay: FixtureNativeRelay = {
+    getAbiVersion: () => 6,
+    execute: jest.fn(),
+    installForegroundRuntime: () => {
+      (globalThis as Record<string, unknown>)[foregroundRuntimeGlobal] = {
+        abiVersion: 6,
+        openAttached: () => ({
+          execute: () => Uint8Array.of(1),
+          tick: () => undefined,
+          close: () => true,
+        }),
+      };
+    },
+  };
+  const relay = loadRelay(nativeRelay);
+  const factory = relay.installNativeForegroundRuntime();
+
+  expect(() => factory.openAttached(new Uint8Array(32))).toThrow(
+    'Jazz native foreground runtime installation failed: the native build did not install a compatible JSI foreground engine. Install a matching native development or release build.'
+  );
+});
+
+it('uses a compact versioned byte vocabulary for the initial foreground NativeDb slice', () => {
+  const relay = loadRelay({ getAbiVersion: () => 6, execute: jest.fn() });
+
+  expect(relay.encodeNativeForegroundCommand('probe')).toEqual(
+    Uint8Array.of(0)
+  );
+  expect(relay.encodeNativeForegroundCommand('tick')).toEqual(Uint8Array.of(1));
+  expect(relay.encodeNativeForegroundCommand('close')).toEqual(
+    Uint8Array.of(7)
+  );
+  expect(
+    relay.encodeNativeForegroundCommand({
+      type: 'prepareQuery',
+      query: Uint8Array.of(1, 2),
+    })
+  ).toEqual(Uint8Array.of(2, 2, 1, 2));
+  expect(
+    relay.encodeNativeForegroundCommand({ type: 'all', query: 129 })
+  ).toEqual(Uint8Array.of(3, 129, 1));
+  expect(relay.decodeNativeForegroundResponse(Uint8Array.of(0, 6))).toEqual({
+    type: 'probe',
+    abiVersion: 6,
+  });
+  expect(relay.decodeNativeForegroundResponse(Uint8Array.of(1))).toEqual({
+    type: 'ticked',
+  });
+  expect(relay.decodeNativeForegroundResponse(Uint8Array.of(7, 1))).toEqual({
+    type: 'closed',
+    closed: true,
+  });
+  expect(() =>
+    relay.decodeNativeForegroundResponse(Uint8Array.of(1, 0))
+  ).toThrow('unknown or malformed command response');
 });

--- a/crates/jazz-rn/src/index.tsx
+++ b/crates/jazz-rn/src/index.tsx
@@ -1,9 +1,22 @@
 /**
- * React Native does not receive a second Jazz runtime. This package exposes
- * only the thin native-relay command transport; `jazz-tools` will gain its
- * runtime adapter after a matching Rust relay artifact is embedded.
+ * React Native does not receive a second JavaScript/WASM Jazz runtime. This
+ * package exposes the thin native-relay command transport and the source-tested
+ * private JSI foreground-runtime installer; `jazz-tools` will consume that
+ * installer only after a matching Rust foreground engine is embedded.
  */
 // Deliberately list the public relay ABI rather than forwarding every future
 // relay export through this package entry point.
-export { NATIVE_RELAY_ABI, executeNativeRelayCommand } from './relay';
-export type { NativeRelayAbiRange } from './relay';
+export {
+  NATIVE_RELAY_ABI,
+  decodeNativeForegroundResponse,
+  encodeNativeForegroundCommand,
+  executeNativeRelayCommand,
+  installNativeForegroundRuntime,
+} from './relay';
+export type {
+  NativeForegroundCommand,
+  NativeForegroundResponse,
+  NativeForegroundRuntime,
+  NativeForegroundRuntimeFactory,
+  NativeRelayAbiRange,
+} from './relay';

--- a/crates/jazz-rn/src/relay.ts
+++ b/crates/jazz-rn/src/relay.ts
@@ -1,13 +1,23 @@
 import nativeRelay from './NativeJazzRelay';
 
+/**
+ * Versioned private global installed by the native JSI bridge.
+ *
+ * This is an implementation detail of `jazz-rn`: applications keep using
+ * `jazz-tools/react-native`; they neither construct nor retain a foreground
+ * engine directly. A string key lets native C++ install a JSI HostObject in the
+ * current JavaScript runtime without a second JavaScript/WASM loader.
+ */
+const NATIVE_FOREGROUND_RUNTIME_GLOBAL = '__jazzNativeForegroundRuntimeV1';
+
 export interface NativeRelayAbiRange {
   minimum: number;
   maximum: number;
 }
 
 export const NATIVE_RELAY_ABI: NativeRelayAbiRange = {
-  minimum: 3,
-  maximum: 3,
+  minimum: 6,
+  maximum: 6,
 };
 
 function requireNativeRelay() {
@@ -19,19 +29,81 @@ function requireNativeRelay() {
   return nativeRelay;
 }
 
+export type NativeForegroundRuntimeFactory = {
+  /** Must match the enclosing native relay ABI before a runtime is opened. */
+  readonly abiVersion: number;
+  /**
+   * Create one memory-only foreground runtime for an already admitted scope.
+   * The returned JSI HostObject is consumed only by Jazz's internal native
+   * adapter; its database method contract is intentionally not duplicated in
+   * this package.
+   */
+  openAttached(capability: Uint8Array): NativeForegroundRuntime;
+};
+
 /**
- * Execute one opaque base64-encoded native-relay command after checking the
- * embedded ABI.
+ * Private, byte-oriented handle for one native in-memory foreground `Db`.
  *
- * The command codec is intentionally not defined by this package yet: it will
- * be generated from the shared relay command contract once the native module
- * is implemented. This adapter establishes the only permitted JS/native shape
- * in advance—one version probe plus encoded-binary commands—not a row-object
- * API.
+ * The command and response bytes are postcard values owned by the shared Rust
+ * relay ABI. This is deliberately not a React-Native-shaped row/query API:
+ * `jazz-tools` is the sole adapter that will map its existing `NativeDb`
+ * contract onto these commands.
  */
-export async function executeNativeRelayCommand(
-  commandBase64: string
-): Promise<string> {
+export type NativeForegroundRuntime = {
+  execute(command: Uint8Array): Uint8Array;
+  /** Register the runtime-local wake receiver used by the native adapter.
+   * Native work is coalesced before this callback runs; it must schedule an
+   * ordinary JS-side tick rather than calling back into native synchronously. */
+  setTickScheduler(
+    callback: (urgency: "immediate" | "deferred" | `after:${number}`) => void,
+  ): void;
+  tick(): void;
+  close(): boolean;
+};
+
+/**
+ * Shared foreground NativeDb command vocabulary. Query bytes are the
+ * canonical postcard query bytes from `jazz-tools`' existing codec, never a
+ * React-Native-shaped query object. The first read slice intentionally fixes
+ * `ReadOpts` to the regular local-first defaults; callers must not silently
+ * reinterpret remote tiers, views, or relation terminal operations.
+ */
+export type NativeForegroundCommand =
+  | "probe"
+  | "tick"
+  | { type: "prepareQuery"; query: Uint8Array }
+  | { type: "all"; query: number }
+  | { type: "subscribe"; query: number }
+  | { type: "drainSubscription"; subscription: number }
+  | { type: "unsubscribe"; subscription: number }
+  | "close";
+
+export type NativeForegroundResponse =
+  | { type: "probe"; abiVersion: number }
+  | { type: "ticked" }
+  | { type: "preparedQuery"; query: number }
+  | { type: "rows"; rows: Uint8Array }
+  | { type: "subscribed"; subscription: number }
+  | { type: "subscriptionEvents"; events: NativeForegroundSubscriptionEvent[] }
+  | { type: "unsubscribed"; closed: boolean }
+  | { type: "closed"; closed: boolean };
+
+export type NativeForegroundSubscriptionEvent =
+  | { type: "delta"; reset: boolean; settled: boolean; tier: string; delta: Uint8Array }
+  | { type: "rejected"; reason: string }
+  | { type: "closed" };
+
+type NativeRelayWithForegroundInstaller = {
+  installForegroundRuntime?: () => void;
+};
+
+function foregroundRuntimeInstallationError(): Error {
+  return new Error(
+    'Jazz native foreground runtime installation failed: the native build did not install a compatible JSI foreground engine. Install a matching native development or release build.'
+  );
+}
+
+function requireCompatibleRelay() {
   const relay = requireNativeRelay();
   const nativeAbi = relay.getAbiVersion();
   if (nativeAbi === 0) {
@@ -47,5 +119,372 @@ export async function executeNativeRelayCommand(
       `Jazz native relay ABI ${nativeAbi} is incompatible with JavaScript ABI ${NATIVE_RELAY_ABI.minimum}..=${NATIVE_RELAY_ABI.maximum}; install a matching native development or release build.`
     );
   }
+  return relay;
+}
+
+/**
+ * Install and retrieve the private JSI foreground-runtime factory.
+ *
+ * It verifies the embedded relay before looking at the global: an OTA bundle
+ * must not attach an old factory merely because a stale global survives a
+ * bridge reload. The factory receives only the platform-issued opaque
+ * capability, never path/schema/claims/identity/token configuration.
+ *
+ * @internal `jazz-tools/react-native` will call this once it selects the
+ * native JSI engine instead of the browser/WASM runtime.
+ */
+export function installNativeForegroundRuntime(): NativeForegroundRuntimeFactory {
+  const relay = requireCompatibleRelay() as typeof nativeRelay &
+    NativeRelayWithForegroundInstaller;
+  if (typeof relay.installForegroundRuntime !== 'function') {
+    throw new Error(
+      'Jazz native foreground runtime is unavailable: install a matching native development or release build containing the JSI foreground engine. Expo Go never includes it.'
+    );
+  }
+
+  // A bridge reload can leave a same-ABI global behind. Remove it before every
+  // install so a native no-op cannot accidentally hand the new adapter a JSI
+  // HostObject owned by a previous runtime. Native installation must replace
+  // this configurable own property synchronously in the current JS runtime.
+  if (!Reflect.deleteProperty(globalThis, NATIVE_FOREGROUND_RUNTIME_GLOBAL)) {
+    throw foregroundRuntimeInstallationError();
+  }
+  relay.installForegroundRuntime();
+  const descriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    NATIVE_FOREGROUND_RUNTIME_GLOBAL
+  );
+  const factory = descriptor?.value;
+  if (
+    !factory ||
+    typeof factory !== 'object' ||
+    (factory as { abiVersion?: unknown }).abiVersion !==
+      relay.getAbiVersion() ||
+    typeof (factory as { openAttached?: unknown }).openAttached !== 'function'
+  ) {
+    throw foregroundRuntimeInstallationError();
+  }
+  const installed = factory as NativeForegroundRuntimeFactory;
+  return {
+    abiVersion: installed.abiVersion,
+    openAttached(capability: Uint8Array): NativeForegroundRuntime {
+      // This is not the authorization check--the native host still validates
+      // capability admission and copies its bytes before queuing work. It does
+      // keep malformed JavaScript input from reaching the JSI command bridge.
+      if (!(capability instanceof Uint8Array) || capability.byteLength !== 32) {
+        throw new Error(
+          'Jazz native foreground runtime requires a 32-byte admitted capability'
+        );
+      }
+      const foreground = installed.openAttached(capability) as Partial<NativeForegroundRuntime>;
+      if (
+        !foreground ||
+        typeof foreground.execute !== "function" ||
+        typeof foreground.setTickScheduler !== "function" ||
+        typeof foreground.tick !== "function" ||
+        typeof foreground.close !== "function"
+      ) {
+        throw foregroundRuntimeInstallationError();
+      }
+      return {
+        execute(command: Uint8Array): Uint8Array {
+          if (!(command instanceof Uint8Array)) {
+            throw new Error("Jazz native foreground command requires a Uint8Array");
+          }
+          const response = foreground.execute!(command);
+          if (!(response instanceof Uint8Array)) {
+            throw foregroundRuntimeInstallationError();
+          }
+          return response;
+        },
+        setTickScheduler(
+          callback: (urgency: "immediate" | "deferred" | `after:${number}`) => void,
+        ): void {
+          if (typeof callback !== "function") {
+            throw new Error("Jazz native foreground tick scheduler requires a function");
+          }
+          foreground.setTickScheduler!(callback);
+        },
+        tick(): void {
+          foreground.tick!();
+        },
+        close(): boolean {
+          return foreground.close!();
+        },
+      };
+    },
+  };
+}
+
+/** Encode one foreground NativeDb command without exposing a row/object ABI. */
+export function encodeNativeForegroundCommand(
+  command: NativeForegroundCommand
+): Uint8Array {
+  if (command === 'probe') return Uint8Array.of(0);
+  if (command === 'tick') return Uint8Array.of(1);
+  if (command === 'close') return Uint8Array.of(7);
+  if (command.type === 'prepareQuery') {
+    return concatForegroundBytes(
+      Uint8Array.of(2),
+      encodeForegroundBytes(command.query)
+    );
+  }
+  if (command.type === 'all')
+    return concatForegroundBytes(
+      Uint8Array.of(3),
+      encodeForegroundU64(command.query)
+    );
+  if (command.type === 'subscribe')
+    return concatForegroundBytes(
+      Uint8Array.of(4),
+      encodeForegroundU64(command.query)
+    );
+  if (command.type === 'drainSubscription')
+    return concatForegroundBytes(
+      Uint8Array.of(5),
+      encodeForegroundU64(command.subscription)
+    );
+  return concatForegroundBytes(
+    Uint8Array.of(6),
+    encodeForegroundU64(command.subscription)
+  );
+}
+
+/** Decode the first vertical-slice foreground NativeDb response vocabulary. */
+export function decodeNativeForegroundResponse(
+  bytes: Uint8Array
+): NativeForegroundResponse {
+  if (!(bytes instanceof Uint8Array) || bytes.length === 0) {
+    throw new Error(
+      'Jazz native foreground returned an empty or malformed command response'
+    );
+  }
+  const tag = bytes[0]!;
+  if (tag === 0) {
+    const abiVersion = decodePostcardU16(bytes.subarray(1));
+    if (abiVersion === null) {
+      throw new Error(
+        'Jazz native foreground returned a malformed probe response'
+      );
+    }
+    return { type: 'probe', abiVersion };
+  }
+  if (tag === 1 && bytes.length === 1) return { type: 'ticked' };
+  if (tag === 2)
+    return {
+      type: 'preparedQuery',
+      query: decodeForegroundU64(bytes.subarray(1), 'prepared query'),
+    };
+  if (tag === 3)
+    return {
+      type: 'rows',
+      rows: decodeForegroundBytes(bytes.subarray(1), 'rows'),
+    };
+  if (tag === 4)
+    return {
+      type: 'subscribed',
+      subscription: decodeForegroundU64(bytes.subarray(1), 'subscription'),
+    };
+  if (tag === 5)
+    return {
+      type: 'subscriptionEvents',
+      events: decodeForegroundSubscriptionEvents(bytes.subarray(1)),
+    };
+  if (tag === 6 && bytes.length === 2 && (bytes[1] === 0 || bytes[1] === 1)) {
+    return { type: 'unsubscribed', closed: bytes[1] === 1 };
+  }
+  if (tag === 7 && bytes.length === 2 && (bytes[1] === 0 || bytes[1] === 1)) {
+    return { type: 'closed', closed: bytes[1] === 1 };
+  }
+  throw new Error(
+    'Jazz native foreground returned an unknown or malformed command response'
+  );
+}
+
+function encodeForegroundU64(value: number): Uint8Array {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(
+      'Jazz native foreground handle must be a non-negative safe integer'
+    );
+  }
+  const bytes: number[] = [];
+  let remaining = value;
+  do {
+    let byte = remaining % 128;
+    remaining = Math.floor(remaining / 128);
+    if (remaining > 0) byte |= 0x80;
+    bytes.push(byte);
+  } while (remaining > 0);
+  return Uint8Array.from(bytes);
+}
+
+function encodeForegroundBytes(value: Uint8Array): Uint8Array {
+  if (!(value instanceof Uint8Array))
+    throw new Error('Jazz native foreground query requires Uint8Array bytes');
+  return concatForegroundBytes(encodeForegroundU64(value.byteLength), value);
+}
+
+function concatForegroundBytes(...parts: Uint8Array[]): Uint8Array {
+  const result = new Uint8Array(
+    parts.reduce((length, part) => length + part.byteLength, 0)
+  );
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.byteLength;
+  }
+  return result;
+}
+
+function decodeForegroundU64(bytes: Uint8Array, label: string): number {
+  let value = 0;
+  let multiplier = 1;
+  for (let index = 0; index < bytes.length && index < 10; index += 1) {
+    const byte = bytes[index]!;
+    value += (byte & 0x7f) * multiplier;
+    if (
+      (byte & 0x80) === 0 &&
+      index + 1 === bytes.length &&
+      Number.isSafeInteger(value)
+    )
+      return value;
+    multiplier *= 128;
+  }
+  throw new Error(`Jazz native foreground returned malformed ${label}`);
+}
+
+function decodeForegroundBytes(bytes: Uint8Array, label: string): Uint8Array {
+  let length = 0;
+  let multiplier = 1;
+  for (let index = 0; index < bytes.length && index < 10; index += 1) {
+    const byte = bytes[index]!;
+    length += (byte & 0x7f) * multiplier;
+    if ((byte & 0x80) === 0) {
+      const body = bytes.subarray(index + 1);
+      if (body.byteLength === length) return body;
+      break;
+    }
+    multiplier *= 128;
+  }
+  throw new Error(`Jazz native foreground returned malformed ${label}`);
+}
+
+function decodeForegroundSubscriptionEvents(
+  bytes: Uint8Array
+): NativeForegroundSubscriptionEvent[] {
+  // This slice intentionally exposes the encoded event envelope only through
+  // this module. `jazz-tools` will consume the normal binding delta bytes;
+  // malformed/unknown events fail closed instead of becoming an empty update.
+  let offset = 0;
+  const readVarint = (): number => {
+    let value = 0;
+    let multiplier = 1;
+    for (let index = 0; index < 10; index += 1) {
+      const byte = bytes[offset++];
+      if (byte === undefined)
+        throw new Error(
+          'Jazz native foreground returned truncated subscription events'
+        );
+      value += (byte & 0x7f) * multiplier;
+      if ((byte & 0x80) === 0 && Number.isSafeInteger(value)) return value;
+      multiplier *= 128;
+    }
+    throw new Error(
+      'Jazz native foreground returned malformed subscription events'
+    );
+  };
+  const count = readVarint();
+  const events: NativeForegroundSubscriptionEvent[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const tag = readVarint();
+    if (tag === 0) {
+      const reset = bytes[offset++];
+      const settled = bytes[offset++];
+      if ((reset !== 0 && reset !== 1) || (settled !== 0 && settled !== 1))
+        throw new Error(
+          'Jazz native foreground returned malformed delta flags'
+        );
+      const tierLength = readVarint();
+      const tier = decodeForegroundUtf8(bytes, offset, tierLength, 'tier');
+      offset += tierLength;
+      const deltaLength = readVarint();
+      const delta = bytes.slice(offset, offset + deltaLength);
+      offset += deltaLength;
+      if (delta.byteLength !== deltaLength)
+        throw new Error(
+          'Jazz native foreground returned truncated subscription delta'
+        );
+      events.push({
+        type: 'delta',
+        reset: reset === 1,
+        settled: settled === 1,
+        tier,
+        delta,
+      });
+    } else if (tag === 1) {
+      const length = readVarint();
+      const reason = decodeForegroundUtf8(bytes, offset, length, 'rejection');
+      offset += length;
+      events.push({ type: 'rejected', reason });
+    } else if (tag === 2) events.push({ type: 'closed' });
+    else
+      throw new Error(
+        'Jazz native foreground returned unknown subscription event'
+      );
+  }
+  if (offset !== bytes.length)
+    throw new Error(
+      'Jazz native foreground returned trailing subscription bytes'
+    );
+  return events;
+}
+
+function decodeForegroundUtf8(
+  bytes: Uint8Array,
+  start: number,
+  length: number,
+  label: string
+): string {
+  const slice = bytes.subarray(start, start + length);
+  if (slice.byteLength !== length)
+    throw new Error(`Jazz native foreground returned truncated ${label}`);
+  // React Native's configured TS lib deliberately does not promise
+  // `TextDecoder`; `decodeURIComponent` is available in Hermes and gives us a
+  // strict UTF-8 decode without adding a platform polyfill to this tiny ABI.
+  let escaped = '';
+  for (const byte of slice) escaped += `%${byte.toString(16).padStart(2, '0')}`;
+  try {
+    return decodeURIComponent(escaped);
+  } catch {
+    throw new Error(`Jazz native foreground returned malformed UTF-8 ${label}`);
+  }
+}
+
+function decodePostcardU16(bytes: Uint8Array): number | null {
+  let value = 0;
+  for (let index = 0; index < bytes.length && index < 3; index += 1) {
+    const byte = bytes[index]!;
+    value |= (byte & 0x7f) << (index * 7);
+    if ((byte & 0x80) === 0) {
+      return value <= 0xffff && index + 1 === bytes.length ? value : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Execute one opaque base64-encoded native-relay command after checking the
+ * embedded ABI.
+ *
+ * The command codec is intentionally not defined by this package yet: it will
+ * be generated from the shared relay command contract once the native module
+ * is implemented. This adapter establishes the only permitted JS/native shape
+ * in advance—one version probe plus encoded-binary commands—not a row-object
+ * API.
+ */
+export async function executeNativeRelayCommand(
+  commandBase64: string
+): Promise<string> {
+  const relay = requireCompatibleRelay();
   return relay.execute(commandBase64);
 }

--- a/crates/jazz/SPEC/19_native_relays.md
+++ b/crates/jazz/SPEC/19_native_relays.md
@@ -91,10 +91,11 @@ alias has yet been opened.
 Auth switching is ordered: revoke every capability for the old authenticated
 scope (which atomically closes its relay and UI-client aliases), then admit the
 new complete scope. A revoked or guessed capability cannot open or attach a
-client. Platform host destruction occurs only after its foreground runtime
-leases and trusted capabilities are both gone, at which point it calls
-`jazz_native_relay_host_free`; it does not retain Rust `Db` pointers across
-that lifecycle.
+client. Platform invalidation first makes every foreground-runtime lease
+uncallable, then releases its host wrapper. Each installed JSI factory retains
+an opaque host-state lease so a late finalizer cannot dereference freed state;
+that retained state is released only when the final factory/foreground object
+is gone. No platform binding retains a Rust `Db` pointer across that lifecycle.
 
 `Db` and its peer connections are executor-local. A native relay therefore owns
 all core values on one dedicated native owner thread. Host calls are encoded
@@ -217,6 +218,244 @@ and Maven/Kotlin packages consume the same relay core and artifact slices.
 CI caches Cargo+sccache, pnpm, Gradle, CocoaPods, and native artifacts by
 toolchain + lockfile + native-source fingerprint. Native artifacts are built
 independently from JS-only scenario changes.
+
+### 19.6 Foreground native-runtime execution
+
+React Native does **not** use the browser/WASM runtime as its foreground
+engine. Hermes does not expose the WebAssembly API required by the generated
+browser binding, and bundling that binding would duplicate a large core image
+beside the native relay. Switching a test app from Hermes to a different JS
+engine is not a supported workaround: it changes the application engine rather
+than supplying Jazz's native runtime.
+
+Instead, each foreground JavaScript client is backed by one distinct in-memory
+ordinary `Db` owned by the same native relay owner thread. This preserves the
+topology from 19.1--there are still two memory-only UI replicas and one durable
+SQLite relay replica--while eliminating the browser-WASM dependency:
+
+```text
+JS runtime A ─ JSI encoded binding calls ─ foreground Db A ┐
+JS runtime B ─ JSI encoded binding calls ─ foreground Db B ├─ relay Db ─ upstream
+                                                   (one native owner thread)
+```
+
+The foreground `Db`s are not views into SQLite and do not share query,
+transaction, subscription, or lifecycle state. The relay owner merely
+serializes their ordinary core operations and their normal peer links. A
+foreground write is committed in its own in-memory `Db`, crosses the ordinary
+peer connection to the relay on a bounded pump, and then follows the existing
+fate/subscription path. In particular, no RN binding may answer a query by
+reading relay SQLite directly.
+
+#### 19.6.1 JSI boundary
+
+`JazzRelay` remains the small TurboModule used for package discovery, ABI
+diagnostics, trusted platform admission, and lifecycle control. It installs a
+private versioned JSI foreground-runtime factory; the factory is not an
+object-per-row API and it is not a second JavaScript implementation of Jazz.
+
+The factory opens a foreground runtime only from a 32-byte admitted capability:
+
+```ts
+// Binding-internal shape, not an application configuration object.
+const foreground = installNativeForegroundRuntime().openAttached(capability);
+```
+
+It never accepts a SQLite path, schema, session claims, token, identity, or
+server URL. `openAttached` causes the host to create one fresh foreground `Db`
+using the schema, admitted author, claims, and relay scope already validated at
+the trusted native boundary. A guessed, revoked, or mismatched capability
+fails before a runtime object is returned. Closing the runtime releases exactly
+that foreground alias; revoking its capability closes every alias for that
+scope as specified in 19.1.
+
+The installer first removes the private global and then requires the native
+module to synchronously replace it with a configurable own property of the
+current JS runtime. ABI equality alone is not enough: a no-op installer must
+not reuse a same-ABI HostObject from a preceding bridge/runtime. The JS wrapper
+also rejects a non-`Uint8Array` or non-32-byte argument before it crosses JSI;
+the native host remains responsible for admission validation and copying those
+bytes into its bounded owner-thread command.
+
+The JSI object implements the existing internal byte-oriented `NativeDb`
+contract consumed by `NativeRuntimeAdapter`: encoded schemas, prepared queries,
+row batches, mutations, write receipts, transaction handles, subscriptions,
+and peer/tick scheduling use the same binding codecs as other native bindings.
+The TypeScript public `Db` API stays unchanged. Rust-owned result memory is
+copied into JS-owned `Uint8Array`/ArrayBuffer values before returning; no JSI
+object exposes a Rust pointer or borrows Rust-owned bytes after a call returns.
+
+#### 19.6.2 Serialized foreground `NativeDb` command contract
+
+The foreground JSI HostObject has one binary operation:
+
+```ts
+foreground.execute(request: Uint8Array): Uint8Array
+```
+
+It copies a complete postcard `ForegroundDbCommandRequest` into the relay
+owner queue and returns one complete postcard `ForegroundDbCommandResponse`.
+The foreground handle travels as an out-of-band opaque C/JSI handle; it is not
+encoded in the request and no command can open a different scope. `execute` is
+private binding machinery: applications interact only with the maintained
+TypeScript `Db` API.
+
+The vocabulary is shared by every native host (RN JSI, Swift, Kotlin, and any
+future NAPI-compatible host). It is not an RN object API. Its operation mapping
+is intentionally the maintained `NativeDb` contract, grouped to keep the wire
+surface orderly:
+
+| Command family           | Existing `NativeDb` operations mapped by the binding                                                     | Response / handle rule                                                                                                                 |
+| ------------------------ | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| lifecycle and scheduling | `Probe`, `tick`, `close`, `setTickScheduler`, `onMutationError`                                          | probe and bounded tick are synchronous; close is idempotent; native-to-JS wakes are coalesced callbacks, never a borrowed Rust closure |
+| schema and identity      | `registerSchema`, `setIdentityClaims`, `setNonDurableClient`, `setRelayAuthoritySessionOwner`            | schema/view handles are opaque native IDs scoped to their foreground                                                                   |
+| query and attachment     | `prepareQuery`, `all*`, relation reads, attach/covered/detach                                            | query and attachment handles are opaque; rows are existing encoded row-batch bytes                                                     |
+| subscriptions            | `subscribe*`, `readAll`/`drain`, cancel                                                                  | subscription handles are opaque; batches are existing encoded subscription payloads                                                    |
+| writes and transactions  | `begin/commit/rollback`, attach tx, insert/update/upsert/delete/restore, `writeState`, `wait`            | transaction and write handles are opaque; write receipts retain the existing encoded receipt contract                                  |
+| large values and advice  | staging policy/eviction, range/text/JSON reads, append/splice/diffs, streaming upload, permission advice | existing value and advice payload codecs; streaming/advice handles are opaque and explicitly finished/cancelled                        |
+| peer transport           | `connectUpstream*`, accept subscriber, receive/send frames, close                                        | normal canonical peer-frame bytes; this remains the only route between foreground and relay/upstream                                   |
+
+Commands are append-only within a native ABI version: adding a new discriminant
+is allowed only when older bindings cannot select or decode it; changing a
+discriminant's fields, response layout, semantic meaning, or an existing codec
+is a breaking native ABI change. The top-level relay ABI is bumped for such a
+change and the JS wrapper's supported range rejects an OTA/native mismatch
+before opening a foreground. Unknown or malformed command/response bytes fail
+closed, with no partially returned buffer. Command outputs are copied into
+JS-owned memory before Rust frees its response allocation.
+
+**V1 vertical slice.** Native relay ABI 6 defines the first concrete
+foreground vocabulary: `Probe`, bounded `Tick`, idempotent `Close`, and the
+local-first query lifecycle `PrepareQuery`, `All`, `Subscribe`,
+`DrainSubscription`, `Unsubscribe`. Query inputs are exactly the canonical
+postcard `Query` bytes used by the existing native `prepareQuery`; read output
+is the existing `binding_codec::encode_rows` payload and subscription deltas
+are the existing `binding_codec::encode_subscription_delta` payload. Query and
+subscription identifiers are owner-thread-local opaque u64 handles allocated
+once across every foreground attached to that relay, so a value copied from a
+sibling foreground cannot alias a same-number local resource.
+`All` and `DrainSubscription` first poll their foreground-owned operation and
+return its ordinary rows/events only when ready. If physical large-value
+hydration needs chunk or peer I/O, they instead return an opaque pending
+operation handle. `Poll` reports the exact ready, pending, or terminal-error
+state; `Cancel` drops a pending operation and reports whether it owned that
+cancellation. A draining subscription keeps its already-dequeued raw event
+batch subscription-owned until a ready response has published it. Thus a
+cancelled or failed hydration attempt returns that exact batch, in order, on
+the next drain rather than dropping or duplicating events; unsubscribe,
+foreground close, and capability revocation intentionally discard it together
+with the whole subscription. A pending operation is scoped to the foreground,
+bounded, and cancelled automatically by its owning unsubscribe, foreground
+close, or capability revocation. Crucially, the owner thread never waits for that work:
+the platform runs its normal bounded `Tick`/peer pump, then polls again. An
+in-process foreground relay routes its auxiliary chunk request/response lane
+through the same `PeerIoPump` boundary before attempting a semantic `Db` tick;
+that lane never takes the semantic node lock, so a hydration future holding
+that lock cannot deadlock its own fulfillment. Semantic foreground ticks wait
+until that pending operation completes or is cancelled.
+`Unsubscribe` retires the handle synchronously and queues the ordinary core
+cleanup; the next bounded `Tick` performs its finalization, because awaiting
+that acknowledgement while already executing on the core owner thread would
+deadlock. Repeated close or unsubscribe reports `false`.
+
+This V1 subset deliberately supports only `ReadOpts::default()` local-first
+reads. It fails closed for remote tiers/read views, relation terminal
+operations, writes, transactions, permission advice, and async suspension;
+those remain required extension work rather than silently receiving a distinct
+RN meaning. The admitted native scope continues to own schema, canonical
+session/author identity, claims, and ordinary peer synchronization; JavaScript
+only provides canonical query bytes. `tick`/`close` convenience JSI methods may
+remain internal compatibility shorthands only while they invoke the same
+foreground lifecycle; `jazz-tools` must move to `execute` as each family is
+implemented.
+
+**Wake registration.** ABI 6 leaves that postcard command vocabulary unchanged
+and adds the private JSI `setTickScheduler(callback)` companion on each
+foreground handle. The callback receives `"immediate"`, `"deferred"`, or
+`"after:<milliseconds>"`; it schedules the adapter's normal JS-side tick and
+does not synchronously call the native handle. Rust records one opaque platform
+callback per foreground Db. The C++ registration coalesces owner-thread signals
+per foreground/runtime through that runtime's `CallInvoker`, chooses the most
+urgent pending wake, and never invokes JavaScript while a host or relay mutex
+is held. Teardown synchronously clears Rust's callback before freeing its
+platform context; scope revocation sends a terminal cancel signal, so an
+already queued callback becomes a no-op. This is a JSI lifecycle extension,
+not a new byte command discriminant.
+
+Synchronous local operations (opening an attached foreground runtime, local
+writes, transaction bookkeeping, and ready local reads) may synchronously send
+a bounded command to the native owner thread and wait for its response. A read
+or subscription operation that needs asynchronous chunk/peer progress returns
+the existing pending binding object and is resumed by the adapter's scheduler;
+it must not block the JS thread while waiting for storage or the network.
+
+#### 19.6.3 Ownership, callbacks, and teardown
+
+- The application/authentication layer alone admits and revokes scope
+  capabilities. JavaScript can carry a capability to the factory but cannot
+  construct scope configuration.
+- The native host owns all `Db`, SQLite, peer connection, and queue state on
+  its dedicated owner thread. JSI calls copy an encoded request into that
+  thread's bounded command queue and copy the response back. A JSI object never
+  retains a Rust `Db` pointer.
+- Core wakeups cross from the owner thread through React Native's `CallInvoker`
+  to a registered JavaScript scheduler callback. They are coalesced by runtime
+  and only schedule an ordinary adapter tick; they never invoke JavaScript while
+  holding a host/relay mutex.
+- Subscription delivery crosses as encoded batches. The JS adapter owns user
+  callbacks and cancellation; the native runtime owns the underlying core
+  subscription until that cancellation/close command has been processed.
+- The native module invalidation path first marks each factory lease inactive
+  under its lifecycle lock, then releases the platform's host-wrapper pointer.
+  Every installed factory and foreground HostObject holds an opaque retained
+  Rust-host lease; that lease keeps host state alive until finalization, but
+  rejects all further foreground FFI calls after invalidation. Thus an Android
+  activity recreation or iOS bridge reload cannot race a late JSI callback or
+  finalizer into freed Rust state. The final retained lease releases host state
+  only after the last foreground object is gone; trusted capabilities remain
+  owned by the platform lifecycle as in 19.1.
+
+#### 19.6.4 Platform and packaging contract
+
+Android and iOS implement the same C ABI and JSI factory protocol. Android's
+JNI/Kotlin and iOS's Objective-C++/Swift layers are thin converters for
+byte/typed-array ownership, trusted admission, and lifecycle events; neither
+contains query evaluation or peer semantics. The JSI factory is packaged with
+the same Android ABI slices and iOS XCFramework slices as the relay, so its
+version is covered by the native relay ABI check before startup.
+
+Bare React Native applications obtain the module through autolinking. Expo
+prebuild/CNG and Expo development builds obtain that same module through the
+config plugin and autolinking. Expo Go remains unsupported because it cannot
+contain the native JSI/relay artifact. An over-the-air JavaScript update whose
+factory ABI is incompatible fails before opening a runtime with the existing
+"new native development/release build required" diagnostic.
+
+#### 19.6.5 Implementation and acceptance sequence
+
+1. Define and source-test the versioned private JSI factory installer and its
+   capability-only `openAttached` entry. This is a binding contract, not yet a
+   claim of device support.
+2. Implement the capability-only Rust host substrate against the already
+   attached `MemoryStorage` client: it opens an opaque foreground alias and
+   executes postcard `Probe`/`Tick`/`Close` commands through a bounded owner
+   queue. This V1 command slice is implemented and tested at the C ABI and
+   JSI wrapper boundaries; it is not yet a complete JS database binding.
+3. The shared C++ JSI factory is now installed through Android JNI and iOS
+   Objective-C++ and exposes capability-only opening plus the binary command
+   seam. Complete the remaining `NativeDb` families in that seam, then make
+   `jazz-tools/react-native` select this runtime source rather than loading
+   `jazz-wasm`; remove the JavaScript relay-frame adapter from the foreground
+   path once the host owns the peer link.
+4. Add black-box Rust, TypeScript, Android-emulator, and iOS-simulator
+   receipts: open two foreground runtimes from one admitted capability; write
+   in A; observe the subscription change in B; reload B without losing relay
+   durability; revoke the capability and prove every foreground operation
+   fails. Plant a wrong/missing B observation and require the device receipt
+   to fail.
+5. Add native upstream transport/auth-refresh ownership after the local
+   two-runtime receipt is stable. Tokens remain in platform-owned session
+   negotiation and never enter the JSI foreground factory.
 
 ## Implementation ledger
 

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import test from "node:test";
 import { createRequire } from "node:module";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { parse } from "yaml";
@@ -491,6 +491,160 @@ test("the canonical Expo scaffold really prebuilds both relay-only platforms", (
       assert.match(iosPodfileText, /use_native_modules!/);
     },
   );
+});
+
+test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", async () => {
+  // The canonical example is useful, but its workspace link can accidentally
+  // hide npm-packaging mistakes. This receipt instead constructs the smallest
+  // possible Expo app in a new directory, mounts the tarball that an adopter
+  // would receive as its direct dependency, and runs the two prebuild paths.
+  // The scaffold borrows Expo's already-installed dependency graph rather than
+  // running a package-manager install: this keeps a packaging receipt fully
+  // offline and deterministic while still proving that the app resolves
+  // `jazz-rn` from the packed bytes rather than from this workspace.
+  const directory = await mkdtemp(join(tmpdir(), "jazz-rn-fresh-expo-"));
+  const packageDirectory = join(directory, "package");
+  const appDirectory = join(directory, "app");
+  const appNodeModules = join(appDirectory, "node_modules");
+  const canonicalNodeModules = new URL(
+    "../../../examples/todo-client-localfirst-expo/node_modules/",
+    import.meta.url,
+  ).pathname;
+  try {
+    await mkdir(packageDirectory, { recursive: true });
+    const packed = JSON.parse(
+      execFileSync(
+        "npm",
+        ["pack", "--ignore-scripts", "--json", "--pack-destination", packageDirectory],
+        {
+          cwd: new URL("../../../crates/jazz-rn/", import.meta.url),
+          encoding: "utf8",
+        },
+      ),
+    );
+    assert.deepEqual(packed.length, 1, "packing jazz-rn must produce one npm tarball");
+    const tarball = join(packageDirectory, packed[0].filename);
+
+    await mkdir(appDirectory, { recursive: true });
+    await writeFile(
+      join(appDirectory, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "jazz-rn-fresh-expo-receipt",
+          version: "0.0.0",
+          private: true,
+          dependencies: {
+            expo: "54.0.37",
+            "jazz-rn": `file:../package/${packed[0].filename}`,
+            react: "19.2.4",
+            "react-native": "0.81.5",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile(
+      join(appDirectory, "app.json"),
+      `${JSON.stringify(
+        {
+          expo: {
+            name: "Jazz RN fresh install receipt",
+            slug: "jazz-rn-fresh-install-receipt",
+            version: "1.0.0",
+            plugins: ["jazz-rn"],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile(
+      join(appDirectory, "App.tsx"),
+      [
+        'import { NATIVE_RELAY_ABI } from "jazz-rn";',
+        "",
+        "export const relayAbi: number = NATIVE_RELAY_ABI.maximum;",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(
+      join(appDirectory, "tsconfig.json"),
+      `${JSON.stringify({ extends: "expo/tsconfig.base", include: ["App.tsx"] }, null, 2)}\n`,
+    );
+    await mkdir(appNodeModules, { recursive: true });
+    execFileSync("tar", ["-xzf", tarball, "-C", packageDirectory]);
+    await symlink(join(packageDirectory, "package"), join(appNodeModules, "jazz-rn"));
+    for (const dependency of ["@types", "expo", "react", "react-native", "typescript"]) {
+      await symlink(join(canonicalNodeModules, dependency), join(appNodeModules, dependency));
+    }
+    execFileSync(join(appNodeModules, "typescript", "bin", "tsc"), ["--noEmit"], {
+      cwd: appDirectory,
+      stdio: "inherit",
+    });
+    const bareReactNativeConfig = JSON.parse(
+      execFileSync(join(canonicalNodeModules, ".bin", "react-native"), ["config"], {
+        cwd: appDirectory,
+        encoding: "utf8",
+      }),
+    );
+    assert.equal(
+      bareReactNativeConfig.dependencies["jazz-rn"].platforms.android.packageInstance,
+      "new JazzRelayPackage()",
+      "a bare React Native host must discover the packed relay package too",
+    );
+    for (const platform of ["android", "ios"]) {
+      execFileSync(
+        join(canonicalNodeModules, ".bin", "expo"),
+        ["prebuild", "--platform", platform, "--clean", "--no-install"],
+        {
+          cwd: appDirectory,
+          env: { ...process.env, CI: "1" },
+          stdio: "inherit",
+        },
+      );
+    }
+
+    const [androidProperties, androidSettings, iosProperties, iosPodfile] = await Promise.all([
+      readFile(join(appDirectory, "android/gradle.properties"), "utf8"),
+      readFile(join(appDirectory, "android/settings.gradle"), "utf8"),
+      readFile(join(appDirectory, "ios/Podfile.properties.json"), "utf8"),
+      readFile(join(appDirectory, "ios/Podfile"), "utf8"),
+    ]);
+    assert.match(androidProperties, /^newArchEnabled=true$/m);
+    assert.match(androidSettings, /autolinkLibrariesFromCommand/);
+    assert.match(iosProperties, /"newArchEnabled": "true"/);
+    assert.match(iosPodfile, /use_native_modules!/);
+
+    const androidAutolink = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          "--no-warnings",
+          "--eval",
+          "require('expo/bin/autolinking')",
+          "expo-modules-autolinking",
+          "react-native-config",
+          "--json",
+          "--platform",
+          "android",
+        ],
+        { cwd: appDirectory, encoding: "utf8" },
+      ),
+    );
+    assert.equal(
+      androidAutolink.dependencies["jazz-rn"].platforms.android.packageInstance,
+      "new JazzRelayPackage()",
+      "the packed tarball, not a workspace symlink, must autolink the relay host",
+    );
+    assert.equal(
+      require.resolve("jazz-rn/package.json", { paths: [appDirectory] }),
+      join(packageDirectory, "package", "package.json"),
+      "the receipt must resolve jazz-rn from the extracted npm tarball",
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
 test("jazz-rn autolinks a New-Architecture relay host without legacy artifacts", async () => {

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -17,20 +17,30 @@ const packageJson = JSON.parse(
 const withJazzRn = require("../../../crates/jazz-rn/app.plugin.js");
 
 // This is a fixed ABI, not a denylist of sensitive-looking names. The public
-// JavaScript surface may only probe the ABI and submit one opaque command.
-// Trusted native scope admission deliberately has no entry in these tables.
+// JavaScript surface may only probe the ABI, install/open the private JSI
+// factory, and submit opaque relay/foreground byte commands. Trusted native
+// scope admission deliberately has no entry in these tables.
 const relayJsExports = new Set([
   "NativeRelayAbiRange",
+  "NativeForegroundRuntimeFactory",
+  "NativeForegroundRuntime",
+  "NativeForegroundCommand",
+  "NativeForegroundResponse",
   "NATIVE_RELAY_ABI",
+  "installNativeForegroundRuntime",
+  "encodeNativeForegroundCommand",
+  "decodeNativeForegroundResponse",
   "executeNativeRelayCommand",
 ]);
-const nativeSpecMethods = new Set(["getAbiVersion", "execute"]);
-const androidRelayMethods = new Set(["getAbiVersion", "execute"]);
+const nativeSpecMethods = new Set(["getAbiVersion", "installForegroundRuntime", "execute"]);
+const androidRelayMethods = new Set(["getAbiVersion", "installForegroundRuntime", "execute"]);
 // This includes lifecycle/generated hooks, which are not JavaScript methods.
 // Keeping them explicit catches accidental methods added beside the ABI.
 const iosRelaySelectors = new Set([
   "init",
   "getAbiVersion",
+  "installForegroundRuntime",
+  "installJSIBindingsWithRuntime",
   "execute",
   "invalidate",
   "getTurboModule",
@@ -169,6 +179,16 @@ function assertExactNativeSpecMethod(member, name) {
     return;
   }
 
+  if (name === "installForegroundRuntime") {
+    assert.equal(member.parameters.length, 0, "installForegroundRuntime takes no arguments");
+    assert.equal(
+      member.type?.kind,
+      ts.SyntaxKind.VoidKeyword,
+      "installForegroundRuntime returns void",
+    );
+    return;
+  }
+
   assert.equal(member.parameters.length, 1, "execute takes exactly one argument");
   const parameter = member.parameters[0];
   assert.ok(ts.isIdentifier(parameter.name));
@@ -232,49 +252,51 @@ function assertExactTsRelaySurface(nativeSpec, relay, index) {
   );
   assert.notEqual(specExports[1].isExportEquals, true);
 
-  assert.equal(relayExports.length, 3, "relay must expose exactly its fixed ABI declarations");
-  assert.ok(
-    ts.isInterfaceDeclaration(relayExports[0]),
-    "relay must export NativeRelayAbiRange as an interface",
-  );
-  assert.equal(relayExports[0].name.text, "NativeRelayAbiRange");
-  assert.ok(
-    ts.isVariableStatement(relayExports[1]),
-    "relay must export NATIVE_RELAY_ABI as a variable",
-  );
-  assert.notEqual(
-    relayExports[1].declarationList.flags & ts.NodeFlags.Const,
-    0,
-    "relay must export NATIVE_RELAY_ABI as a const",
-  );
-  assert.equal(relayExports[1].declarationList.declarations.length, 1);
-  assert.equal(relayExports[1].declarationList.declarations[0].name.getText(), "NATIVE_RELAY_ABI");
-  assert.ok(
-    ts.isFunctionDeclaration(relayExports[2]),
-    "relay must export executeNativeRelayCommand as a function",
-  );
-  assert.equal(relayExports[2].name?.text, "executeNativeRelayCommand");
   assertExactNames(
     "relay TypeScript module",
     new Set(relayExports.map(exportedDeclarationName).filter(Boolean)),
-    relayJsExports,
+    new Set([
+      "NativeRelayAbiRange",
+      "NATIVE_RELAY_ABI",
+      "NativeForegroundRuntimeFactory",
+      "NativeForegroundRuntime",
+      "NativeForegroundCommand",
+      "NativeForegroundResponse",
+      "installNativeForegroundRuntime",
+      "encodeNativeForegroundCommand",
+      "decodeNativeForegroundResponse",
+      "executeNativeRelayCommand",
+    ]),
   );
+  assert.equal(relayExports.length, 10, "relay must expose exactly its fixed ABI declarations");
 
   assert.equal(
     indexExports.length,
     2,
-    "relay package entry point must contain only its two fixed re-exports",
+    "relay package entry point must contain only its fixed re-exports",
   );
   assertNamedRelayReexport(
     "relay package entry point",
     indexExports[0],
-    ["NATIVE_RELAY_ABI", "executeNativeRelayCommand"],
+    [
+      "NATIVE_RELAY_ABI",
+      "decodeNativeForegroundResponse",
+      "encodeNativeForegroundCommand",
+      "executeNativeRelayCommand",
+      "installNativeForegroundRuntime",
+    ],
     false,
   );
   assertNamedRelayReexport(
     "relay package entry point",
     indexExports[1],
-    ["NativeRelayAbiRange"],
+    [
+      "NativeForegroundCommand",
+      "NativeForegroundResponse",
+      "NativeForegroundRuntime",
+      "NativeForegroundRuntimeFactory",
+      "NativeRelayAbiRange",
+    ],
     true,
   );
 
@@ -298,7 +320,7 @@ function assertExactTsRelaySurface(nativeSpec, relay, index) {
   assert.equal(
     spec.members.length,
     nativeSpecMethods.size,
-    "NativeJazzRelay TurboModule has exactly its two ABI methods",
+    "NativeJazzRelay TurboModule has exactly its fixed ABI methods",
   );
   assertExactNames("NativeJazzRelay TurboModule", new Set(membersByName.keys()), nativeSpecMethods);
   for (const name of nativeSpecMethods) {
@@ -306,7 +328,7 @@ function assertExactTsRelaySurface(nativeSpec, relay, index) {
   }
   assert.match(
     commentFreeSpec,
-    /^\s*export\s+default\s+TurboModuleRegistry\.get<Spec>\('JazzRelay'\);\s*$/m,
+    /^\s*export\s+default\s+TurboModuleRegistry\.get<Spec>\(["']JazzRelay["']\);\s*$/m,
     "NativeJazzRelay may only default-export its registry lookup",
   );
 }
@@ -323,6 +345,28 @@ function assertOpaqueAndroidRelaySurface(androidModule) {
     // Generated TurboModule methods use @Override; handwritten React Native
     // modules use @ReactMethod, including its fully-qualified spelling.
     if (/(?:@Override\b|@[A-Za-z_$][A-Za-z0-9_$.]*\.ReactMethod\b|@ReactMethod\b)/.test(match[1])) {
+      // This is New Architecture installation plumbing, invoked by React
+      // Native while it owns a JSI runtime; it is not a JS-visible
+      // TurboModule method. Keep its exact native-only type checked here so a
+      // similarly named public JavaScript method cannot hide behind it.
+      if (match[2] === "getBindingsInstaller") {
+        assert.match(
+          match[0],
+          /BindingsInstallerHolder\s+getBindingsInstaller\s*\(/,
+          "Android's only extra New Architecture hook must return a bindings installer",
+        );
+        continue;
+      }
+      // These React Native lifecycle hooks retain/release the native host for
+      // the lifetime of this module instance. They are not TurboModule ABI.
+      if (match[2] === "initialize" || match[2] === "invalidate") {
+        assert.match(
+          match[0],
+          /void\s+(initialize|invalidate)\s*\(\s*\)/,
+          "Android lifecycle hooks must stay parameterless void hooks",
+        );
+        continue;
+      }
       exportedMethods.add(match[2]);
     }
   }
@@ -430,6 +474,34 @@ test("jazz-rn publishes an Expo config plugin for a New Architecture development
   assert.equal(packageJson.bugs.url, "https://github.com/garden-co/jazz/issues");
 });
 
+test("the canonical Expo scaffold preserves the direct native-package contract", async () => {
+  const [manifestText, appConfigText, readme] = await Promise.all([
+    readFile(
+      new URL("../../../examples/todo-client-localfirst-expo/package.json", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../examples/todo-client-localfirst-expo/app.json", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../examples/todo-client-localfirst-expo/README.md", import.meta.url),
+      "utf8",
+    ),
+  ]);
+  const manifest = JSON.parse(manifestText);
+  const appConfig = JSON.parse(appConfigText).expo;
+
+  assert.equal(manifest.dependencies["jazz-rn"], "workspace:*");
+  assert.equal(manifest.scripts["verify:expo"], "pnpm verify:expo:android && pnpm verify:expo:ios");
+  assert.equal(appConfig.newArchEnabled, true);
+  assert.deepEqual(appConfig.plugins, ["jazz-rn"]);
+  assert.match(readme, /jazz-rn@alpha/);
+  assert.match(readme, /direct app dependency/);
+  assert.match(readme, /does \*\*not\*\* run in Expo Go/);
+  assert.match(readme, /not a runnable persistent Jazz client/);
+});
+
 test("the canonical Expo scaffold really prebuilds both relay-only platforms", () => {
   const root = new URL("../../../", import.meta.url);
   const expoBin = new URL(
@@ -493,6 +565,58 @@ test("the canonical Expo scaffold really prebuilds both relay-only platforms", (
   );
 });
 
+test("React Native installation docs advertise only the currently proven package boundary", async () => {
+  const [readme, installGuide, clientSetupGuide, durabilityGuide, exampleReadme, previewWorkflow] = await Promise.all([
+    readFile(new URL("../../../crates/jazz-rn/README.md", import.meta.url), "utf8"),
+    readFile(new URL("../../../docs/content/docs/install/client.mdx", import.meta.url), "utf8"),
+    readFile(
+      new URL("../../../docs/content/docs/getting-started/client-setup.mdx", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../docs/content/docs/reference/durability-tiers.mdx", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../examples/todo-client-localfirst-expo/README.md", import.meta.url),
+      "utf8",
+    ),
+    readFile(new URL("../../../.github/workflows/preview-build.yml", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(readme, /pnpm add jazz-rn@alpha/);
+  assert.match(readme, /"plugins": \["jazz-rn"\]/);
+  assert.match(readme, /npx expo prebuild --clean/);
+  assert.match(readme, /newArchEnabled=true/);
+  assert.match(readme, /RCT_NEW_ARCH_ENABLED=1 bundle exec pod install/);
+  assert.match(readme, /Expo Go is not\s+supported/);
+  assert.match(readme, /not yet a supported high-level React Native Jazz client/);
+  assert.match(readme, /rn-preview-release/);
+  assert.match(
+    previewWorkflow,
+    /contains\(github\.event\.pull_request\.labels\.\*\.name, 'rn-preview-release'\)/,
+    "the documented preview label must still opt into the actual artifact workflow",
+  );
+  assert.match(
+    installGuide,
+    /React Native and Expo are intentionally not part of this application quickstart yet[\s\S]*not a supported React Native Jazz client/,
+    "the public install guide must put the unsupported RN boundary before its runtime quickstart",
+  );
+  for (const [name, guide] of [
+    ["install guide", installGuide],
+    ["client setup guide", clientSetupGuide],
+    ["durability guide", durabilityGuide],
+  ]) {
+    assert.doesNotMatch(
+      guide,
+    /<Tab value="Expo">|jazz-tools\/expo|todo-client-localfirst-expo/,
+      `${name} must not retain runnable-looking Expo tabs or RN runtime snippets`,
+    );
+  }
+  assert.match(exampleReadme, /native-relay install\/ABI boundary/);
+  assert.match(exampleReadme, /not a runnable persistent Jazz client/);
+});
+
 test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", async () => {
   // The canonical example is useful, but its workspace link can accidentally
   // hide npm-packaging mistakes. This receipt instead constructs the smallest
@@ -509,6 +633,8 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
   const installedNodeModules = join(installDirectory, "node_modules");
   const appDirectory = join(directory, "app");
   const appNodeModules = join(appDirectory, "node_modules");
+  const bareAppDirectory = join(directory, "bare-react-native-app");
+  const bareAppNodeModules = join(bareAppDirectory, "node_modules");
   const canonicalNodeModules = new URL(
     "../../../examples/todo-client-localfirst-expo/node_modules/",
     import.meta.url,
@@ -614,6 +740,118 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
     for (const dependency of ["@types", "expo", "react", "react-native", "typescript"]) {
       await symlink(join(canonicalNodeModules, dependency), join(appNodeModules, dependency));
     }
+    // Typechecking and autolinking prove that the packed package is present,
+    // but neither executes the JavaScript an app actually imports. Run the
+    // compiled entry point from the installed tarball under a deliberately
+    // tiny native-module shim. The shim is a Node loader rather than a copied
+    // package file: `jazz-rn` still resolves its own published
+    // `NativeJazzRelay.js`, which in turn resolves the host's `react-native`
+    // import in exactly the ordinary package graph.
+    //
+    // This is not a substitute for the linked Android/iOS receipts. It makes
+    // the installation boundary executable: a tarball with stale/missing
+    // compiled JavaScript, a broken package export, or a changed ABI failure
+    // path cannot pass merely because its declarations and Podspec parse.
+    const nativeModuleShim = join(directory, "native-relay-shim.mjs");
+    const nativeModuleLoader = join(directory, "native-relay-loader.mjs");
+    await writeFile(
+      nativeModuleShim,
+      [
+        "const available = process.env.JAZZ_RN_PACKED_NATIVE_AVAILABLE === '1';",
+        "const abi = Number(process.env.JAZZ_RN_PACKED_NATIVE_ABI);",
+        "export const TurboModuleRegistry = {",
+        "  get() {",
+        "    return available ? {",
+        "      getAbiVersion: () => abi,",
+        "      execute: async (command) => `native:${command}`,",
+        "    } : null;",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(
+      nativeModuleLoader,
+      [
+        "export async function resolve(specifier, context, nextResolve) {",
+        '  if (specifier !== "react-native") return nextResolve(specifier, context);',
+        "  return { url: new URL('./native-relay-shim.mjs', import.meta.url).href, shortCircuit: true };",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    const runPackedRelay = (environment, program) =>
+      execFileSync(
+        process.execPath,
+        [
+          "--no-warnings",
+          "--experimental-loader",
+          nativeModuleLoader,
+          "--input-type=module",
+          "--eval",
+          program,
+        ],
+        {
+          cwd: appDirectory,
+          env: { ...process.env, ...environment },
+          encoding: "utf8",
+        },
+      );
+    assert.equal(
+      runPackedRelay(
+        {
+          JAZZ_RN_PACKED_NATIVE_AVAILABLE: "1",
+          JAZZ_RN_PACKED_NATIVE_ABI: "3",
+        },
+        'const { executeNativeRelayCommand } = await import("jazz-rn"); process.stdout.write(await executeNativeRelayCommand("AQI="));',
+      ),
+      "native:AQI=",
+      "the fresh app must execute the published relay entry point through its installed native module",
+    );
+    for (const [name, environment, expected] of [
+      [
+        "missing native module",
+        {
+          JAZZ_RN_PACKED_NATIVE_AVAILABLE: "0",
+          JAZZ_RN_PACKED_NATIVE_ABI: "3",
+        },
+        /native relay is unavailable.*Expo Go never includes it/i,
+      ],
+      [
+        "source-only ABI zero",
+        {
+          JAZZ_RN_PACKED_NATIVE_AVAILABLE: "1",
+          JAZZ_RN_PACKED_NATIVE_ABI: "0",
+        },
+        /source fallback \(ABI 0\)/i,
+      ],
+      [
+        "incompatible native ABI",
+        {
+          JAZZ_RN_PACKED_NATIVE_AVAILABLE: "1",
+          JAZZ_RN_PACKED_NATIVE_ABI: "4",
+        },
+        /ABI 4 is incompatible with JavaScript ABI 3\.\.=3/i,
+      ],
+    ]) {
+      const diagnostic = runPackedRelay(
+        environment,
+        [
+          'const { executeNativeRelayCommand } = await import("jazz-rn");',
+          "try {",
+          '  await executeNativeRelayCommand("AQI=");',
+          '  throw new Error("packed relay unexpectedly accepted this unavailable native state");',
+          "} catch (error) {",
+          "  process.stdout.write(error instanceof Error ? error.message : String(error));",
+          "}",
+        ].join("\n"),
+      );
+      assert.match(
+        diagnostic,
+        expected,
+        `the fresh packed runtime must explain ${name} before attempting relay I/O`,
+      );
+    }
     execFileSync(join(appNodeModules, "typescript", "bin", "tsc"), ["--noEmit"], {
       cwd: appDirectory,
       stdio: "inherit",
@@ -633,6 +871,132 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
       bareReactNativeConfig.dependencies["jazz-rn"].platforms.ios.podspecPath,
       /JazzRn\.podspec$/,
       "a bare React Native host must discover the packed iOS podspec too",
+    );
+    // Expo prebuild hosts an ordinary React Native app, but it also brings
+    // Expo's config/plugin machinery. Keep an explicitly bare scaffold in
+    // this receipt so an Expo-specific resolver, transitive workspace link,
+    // or config convention cannot accidentally stand in for the direct React
+    // Native installation path.
+    await mkdir(bareAppDirectory, { recursive: true });
+    await writeFile(
+      join(bareAppDirectory, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "jazz-rn-fresh-bare-receipt",
+          version: "0.0.0",
+          private: true,
+          dependencies: {
+            "jazz-rn": `file:../package/${packed[0].filename}`,
+            react: "19.2.4",
+            "react-native": "0.81.5",
+          },
+          devDependencies: {
+            "@types/react": "19.2.14",
+            typescript: "6.0.2",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile(
+      join(bareAppDirectory, "index.js"),
+      [
+        'import { AppRegistry } from "react-native";',
+        'import App from "./App";',
+        'AppRegistry.registerComponent("JazzRnFreshBareReceipt", () => App);',
+        "",
+      ].join("\n"),
+    );
+    await writeFile(
+      join(bareAppDirectory, "App.tsx"),
+      [
+        'import { Text } from "react-native";',
+        'import { NATIVE_RELAY_ABI } from "jazz-rn";',
+        "",
+        "export default function App() {",
+        "  return <Text>Jazz Relay ABI {NATIVE_RELAY_ABI.maximum}</Text>;",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(
+      join(bareAppDirectory, "tsconfig.json"),
+      `${JSON.stringify(
+        {
+          compilerOptions: {
+            jsx: "react-jsx",
+            module: "esnext",
+            moduleResolution: "bundler",
+            noEmit: true,
+            skipLibCheck: true,
+            target: "es2022",
+          },
+          include: ["App.tsx"],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await mkdir(bareAppNodeModules, { recursive: true });
+    await cp(join(installedNodeModules, "jazz-rn"), join(bareAppNodeModules, "jazz-rn"), {
+      recursive: true,
+      dereference: true,
+    });
+    for (const dependency of ["react", "react-native", "typescript"]) {
+      await symlink(join(canonicalNodeModules, dependency), join(bareAppNodeModules, dependency));
+    }
+    await mkdir(join(bareAppNodeModules, "@types"), { recursive: true });
+    await symlink(
+      new URL("../../../node_modules/.pnpm/node_modules/@types/react", import.meta.url).pathname,
+      join(bareAppNodeModules, "@types", "react"),
+    );
+    execFileSync(join(bareAppNodeModules, "typescript", "bin", "tsc"), ["--noEmit"], {
+      cwd: bareAppDirectory,
+      stdio: "inherit",
+    });
+    const directBareReactNativeConfig = JSON.parse(
+      execFileSync(join(canonicalNodeModules, ".bin", "react-native"), ["config"], {
+        cwd: bareAppDirectory,
+        encoding: "utf8",
+      }),
+    );
+    const directBareJazzRn = directBareReactNativeConfig.dependencies["jazz-rn"];
+    assert.ok(directBareJazzRn, "a direct bare host must discover the packed jazz-rn package");
+    assert.throws(
+      () => require.resolve("expo/package.json", { paths: [bareAppDirectory] }),
+      { code: "MODULE_NOT_FOUND" },
+      "the direct bare receipt must not resolve Expo from its application graph",
+    );
+    assert.equal(
+      directBareJazzRn.root,
+      join(bareAppNodeModules, "jazz-rn"),
+      "a direct bare host must discover its tarball installation, not the workspace package",
+    );
+    assert.equal(
+      directBareJazzRn.platforms.android.packageInstance,
+      "new JazzRelayPackage()",
+      "a direct bare host must expose the generated Android relay package to autolinking",
+    );
+    assert.match(
+      directBareJazzRn.platforms.android.sourceDir,
+      new RegExp(`${bareAppNodeModules.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[\\/]jazz-rn[\\/]android$`),
+      "a direct bare host must retain the Android source from its packed installation",
+    );
+    assert.equal(
+      directBareJazzRn.platforms.ios.podspecPath,
+      join(bareAppNodeModules, "jazz-rn", "JazzRn.podspec"),
+      "a direct bare host must retain the iOS podspec from its packed installation",
+    );
+    assert.equal(
+      require.resolve("jazz-rn/package.json", { paths: [bareAppDirectory] }),
+      join(bareAppNodeModules, "jazz-rn", "package.json"),
+      "the direct bare receipt must resolve jazz-rn from the copied packed tarball",
+    );
+    assert.equal(
+      require.resolve("jazz-rn", { paths: [bareAppDirectory] }),
+      join(bareAppNodeModules, "jazz-rn", "lib", "module", "index.js"),
+      "the direct bare receipt must resolve the published JavaScript entry, not workspace source",
     );
     for (const platform of ["android", "ios"]) {
       execFileSync(
@@ -785,7 +1149,7 @@ test("jazz-rn reserves a thin binary relay TurboModule boundary for matching nat
 
   assert.equal(packageJson.exports["./relay"].source, "./src/relay.ts");
   assert.equal(packageJson.scripts["test:codegen"], "bash scripts/test-codegen.sh");
-  assert.match(nativeSpec, /TurboModuleRegistry\.get<Spec>\('JazzRelay'\)/);
+  assert.match(nativeSpec, /TurboModuleRegistry\.get<Spec>\(["']JazzRelay["']\)/);
   assert.match(nativeSpec, /execute\(commandBase64: string\): Promise<string>/);
   assert.match(relay, /getAbiVersion\(\)/);
   assert.match(relay, /matching native development or release build/);
@@ -1042,6 +1406,8 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
   assert.match(androidBridge, /trustedCapabilities \+=/);
   assert.match(androidBridge, /trustedCapabilities -=/);
   assert.match(androidBridge, /releaseRuntime/);
+  assert.match(androidModule, /void initialize\(\)[\s\S]*?bridge\.acquireRuntime\(\)/);
+  assert.match(androidModule, /void invalidate\(\)[\s\S]*?bridge\.releaseRuntime\(runtimeToken\)/);
   assert.match(iosRelay, /JazzRelayTrustedAdmission/);
   assert.match(iosRelay, /jazz_native_relay_host_admit_scope_json/);
   assert.match(iosRelay, /jazz_native_relay_host_revoke_scope_capability/);
@@ -1049,6 +1415,174 @@ test("trusted relay admission stays outside the JavaScript command channel", asy
   assert.match(iosRelay, /\[trustedCapabilities removeObject:capability\]/);
   assert.match(header, /jazz_native_relay_host_admit_scope_json/);
   assert.match(header, /jazz_native_relay_host_revoke_scope_capability/);
+});
+
+test("the private foreground JSI host retains teardown ownership and rejects malformed views", async () => {
+  const [runtime, header, androidBridge, androidModule, androidCpp, iosRelay] = await Promise.all([
+    readFile(
+      new URL("../../../crates/jazz-rn/native/foreground-runtime.cpp", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../crates/jazz-native-relay/include/jazz_native_relay.h", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayBridge.kt", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../../../crates/jazz-rn/android/src/main/java/com/jazzrn/JazzRelayModule.java", import.meta.url),
+      "utf8",
+    ),
+    readFile(new URL("../../../crates/jazz-rn/android/cpp-relay.cpp", import.meta.url), "utf8"),
+    readFile(new URL("../../../crates/jazz-rn/ios/JazzRelay.mm", import.meta.url), "utf8"),
+  ]);
+
+  // The HostObjects only call lease APIs while holding the lifecycle lock. A
+  // raw host pointer could otherwise be freed after an `active()` observation
+  // but before a JS finalizer calls tick/close.
+  assert.match(runtime, /lockIfActive\(\)/);
+  assert.match(
+    runtime,
+    /jazz_native_relay_host_lease_invalidate_foreground_runtime\(lease_\)/,
+    "platform teardown must retire Rust foreground aliases before making JSI finalizers inert",
+  );
+  assert.match(
+    header,
+    /jazz_native_relay_host_lease_invalidate_foreground_runtime/,
+    "the staged native header must expose the token-scoped teardown ABI",
+  );
+  assert.match(
+    androidBridge,
+    /fun acquireRuntime\(\): Long[\s\S]*?activeRuntimeTokens\.add\(token\)/,
+    "Android must issue one explicit stable token per JS runtime",
+  );
+  assert.match(
+    androidBridge,
+    /fun releaseRuntime\(runtimeToken: Long\)[\s\S]*?nativeInvalidateForegroundRuntime\(host, runtimeToken\)/,
+    "Android teardown must invalidate only its own runtime token",
+  );
+  assert.match(androidModule, /private long runtimeToken = 0;/);
+  assert.match(androidModule, /private boolean ownsRuntimeLease = false;/);
+  assert.match(androidModule, /bridge\.releaseRuntime\(releasedToken\)/);
+  assert.match(
+    androidModule,
+    /ownsRuntimeLease = false;[\s\S]*?runtimeToken = 0;[\s\S]*?bridge\.releaseRuntime\(releasedToken\)/,
+    "Android must clear a module's runtime ownership before release so repeated invalidation cannot consume a sibling lease",
+  );
+  assert.match(
+    androidCpp,
+    /unordered_map<uint64_t, std::shared_ptr<ForegroundRuntimeInstallation>>/,
+    "Android's native registry must key installations by stable runtime token, not host pointer",
+  );
+  assert.match(androidCpp, /nativeInvalidateForegroundRuntime\([\s\S]*?jlong runtime_token/);
+  assert.doesNotMatch(androidCpp, /unordered_map<jazz_native_relay_host \*/);
+  assert.match(iosRelay, /uint64_t foregroundRuntimeToken/);
+  assert.match(iosRelay, /BOOL ownsForegroundRuntimeLease/);
+  assert.match(
+    iosRelay,
+    /unordered_map<uint64_t, std::shared_ptr<ForegroundRuntimeInstallation>>/,
+    "iOS must keep separate foreground leases for separately invalidated runtimes",
+  );
+  assert.match(iosRelay, /InvalidateForegroundInstallation\(EnsureRelayHost\(\), self\.foregroundRuntimeToken\)/);
+  assert.match(
+    iosRelay,
+    /ownsForegroundRuntimeLease = NO;[\s\S]*?foregroundRuntimeToken = 0;[\s\S]*?InvalidateForegroundInstallation\(EnsureRelayHost\(\), releasedToken\)/,
+    "iOS must clear a module's runtime ownership before release so repeated invalidation cannot decrement a sibling lease",
+  );
+  assert.doesNotMatch(iosRelay, /static facebook::jsi::Runtime \*foregroundJsiRuntime/);
+  assert.match(runtime, /jazz_native_relay_host_lease_open_attached_foreground/);
+  assert.match(runtime, /jazz_native_relay_host_lease_tick_attached_foreground/);
+  assert.match(runtime, /jazz_native_relay_host_lease_close_attached_foreground/);
+  assert.match(runtime, /jazz_native_relay_host_lease_execute_foreground/);
+  assert.match(runtime, /copyForegroundCommand/);
+  assert.match(runtime, /foregroundResponse/);
+  // The factory's reported ABI must come from the embedded Rust relay, not a
+  // second C++ literal. Otherwise an additive foreground command can bump the
+  // shared relay ABI while every real JSI factory keeps advertising the old
+  // value and the JS wrapper rejects it at installation.
+  assert.match(runtime, /jazz_native_relay_abi_version\(\)/);
+  assert.doesNotMatch(runtime, /kForegroundAbiVersion/);
+  assert.doesNotMatch(runtime, /jazz_native_relay_host_tick_attached_foreground\(lease_->/);
+
+  // Validate floating JSI numbers before narrowing byteOffset to size_t, and
+  // reject a DataView/lookalike before copying its selected ArrayBuffer range.
+  assert.match(runtime, /getProperty\(runtime, "Uint8Array"\)/);
+  assert.match(runtime, /Object::strictEquals/);
+  assert.match(runtime, /std::isfinite\(offset_number\)/);
+  assert.match(runtime, /std::floor\(offset_number\) != offset_number/);
+  assert.match(runtime, /numeric_limits<size_t>::max/);
+  assert.throws(
+    () => {
+      const broken = runtime.replaceAll("std::isfinite(offset_number) ||", "");
+      assert.match(broken, /std::isfinite\(offset_number\)/);
+    },
+    /isfinite/,
+    "the receipt is sensitive to removing finite-offset validation",
+  );
+  assert.throws(
+    () => {
+      const broken = runtime.replaceAll("Object::strictEquals", "Object::weakEquals");
+      assert.match(broken, /Object::strictEquals/);
+    },
+    /strictEquals/,
+    "the receipt is sensitive to accepting non-Uint8Array lookalikes",
+  );
+  assert.match(header, /jazz_native_relay_host_retain/);
+  assert.match(header, /jazz_native_relay_host_lease_free/);
+  assert.match(header, /jazz_native_relay_host_lease_execute_foreground/);
+
+  // Wake registration is deliberately a per-foreground JSI lifecycle seam,
+  // not another public TurboModule method or foreground command tag. The
+  // owner thread can only enqueue CallInvoker work; each JS runtime later
+  // drains/ticks itself. These concrete guards make this source receipt
+  // sensitive to collapsing wake state across aliases or reintroducing a
+  // synchronous callback path.
+  assert.match(header, /jazz_native_relay_foreground_wake_callback/);
+  assert.match(header, /jazz_native_relay_host_lease_set_foreground_wake_callback/);
+  assert.match(runtime, /class ForegroundWakeRegistration/);
+  assert.match(runtime, /foreground_/);
+  assert.match(runtime, /callbackKey\(\).*foreground_/);
+  assert.match(runtime, /CallInvoker/);
+  assert.match(runtime, /invokeAsync/);
+  assert.match(runtime, /wakeFromOwner\([^)]*\) noexcept/);
+  assert.match(runtime, /void schedule\([^)]*\) noexcept/);
+  assert.match(runtime, /catch \(\.\.\.\)[\s\S]*scheduled_ = false;/);
+  assert.match(runtime, /if \(scheduled_ \|\| !callInvoker_\) return;/);
+  assert.match(runtime, /deactivateAndClear/);
+  assert.match(runtime, /kWakeCancelled/);
+  const openAttached = runtime.match(
+    /jazz_native_relay_host_lease_open_attached_foreground\([\s\S]*?Object::createFromHostObject/,
+  )?.[0];
+  assert.ok(openAttached, "the foreground factory must open through the retained lease");
+  assert.match(
+    openAttached,
+    /lease_lock\.unlock\(\);[\s\S]*Object::createFromHostObject/,
+    "ForegroundHandle registration takes the same lifecycle mutex, so construction must happen after the open lock is released",
+  );
+  assert.throws(
+    () => {
+      const broken = runtime.replace(
+        "if (scheduled_ || !callInvoker_) return;",
+        "if (!callInvoker_) return;",
+      );
+      assert.match(broken, /if \(scheduled_ \|\| !callInvoker_\) return;/);
+    },
+    /scheduled_/,
+    "the receipt is sensitive to removing per-runtime wake coalescing",
+  );
+  assert.throws(
+    () => {
+      const broken = runtime.replace("lease_lock.unlock();", "");
+      const brokenOpen = broken.match(
+        /jazz_native_relay_host_lease_open_attached_foreground\([\s\S]*?Object::createFromHostObject/,
+      )?.[0];
+      assert.match(brokenOpen, /lease_lock\.unlock\(\);/);
+    },
+    /unlock/,
+    "the receipt is sensitive to reintroducing the foreground-open self-deadlock",
+  );
 });
 
 test("relay artifact staging targets every Android ABI and iOS framework slice", async () => {

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import test from "node:test";
 import { createRequire } from "node:module";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { cp, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { parse } from "yaml";
@@ -498,12 +498,15 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
   // hide npm-packaging mistakes. This receipt instead constructs the smallest
   // possible Expo app in a new directory, mounts the tarball that an adopter
   // would receive as its direct dependency, and runs the two prebuild paths.
-  // The scaffold borrows Expo's already-installed dependency graph rather than
-  // running a package-manager install: this keeps a packaging receipt fully
-  // offline and deterministic while still proving that the app resolves
-  // `jazz-rn` from the packed bytes rather than from this workspace.
+  // An isolated npm install consumes the packed tarball in offline mode before
+  // the Expo scaffold receives a copy of that installed package. The package
+  // must therefore declare every direct dependency it needs; it cannot
+  // accidentally reach this workspace's jazz-rn sources. The scaffold itself
+  // supplies only its explicit Expo/React/React-Native peer graph.
   const directory = await mkdtemp(join(tmpdir(), "jazz-rn-fresh-expo-"));
   const packageDirectory = join(directory, "package");
+  const installDirectory = join(directory, "installed-package");
+  const installedNodeModules = join(installDirectory, "node_modules");
   const appDirectory = join(directory, "app");
   const appNodeModules = join(appDirectory, "node_modules");
   const canonicalNodeModules = new URL(
@@ -524,6 +527,37 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
     );
     assert.deepEqual(packed.length, 1, "packing jazz-rn must produce one npm tarball");
     const tarball = join(packageDirectory, packed[0].filename);
+
+    await mkdir(installDirectory, { recursive: true });
+    await writeFile(
+      join(installDirectory, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "jazz-rn-packed-install-receipt",
+          version: "0.0.0",
+          private: true,
+          dependencies: { "jazz-rn": `file:../package/${packed[0].filename}` },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    execFileSync(
+      "npm",
+      ["install", "--offline", "--ignore-scripts", "--omit=peer", "--legacy-peer-deps"],
+      {
+        cwd: installDirectory,
+        stdio: "inherit",
+      },
+    );
+    const packedManifest = JSON.parse(
+      await readFile(join(installedNodeModules, "jazz-rn", "package.json"), "utf8"),
+    );
+    assert.deepEqual(
+      Object.keys(packedManifest.peerDependencies).sort(),
+      ["expo", "react", "react-native"],
+      "the packed relay must declare every host runtime it imports as a peer dependency",
+    );
 
     await mkdir(appDirectory, { recursive: true });
     await writeFile(
@@ -573,8 +607,10 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
       `${JSON.stringify({ extends: "expo/tsconfig.base", include: ["App.tsx"] }, null, 2)}\n`,
     );
     await mkdir(appNodeModules, { recursive: true });
-    execFileSync("tar", ["-xzf", tarball, "-C", packageDirectory]);
-    await symlink(join(packageDirectory, "package"), join(appNodeModules, "jazz-rn"));
+    await cp(join(installedNodeModules, "jazz-rn"), join(appNodeModules, "jazz-rn"), {
+      recursive: true,
+      dereference: true,
+    });
     for (const dependency of ["@types", "expo", "react", "react-native", "typescript"]) {
       await symlink(join(canonicalNodeModules, dependency), join(appNodeModules, dependency));
     }
@@ -592,6 +628,11 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
       bareReactNativeConfig.dependencies["jazz-rn"].platforms.android.packageInstance,
       "new JazzRelayPackage()",
       "a bare React Native host must discover the packed relay package too",
+    );
+    assert.match(
+      bareReactNativeConfig.dependencies["jazz-rn"].platforms.ios.podspecPath,
+      /JazzRn\.podspec$/,
+      "a bare React Native host must discover the packed iOS podspec too",
     );
     for (const platform of ["android", "ios"]) {
       execFileSync(
@@ -616,31 +657,39 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
     assert.match(iosProperties, /"newArchEnabled": "true"/);
     assert.match(iosPodfile, /use_native_modules!/);
 
-    const androidAutolink = JSON.parse(
-      execFileSync(
-        process.execPath,
-        [
-          "--no-warnings",
-          "--eval",
-          "require('expo/bin/autolinking')",
-          "expo-modules-autolinking",
-          "react-native-config",
-          "--json",
-          "--platform",
-          "android",
-        ],
-        { cwd: appDirectory, encoding: "utf8" },
-      ),
-    );
+    const expoAutolink = (platform) =>
+      JSON.parse(
+        execFileSync(
+          process.execPath,
+          [
+            "--no-warnings",
+            "--eval",
+            "require('expo/bin/autolinking')",
+            "expo-modules-autolinking",
+            "react-native-config",
+            "--json",
+            "--platform",
+            platform,
+          ],
+          { cwd: appDirectory, encoding: "utf8" },
+        ),
+      );
+    const androidAutolink = expoAutolink("android");
+    const iosAutolink = expoAutolink("ios");
     assert.equal(
       androidAutolink.dependencies["jazz-rn"].platforms.android.packageInstance,
       "new JazzRelayPackage()",
       "the packed tarball, not a workspace symlink, must autolink the relay host",
     );
+    assert.match(
+      iosAutolink.dependencies["jazz-rn"].platforms.ios.podspecPath,
+      /JazzRn\.podspec$/,
+      "the packed tarball must autolink the relay iOS podspec too",
+    );
     assert.equal(
       require.resolve("jazz-rn/package.json", { paths: [appDirectory] }),
-      join(packageDirectory, "package", "package.json"),
-      "the receipt must resolve jazz-rn from the extracted npm tarball",
+      join(appNodeModules, "jazz-rn", "package.json"),
+      "the receipt must resolve jazz-rn from the npm-installed packed tarball",
     );
   } finally {
     await rm(directory, { recursive: true, force: true });

--- a/dev/rn-device-acceptance/scripts/boot-android-emulator.test.mjs
+++ b/dev/rn-device-acceptance/scripts/boot-android-emulator.test.mjs
@@ -21,10 +21,10 @@ const withFixture = (name, adbBody, emulatorBody, assertion, options = {}) => {
     // macOS has neither GNU `setsid` nor GNU `timeout`. These deliberately
     // small test doubles exercise the receipt's bounded state machine without
     // claiming to prove Linux process-group cleanup (covered below on Linux).
-    writeFileSync(sessionLauncher, "#!/usr/bin/env bash\nexec \"$@\"\n");
+    writeFileSync(sessionLauncher, '#!/usr/bin/env bash\nexec "$@"\n');
     writeFileSync(
       timeout,
-      "#!/usr/bin/env bash\nduration=${2%s}\nshift 2\nexec perl -e 'alarm shift; exec @ARGV' \"$duration\" \"$@\"\n",
+      '#!/usr/bin/env bash\nduration=${2%s}\nshift 2\nexec perl -e \'alarm shift; exec @ARGV\' "$duration" "$@"\n',
     );
     writeFileSync(config, "avd.id=acceptance\n");
     chmodSync(adb, 0o755);
@@ -57,12 +57,17 @@ const withFixture = (name, adbBody, emulatorBody, assertion, options = {}) => {
 };
 
 test("Android boot receipt fails under its own deadline when adb has no device", () => {
-  withFixture("no-device", '[[ "$1" == get-state ]] && exit 1', 'echo "still starting"; sleep 10', (result) => {
-    assert.equal(result.status, 1);
-    assert.match(result.stderr, /within 1s/);
-    assert.match(result.stderr, /emulator log/);
-    assert.doesNotMatch(result.stderr, /wait-for-device/);
-  });
+  withFixture(
+    "no-device",
+    '[[ "$1" == get-state ]] && exit 1',
+    'echo "still starting"; sleep 10',
+    (result) => {
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /within 1s/);
+      assert.match(result.stderr, /emulator log/);
+      assert.doesNotMatch(result.stderr, /wait-for-device/);
+    },
+  );
 });
 
 test("Android boot receipt caps a long poll interval at its boot deadline", () => {
@@ -81,7 +86,7 @@ test("Android boot receipt caps a long poll interval at its boot deadline", () =
 });
 
 test("Android boot receipt diagnoses an emulator that exits before adb registration", () => {
-  withFixture("early-exit", 'exit 1', 'echo "fatal startup"; exit 17', (result) => {
+  withFixture("early-exit", "exit 1", 'echo "fatal startup"; exit 17', (result) => {
     assert.equal(result.status, 1);
     assert.match(result.stderr, /process exited before boot completed/);
     assert.match(result.stderr, /fatal startup/);
@@ -125,59 +130,71 @@ test("Android boot receipt supports the macOS test launcher without relaxing the
   );
 });
 
-test("Android boot receipt cleans up the complete emulator process group on failure", { skip: process.platform !== "linux" }, () => {
-  const childFile = join(tmpdir(), `jazz-rn-boot-child-${process.pid}-${Date.now()}`);
-  try {
-    withFixture(
-      "child-cleanup",
-      '[[ "$1" == get-state ]] && exit 1',
-      'sleep 10 & echo $! > "$JAZZ_TEST_CHILD_PID"; wait',
-      (result) => assert.equal(result.status, 1),
-      { env: { JAZZ_TEST_CHILD_PID: childFile } },
-    );
-    const childPid = readFileSync(childFile, "utf8").trim();
-    assert.throws(() => process.kill(Number(childPid), 0), { code: "ESRCH" });
-  } finally {
-    rmSync(childFile, { force: true });
-  }
-});
+test(
+  "Android boot receipt cleans up the complete emulator process group on failure",
+  { skip: process.platform !== "linux" },
+  () => {
+    const childFile = join(tmpdir(), `jazz-rn-boot-child-${process.pid}-${Date.now()}`);
+    try {
+      withFixture(
+        "child-cleanup",
+        '[[ "$1" == get-state ]] && exit 1',
+        'sleep 10 & echo $! > "$JAZZ_TEST_CHILD_PID"; wait',
+        (result) => assert.equal(result.status, 1),
+        { env: { JAZZ_TEST_CHILD_PID: childFile } },
+      );
+      const childPid = readFileSync(childFile, "utf8").trim();
+      assert.throws(() => process.kill(Number(childPid), 0), { code: "ESRCH" });
+    } finally {
+      rmSync(childFile, { force: true });
+    }
+  },
+);
 
-test("Android boot receipt removes its emulator process group when cancelled", { skip: process.platform !== "linux" }, async () => {
-  const fixture = mkdtempSync(join(tmpdir(), "jazz-rn-boot-cancel-"));
-  const adb = join(fixture, "adb");
-  const emulator = join(fixture, "emulator");
-  const log = join(fixture, "emulator.log");
-  const config = join(fixture, "config.ini");
-  const childFile = join(fixture, "child.pid");
-  writeFileSync(adb, '#!/usr/bin/env bash\nexit 1\n');
-  writeFileSync(emulator, '#!/usr/bin/env bash\nsleep 30 & echo $! > "$JAZZ_TEST_CHILD_PID"; wait\n');
-  writeFileSync(config, "avd.id=acceptance\n");
-  chmodSync(adb, 0o755);
-  chmodSync(emulator, 0o755);
-  try {
-    const receipt = spawn("bash", [script, "test-avd", log, config], {
-      env: {
-        ...process.env,
-        JAZZ_DEVICE_ADB: adb,
-        JAZZ_DEVICE_EMULATOR: emulator,
-        JAZZ_TEST_CHILD_PID: childFile,
-        JAZZ_ANDROID_BOOT_TIMEOUT_SECONDS: "30",
-        JAZZ_ANDROID_BOOT_POLL_SECONDS: "0.05",
-      },
-    });
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    receipt.kill("SIGTERM");
-    const status = await new Promise((resolve) => receipt.on("close", resolve));
-    assert.equal(status, 143);
-    const childPid = Number(readFileSync(childFile, "utf8").trim());
-    assert.throws(() => process.kill(childPid, 0), { code: "ESRCH" });
-  } finally {
-    rmSync(fixture, { recursive: true, force: true });
-  }
-});
+test(
+  "Android boot receipt removes its emulator process group when cancelled",
+  { skip: process.platform !== "linux" },
+  async () => {
+    const fixture = mkdtempSync(join(tmpdir(), "jazz-rn-boot-cancel-"));
+    const adb = join(fixture, "adb");
+    const emulator = join(fixture, "emulator");
+    const log = join(fixture, "emulator.log");
+    const config = join(fixture, "config.ini");
+    const childFile = join(fixture, "child.pid");
+    writeFileSync(adb, "#!/usr/bin/env bash\nexit 1\n");
+    writeFileSync(
+      emulator,
+      '#!/usr/bin/env bash\nsleep 30 & echo $! > "$JAZZ_TEST_CHILD_PID"; wait\n',
+    );
+    writeFileSync(config, "avd.id=acceptance\n");
+    chmodSync(adb, 0o755);
+    chmodSync(emulator, 0o755);
+    try {
+      const receipt = spawn("bash", [script, "test-avd", log, config], {
+        env: {
+          ...process.env,
+          JAZZ_DEVICE_ADB: adb,
+          JAZZ_DEVICE_EMULATOR: emulator,
+          JAZZ_TEST_CHILD_PID: childFile,
+          JAZZ_ANDROID_BOOT_TIMEOUT_SECONDS: "30",
+          JAZZ_ANDROID_BOOT_POLL_SECONDS: "0.05",
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      receipt.kill("SIGTERM");
+      const status = await new Promise((resolve) => receipt.on("close", resolve));
+      assert.equal(status, 143);
+      const childPid = Number(readFileSync(childFile, "utf8").trim());
+      assert.throws(() => process.kill(childPid, 0), { code: "ESRCH" });
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  },
+);
 
 test("workflow delegates Android boot to the bounded receipt script", () => {
-  const workflow = new URL("../../../.github/workflows/rn-device-acceptance.yml", import.meta.url).pathname;
+  const workflow = new URL("../../../.github/workflows/rn-device-acceptance.yml", import.meta.url)
+    .pathname;
   const text = readFileSync(workflow, "utf8");
   assert.ok(workflow.endsWith("rn-device-acceptance.yml"));
   assert.match(text, /boot-android-emulator\.sh/);


### PR DESCRIPTION
🤖 Specify and scaffold the native JSI boundary required for real foreground Jazz runtimes on React Native. This advances #2291 without claiming the two-runtime device scenario is implemented yet.

## Decision

React Native will not ship the browser WASM runtime or depend on Hermes gaining `WebAssembly`. Each foreground app instance owns a memory-only Groove/Jazz engine exposed through a thin native JSI byte API. Those engines attach, using an admitted 32-byte capability, to the separately owned persistent native relay already established by the lower stack.

This keeps the semantic split explicit:

- **foreground runtime:** app/query/IVM state, one per JS runtime, memory-only;
- **native relay:** trusted admission, persistent SQLite-backed sync/authority transport, shared per auth scope;
- **JS adapter:** existing encoded `NativeDb` contract, lifecycle ownership, and callbacks;
- **future Swift/Kotlin:** consume the same native owner/command ABI without inheriting React Native objects.

## Call flow

```text
JS runtime
  → install native JSI foreground factory
  → openAttached(admittedCapability)
  → native owner thread creates memory-only Jazz engine
  → engine exchanges frames through the admitted persistent relay
  → bounded callbacks return encoded query/write/subscription events
```

Opening, callback delivery, close, capability revocation, bridge reload, and native-host shutdown have distinct documented ownership and ordering rules. Expo prebuild and bare RN include the native module; Expo Go remains unsupported because it cannot contain this code.

## This PR

- Adds the normative architecture, threading, teardown, packaging, and staged two-runtime acceptance plan.
- Adds a capability-only V1 factory installer scaffold.
- Clears the private JSI slot before every install and requires native code to synchronously create a fresh own factory; a same-ABI HostObject from an old bridge cannot be reused.
- Rejects non-`Uint8Array` and non-32-byte capabilities before crossing JSI. Native admission remains authoritative.
- Keeps the current relay-only public surface working while the actual native `NativeDb` engine is implemented.

## Not yet claimed

The C++/Rust JSI `NativeDb` byte adapter, real foreground engine owner, complete callback bridge, and two-foreground device receipt remain follow-up work under #2291. This PR deliberately throws a clear installation error when the packaged native build does not yet provide that engine.

## Verification

- RN Jest suite: 8/8.
- RN TypeScript check passes.
- Tests reject missing, malformed, ABI-incompatible, stale/no-op installers and malformed capabilities.
- Independent review planted a same-ABI stale factory; the repaired installer rejects it before any call.

