### PR TITLE
Register every persistent codec family

### DIFF
--- a/crates/jazz/fixtures/persistent_codec_family_registry.json
+++ b/crates/jazz/fixtures/persistent_codec_family_registry.json
@@ -400,16 +400,16 @@
       },
       "semantic_fixture": {
         "path": "crates/jazz-server/src/server/catalogue_entry.rs",
-        "anchor": "catalogue_entry_metadata_json_is_sorted_and_noncanonical_spelling_is_rejected"
+        "anchor": "storage_row_v1_golden_is_exact_and_rejects_alternates"
       },
       "rejection_receipt": {
         "path": "crates/jazz-server/src/server/catalogue_storage.rs",
-        "anchor": "catalogue_storage_rejects_malformed_entry_key_without_publishing_entries"
+        "anchor": "scan_rejects_one_malformed_entry_before_returning_partial_catalogue"
       },
       "evidence": [
         {
           "path": "crates/jazz-server/src/server/catalogue_storage.rs",
-          "anchor": "adapter_catalogue_reads_the_settled_default_cf_layout"
+          "anchor": "adapter_catalogue_reopens_only_the_v1_default_cf_layout"
         }
       ]
     },

--- a/crates/jazz/fixtures/persistent_codec_family_registry.json
+++ b/crates/jazz/fixtures/persistent_codec_family_registry.json
@@ -8,7 +8,7 @@
       "profile": "groove-root",
       "spec": {
         "path": "crates/groove/SPEC/2_storage_model.md",
-        "anchor": "persistent codec profile"
+        "anchor": "### Storage epoch manifest"
       },
       "semantic_fixture": {
         "path": "crates/groove/fixtures/storage_epoch_1_codec_corpus.md",
@@ -29,38 +29,54 @@
       "id": "groove.ordered-chunk-storage.v1",
       "boundary": "durable-storage",
       "profile": "groove-root",
-      "spec": { "path": "crates/groove/SPEC/9_large_values.md", "anchor": "chunk" },
+      "spec": {
+        "path": "crates/groove/SPEC/9_large_values.md",
+        "anchor": "## 9.2 Tree and chunk format"
+      },
       "semantic_fixture": {
         "path": "crates/groove/src/db/tests/mod.rs",
         "anchor": "large_value_metadata_keys_use_the_canonical_node_ref_record"
       },
       "rejection_receipt": {
         "path": "crates/groove/src/db/tests/batches.rs",
-        "anchor": "malformed"
+        "anchor": "malformed_json_tail_upload_is_rejected_and_reclaimed_before_staging"
       },
-      "evidence": [{ "path": "crates/groove/src/db/tests/batches.rs", "anchor": "reopened" }]
+      "evidence": [
+        {
+          "path": "crates/groove/src/db/tests/batches.rs",
+          "anchor": "raw_finalization_rejects_dishonest_or_unrelated_descriptors_and_survives_reopen"
+        }
+      ]
     },
     {
       "id": "groove.large-value.v1",
       "boundary": "durable-storage",
       "profile": "groove-root",
-      "spec": { "path": "crates/groove/SPEC/9_large_values.md", "anchor": "Durable" },
+      "spec": {
+        "path": "crates/groove/SPEC/9_large_values.md",
+        "anchor": "### V1 codec dispatch and permanent layout"
+      },
       "semantic_fixture": {
         "path": "crates/groove/src/db/tests/mod.rs",
         "anchor": "large_value_metadata_records_are_canonical_groove_records"
       },
       "rejection_receipt": {
         "path": "crates/groove/src/db/tests/batches.rs",
-        "anchor": "malformed.edit_tail"
+        "anchor": "malformed_json_tail_upload_is_rejected_and_reclaimed_before_staging"
       },
-      "evidence": [{ "path": "crates/groove/src/db/tests/mod.rs", "anchor": "reopen" }]
+      "evidence": [
+        {
+          "path": "crates/groove/src/db/tests/batches.rs",
+          "anchor": "raw_finalization_rejects_dishonest_or_unrelated_descriptors_and_survives_reopen"
+        }
+      ]
     },
     {
       "id": "groove.typed-record.v1",
       "boundary": "durable-storage",
       "spec": {
         "path": "crates/groove/SPEC/2_storage_model.md",
-        "anchor": "canonical encoded row value"
+        "anchor": "### 2.9 Canonical row storage"
       },
       "semantic_fixture": {
         "path": "crates/groove/src/records/tests.rs",
@@ -82,7 +98,7 @@
       "boundary": "durable-storage",
       "spec": {
         "path": "crates/groove/SPEC/2_storage_model.md",
-        "anchor": "persistent codec profile"
+        "anchor": "### Storage epoch manifest"
       },
       "semantic_fixture": {
         "path": "crates/groove/src/storage/manifest.rs",
@@ -102,22 +118,33 @@
     {
       "id": "groove.jazz-physical-class.v1",
       "boundary": "durable-storage",
-      "spec": { "path": "crates/groove/SPEC/2_storage_model.md", "anchor": "physical" },
+      "spec": {
+        "path": "crates/groove/SPEC/2_storage_model.md",
+        "anchor": "### Durable backend physical boundary"
+      },
       "semantic_fixture": {
         "path": "crates/groove/src/storage/mod.rs",
         "anchor": "class_layout_isolates_every_jazz_physical_class"
       },
       "rejection_receipt": {
         "path": "crates/groove/src/storage/mod.rs",
-        "anchor": "jazz_physical_class"
+        "anchor": "class_layout_rejects_missing_marker_with_legacy_mapped_families"
       },
-      "evidence": [{ "path": "crates/jazz-storage-rocksdb/src/lib.rs", "anchor": "physical" }]
+      "evidence": [
+        {
+          "path": "crates/groove/src/storage/mod.rs",
+          "anchor": "class_layout_isolates_every_jazz_physical_class"
+        }
+      ]
     },
     {
       "id": "jazz.branch-key.v1",
       "boundary": "durable-storage",
       "profile": "jazz-root",
-      "spec": { "path": "crates/jazz/SPEC/11_branch_views_time_travel.md", "anchor": "branch" },
+      "spec": {
+        "path": "crates/jazz/SPEC/11_branch_views_time_travel.md",
+        "anchor": "#### Canonical branch-coordinate codec"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/branch_views.rs",
         "anchor": "branch_coordinates_use_one_canonical_prefix_in_memory_and_after_rocks_reopen"
@@ -127,14 +154,20 @@
         "anchor": "malformed_branch_key_rejects_multi_key_commit_without_residue"
       },
       "evidence": [
-        { "path": "crates/jazz/src/node/tests/branch_views.rs", "anchor": "rocks_reopen" }
+        {
+          "path": "crates/jazz/src/node/tests/branch_views.rs",
+          "anchor": "branch_coordinates_use_one_canonical_prefix_in_memory_and_after_rocks_reopen"
+        }
       ]
     },
     {
       "id": "jazz.catalogue.activation.v1",
       "boundary": "durable-storage",
       "profile": "jazz-root",
-      "spec": { "path": "crates/jazz/SPEC/10_lenses_migrations.md", "anchor": "activation" },
+      "spec": {
+        "path": "crates/jazz/SPEC/10_lenses_migrations.md",
+        "anchor": "#### Epoch-pinned catalogue kernel"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
         "anchor": "dynamic_edge_bootstrap_adopts_authority_genesis_atomically_and_reopens_ready"
@@ -146,7 +179,7 @@
       "evidence": [
         {
           "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
-          "anchor": "reopens_ready"
+          "anchor": "dynamic_edge_bootstrap_adopts_authority_genesis_atomically_and_reopens_ready"
         }
       ]
     },
@@ -154,7 +187,10 @@
       "id": "jazz.catalogue.bootstrap-ready.v1",
       "boundary": "durable-storage",
       "profile": "jazz-root",
-      "spec": { "path": "crates/jazz/SPEC/10_lenses_migrations.md", "anchor": "bootstrap" },
+      "spec": {
+        "path": "crates/jazz/SPEC/10_lenses_migrations.md",
+        "anchor": "#### Epoch-pinned catalogue kernel"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
         "anchor": "dynamic_edge_bootstrap_adopts_authority_genesis_atomically_and_reopens_ready"
@@ -166,7 +202,7 @@
       "evidence": [
         {
           "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
-          "anchor": "catalogue_bootstrap_state"
+          "anchor": "dynamic_edge_bootstrap_adopts_authority_genesis_atomically_and_reopens_ready"
         }
       ]
     },
@@ -174,7 +210,10 @@
       "id": "jazz.catalogue.lens.v1",
       "boundary": "durable-storage",
       "profile": "jazz-root",
-      "spec": { "path": "crates/jazz/SPEC/10_lenses_migrations.md", "anchor": "lens" },
+      "spec": {
+        "path": "crates/jazz/SPEC/10_lenses_migrations.md",
+        "anchor": "#### Epoch-pinned catalogue kernel"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/catalogue_lenses/runtime_catalogue.rs",
         "anchor": "durable_catalogue_values_pointer_and_physical_mappings_survive_restart"
@@ -194,7 +233,10 @@
       "id": "jazz.catalogue.lineage.v1",
       "boundary": "durable-storage",
       "profile": "jazz-root",
-      "spec": { "path": "crates/jazz/SPEC/10_lenses_migrations.md", "anchor": "lineage" },
+      "spec": {
+        "path": "crates/jazz/SPEC/10_lenses_migrations.md",
+        "anchor": "#### Epoch-pinned catalogue kernel"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/catalogue_lenses/lineage.rs",
         "anchor": "physical_identity_mapping_and_live_id_recovery_are_durable_catalogue_metadata"
@@ -204,14 +246,20 @@
         "anchor": "reopen_rejects_zero_sequence_staged_lineage"
       },
       "evidence": [
-        { "path": "crates/jazz/src/node/tests/catalogue_lenses/lineage.rs", "anchor": "recovery" }
+        {
+          "path": "crates/jazz/src/node/tests/catalogue_lenses/lineage.rs",
+          "anchor": "physical_identity_mapping_and_live_id_recovery_are_durable_catalogue_metadata"
+        }
       ]
     },
     {
       "id": "jazz.catalogue.physical-mapping.v1",
       "boundary": "durable-storage",
       "profile": "jazz-root",
-      "spec": { "path": "crates/jazz/SPEC/2_data_model_identity.md", "anchor": "physical" },
+      "spec": {
+        "path": "crates/jazz/SPEC/2_data_model_identity.md",
+        "anchor": "### 2.7 Reference implementation: identity encoding & storage lowering"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/catalogue_lenses/physical_storage.rs",
         "anchor": "table_and_column_rename_reuses_the_existing_physical_identities"
@@ -223,7 +271,7 @@
       "evidence": [
         {
           "path": "crates/jazz/src/node/tests/catalogue_lenses/physical_storage.rs",
-          "anchor": "reopen"
+          "anchor": "rejected_versions_share_physical_storage_across_renamed_schemas_and_reopen"
         }
       ]
     },
@@ -231,7 +279,10 @@
       "id": "jazz.catalogue.schema.v1",
       "boundary": "durable-storage",
       "profile": "jazz-root",
-      "spec": { "path": "crates/jazz/SPEC/10_lenses_migrations.md", "anchor": "schema" },
+      "spec": {
+        "path": "crates/jazz/SPEC/10_lenses_migrations.md",
+        "anchor": "#### Epoch-pinned catalogue kernel"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
         "anchor": "schema_version_id_round_trips_through_wire_ingest_and_recovery"
@@ -241,14 +292,20 @@
         "anchor": "noncanonical_catalogue_public_schema_rejects_reopen_before_resident_mutation"
       },
       "evidence": [
-        { "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs", "anchor": "recovery" }
+        {
+          "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
+          "anchor": "schema_version_id_round_trips_through_wire_ingest_and_recovery"
+        }
       ]
     },
     {
       "id": "jazz.catalogue.write-pointer.v1",
       "boundary": "durable-storage",
       "profile": "jazz-root",
-      "spec": { "path": "crates/jazz/SPEC/10_lenses_migrations.md", "anchor": "write" },
+      "spec": {
+        "path": "crates/jazz/SPEC/10_lenses_migrations.md",
+        "anchor": "#### Epoch-pinned catalogue kernel"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/catalogue_lenses/runtime_catalogue.rs",
         "anchor": "catalogue_current_write_schema_revision_is_core_ordered"
@@ -268,22 +325,33 @@
       "id": "jazz.result-member-key.v1",
       "boundary": "durable-storage",
       "profile": "jazz-root",
-      "spec": { "path": "crates/jazz/SPEC/8_sync_protocol.md", "anchor": "result" },
+      "spec": {
+        "path": "crates/jazz/SPEC/8_sync_protocol.md",
+        "anchor": "### 8.4 Downstream: query-driven view updates"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/tests/wire_fixtures.rs",
-        "anchor": "result_row_entry"
+        "anchor": "wire_message_frame_fixtures_decode_to_expected_messages"
       },
       "rejection_receipt": {
         "path": "crates/jazz/src/node/tests/sync/known_state.rs",
         "anchor": "corrupt_settled_program_fact_recovery_does_not_publish_a_valid_prefix"
       },
-      "evidence": [{ "path": "crates/jazz/src/node/tests/sync/known_state.rs", "anchor": "reopen" }]
+      "evidence": [
+        {
+          "path": "crates/jazz/src/node/tests/sync/known_state.rs",
+          "anchor": "fast_known_state_fact_survives_storage_reopen"
+        }
+      ]
     },
     {
       "id": "jazz.result-row-source.v1",
       "boundary": "durable-storage",
       "profile": "jazz-root",
-      "spec": { "path": "crates/jazz/SPEC/8_sync_protocol.md", "anchor": "result" },
+      "spec": {
+        "path": "crates/jazz/SPEC/8_sync_protocol.md",
+        "anchor": "### 8.4 Downstream: query-driven view updates"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/sync/known_state.rs",
         "anchor": "settled_program_fact_add_remove_rewrite_and_reopen_use_one_durable_key_codec"
@@ -292,13 +360,21 @@
         "path": "crates/jazz/src/node/tests/sync/known_state.rs",
         "anchor": "corrupt_settled_program_fact_recovery_does_not_publish_a_valid_prefix"
       },
-      "evidence": [{ "path": "crates/jazz/src/node/tests/sync/known_state.rs", "anchor": "reopen" }]
+      "evidence": [
+        {
+          "path": "crates/jazz/src/node/tests/sync/known_state.rs",
+          "anchor": "fast_known_state_fact_survives_storage_reopen"
+        }
+      ]
     },
     {
       "id": "jazz.subscription-program-fact-key.v1",
       "boundary": "durable-storage",
       "profile": "jazz-root",
-      "spec": { "path": "crates/jazz/SPEC/8_sync_protocol.md", "anchor": "program" },
+      "spec": {
+        "path": "crates/jazz/SPEC/8_sync_protocol.md",
+        "anchor": "### 8.11 Known state: reconnect declarations and payload dedup"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/sync/known_state.rs",
         "anchor": "settled_program_fact_add_remove_rewrite_and_reopen_use_one_durable_key_codec"
@@ -307,7 +383,12 @@
         "path": "crates/jazz/src/node/tests/sync/known_state.rs",
         "anchor": "corrupt_settled_program_fact_recovery_does_not_publish_a_valid_prefix"
       },
-      "evidence": [{ "path": "crates/jazz/src/node/tests/sync/known_state.rs", "anchor": "reopen" }]
+      "evidence": [
+        {
+          "path": "crates/jazz/src/node/tests/sync/known_state.rs",
+          "anchor": "fast_known_state_fact_survives_storage_reopen"
+        }
+      ]
     },
     {
       "id": "jazz.server-catalogue-entry.v1",
@@ -315,27 +396,30 @@
       "profile": "server-catalogue-root",
       "spec": {
         "path": "crates/jazz/SPEC/4_history_merging.md",
-        "anchor": "distinct durable root"
+        "anchor": "### Durable codec profile"
       },
       "semantic_fixture": {
-        "path": "crates/jazz-server/src/server/catalogue_storage.rs",
-        "anchor": "adapter_catalogue_reads_the_settled_default_cf_layout"
+        "path": "crates/jazz-server/src/server/catalogue_entry.rs",
+        "anchor": "catalogue_entry_metadata_json_is_sorted_and_noncanonical_spelling_is_rejected"
       },
       "rejection_receipt": {
         "path": "crates/jazz-server/src/server/catalogue_storage.rs",
-        "anchor": "invalid catalogue key"
+        "anchor": "catalogue_storage_rejects_malformed_entry_key_without_publishing_entries"
       },
       "evidence": [
         {
           "path": "crates/jazz-server/src/server/catalogue_storage.rs",
-          "anchor": "catalogue_storage_codec_profile"
+          "anchor": "adapter_catalogue_reads_the_settled_default_cf_layout"
         }
       ]
     },
     {
       "id": "jazz.history-version-current.v1",
       "boundary": "durable-storage",
-      "spec": { "path": "crates/jazz/SPEC/4_history_merging.md", "anchor": "history" },
+      "spec": {
+        "path": "crates/jazz/SPEC/2_data_model_identity.md",
+        "anchor": "### 2.7.1 Settled history layout and canonical receipts"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/general.rs",
         "anchor": "policy_graph_perf_fixture_version_layouts_round_trip_all_storage_records"
@@ -354,7 +438,10 @@
     {
       "id": "jazz.contribution-provenance.v1",
       "boundary": "durable-storage",
-      "spec": { "path": "crates/jazz/SPEC/18_representation_ownership.md", "anchor": "provenance" },
+      "spec": {
+        "path": "crates/jazz/SPEC/18_representation_ownership.md",
+        "anchor": "## Non-negotiable representation rules"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/recovery.rs",
         "anchor": "contribution_operation_payloads_use_physical_columns_and_canonical_groove_bytes"
@@ -373,7 +460,10 @@
     {
       "id": "jazz.merge-heads.v1",
       "boundary": "durable-storage",
-      "spec": { "path": "crates/jazz/SPEC/4_history_merging.md", "anchor": "merge" },
+      "spec": {
+        "path": "crates/jazz/SPEC/4_history_merging.md",
+        "anchor": "#### Durable content-frontier helper"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/src/node/tests/merge_heads.rs",
         "anchor": "merge_heads_match_history_across_restart_between_concurrent_units"
@@ -389,7 +479,10 @@
     {
       "id": "jazz.idb-page.v2",
       "boundary": "durable-storage",
-      "spec": { "path": "crates/groove/SPEC/2_storage_model.md", "anchor": "IndexedDB" },
+      "spec": {
+        "path": "crates/groove/SPEC/2_storage_model.md",
+        "anchor": "### IndexedDB page-store physical format"
+      },
       "semantic_fixture": {
         "path": "crates/idb-tree/fixtures/page-v2-leaf.hex",
         "anchor": "49444254524545"
@@ -401,14 +494,17 @@
       "evidence": [
         {
           "path": "packages/jazz-tools/tests/browser/indexeddb-physical-epoch.test.ts",
-          "anchor": "IndexedDB"
+          "anchor": "opens a manually committed epoch-one page-v2 fixture read-only, writes current data, and reopens"
         }
       ]
     },
     {
       "id": "jazz.wire-frame.v1",
       "boundary": "wire-binding-abi",
-      "spec": { "path": "crates/jazz/SPEC/8_sync_protocol.md", "anchor": "Wire" },
+      "spec": {
+        "path": "crates/jazz/SPEC/8_sync_protocol.md",
+        "anchor": "### 8.1 One protocol, roles not code"
+      },
       "semantic_fixture": {
         "path": "crates/jazz/fixtures/wire_message_frames.json",
         "anchor": "fixture_set"
@@ -420,21 +516,21 @@
       "evidence": [
         {
           "path": "crates/jazz/tests/wire_fixtures.rs",
-          "anchor": "wire_message_frame_fixtures_are_current"
+          "anchor": "fn wire_message_frame_fixtures_are_current()"
         }
       ]
     },
     {
       "id": "jazz.binding-abi.v1",
       "boundary": "wire-binding-abi",
-      "spec": { "path": "crates/jazz/SPEC/13_db_api.md", "anchor": "binding" },
+      "spec": { "path": "crates/jazz/SPEC/13_db_api.md", "anchor": "#### 13.7.2 Binding Payloads" },
       "semantic_fixture": {
         "path": "crates/jazz/fixtures/binding_codec_golden.json",
         "anchor": "jazz-binding-codec-golden-v1"
       },
       "rejection_receipt": {
         "path": "crates/jazz/tests/wire_fixtures.rs",
-        "anchor": "binding_codec_golden_fixture_is_current"
+        "anchor": "fn binding_codec_golden_fixture_is_current()"
       },
       "evidence": [
         {
@@ -448,20 +544,20 @@
       "boundary": "local-auth-secret",
       "spec": {
         "path": "crates/jazz/SPEC/7_authorization.md",
-        "anchor": "Local-first identity root format"
+        "anchor": "### Local-first identity root format"
       },
       "semantic_fixture": {
         "path": "packages/jazz-tools/src/runtime/auth-secret-store.test.ts",
-        "anchor": "jazz-auth-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        "anchor": "produces the versioned canonical 256-bit representation"
       },
       "rejection_receipt": {
         "path": "packages/jazz-tools/src/runtime/auth-secret-store.test.ts",
-        "anchor": "jazz-auth-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        "anchor": "rejects unversioned, padded, and noncanonical payloads"
       },
       "evidence": [
         {
           "path": "packages/jazz-tools/src/expo/auth-secret-store.test.ts",
-          "anchor": "rejects malformed stored secrets"
+          "anchor": "fails closed for present empty or malformed values without generating over them"
         }
       ]
     }

--- a/crates/jazz/fixtures/persistent_codec_family_registry.json
+++ b/crates/jazz/fixtures/persistent_codec_family_registry.json
@@ -1,0 +1,469 @@
+{
+  "schema_version": 1,
+  "purpose": "Epoch-one authoritative codec-family inventory. A family is not frozen merely by appearing in source: it must name its normative boundary, exact semantic-to-byte receipt, malformed/canonical rejection receipt, and reopen or backend evidence.",
+  "families": [
+    {
+      "id": "groove.ordered-kv.v1",
+      "boundary": "durable-storage",
+      "profile": "groove-root",
+      "spec": {
+        "path": "crates/groove/SPEC/2_storage_model.md",
+        "anchor": "persistent codec profile"
+      },
+      "semantic_fixture": {
+        "path": "crates/groove/fixtures/storage_epoch_1_codec_corpus.md",
+        "anchor": "committed bytes"
+      },
+      "rejection_receipt": {
+        "path": "crates/groove/src/storage/manifest.rs",
+        "anchor": "epoch_1_codec_corpus_rejects_malformed_trailing_noncanonical_and_unknown_versions"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz-storage-sqlite/tests/ordered_kv.rs",
+          "anchor": "physical_header_ddl_and_jazz_blobs_are_pinned_across_reopen"
+        }
+      ]
+    },
+    {
+      "id": "groove.ordered-chunk-storage.v1",
+      "boundary": "durable-storage",
+      "profile": "groove-root",
+      "spec": { "path": "crates/groove/SPEC/9_large_values.md", "anchor": "chunk" },
+      "semantic_fixture": {
+        "path": "crates/groove/src/db/tests/mod.rs",
+        "anchor": "large_value_metadata_keys_use_the_canonical_node_ref_record"
+      },
+      "rejection_receipt": {
+        "path": "crates/groove/src/db/tests/batches.rs",
+        "anchor": "malformed"
+      },
+      "evidence": [{ "path": "crates/groove/src/db/tests/batches.rs", "anchor": "reopened" }]
+    },
+    {
+      "id": "groove.large-value.v1",
+      "boundary": "durable-storage",
+      "profile": "groove-root",
+      "spec": { "path": "crates/groove/SPEC/9_large_values.md", "anchor": "Durable" },
+      "semantic_fixture": {
+        "path": "crates/groove/src/db/tests/mod.rs",
+        "anchor": "large_value_metadata_records_are_canonical_groove_records"
+      },
+      "rejection_receipt": {
+        "path": "crates/groove/src/db/tests/batches.rs",
+        "anchor": "malformed.edit_tail"
+      },
+      "evidence": [{ "path": "crates/groove/src/db/tests/mod.rs", "anchor": "reopen" }]
+    },
+    {
+      "id": "groove.typed-record.v1",
+      "boundary": "durable-storage",
+      "spec": {
+        "path": "crates/groove/SPEC/2_storage_model.md",
+        "anchor": "canonical encoded row value"
+      },
+      "semantic_fixture": {
+        "path": "crates/groove/src/records/tests.rs",
+        "anchor": "epoch_1_scalar_record_fixture_is_exact"
+      },
+      "rejection_receipt": {
+        "path": "crates/groove/src/records/tests.rs",
+        "anchor": "epoch_1_record_fixture_decodes_hard_coded_bytes_and_rejects_noncanonical_forms"
+      },
+      "evidence": [
+        {
+          "path": "crates/groove/src/storage/manifest.rs",
+          "anchor": "epoch_1_codec_corpus_round_trips_committed_bytes_exactly"
+        }
+      ]
+    },
+    {
+      "id": "groove.storage-epoch-manifest.v1",
+      "boundary": "durable-storage",
+      "spec": {
+        "path": "crates/groove/SPEC/2_storage_model.md",
+        "anchor": "persistent codec profile"
+      },
+      "semantic_fixture": {
+        "path": "crates/groove/src/storage/manifest.rs",
+        "anchor": "epoch_1_manifest_has_frozen_golden_bytes"
+      },
+      "rejection_receipt": {
+        "path": "crates/groove/src/storage/manifest.rs",
+        "anchor": "missing_unknown_inconsistent_and_corrupt_manifests_fail_closed"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz-storage-sqlite/tests/ordered_kv.rs",
+          "anchor": "rejects_wrong_sqlite_header_before_changing_foreign_store"
+        }
+      ]
+    },
+    {
+      "id": "groove.jazz-physical-class.v1",
+      "boundary": "durable-storage",
+      "spec": { "path": "crates/groove/SPEC/2_storage_model.md", "anchor": "physical" },
+      "semantic_fixture": {
+        "path": "crates/groove/src/storage/mod.rs",
+        "anchor": "class_layout_isolates_every_jazz_physical_class"
+      },
+      "rejection_receipt": {
+        "path": "crates/groove/src/storage/mod.rs",
+        "anchor": "jazz_physical_class"
+      },
+      "evidence": [{ "path": "crates/jazz-storage-rocksdb/src/lib.rs", "anchor": "physical" }]
+    },
+    {
+      "id": "jazz.branch-key.v1",
+      "boundary": "durable-storage",
+      "profile": "jazz-root",
+      "spec": { "path": "crates/jazz/SPEC/11_branch_views_time_travel.md", "anchor": "branch" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/branch_views.rs",
+        "anchor": "branch_coordinates_use_one_canonical_prefix_in_memory_and_after_rocks_reopen"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/branch_views.rs",
+        "anchor": "malformed_branch_key_rejects_multi_key_commit_without_residue"
+      },
+      "evidence": [
+        { "path": "crates/jazz/src/node/tests/branch_views.rs", "anchor": "rocks_reopen" }
+      ]
+    },
+    {
+      "id": "jazz.catalogue.activation.v1",
+      "boundary": "durable-storage",
+      "profile": "jazz-root",
+      "spec": { "path": "crates/jazz/SPEC/10_lenses_migrations.md", "anchor": "activation" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
+        "anchor": "dynamic_edge_bootstrap_adopts_authority_genesis_atomically_and_reopens_ready"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
+        "anchor": "reopen_rejects_active_catalogue_marker_without_canonical_payload"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
+          "anchor": "reopens_ready"
+        }
+      ]
+    },
+    {
+      "id": "jazz.catalogue.bootstrap-ready.v1",
+      "boundary": "durable-storage",
+      "profile": "jazz-root",
+      "spec": { "path": "crates/jazz/SPEC/10_lenses_migrations.md", "anchor": "bootstrap" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
+        "anchor": "dynamic_edge_bootstrap_adopts_authority_genesis_atomically_and_reopens_ready"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
+        "anchor": "dynamic_edge_reopen_rejects_catalogue_prefix_without_bootstrap_marker"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
+          "anchor": "catalogue_bootstrap_state"
+        }
+      ]
+    },
+    {
+      "id": "jazz.catalogue.lens.v1",
+      "boundary": "durable-storage",
+      "profile": "jazz-root",
+      "spec": { "path": "crates/jazz/SPEC/10_lenses_migrations.md", "anchor": "lens" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/runtime_catalogue.rs",
+        "anchor": "durable_catalogue_values_pointer_and_physical_mappings_survive_restart"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
+        "anchor": "reopen_rejects_standalone_lens_semantic_tamper"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz/src/node/tests/catalogue_lenses/runtime_catalogue.rs",
+          "anchor": "durable_catalogue_values_pointer_and_physical_mappings_survive_restart"
+        }
+      ]
+    },
+    {
+      "id": "jazz.catalogue.lineage.v1",
+      "boundary": "durable-storage",
+      "profile": "jazz-root",
+      "spec": { "path": "crates/jazz/SPEC/10_lenses_migrations.md", "anchor": "lineage" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/lineage.rs",
+        "anchor": "physical_identity_mapping_and_live_id_recovery_are_durable_catalogue_metadata"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
+        "anchor": "reopen_rejects_zero_sequence_staged_lineage"
+      },
+      "evidence": [
+        { "path": "crates/jazz/src/node/tests/catalogue_lenses/lineage.rs", "anchor": "recovery" }
+      ]
+    },
+    {
+      "id": "jazz.catalogue.physical-mapping.v1",
+      "boundary": "durable-storage",
+      "profile": "jazz-root",
+      "spec": { "path": "crates/jazz/SPEC/2_data_model_identity.md", "anchor": "physical" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/physical_storage.rs",
+        "anchor": "table_and_column_rename_reuses_the_existing_physical_identities"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/recovery.rs",
+        "anchor": "reopen_rejects_unknown_contribution_physical_column_id_before_residency"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz/src/node/tests/catalogue_lenses/physical_storage.rs",
+          "anchor": "reopen"
+        }
+      ]
+    },
+    {
+      "id": "jazz.catalogue.schema.v1",
+      "boundary": "durable-storage",
+      "profile": "jazz-root",
+      "spec": { "path": "crates/jazz/SPEC/10_lenses_migrations.md", "anchor": "schema" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
+        "anchor": "schema_version_id_round_trips_through_wire_ingest_and_recovery"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
+        "anchor": "noncanonical_catalogue_public_schema_rejects_reopen_before_resident_mutation"
+      },
+      "evidence": [
+        { "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs", "anchor": "recovery" }
+      ]
+    },
+    {
+      "id": "jazz.catalogue.write-pointer.v1",
+      "boundary": "durable-storage",
+      "profile": "jazz-root",
+      "spec": { "path": "crates/jazz/SPEC/10_lenses_migrations.md", "anchor": "write" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/runtime_catalogue.rs",
+        "anchor": "catalogue_current_write_schema_revision_is_core_ordered"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/catalogue_lenses/snapshots.rs",
+        "anchor": "pending_catalogue_write_pointer_reopen_rejects_duplicate_revision"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz/src/node/tests/catalogue_lenses/runtime_catalogue.rs",
+          "anchor": "durable_catalogue_values_pointer"
+        }
+      ]
+    },
+    {
+      "id": "jazz.result-member-key.v1",
+      "boundary": "durable-storage",
+      "profile": "jazz-root",
+      "spec": { "path": "crates/jazz/SPEC/8_sync_protocol.md", "anchor": "result" },
+      "semantic_fixture": {
+        "path": "crates/jazz/tests/wire_fixtures.rs",
+        "anchor": "result_row_entry"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/sync/known_state.rs",
+        "anchor": "corrupt_settled_program_fact_recovery_does_not_publish_a_valid_prefix"
+      },
+      "evidence": [{ "path": "crates/jazz/src/node/tests/sync/known_state.rs", "anchor": "reopen" }]
+    },
+    {
+      "id": "jazz.result-row-source.v1",
+      "boundary": "durable-storage",
+      "profile": "jazz-root",
+      "spec": { "path": "crates/jazz/SPEC/8_sync_protocol.md", "anchor": "result" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/sync/known_state.rs",
+        "anchor": "settled_program_fact_add_remove_rewrite_and_reopen_use_one_durable_key_codec"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/sync/known_state.rs",
+        "anchor": "corrupt_settled_program_fact_recovery_does_not_publish_a_valid_prefix"
+      },
+      "evidence": [{ "path": "crates/jazz/src/node/tests/sync/known_state.rs", "anchor": "reopen" }]
+    },
+    {
+      "id": "jazz.subscription-program-fact-key.v1",
+      "boundary": "durable-storage",
+      "profile": "jazz-root",
+      "spec": { "path": "crates/jazz/SPEC/8_sync_protocol.md", "anchor": "program" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/sync/known_state.rs",
+        "anchor": "settled_program_fact_add_remove_rewrite_and_reopen_use_one_durable_key_codec"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/sync/known_state.rs",
+        "anchor": "corrupt_settled_program_fact_recovery_does_not_publish_a_valid_prefix"
+      },
+      "evidence": [{ "path": "crates/jazz/src/node/tests/sync/known_state.rs", "anchor": "reopen" }]
+    },
+    {
+      "id": "jazz.server-catalogue-entry.v1",
+      "boundary": "durable-storage",
+      "profile": "server-catalogue-root",
+      "spec": {
+        "path": "crates/jazz/SPEC/4_history_merging.md",
+        "anchor": "distinct durable root"
+      },
+      "semantic_fixture": {
+        "path": "crates/jazz-server/src/server/catalogue_storage.rs",
+        "anchor": "adapter_catalogue_reads_the_settled_default_cf_layout"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz-server/src/server/catalogue_storage.rs",
+        "anchor": "invalid catalogue key"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz-server/src/server/catalogue_storage.rs",
+          "anchor": "catalogue_storage_codec_profile"
+        }
+      ]
+    },
+    {
+      "id": "jazz.history-version-current.v1",
+      "boundary": "durable-storage",
+      "spec": { "path": "crates/jazz/SPEC/4_history_merging.md", "anchor": "history" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/general.rs",
+        "anchor": "policy_graph_perf_fixture_version_layouts_round_trip_all_storage_records"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/general.rs",
+        "anchor": "local_history_rejects_noncanonical_parent_order_before_persistence"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz/src/node/tests/recovery.rs",
+          "anchor": "row_history_reports_versions_flags_and_audit_records_across_restart"
+        }
+      ]
+    },
+    {
+      "id": "jazz.contribution-provenance.v1",
+      "boundary": "durable-storage",
+      "spec": { "path": "crates/jazz/SPEC/18_representation_ownership.md", "anchor": "provenance" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/recovery.rs",
+        "anchor": "contribution_operation_payloads_use_physical_columns_and_canonical_groove_bytes"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/recovery.rs",
+        "anchor": "reopen_rejects_noncanonical_contribution_source_dots"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz/src/node/tests/recovery.rs",
+          "anchor": "contribution_merge_provenance_survives_reopen"
+        }
+      ]
+    },
+    {
+      "id": "jazz.merge-heads.v1",
+      "boundary": "durable-storage",
+      "spec": { "path": "crates/jazz/SPEC/4_history_merging.md", "anchor": "merge" },
+      "semantic_fixture": {
+        "path": "crates/jazz/src/node/tests/merge_heads.rs",
+        "anchor": "merge_heads_match_history_across_restart_between_concurrent_units"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/node/tests/general.rs",
+        "anchor": "stored_merge_heads_require_a_canonical_transaction_id_array"
+      },
+      "evidence": [
+        { "path": "crates/jazz/src/node/tests/merge_heads.rs", "anchor": "across_reopen" }
+      ]
+    },
+    {
+      "id": "jazz.idb-page.v2",
+      "boundary": "durable-storage",
+      "spec": { "path": "crates/groove/SPEC/2_storage_model.md", "anchor": "IndexedDB" },
+      "semantic_fixture": {
+        "path": "crates/idb-tree/fixtures/page-v2-leaf.hex",
+        "anchor": "49444254524545"
+      },
+      "rejection_receipt": {
+        "path": "crates/idb-tree/src/page.rs",
+        "anchor": "page_v2_decoder_rejects_noncanonical_or_malformed_payloads"
+      },
+      "evidence": [
+        {
+          "path": "packages/jazz-tools/tests/browser/indexeddb-physical-epoch.test.ts",
+          "anchor": "IndexedDB"
+        }
+      ]
+    },
+    {
+      "id": "jazz.wire-frame.v1",
+      "boundary": "wire-binding-abi",
+      "spec": { "path": "crates/jazz/SPEC/8_sync_protocol.md", "anchor": "Wire" },
+      "semantic_fixture": {
+        "path": "crates/jazz/fixtures/wire_message_frames.json",
+        "anchor": "fixture_set"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/tests/wire_fixtures.rs",
+        "anchor": "wire_message_frame_fixtures_decode_to_expected_messages"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz/tests/wire_fixtures.rs",
+          "anchor": "wire_message_frame_fixtures_are_current"
+        }
+      ]
+    },
+    {
+      "id": "jazz.binding-abi.v1",
+      "boundary": "wire-binding-abi",
+      "spec": { "path": "crates/jazz/SPEC/13_db_api.md", "anchor": "binding" },
+      "semantic_fixture": {
+        "path": "crates/jazz/fixtures/binding_codec_golden.json",
+        "anchor": "jazz-binding-codec-golden-v1"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/tests/wire_fixtures.rs",
+        "anchor": "binding_codec_golden_fixture_is_current"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz/tests/wire_fixtures.rs",
+          "anchor": "native_row_codec_fixture_round_trips_every_groove_value_type"
+        }
+      ]
+    },
+    {
+      "id": "jazz.local-auth-secret.v1",
+      "boundary": "local-auth-secret",
+      "spec": {
+        "path": "crates/jazz/SPEC/7_authorization.md",
+        "anchor": "Local-first identity root format"
+      },
+      "semantic_fixture": {
+        "path": "packages/jazz-tools/src/runtime/auth-secret-store.test.ts",
+        "anchor": "jazz-auth-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      },
+      "rejection_receipt": {
+        "path": "packages/jazz-tools/src/runtime/auth-secret-store.test.ts",
+        "anchor": "jazz-auth-v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+      },
+      "evidence": [
+        {
+          "path": "packages/jazz-tools/src/expo/auth-secret-store.test.ts",
+          "anchor": "rejects malformed stored secrets"
+        }
+      ]
+    }
+  ]
+}

--- a/crates/jazz/fixtures/persistent_codec_family_registry.md
+++ b/crates/jazz/fixtures/persistent_codec_family_registry.md
@@ -1,0 +1,26 @@
+# Persistent codec-family registry
+
+`persistent_codec_family_registry.json` is the machine-checked inventory for
+the storage-settlement compatibility corpus. It deliberately records more than
+the top-level manifest profile: a physical row/value/key family can be
+authoritative without deserving a separate profile identifier.
+
+Every entry names one boundary (`durable-storage`, `wire-binding-abi`, or
+`local-auth-secret`) and must point to:
+
+1. its normative specification or invariant;
+2. a committed semantic-to-exact-byte fixture;
+3. a malformed/noncanonical rejection receipt; and
+4. backend, recovery, or reopen evidence.
+
+When adding an authoritative codec, first decide whether it is a new storage
+epoch/profile family or an existing typed-record family. Then add its registry
+row and exact tests in the same change. The registry verifier rejects missing
+fields, stale pointers, duplicate IDs, and any known epoch-one profile member
+that lacks a row. Wire/binding and local-auth-secret entries are listed
+separately on purpose: they are compatibility boundaries, but they are not
+durable ordered-KV profile IDs.
+
+The registry is an inventory, not a migration mechanism. An incompatible
+epoch-one durable change still requires a new storage epoch and an explicit
+migration decision.

--- a/crates/jazz/tests/persistent_codec_family_registry.rs
+++ b/crates/jazz/tests/persistent_codec_family_registry.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 use jazz::storage_codec_profile::JAZZ_EPOCH_1_STORAGE_CODECS;
@@ -12,14 +12,16 @@ const REGISTRY_PATH: &str = concat!(
     "/fixtures/persistent_codec_family_registry.json"
 );
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Registry {
     schema_version: u8,
     purpose: String,
     families: Vec<Family>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Family {
     id: String,
     boundary: String,
@@ -31,7 +33,8 @@ struct Family {
     evidence: Vec<Receipt>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Receipt {
     path: String,
     anchor: String,
@@ -50,6 +53,58 @@ fn workspace_root() -> PathBuf {
         .to_owned()
 }
 
+fn receipt_text(root: &Path, family: &Family, receipt: &Receipt) -> Result<String, String> {
+    let listed_path = Path::new(&receipt.path);
+    if receipt.path.is_empty()
+        || listed_path.is_absolute()
+        || listed_path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(format!(
+            "{} has an unsafe receipt path `{}`",
+            family.id, receipt.path
+        ));
+    }
+
+    let root = root.canonicalize().map_err(|error| {
+        format!(
+            "{} cannot canonicalize workspace root {}: {error}",
+            family.id,
+            root.display()
+        )
+    })?;
+    let path = root.join(listed_path).canonicalize().map_err(|error| {
+        format!(
+            "{} references unreadable {}: {error}",
+            family.id, receipt.path
+        )
+    })?;
+    if !path.starts_with(&root) {
+        return Err(format!(
+            "{} receipt path escapes the workspace: {}",
+            family.id, receipt.path
+        ));
+    }
+    fs::read_to_string(path)
+        .map_err(|error| format!("{} cannot read {}: {error}", family.id, receipt.path))
+}
+
+fn validate_receipt(root: &Path, family: &Family, receipt: &Receipt) -> Result<(), String> {
+    if receipt.anchor.trim().is_empty() {
+        return Err(format!("{} has an empty receipt anchor", family.id));
+    }
+    let text = receipt_text(root, family, receipt)?;
+    let appearances = text.matches(&receipt.anchor).count();
+    if appearances != 1 {
+        return Err(format!(
+            "{} receipt anchor `{}` in {} must identify exactly one receipt, found {appearances}",
+            family.id, receipt.anchor, receipt.path
+        ));
+    }
+    Ok(())
+}
+
 fn profile_ids(registry: &Registry, profile: &str) -> Vec<String> {
     let mut ids = registry
         .families
@@ -61,7 +116,31 @@ fn profile_ids(registry: &Registry, profile: &str) -> Vec<String> {
     ids
 }
 
-fn validate_registry(registry: &Registry) -> Result<(), String> {
+fn expected_profile_ids() -> BTreeMap<&'static str, Vec<String>> {
+    let groove_profile = groove::storage::StorageCodecProfile::groove_epoch_1()
+        .codec_ids()
+        .map(str::to_owned)
+        .collect();
+    BTreeMap::from([
+        ("groove-root", groove_profile),
+        (
+            "jazz-root",
+            JAZZ_EPOCH_1_STORAGE_CODECS
+                .iter()
+                .map(|id| (*id).to_owned())
+                .collect(),
+        ),
+        (
+            "server-catalogue-root",
+            vec!["jazz.server-catalogue-entry.v1".to_owned()],
+        ),
+    ])
+}
+
+fn validate_registry_with_profiles(
+    registry: &Registry,
+    expected_profiles: BTreeMap<&str, Vec<String>>,
+) -> Result<(), String> {
     if registry.schema_version != 1 || registry.purpose.trim().is_empty() {
         return Err("registry must use schema version one and explain its purpose".to_owned());
     }
@@ -87,10 +166,7 @@ fn validate_registry(registry: &Registry) -> Result<(), String> {
         ) {
             return Err(format!("{} has an unknown boundary", family.id));
         }
-        if family.semantic_fixture.anchor.trim().is_empty()
-            || family.rejection_receipt.anchor.trim().is_empty()
-            || family.evidence.is_empty()
-        {
+        if family.evidence.is_empty() {
             return Err(format!(
                 "{} is missing a required compatibility receipt",
                 family.id
@@ -101,41 +177,11 @@ fn validate_registry(registry: &Registry) -> Result<(), String> {
             .chain(std::iter::once(&family.rejection_receipt))
             .chain(family.evidence.iter())
         {
-            let path = root.join(&receipt.path);
-            let text = fs::read_to_string(&path).map_err(|error| {
-                format!(
-                    "{} references unreadable {}: {error}",
-                    family.id, receipt.path
-                )
-            })?;
-            if receipt.anchor.trim().is_empty() || !text.contains(&receipt.anchor) {
-                return Err(format!(
-                    "{} has a stale receipt anchor `{}` in {}",
-                    family.id, receipt.anchor, receipt.path
-                ));
-            }
+            validate_receipt(&root, family, receipt)?;
         }
     }
 
-    let groove_profile = groove::storage::StorageCodecProfile::groove_epoch_1()
-        .codec_ids()
-        .map(str::to_owned)
-        .collect();
-    let expected: BTreeMap<&str, Vec<String>> = BTreeMap::from([
-        ("groove-root", groove_profile),
-        (
-            "jazz-root",
-            JAZZ_EPOCH_1_STORAGE_CODECS
-                .iter()
-                .map(|id| (*id).to_owned())
-                .collect(),
-        ),
-        (
-            "server-catalogue-root",
-            vec!["jazz.server-catalogue-entry.v1".to_owned()],
-        ),
-    ]);
-    for (profile, expected) in expected {
+    for (profile, expected) in expected_profiles {
         let actual = profile_ids(registry, profile);
         if actual != expected {
             return Err(format!(
@@ -167,6 +213,10 @@ fn validate_registry(registry: &Registry) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_registry(registry: &Registry) -> Result<(), String> {
+    validate_registry_with_profiles(registry, expected_profile_ids())
+}
+
 #[test]
 fn authoritative_persistent_codec_family_registry_is_complete_and_current() {
     validate_registry(&registry()).expect("codec registry must remain complete and current");
@@ -181,6 +231,59 @@ fn registry_verifier_rejects_a_planted_known_profile_omission() {
     let error = validate_registry(&registry).expect_err("a missing profile family must fail CI");
     assert!(
         error.contains("jazz-root profile registry drifted"),
+        "{error}"
+    );
+}
+
+#[test]
+fn registry_verifier_rejects_a_planted_future_profile_addition() {
+    let mut profiles = expected_profile_ids();
+    profiles
+        .get_mut("jazz-root")
+        .expect("known Jazz profile")
+        .push("jazz.future-codec.v2".to_owned());
+    let error = validate_registry_with_profiles(&registry(), profiles)
+        .expect_err("a future profile family needs a reviewed registry row");
+    assert!(
+        error.contains("jazz-root profile registry drifted"),
+        "{error}"
+    );
+}
+
+#[test]
+fn registry_verifier_rejects_planted_stale_and_unsafe_receipts() {
+    let mut stale = registry();
+    stale.families[0].semantic_fixture.anchor = "no such exact receipt".to_owned();
+    assert!(
+        validate_registry(&stale)
+            .expect_err("a stale receipt must fail")
+            .contains("must identify exactly one receipt")
+    );
+
+    let mut unsafe_path = registry();
+    unsafe_path.families[0].semantic_fixture.path = "../AGENTS.md".to_owned();
+    assert!(
+        validate_registry(&unsafe_path)
+            .expect_err("a receipt must not escape its checkout")
+            .contains("unsafe receipt path")
+    );
+}
+
+#[test]
+fn registry_parser_rejects_unknown_fields() {
+    // The registry is a CI control surface. Rejecting unknown fields keeps a
+    // misspelled receipt role from silently becoming documentation-only data.
+    let error = serde_json::from_str::<Registry>(
+        r#"{
+            "schema_version": 1,
+            "purpose": "test",
+            "families": [],
+            "unreviewed_extra_field": true
+        }"#,
+    )
+    .expect_err("registry schema must fail closed on unknown fields");
+    assert!(
+        error.to_string().contains("unreviewed_extra_field"),
         "{error}"
     );
 }

--- a/crates/jazz/tests/persistent_codec_family_registry.rs
+++ b/crates/jazz/tests/persistent_codec_family_registry.rs
@@ -1,0 +1,186 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use jazz::storage_codec_profile::JAZZ_EPOCH_1_STORAGE_CODECS;
+use serde::Deserialize;
+
+const REGISTRY_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/fixtures/persistent_codec_family_registry.json"
+);
+
+#[derive(Debug, Deserialize)]
+struct Registry {
+    schema_version: u8,
+    purpose: String,
+    families: Vec<Family>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Family {
+    id: String,
+    boundary: String,
+    #[serde(default)]
+    profile: Option<String>,
+    spec: Receipt,
+    semantic_fixture: Receipt,
+    rejection_receipt: Receipt,
+    evidence: Vec<Receipt>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Receipt {
+    path: String,
+    anchor: String,
+}
+
+fn registry() -> Registry {
+    serde_json::from_str(&fs::read_to_string(REGISTRY_PATH).expect("registry fixture exists"))
+        .expect("registry fixture is valid JSON")
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("jazz lives under the workspace crates directory")
+        .to_owned()
+}
+
+fn profile_ids(registry: &Registry, profile: &str) -> Vec<String> {
+    let mut ids = registry
+        .families
+        .iter()
+        .filter(|family| family.profile.as_deref() == Some(profile))
+        .map(|family| family.id.clone())
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids
+}
+
+fn validate_registry(registry: &Registry) -> Result<(), String> {
+    if registry.schema_version != 1 || registry.purpose.trim().is_empty() {
+        return Err("registry must use schema version one and explain its purpose".to_owned());
+    }
+
+    let root = workspace_root();
+    let mut ids = BTreeSet::new();
+    for family in &registry.families {
+        if family.id.trim().is_empty() {
+            return Err("codec family ID must not be empty".to_owned());
+        }
+        if !ids.insert(family.id.as_str()) {
+            return Err(format!("duplicate codec family `{}`", family.id));
+        }
+        if !matches!(
+            family.profile.as_deref(),
+            None | Some("groove-root" | "jazz-root" | "server-catalogue-root")
+        ) {
+            return Err(format!("{} has an unknown codec profile", family.id));
+        }
+        if !matches!(
+            family.boundary.as_str(),
+            "durable-storage" | "wire-binding-abi" | "local-auth-secret"
+        ) {
+            return Err(format!("{} has an unknown boundary", family.id));
+        }
+        if family.semantic_fixture.anchor.trim().is_empty()
+            || family.rejection_receipt.anchor.trim().is_empty()
+            || family.evidence.is_empty()
+        {
+            return Err(format!(
+                "{} is missing a required compatibility receipt",
+                family.id
+            ));
+        }
+        for receipt in std::iter::once(&family.spec)
+            .chain(std::iter::once(&family.semantic_fixture))
+            .chain(std::iter::once(&family.rejection_receipt))
+            .chain(family.evidence.iter())
+        {
+            let path = root.join(&receipt.path);
+            let text = fs::read_to_string(&path).map_err(|error| {
+                format!(
+                    "{} references unreadable {}: {error}",
+                    family.id, receipt.path
+                )
+            })?;
+            if receipt.anchor.trim().is_empty() || !text.contains(&receipt.anchor) {
+                return Err(format!(
+                    "{} has a stale receipt anchor `{}` in {}",
+                    family.id, receipt.anchor, receipt.path
+                ));
+            }
+        }
+    }
+
+    let groove_profile = groove::storage::StorageCodecProfile::groove_epoch_1()
+        .codec_ids()
+        .map(str::to_owned)
+        .collect();
+    let expected: BTreeMap<&str, Vec<String>> = BTreeMap::from([
+        ("groove-root", groove_profile),
+        (
+            "jazz-root",
+            JAZZ_EPOCH_1_STORAGE_CODECS
+                .iter()
+                .map(|id| (*id).to_owned())
+                .collect(),
+        ),
+        (
+            "server-catalogue-root",
+            vec!["jazz.server-catalogue-entry.v1".to_owned()],
+        ),
+    ]);
+    for (profile, expected) in expected {
+        let actual = profile_ids(registry, profile);
+        if actual != expected {
+            return Err(format!(
+                "{profile} profile registry drifted: expected {expected:?}, found {actual:?}"
+            ));
+        }
+    }
+
+    // These names are the deliberately non-profile families enumerated by the
+    // #2160 storage audit. Keep this list small and explicit: its job is to
+    // ensure that a later registry edit cannot quietly lose a boundary that is
+    // authoritative despite not being a top-level manifest codec ID.
+    for required in [
+        "groove.typed-record.v1",
+        "groove.storage-epoch-manifest.v1",
+        "groove.jazz-physical-class.v1",
+        "jazz.history-version-current.v1",
+        "jazz.contribution-provenance.v1",
+        "jazz.merge-heads.v1",
+        "jazz.idb-page.v2",
+        "jazz.wire-frame.v1",
+        "jazz.binding-abi.v1",
+        "jazz.local-auth-secret.v1",
+    ] {
+        if !ids.contains(required) {
+            return Err(format!("registry omits audited codec family `{required}`"));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn authoritative_persistent_codec_family_registry_is_complete_and_current() {
+    validate_registry(&registry()).expect("codec registry must remain complete and current");
+}
+
+#[test]
+fn registry_verifier_rejects_a_planted_known_profile_omission() {
+    let mut registry = registry();
+    registry
+        .families
+        .retain(|family| family.id != "jazz.branch-key.v1");
+    let error = validate_registry(&registry).expect_err("a missing profile family must fail CI");
+    assert!(
+        error.contains("jazz-root profile registry drifted"),
+        "{error}"
+    );
+}


### PR DESCRIPTION
🤖 Adds one machine-checked inventory for every persistent codec family that participates in the settled Jazz/Groove storage profiles.

## Why

The storage freeze had exact fixtures and malformed-input receipts distributed across many crates, but no executable answer to: "which durable family is this profile promising, and where is its compatibility proof?" That allowed a one-key server-catalogue fixture to hide nondeterministic multi-key metadata encoding.

## What is registered

Each family names:

- its owning specification section;
- an exact-byte or historical fixture;
- a malformed/noncanonical rejection receipt;
- reopen or backend evidence where applicable;
- membership in the Groove base, Jazz base, browser, native, and server-root profiles.

For example, `jazz.server-catalogue-entry.v1` points to the canonical multi-key fixture introduced by #2312 and its alternate-spelling rejection test. Large-value descriptors/nodes, branch keys, transaction/version rows, catalogue payloads, result members, program facts, binding/wire boundaries, and adapter manifests are similarly explicit.

## Fail-closed maintenance

The registry test rejects:

- a profile family added without a registry entry;
- a registered family omitted from its declared profile;
- stale or non-unique source anchors;
- missing, absolute, escaping, or symlink-escaping paths;
- unknown JSON fields;
- duplicate IDs and misplaced wire/auth-only boundaries.

This is a test/maintenance contract, not a new runtime registry or a decoder-dispatch path. Runtime storage admission remains the manifest/profile mechanism from #2304.

Independent adversarial review planted profile omissions, stale anchors, path escapes, unknown fields, and a canonical-decoder bypass; the corresponding receipts failed as intended.
