### PR TITLE
Prove a fresh packed React Native install

### DIFF
--- a/crates/jazz-rn/README.md
+++ b/crates/jazz-rn/README.md
@@ -57,6 +57,43 @@ artifact.
 The wrapper accepts ABI 3, which uses opaque host-generated admission
 capabilities and trusted revocation.
 
+## Expo development-build install path
+
+`jazz-rn` is a direct application dependency: React Native codegen and Expo
+autolinking must discover it from the application, not through `jazz-tools`.
+For an Expo development build, the minimal configuration is:
+
+```bash
+pnpm add jazz-rn@alpha
+```
+
+```json
+{
+  "expo": {
+    "plugins": ["jazz-rn"]
+  }
+}
+```
+
+Then run `npx expo prebuild --clean` and make a development or release build.
+The plugin turns on the New Architecture, and native autolinking registers
+`JazzRelayPackage` on Android and the `JazzRn` pod on iOS. Do not use Expo Go:
+it cannot contain the relay module.
+
+Bare React Native uses the same direct dependency and autolinking metadata, but
+has no Expo plugin: enable the New Architecture in the host project before
+running its platform install/build commands.
+
+The repository's `jazz-rn` packaging receipt packs the actual npm tarball,
+uses it from an otherwise empty Expo SDK 54 app, typechecks an import from its
+published declarations, prebuilds Android and iOS, and verifies Android
+autolinking plus bare React Native discovery. This intentionally proves only
+install-time wiring. A device run also requires a matching release payload with
+the sealed Android relay slices or iOS XCFramework plus platform-owned scope admission; those are produced by
+the native artifact/release workflows and are checked separately by the device
+acceptance app. A source checkout with no staged native artifacts should fail
+at relay use rather than pretend to provide persistence.
+
 ## What remains before React Native is supported
 
 1. Link the staged host lifecycle codec through thin JNI/Swift translation and

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import test from "node:test";
 import { createRequire } from "node:module";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { parse } from "yaml";
@@ -491,6 +491,160 @@ test("the canonical Expo scaffold really prebuilds both relay-only platforms", (
       assert.match(iosPodfileText, /use_native_modules!/);
     },
   );
