### PR TITLE
fix(inspector): attach with the host's verified session

### DIFF
--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # The test-ts runner has 16 CPUs. Turbo gets at most two test tasks, while the
-# jazz-tools browser suite caps Vitest at four file workers so Chromium retains
-# scheduling headroom; both reuse the artifact build completed before this
-# script starts.
+# browser lane runs the Jazz Tools and inspector suites in parallel. Jazz Tools
+# caps Vitest at four file workers so Chromium retains scheduling headroom; all
+# suites reuse the artifact build completed before this script starts.
 set -u
 
 # The runner accepts small command overrides solely so its process-management
@@ -21,7 +21,7 @@ if [[ "${JAZZ_REQUIRE_CI_TEST_COMMANDS:-0}" == "1" ]]; then
 fi
 
 node_tests_command=${JAZZ_NODE_TEST_COMMAND:-"pnpm test --filter=!moon-lander-react --filter=!@jazz/rust --filter=!auth-simple-chat --filter=!auth-workos-chat --filter=!auth-betterauth-chat --filter=!chat-react --filter=!world-tour --filter=!jazz-rn --concurrency=2"}
-browser_tests_command=${JAZZ_BROWSER_TEST_COMMAND:-"pnpm --filter jazz-tools test:browser"}
+browser_tests_command=${JAZZ_BROWSER_TEST_COMMAND:-"pnpm --parallel --filter jazz-tools --filter inspector test:browser"}
 node_tests_pid=""
 browser_tests_pid=""
 log_dir=${RUNNER_TEMP:-/tmp}

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1415,6 +1415,10 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   assert.match(runner, /public export surface is incomplete/);
   assert.match(runner, /Test children only\s+# consume those immutable artifacts/);
   assert.match(runner, /--concurrency=2/);
+  assert.match(
+    runner,
+    /browser_tests_command=.*pnpm --parallel --filter jazz-tools --filter inspector test:browser/,
+  );
   assert.match(runner, /setsid bash -c "\$\{node_tests_command\}" >"\$\{node_tests_log\}" 2>&1 &/);
   assert.match(
     runner,

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -2,20 +2,13 @@ import { useState } from "react";
 import { useDb, useAll, useSession } from "jazz-tools/react";
 import { toast } from "sonner";
 import { app } from "../schema.js";
+import { WriteResult } from "jazz-tools";
 
-type LocalDurabilityHandle = {
-  wait(options: { tier: "local" }): Promise<unknown>;
-};
-
-type MaybeAsyncWrite = LocalDurabilityHandle | Promise<LocalDurabilityHandle>;
-
-function notifyLocalWriteDurable(write: MaybeAsyncWrite) {
-  void Promise.resolve(write)
-    .then((handle) => handle.wait({ tier: "local" }))
+function notifyLocalWriteDurable(write: WriteResult<unknown>) {
+  void write
+    .wait({ tier: "local" })
     .then(() => window.dispatchEvent(new CustomEvent("todo-app:local-write-durable")))
-    .catch(() => {
-      toast.error("Could not save this task locally");
-    });
+    .catch(() => toast.error("Could not save this task locally"));
 }
 
 export function TodoList() {

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -584,6 +584,22 @@ describe("TableDataGrid", () => {
     expect(screen.queryByText("server pushed update")).toBeNull();
   });
 
+  it("keeps an active inline editor open when the current row live-updates", async () => {
+    const { rerender } = renderGrid();
+
+    fireEvent.doubleClick(screen.getByRole("gridcell", { name: "zeta" }));
+    fireEvent.change(screen.getByLabelText("Edit title"), {
+      target: { value: "local draft" },
+    });
+
+    currentRows = [{ ...currentRows[0], title: "server pushed update" }, currentRows[1]!];
+    rerender(renderGridUi());
+
+    await waitFor(() => {
+      expect((screen.getByLabelText("Edit title") as HTMLInputElement).value).toBe("local draft");
+    });
+  });
+
   it("sets nullable columns to NULL from the inline editor action", async () => {
     renderGrid();
 

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -258,6 +258,21 @@ describe("TableDataGrid", () => {
     expect((screen.getByLabelText("Rows per page") as HTMLSelectElement).value).toBe("25");
   });
 
+  it("shows subscription errors instead of presenting them as an empty table", () => {
+    mockUseAll.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("worker query failed"),
+    });
+
+    renderGrid();
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Could not load rows: worker query failed",
+    );
+    expect(screen.queryByText("No rows")).toBeNull();
+  });
+
   it("can show creator and updater columns", () => {
     renderGrid();
 

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -2196,6 +2196,12 @@ function PlainTableView({
           schemaColumn && isEditable
             ? (props) => <QueuedCellEditor {...props} schemaColumn={schemaColumn} />
             : undefined,
+        // Live query delivery and row-change animations can replace an otherwise
+        // unchanged row object. Queued editors own their draft until commit, so
+        // those external identity changes must not close the editor.
+        editorOptions: {
+          closeOnExternalRowChange: false,
+        },
       };
     });
 

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -919,6 +919,7 @@ export function TableDataGrid() {
   const queryResult = useAll<DynamicTableRow>(queryBuilder, queryOptions);
   // show a grid skeleton while the first result is in flight.
   const isInitialLoading = queryResult.isLoading;
+  const queryError = queryResult.error;
   const rows = queryResult.data ?? EMPTY_ROWS;
 
   const allGridColumns = useMemo<GridColumn[]>(
@@ -1270,7 +1271,11 @@ export function TableDataGrid() {
       />
       <div className={styles.contentArea}>
         <div className={styles.gridFrame}>
-          {isInitialLoading ? (
+          {queryError ? (
+            <div className={styles.emptyState} role="alert">
+              Could not load rows: {queryError.message}
+            </div>
+          ) : isInitialLoading ? (
             <GridSkeleton />
           ) : (
             <PlainTableView

--- a/packages/inspector/src/inspector-app.tsx
+++ b/packages/inspector/src/inspector-app.tsx
@@ -146,7 +146,7 @@ export function InspectorApp() {
             ...hostConfig,
             appId: context.appId,
             driver: { type: "persistent", dbName: context.dbName },
-            runtimeSources: { browserWorkerPort },
+            runtimeSources: { ...hostConfig.runtimeSources, browserWorkerPort },
           },
           schema: context.schema,
         });

--- a/packages/inspector/tests/browser/overlay-host.tsx
+++ b/packages/inspector/tests/browser/overlay-host.tsx
@@ -22,10 +22,11 @@ function HostInner({ secondaryReady }: { secondaryReady: boolean }) {
   const { db } = useJazzClient();
   // A real query: creates the host client (so getRuntimeSchema resolves) and
   // registers a public subscription the overlay's Subscriptions tab should display.
-  const { data: todos = [] } = useAll(app.todos.where({ title: "First seeded todo" }).limit(1), {
-    tier: "edge",
-  });
-  const primaryReady = todos.some((todo) => todo.title === "First seeded todo");
+  const { data: readinessTodos = [] } = useAll(
+    app.todos.where({ title: { in: ["First seeded todo", "Second seeded todo"] } }).limit(2),
+    { tier: "edge" },
+  );
+  const primaryReady = readinessTodos.some((todo) => todo.title === "First seeded todo");
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {

--- a/packages/inspector/tests/browser/overlay-host.tsx
+++ b/packages/inspector/tests/browser/overlay-host.tsx
@@ -22,18 +22,22 @@ function HostInner({ secondaryReady }: { secondaryReady: boolean }) {
   const { db } = useJazzClient();
   // A real query: creates the host client (so getRuntimeSchema resolves) and
   // registers a public subscription the overlay's Subscriptions tab should display.
-  useAll(app.todos);
+  const { data: todos = [] } = useAll(app.todos.where({ title: "First seeded todo" }).limit(1), {
+    tier: "edge",
+  });
+  const primaryReady = todos.some((todo) => todo.title === "First seeded todo");
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
-    if (!secondaryReady) return;
+    if (!secondaryReady || !primaryReady) return;
     const iframeWindow = iframeRef.current?.contentWindow;
     if (!iframeWindow) return;
     // The real host-side installer: publishes the handle + pushes subscriptions.
     return installInspectorHost(db, iframeWindow, window.location.origin);
-  }, [db, secondaryReady]);
+  }, [db, primaryReady, secondaryReady]);
 
   if (!secondaryReady) return <p id="host-status">Starting secondary runtime...</p>;
+  if (!primaryReady) return <p id="host-status">Loading primary runtime data...</p>;
 
   return (
     <>
@@ -89,6 +93,7 @@ function HostApp() {
           appId: APP_ID,
           env: TEST_ENV,
           cookieSession: {
+            issuer: "https://inspector.test",
             user_id: "inspector-secondary-user",
             claims: { role: "inspector-test" },
             authMode: "external",

--- a/packages/inspector/tests/browser/overlay.spec.ts
+++ b/packages/inspector/tests/browser/overlay.spec.ts
@@ -139,14 +139,46 @@ test.describe("inspector overlay (embedded, shared runtime peer end-to-end)", ()
     await inspector.getByRole("link", { name: "View todos data" }).click();
     await expect(inspector.getByText("First seeded todo")).toBeVisible({ timeout: 30_000 });
 
-    await runtimeSelect.selectOption(secondaryContextValue!);
-    await expect(inspector.getByRole("link", { name: "Data Explorer" })).toBeVisible({
+    // The attached inspector peer must be admitted as the host's verified
+    // local-first session for writes as well as reads. Leave the host's
+    // readiness row intact while the inspector reconstructs its attachment.
+    const writableRowTitle = "Second seeded todo";
+    const writableRow = inspector.locator('[role="row"]').filter({
+      has: inspector.getByRole("gridcell", { name: writableRowTitle, exact: true }),
+    });
+    const doneToggle = writableRow.getByRole("checkbox");
+    const wasDone = await doneToggle.isChecked();
+    await doneToggle.click();
+    await expect(inspector.getByRole("status")).toContainText("Queued");
+    await inspector.getByRole("button", { name: "Save changes" }).click();
+    await expect(inspector.getByRole("button", { name: "Save changes" })).toHaveCount(0);
+
+    // Reload only the inspector frame. The host remains live, while the
+    // overlay must reconstruct its own peer and read the locally committed
+    // write back through that fresh attachment.
+    await page.locator('iframe[title="jazz-inspector"]').evaluate((iframe) => {
+      iframe.contentWindow?.location.reload();
+    });
+    const reloadedInspector = page.frameLocator('iframe[title="jazz-inspector"]');
+    await expect(reloadedInspector.getByRole("link", { name: "Data Explorer" })).toBeVisible({
+      timeout: 30_000,
+    });
+    await reloadedInspector.getByRole("link", { name: "View todos data" }).click();
+    const reloadedWritableRow = reloadedInspector.locator('[role="row"]').filter({
+      has: reloadedInspector.getByRole("gridcell", { name: writableRowTitle, exact: true }),
+    });
+    await expect(reloadedWritableRow.getByRole("checkbox")).toHaveJSProperty("checked", !wasDone, {
+      timeout: 30_000,
+    });
+
+    await reloadedInspector.getByLabel("Runtime context").selectOption(secondaryContextValue!);
+    await expect(reloadedInspector.getByRole("link", { name: "Data Explorer" })).toBeVisible({
       timeout: 10_000,
     });
 
     // The host's `useAll(app.todos)` subscription is pushed to the Subscriptions tab.
-    await inspector.getByRole("link", { name: "Subscriptions" }).click();
-    await expect(inspector.getByRole("cell", { name: "todos", exact: true })).toBeVisible({
+    await reloadedInspector.getByRole("link", { name: "Subscriptions" }).click();
+    await expect(reloadedInspector.getByRole("cell", { name: "todos", exact: true })).toBeVisible({
       timeout: 30_000,
     });
     expect(browserErrors).toEqual([]);

--- a/packages/inspector/tests/browser/schema.ts
+++ b/packages/inspector/tests/browser/schema.ts
@@ -14,6 +14,6 @@ export const app: App<AppSchema> = defineApp(schema);
 export const permissions = definePermissions(app, ({ policy }) => {
   policy.todos.allowRead.where({});
   policy.todos.allowInsert.never();
-  policy.todos.allowUpdate.never();
+  policy.todos.allowUpdate.where({});
   policy.todos.allowDelete.never();
 });

--- a/packages/jazz-tools/src/dev/inspector-overlay/host-bridge.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/host-bridge.ts
@@ -8,13 +8,17 @@ import {
   type JazzInspectorHost,
 } from "./inspector-host-types.js";
 import { openAggregatedBrowserInspectorControlPort } from "./browser-control-registry.js";
+import { getDbInternalSession } from "../../runtime/db-internal-session.js";
 
 /**
  * Build the ready-to-use browser config in the host bundle, where the host's
  * resolved storage coordinates and worker URL are known. The overlay passes it
  * to its provider verbatim instead of duplicating those resolution rules.
  */
-function buildOverlayDbConfig(config: DbConfig): DbConfig {
+function buildOverlayDbConfig(
+  config: DbConfig,
+  session: ReturnType<typeof getDbInternalSession>,
+): DbConfig {
   const identityCredential = config.jwtToken
     ? { jwtToken: config.jwtToken }
     : config.secret
@@ -32,6 +36,7 @@ function buildOverlayDbConfig(config: DbConfig): DbConfig {
     // `persistent` selects the SharedWorker connection so this client joins
     // the host's IndexedDB-backed runtime. Its main-thread Db remains in-memory.
     driver: { type: "persistent", dbName: resolveDefaultPersistentDbName(config) },
+    ...(session ? { runtimeSources: { browserWorkerSession: structuredClone(session) } } : {}),
   };
 }
 
@@ -50,7 +55,7 @@ export function installInspectorHost(
 
   const handle: JazzInspectorHost = {
     getConnectionConfig() {
-      return buildOverlayDbConfig(db.getConfig());
+      return buildOverlayDbConfig(db.getConfig(), getDbInternalSession(db));
     },
     openControlPort() {
       return openAggregatedBrowserInspectorControlPort(() => db.openInspectorControlPort());

--- a/packages/jazz-tools/src/runtime/context.ts
+++ b/packages/jazz-tools/src/runtime/context.ts
@@ -44,6 +44,14 @@ export interface RuntimeSourcesConfig {
 
   /** @internal Pre-attached worker peer used by the same-origin inspector. */
   browserWorkerPort?: MessagePort;
+
+  /**
+   * @internal Verified identity forwarded by the same-origin inspector host.
+   *
+   * This is only admitted together with `browserWorkerPort`; the native runtime
+   * still verifies reserved-issuer JWT proofs before opening the local peer.
+   */
+  browserWorkerSession?: Session;
 }
 
 /**

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -38,7 +38,10 @@ import {
   type StreamingValueSource,
 } from "./client.js";
 import { type RuntimeSource, type RuntimeTokenOptions } from "./runtime-source.js";
-import { DefaultRuntimeSource } from "./default-runtime-source.js";
+import {
+  DefaultRuntimeSource,
+  trustAttachedBrowserWorkerSession,
+} from "./default-runtime-source.js";
 import type { AuthFailureReason } from "./auth-state.js";
 import { translateQuery } from "./query-adapter.js";
 import { transformRow, transformRows } from "./row-transformer.js";
@@ -1707,8 +1710,11 @@ export class Db {
   getConfig(): DbConfig {
     // Return a copy without internal live transport handles. MessagePorts are
     // neither configuration nor cloneable unless transferred.
-    const { browserWorkerPort: _browserWorkerPort, ...runtimeSources } =
-      this.config.runtimeSources ?? {};
+    const {
+      browserWorkerPort: _browserWorkerPort,
+      browserWorkerSession: _browserWorkerSession,
+      ...runtimeSources
+    } = this.config.runtimeSources ?? {};
     return structuredClone({
       ...this.config,
       runtimeSources: Object.keys(runtimeSources).length > 0 ? runtimeSources : undefined,
@@ -2784,6 +2790,8 @@ export async function createDbWithRuntimeSource<RuntimeConfig extends DbConfig>(
     resolvedConfig = { ...configWithoutAuth, jwtToken };
     setTrustedReservedSession(resolvedConfig, trustedReservedSession);
   }
+
+  trustAttachedBrowserWorkerSession(resolvedConfig);
 
   const driver = resolveStorageDriver(resolvedConfig.driver);
   const db =

--- a/packages/jazz-tools/src/runtime/default-runtime-source.test.ts
+++ b/packages/jazz-tools/src/runtime/default-runtime-source.test.ts
@@ -115,6 +115,27 @@ describe("trustAttachedBrowserWorkerSession", () => {
     );
   });
 
+  it("takes attached claims from the identity token, not the forwarded session object", () => {
+    const config = attachedConfig({
+      runtimeSources: {
+        browserWorkerPort: {} as MessagePort,
+        browserWorkerSession: {
+          ...session,
+          claims: { role: "forged" },
+        },
+      },
+    });
+
+    trustAttachedBrowserWorkerSession(config);
+
+    expect(getTrustedReservedSession(config)).toMatchObject({
+      issuer: LOCAL_FIRST_JWT_ISSUER,
+      user_id: "alice",
+      authMode: "local-first",
+      claims: { role: "writer" },
+    });
+  });
+
   it("does not trust forwarded session data without an attached worker port", () => {
     const config = attachedConfig({ runtimeSources: { browserWorkerSession: session } });
     trustAttachedBrowserWorkerSession(config);

--- a/packages/jazz-tools/src/runtime/default-runtime-source.test.ts
+++ b/packages/jazz-tools/src/runtime/default-runtime-source.test.ts
@@ -6,7 +6,18 @@ import {
   markTrustedReservedSession,
   internalSessionFromVerifiedReservedJwtPayload,
 } from "./client-session.js";
-import { selfSignedClientProofFromConfig } from "./default-runtime-source.js";
+import {
+  selfSignedClientProofFromConfig,
+  trustAttachedBrowserWorkerSession,
+} from "./default-runtime-source.js";
+import { getTrustedReservedSession } from "./db-internal-session.js";
+import type { DbConfig } from "./db.js";
+
+function unsignedJwt(payload: Record<string, unknown>): string {
+  const encode = (value: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "EdDSA", typ: "JWT" })}.${encode(payload)}.test-signature`;
+}
 
 describe("selfSignedClientProofFromConfig", () => {
   it("binds local-first and anonymous runtime opens to their signed author", () => {
@@ -55,5 +66,59 @@ describe("selfSignedClientProofFromConfig", () => {
         },
       ),
     ).toBeUndefined();
+  });
+});
+
+describe("trustAttachedBrowserWorkerSession", () => {
+  const session = {
+    issuer: LOCAL_FIRST_JWT_ISSUER,
+    user_id: "alice",
+    claims: { role: "writer" },
+    authMode: "local-first" as const,
+  };
+
+  function attachedConfig(
+    overrides: { runtimeSources?: DbConfig["runtimeSources"] } = {},
+  ): DbConfig {
+    return {
+      appId: "proof-app",
+      jwtToken: unsignedJwt({
+        iss: LOCAL_FIRST_JWT_ISSUER,
+        sub: "alice",
+        claims: { role: "writer" },
+      }),
+      runtimeSources: {
+        browserWorkerPort: {} as MessagePort,
+        browserWorkerSession: session,
+      },
+      ...overrides,
+    };
+  }
+
+  it("carries a matching reserved session across an attached worker boundary", () => {
+    const config = attachedConfig();
+    trustAttachedBrowserWorkerSession(config);
+
+    expect(getTrustedReservedSession(config)).toEqual(session);
+  });
+
+  it("rejects a host session that does not match the attached identity token", () => {
+    const config = attachedConfig({
+      runtimeSources: {
+        browserWorkerPort: {} as MessagePort,
+        browserWorkerSession: { ...session, user_id: "mallory" },
+      },
+    });
+
+    expect(() => trustAttachedBrowserWorkerSession(config)).toThrow(
+      "Attached browser worker session does not match its identity token",
+    );
+  });
+
+  it("does not trust forwarded session data without an attached worker port", () => {
+    const config = attachedConfig({ runtimeSources: { browserWorkerSession: session } });
+    trustAttachedBrowserWorkerSession(config);
+
+    expect(getTrustedReservedSession(config)).toBeUndefined();
   });
 });

--- a/packages/jazz-tools/src/runtime/default-runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/default-runtime-source.ts
@@ -25,7 +25,9 @@ import { MessagePortBrowserFollowerConnection } from "./native-runtime/browser-f
 import { installWasmTelemetry } from "./sync-telemetry.js";
 import {
   ANONYMOUS_JWT_ISSUER,
+  internalSessionFromVerifiedReservedJwtPayload,
   LOCAL_FIRST_JWT_ISSUER,
+  parseJwtPayload,
   resolveClientInternalSessionSync,
 } from "./client-session.js";
 import type { WasmSchema } from "../drivers/types.js";
@@ -71,6 +73,41 @@ function sessionFromConfig(config: DbConfig) {
     ...config,
     trustedReservedSession: getTrustedReservedSession(config),
   });
+}
+
+/**
+ * Admit the identity carried by a same-origin inspector attachment.
+ *
+ * The session is used only to bind the main-thread peer to the host worker's
+ * identity. Reserved-issuer tokens remain fail-closed: the native constructor
+ * verifies the self-signed proof and audience before this peer can open.
+ */
+export function trustAttachedBrowserWorkerSession(config: DbConfig): void {
+  const attachedSession = config.runtimeSources?.browserWorkerSession;
+  if (!config.runtimeSources?.browserWorkerPort || !attachedSession) return;
+
+  const payload = parseJwtPayload(config.jwtToken ?? "");
+  const authMode =
+    payload?.iss === LOCAL_FIRST_JWT_ISSUER
+      ? "local-first"
+      : payload?.iss === ANONYMOUS_JWT_ISSUER
+        ? "anonymous"
+        : null;
+  if (!authMode) return;
+
+  const tokenSession = internalSessionFromVerifiedReservedJwtPayload(payload ?? {}, authMode);
+  if (
+    !tokenSession ||
+    tokenSession.issuer !== attachedSession.issuer ||
+    tokenSession.user_id !== attachedSession.user_id ||
+    tokenSession.authMode !== attachedSession.authMode
+  ) {
+    throw new Error("Attached browser worker session does not match its identity token");
+  }
+
+  // Claims come from the token, not the cross-realm session object. The native
+  // open below verifies the token before accepting this author.
+  setTrustedReservedSession(config, tokenSession);
 }
 
 function runtimeAuthorFromConfig(config: DbConfig) {


### PR DESCRIPTION
## Stack

1. **This PR** — fix inspector reads and CI coverage
2. `refactor/remove-version-bundles` — remove the duplicate `ViewUpdate.version_bundles` wire field
3. `fix/revert-local-rejected-writes` — propagate rejected optimistic writes to every attached in-memory DB

Review and land this stack from the bottom up.

## Problem

The embedded inspector opened its own persistent-worker connection, but the host bridge did not carry the host's verified runtime session into that connection. The default runtime therefore had neither a verified user session nor an admin credential and correctly rejected row queries with:

> Default runtime requires a verified session or admin credential

The inspector UI initially hid that query error behind an empty grid, making the failure look like a replication or table-selection problem. Inspector browser coverage also existed outside the canonical TypeScript CI browser lane, which allowed the broken path to escape CI.

## Solution

- Forward the host DB's internal session only on the same-origin, pre-attached inspector worker path.
- Reconstruct trust from the reserved-issuer identity token and require its issuer, user id, and auth mode to match the attached session before opening the peer.
- Preserve the host's existing runtime-source configuration when installing the inspector worker port.
- Strip the live worker port and forwarded session from public `Db.getConfig()` copies.
- Surface row-query failures directly in the data grid.
- Harden the overlay browser fixture and run the inspector browser suite alongside the jazz-tools browser suite in CI.

## Governing invariants

- A session object received across the overlay boundary is never trusted on its own.
- The forwarding path is admitted only with a same-origin attached `MessagePort` and a matching reserved-issuer identity token; native token verification remains fail-closed.
- Claims come from the verified token, not from the cross-realm session object.
- This does not add an admin bypass, a runtime-context selector, or broader inspector permissions.

## Worked examples

### Normal path

A logged-in todo app opens the embedded inspector. The inspector joins the host's IndexedDB-backed worker using the same verified principal, subscribes to `todos`, and displays the rows already visible to the app.

### Failure path

If the forwarded session does not match the identity token, connection setup fails explicitly. If the connected principal cannot read a table, the grid displays `Could not load rows: ...` instead of silently rendering an empty result.

## Testing

- Adds/updates unit coverage for attached-session admission and mismatch rejection.
- Repairs the inspector overlay browser fixture and its synchronization canary.
- Adds the inspector browser suite to the canonical parallel TypeScript browser lane.