+});
+
+test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", async () => {
+  // The canonical example is useful, but its workspace link can accidentally
+  // hide npm-packaging mistakes. This receipt instead constructs the smallest
+  // possible Expo app in a new directory, mounts the tarball that an adopter
+  // would receive as its direct dependency, and runs the two prebuild paths.
+  // The scaffold borrows Expo's already-installed dependency graph rather than
+  // running a package-manager install: this keeps a packaging receipt fully
+  // offline and deterministic while still proving that the app resolves
+  // `jazz-rn` from the packed bytes rather than from this workspace.
+  const directory = await mkdtemp(join(tmpdir(), "jazz-rn-fresh-expo-"));
+  const packageDirectory = join(directory, "package");
+  const appDirectory = join(directory, "app");
+  const appNodeModules = join(appDirectory, "node_modules");
+  const canonicalNodeModules = new URL(
+    "../../../examples/todo-client-localfirst-expo/node_modules/",
+    import.meta.url,
+  ).pathname;
+  try {
+    await mkdir(packageDirectory, { recursive: true });
+    const packed = JSON.parse(
+      execFileSync(
+        "npm",
+        ["pack", "--ignore-scripts", "--json", "--pack-destination", packageDirectory],
+        {
+          cwd: new URL("../../../crates/jazz-rn/", import.meta.url),
+          encoding: "utf8",
+        },
+      ),
+    );
+    assert.deepEqual(packed.length, 1, "packing jazz-rn must produce one npm tarball");
+    const tarball = join(packageDirectory, packed[0].filename);
+
+    await mkdir(appDirectory, { recursive: true });
+    await writeFile(
+      join(appDirectory, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "jazz-rn-fresh-expo-receipt",
+          version: "0.0.0",
+          private: true,
+          dependencies: {
+            expo: "54.0.37",
+            "jazz-rn": `file:../package/${packed[0].filename}`,
+            react: "19.2.4",
+            "react-native": "0.81.5",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile(
+      join(appDirectory, "app.json"),
+      `${JSON.stringify(
+        {
+          expo: {
+            name: "Jazz RN fresh install receipt",
+            slug: "jazz-rn-fresh-install-receipt",
+            version: "1.0.0",
+            plugins: ["jazz-rn"],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile(
+      join(appDirectory, "App.tsx"),
+      [
+        'import { NATIVE_RELAY_ABI } from "jazz-rn";',
+        "",
+        "export const relayAbi: number = NATIVE_RELAY_ABI.maximum;",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(
+      join(appDirectory, "tsconfig.json"),
+      `${JSON.stringify({ extends: "expo/tsconfig.base", include: ["App.tsx"] }, null, 2)}\n`,
+    );
+    await mkdir(appNodeModules, { recursive: true });
+    execFileSync("tar", ["-xzf", tarball, "-C", packageDirectory]);
+    await symlink(join(packageDirectory, "package"), join(appNodeModules, "jazz-rn"));
+    for (const dependency of ["@types", "expo", "react", "react-native", "typescript"]) {
+      await symlink(join(canonicalNodeModules, dependency), join(appNodeModules, dependency));
+    }
+    execFileSync(join(appNodeModules, "typescript", "bin", "tsc"), ["--noEmit"], {
+      cwd: appDirectory,
+      stdio: "inherit",
+    });
+    const bareReactNativeConfig = JSON.parse(
+      execFileSync(join(canonicalNodeModules, ".bin", "react-native"), ["config"], {
+        cwd: appDirectory,
+        encoding: "utf8",
+      }),
+    );
+    assert.equal(
+      bareReactNativeConfig.dependencies["jazz-rn"].platforms.android.packageInstance,
+      "new JazzRelayPackage()",
+      "a bare React Native host must discover the packed relay package too",
+    );
+    for (const platform of ["android", "ios"]) {
+      execFileSync(
+        join(canonicalNodeModules, ".bin", "expo"),
+        ["prebuild", "--platform", platform, "--clean", "--no-install"],
+        {
+          cwd: appDirectory,
+          env: { ...process.env, CI: "1" },
+          stdio: "inherit",
+        },
+      );
+    }
+
+    const [androidProperties, androidSettings, iosProperties, iosPodfile] = await Promise.all([
+      readFile(join(appDirectory, "android/gradle.properties"), "utf8"),
+      readFile(join(appDirectory, "android/settings.gradle"), "utf8"),
+      readFile(join(appDirectory, "ios/Podfile.properties.json"), "utf8"),
+      readFile(join(appDirectory, "ios/Podfile"), "utf8"),
+    ]);
+    assert.match(androidProperties, /^newArchEnabled=true$/m);
+    assert.match(androidSettings, /autolinkLibrariesFromCommand/);
+    assert.match(iosProperties, /"newArchEnabled": "true"/);
+    assert.match(iosPodfile, /use_native_modules!/);
+
+    const androidAutolink = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          "--no-warnings",
+          "--eval",
+          "require('expo/bin/autolinking')",
+          "expo-modules-autolinking",
+          "react-native-config",
+          "--json",
+          "--platform",
+          "android",
+        ],
+        { cwd: appDirectory, encoding: "utf8" },
+      ),
+    );
+    assert.equal(
+      androidAutolink.dependencies["jazz-rn"].platforms.android.packageInstance,
+      "new JazzRelayPackage()",
+      "the packed tarball, not a workspace symlink, must autolink the relay host",
+    );
+    assert.equal(
+      require.resolve("jazz-rn/package.json", { paths: [appDirectory] }),
+      join(packageDirectory, "package", "package.json"),
+      "the receipt must resolve jazz-rn from the extracted npm tarball",
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
 test("jazz-rn autolinks a New-Architecture relay host without legacy artifacts", async () => {

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import test from "node:test";
 import { createRequire } from "node:module";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { cp, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { parse } from "yaml";
@@ -498,12 +498,15 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
   // hide npm-packaging mistakes. This receipt instead constructs the smallest
   // possible Expo app in a new directory, mounts the tarball that an adopter
   // would receive as its direct dependency, and runs the two prebuild paths.
-  // The scaffold borrows Expo's already-installed dependency graph rather than
-  // running a package-manager install: this keeps a packaging receipt fully
-  // offline and deterministic while still proving that the app resolves
-  // `jazz-rn` from the packed bytes rather than from this workspace.
+  // An isolated npm install consumes the packed tarball in offline mode before
+  // the Expo scaffold receives a copy of that installed package. The package
+  // must therefore declare every direct dependency it needs; it cannot
+  // accidentally reach this workspace's jazz-rn sources. The scaffold itself
+  // supplies only its explicit Expo/React/React-Native peer graph.
   const directory = await mkdtemp(join(tmpdir(), "jazz-rn-fresh-expo-"));
   const packageDirectory = join(directory, "package");
+  const installDirectory = join(directory, "installed-package");
+  const installedNodeModules = join(installDirectory, "node_modules");
   const appDirectory = join(directory, "app");
   const appNodeModules = join(appDirectory, "node_modules");
   const canonicalNodeModules = new URL(
@@ -524,6 +527,37 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
     );
     assert.deepEqual(packed.length, 1, "packing jazz-rn must produce one npm tarball");
     const tarball = join(packageDirectory, packed[0].filename);
+
+    await mkdir(installDirectory, { recursive: true });
+    await writeFile(
+      join(installDirectory, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "jazz-rn-packed-install-receipt",
+          version: "0.0.0",
+          private: true,
+          dependencies: { "jazz-rn": `file:../package/${packed[0].filename}` },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    execFileSync(
+      "npm",
+      ["install", "--offline", "--ignore-scripts", "--omit=peer", "--legacy-peer-deps"],
+      {
+        cwd: installDirectory,
+        stdio: "inherit",
+      },
+    );
+    const packedManifest = JSON.parse(
+      await readFile(join(installedNodeModules, "jazz-rn", "package.json"), "utf8"),
+    );
+    assert.deepEqual(
+      Object.keys(packedManifest.peerDependencies).sort(),
+      ["expo", "react", "react-native"],
+      "the packed relay must declare every host runtime it imports as a peer dependency",
+    );
 
     await mkdir(appDirectory, { recursive: true });
     await writeFile(
@@ -573,8 +607,10 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
       `${JSON.stringify({ extends: "expo/tsconfig.base", include: ["App.tsx"] }, null, 2)}\n`,
     );
     await mkdir(appNodeModules, { recursive: true });
-    execFileSync("tar", ["-xzf", tarball, "-C", packageDirectory]);
-    await symlink(join(packageDirectory, "package"), join(appNodeModules, "jazz-rn"));
+    await cp(join(installedNodeModules, "jazz-rn"), join(appNodeModules, "jazz-rn"), {
+      recursive: true,
+      dereference: true,
+    });
     for (const dependency of ["@types", "expo", "react", "react-native", "typescript"]) {
       await symlink(join(canonicalNodeModules, dependency), join(appNodeModules, dependency));
     }
@@ -592,6 +628,11 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
       bareReactNativeConfig.dependencies["jazz-rn"].platforms.android.packageInstance,
       "new JazzRelayPackage()",
       "a bare React Native host must discover the packed relay package too",
+    );
+    assert.match(
+      bareReactNativeConfig.dependencies["jazz-rn"].platforms.ios.podspecPath,
+      /JazzRn\.podspec$/,
+      "a bare React Native host must discover the packed iOS podspec too",
     );
     for (const platform of ["android", "ios"]) {
       execFileSync(
@@ -616,31 +657,39 @@ test("a freshly installed Expo app prebuilds the packed jazz-rn relay host", asy
     assert.match(iosProperties, /"newArchEnabled": "true"/);
     assert.match(iosPodfile, /use_native_modules!/);
 
-    const androidAutolink = JSON.parse(
-      execFileSync(
-        process.execPath,
-        [
-          "--no-warnings",
-          "--eval",
-          "require('expo/bin/autolinking')",
-          "expo-modules-autolinking",
-          "react-native-config",
-          "--json",
-          "--platform",
-          "android",
-        ],
-        { cwd: appDirectory, encoding: "utf8" },
-      ),
-    );
+    const expoAutolink = (platform) =>
+      JSON.parse(
+        execFileSync(
+          process.execPath,
+          [
+            "--no-warnings",
+            "--eval",
+            "require('expo/bin/autolinking')",
+            "expo-modules-autolinking",
+            "react-native-config",
+            "--json",
+            "--platform",
+            platform,
+          ],
+          { cwd: appDirectory, encoding: "utf8" },
+        ),
+      );
+    const androidAutolink = expoAutolink("android");
+    const iosAutolink = expoAutolink("ios");
     assert.equal(
       androidAutolink.dependencies["jazz-rn"].platforms.android.packageInstance,
       "new JazzRelayPackage()",
       "the packed tarball, not a workspace symlink, must autolink the relay host",
     );
+    assert.match(
+      iosAutolink.dependencies["jazz-rn"].platforms.ios.podspecPath,
+      /JazzRn\.podspec$/,
+      "the packed tarball must autolink the relay iOS podspec too",
+    );
     assert.equal(
       require.resolve("jazz-rn/package.json", { paths: [appDirectory] }),
-      join(packageDirectory, "package", "package.json"),
-      "the receipt must resolve jazz-rn from the extracted npm tarball",
+      join(appNodeModules, "jazz-rn", "package.json"),
+      "the receipt must resolve jazz-rn from the npm-installed packed tarball",
     );
   } finally {
     await rm(directory, { recursive: true, force: true });

--- a/dev/rn-device-acceptance/scripts/boot-android-emulator.test.mjs
+++ b/dev/rn-device-acceptance/scripts/boot-android-emulator.test.mjs
@@ -21,10 +21,10 @@ const withFixture = (name, adbBody, emulatorBody, assertion, options = {}) => {
     // macOS has neither GNU `setsid` nor GNU `timeout`. These deliberately
     // small test doubles exercise the receipt's bounded state machine without
     // claiming to prove Linux process-group cleanup (covered below on Linux).
-    writeFileSync(sessionLauncher, "#!/usr/bin/env bash\nexec \"$@\"\n");
+    writeFileSync(sessionLauncher, '#!/usr/bin/env bash\nexec "$@"\n');
     writeFileSync(
       timeout,
-      "#!/usr/bin/env bash\nduration=${2%s}\nshift 2\nexec perl -e 'alarm shift; exec @ARGV' \"$duration\" \"$@\"\n",
+      '#!/usr/bin/env bash\nduration=${2%s}\nshift 2\nexec perl -e \'alarm shift; exec @ARGV\' "$duration" "$@"\n',
     );
     writeFileSync(config, "avd.id=acceptance\n");
     chmodSync(adb, 0o755);
@@ -57,12 +57,17 @@ const withFixture = (name, adbBody, emulatorBody, assertion, options = {}) => {
 };
 
 test("Android boot receipt fails under its own deadline when adb has no device", () => {
-  withFixture("no-device", '[[ "$1" == get-state ]] && exit 1', 'echo "still starting"; sleep 10', (result) => {
-    assert.equal(result.status, 1);
-    assert.match(result.stderr, /within 1s/);
-    assert.match(result.stderr, /emulator log/);
-    assert.doesNotMatch(result.stderr, /wait-for-device/);
-  });
+  withFixture(
+    "no-device",
+    '[[ "$1" == get-state ]] && exit 1',
+    'echo "still starting"; sleep 10',
+    (result) => {
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /within 1s/);
+      assert.match(result.stderr, /emulator log/);
+      assert.doesNotMatch(result.stderr, /wait-for-device/);
+    },
+  );
 });
 
 test("Android boot receipt caps a long poll interval at its boot deadline", () => {
@@ -81,7 +86,7 @@ test("Android boot receipt caps a long poll interval at its boot deadline", () =
 });
 
 test("Android boot receipt diagnoses an emulator that exits before adb registration", () => {
-  withFixture("early-exit", 'exit 1', 'echo "fatal startup"; exit 17', (result) => {
+  withFixture("early-exit", "exit 1", 'echo "fatal startup"; exit 17', (result) => {
     assert.equal(result.status, 1);
     assert.match(result.stderr, /process exited before boot completed/);
     assert.match(result.stderr, /fatal startup/);
@@ -125,59 +130,71 @@ test("Android boot receipt supports the macOS test launcher without relaxing the
   );
 });
 
-test("Android boot receipt cleans up the complete emulator process group on failure", { skip: process.platform !== "linux" }, () => {
-  const childFile = join(tmpdir(), `jazz-rn-boot-child-${process.pid}-${Date.now()}`);
-  try {
-    withFixture(
-      "child-cleanup",
-      '[[ "$1" == get-state ]] && exit 1',
-      'sleep 10 & echo $! > "$JAZZ_TEST_CHILD_PID"; wait',
-      (result) => assert.equal(result.status, 1),
-      { env: { JAZZ_TEST_CHILD_PID: childFile } },
-    );
-    const childPid = readFileSync(childFile, "utf8").trim();
-    assert.throws(() => process.kill(Number(childPid), 0), { code: "ESRCH" });
-  } finally {
-    rmSync(childFile, { force: true });
-  }
-});
+test(
+  "Android boot receipt cleans up the complete emulator process group on failure",
+  { skip: process.platform !== "linux" },
+  () => {
+    const childFile = join(tmpdir(), `jazz-rn-boot-child-${process.pid}-${Date.now()}`);
+    try {
+      withFixture(
+        "child-cleanup",
+        '[[ "$1" == get-state ]] && exit 1',
+        'sleep 10 & echo $! > "$JAZZ_TEST_CHILD_PID"; wait',
+        (result) => assert.equal(result.status, 1),
+        { env: { JAZZ_TEST_CHILD_PID: childFile } },
+      );
+      const childPid = readFileSync(childFile, "utf8").trim();
+      assert.throws(() => process.kill(Number(childPid), 0), { code: "ESRCH" });
+    } finally {
+      rmSync(childFile, { force: true });
+    }
+  },
+);
 
-test("Android boot receipt removes its emulator process group when cancelled", { skip: process.platform !== "linux" }, async () => {
-  const fixture = mkdtempSync(join(tmpdir(), "jazz-rn-boot-cancel-"));
-  const adb = join(fixture, "adb");
-  const emulator = join(fixture, "emulator");
-  const log = join(fixture, "emulator.log");
-  const config = join(fixture, "config.ini");
-  const childFile = join(fixture, "child.pid");
-  writeFileSync(adb, '#!/usr/bin/env bash\nexit 1\n');
-  writeFileSync(emulator, '#!/usr/bin/env bash\nsleep 30 & echo $! > "$JAZZ_TEST_CHILD_PID"; wait\n');
-  writeFileSync(config, "avd.id=acceptance\n");
-  chmodSync(adb, 0o755);
-  chmodSync(emulator, 0o755);
-  try {
-    const receipt = spawn("bash", [script, "test-avd", log, config], {
-      env: {
-        ...process.env,
-        JAZZ_DEVICE_ADB: adb,
-        JAZZ_DEVICE_EMULATOR: emulator,
-        JAZZ_TEST_CHILD_PID: childFile,
-        JAZZ_ANDROID_BOOT_TIMEOUT_SECONDS: "30",
-        JAZZ_ANDROID_BOOT_POLL_SECONDS: "0.05",
-      },
-    });
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    receipt.kill("SIGTERM");
-    const status = await new Promise((resolve) => receipt.on("close", resolve));
-    assert.equal(status, 143);
-    const childPid = Number(readFileSync(childFile, "utf8").trim());
-    assert.throws(() => process.kill(childPid, 0), { code: "ESRCH" });
-  } finally {
-    rmSync(fixture, { recursive: true, force: true });
-  }
-});
+test(
+  "Android boot receipt removes its emulator process group when cancelled",
+  { skip: process.platform !== "linux" },
+  async () => {
+    const fixture = mkdtempSync(join(tmpdir(), "jazz-rn-boot-cancel-"));
+    const adb = join(fixture, "adb");
+    const emulator = join(fixture, "emulator");
+    const log = join(fixture, "emulator.log");
+    const config = join(fixture, "config.ini");
+    const childFile = join(fixture, "child.pid");
+    writeFileSync(adb, "#!/usr/bin/env bash\nexit 1\n");
+    writeFileSync(
+      emulator,
+      '#!/usr/bin/env bash\nsleep 30 & echo $! > "$JAZZ_TEST_CHILD_PID"; wait\n',
+    );
+    writeFileSync(config, "avd.id=acceptance\n");
+    chmodSync(adb, 0o755);
+    chmodSync(emulator, 0o755);
+    try {
+      const receipt = spawn("bash", [script, "test-avd", log, config], {
+        env: {
+          ...process.env,
+          JAZZ_DEVICE_ADB: adb,
+          JAZZ_DEVICE_EMULATOR: emulator,
+          JAZZ_TEST_CHILD_PID: childFile,
+          JAZZ_ANDROID_BOOT_TIMEOUT_SECONDS: "30",
+          JAZZ_ANDROID_BOOT_POLL_SECONDS: "0.05",
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      receipt.kill("SIGTERM");
+      const status = await new Promise((resolve) => receipt.on("close", resolve));
+      assert.equal(status, 143);
+      const childPid = Number(readFileSync(childFile, "utf8").trim());
+      assert.throws(() => process.kill(childPid, 0), { code: "ESRCH" });
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  },
+);
 
 test("workflow delegates Android boot to the bounded receipt script", () => {
-  const workflow = new URL("../../../.github/workflows/rn-device-acceptance.yml", import.meta.url).pathname;
+  const workflow = new URL("../../../.github/workflows/rn-device-acceptance.yml", import.meta.url)
+    .pathname;
   const text = readFileSync(workflow, "utf8");
   assert.ok(workflow.endsWith("rn-device-acceptance.yml"));
   assert.match(text, /boot-android-emulator\.sh/);


### PR DESCRIPTION
🤖 Prove that an adopter can install the published `jazz-rn` package into a fresh Expo or bare React Native app without workspace-only wiring.

## Before

The repository acceptance app proved native code could build, but it lived inside the monorepo and reused its dependency graph. A missing peer dependency, omitted podspec/config file, or workspace-only source import could therefore pass while an installed npm tarball failed to prebuild or autolink.

## After

The packaging gate now:

1. packs the actual `jazz-rn` npm tarball;
2. installs that tarball into an isolated directory using offline npm resolution;
3. copies only the installed package into a newly generated minimal Expo SDK 54 app;
4. provides only Expo/React/React Native/TypeScript peers;
5. typechecks the package's published declarations;
6. runs clean Android and iOS Expo prebuilds with New Architecture enabled;
7. verifies Expo autolinking on both platforms;
8. verifies bare RN discovers the Android package and iOS podspec;
9. proves resolution comes from the npm-installed tarball, never workspace source.

The install docs describe the direct dependency/config-plugin path, bare RN New Architecture requirement, and why Expo Go cannot work with a custom native module.

## Boundary

This receipt proves installation, code generation, and native discovery. It does not claim that an arbitrary fresh app already contains sealed relay artifacts, trusted admission configuration, or the foreground engine from #2291; those remain explicit runtime requirements.

## Verification

- Packaging gate: 11/11.
- Planted Android package-name corruption fails bare RN discovery.
- Planted missing `react-native` peer metadata fails the packed-manifest assertion.
- A manual current `create-expo-app` scaffold also accepted the packed tarball and completed Android/iOS prebuild plus TypeScript checking.

