### PR TITLE
fix(sync): roll back rejected writes in every attached DB

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1628,6 +1628,23 @@ fn register_local_fate_route(
     tx_id: TxId,
     queue: &PendingDownstreamFates,
 ) {
+    register_local_fate_route_with_acknowledgement(routes, tx_id, queue, false);
+}
+
+fn register_local_fate_observer(
+    routes: &LocalFateRoutes,
+    tx_id: TxId,
+    queue: &PendingDownstreamFates,
+) {
+    register_local_fate_route_with_acknowledgement(routes, tx_id, queue, true);
+}
+
+fn register_local_fate_route_with_acknowledgement(
+    routes: &LocalFateRoutes,
+    tx_id: TxId,
+    queue: &PendingDownstreamFates,
+    local_acknowledged: bool,
+) {
     let mut routes = routes.borrow_mut();
     routes.retain(|_, pending| {
         pending.retain(|candidate| candidate.queue.upgrade().is_some());
@@ -1645,7 +1662,7 @@ fn register_local_fate_route(
     }
     routes.entry(tx_id).or_default().push(LocalFateRoute {
         queue: Rc::downgrade(queue),
-        local_acknowledged: false,
+        local_acknowledged,
     });
 }
 

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -867,7 +867,14 @@ where
                         &update,
                     )
                 });
-                send_with_sync_context(&self.node, peer, self.transport.as_mut(), update)?;
+                send_subscriber_with_sync_context(
+                    &self.node,
+                    peer,
+                    self.transport.as_mut(),
+                    &self.local_fate_routes,
+                    &self.downstream_fates,
+                    update,
+                )?;
                 if let Some((subscription, receipt)) = receipt {
                     queue_direct_control(
                         &mut self.pending_control_responses,
@@ -884,7 +891,14 @@ where
                 let mut node = self.node.lock().await;
                 peer.current_rows_update(&mut node, table).await?
             };
-            send_with_sync_context(&self.node, peer, self.transport.as_mut(), update)?;
+            send_subscriber_with_sync_context(
+                &self.node,
+                peer,
+                self.transport.as_mut(),
+                &self.local_fate_routes,
+                &self.downstream_fates,
+                update,
+            )?;
         }
 
         self.observed_session_claim_revision.set(current_revision);
@@ -1070,7 +1084,14 @@ where
                         &update,
                     )
                 });
-                send_with_sync_context(&self.node, peer, self.transport.as_mut(), update)?;
+                send_subscriber_with_sync_context(
+                    &self.node,
+                    peer,
+                    self.transport.as_mut(),
+                    &self.local_fate_routes,
+                    &self.downstream_fates,
+                    update,
+                )?;
                 if let Some((subscription, receipt)) = receipt {
                     queue_direct_control(
                         &mut self.pending_control_responses,
@@ -3278,10 +3299,12 @@ where
                                             &update,
                                         )
                                     });
-                                send_with_sync_context(
+                                send_subscriber_with_sync_context(
                                     &self.node,
                                     peer,
                                     self.transport.as_mut(),
+                                    &self.local_fate_routes,
+                                    &self.downstream_fates,
                                     update,
                                 )?;
                                 if let Some((subscription, receipt)) = receipt {
@@ -3725,10 +3748,12 @@ where
                                     &update,
                                 )
                             });
-                            send_with_sync_context(
+                            send_subscriber_with_sync_context(
                                 &self.node,
                                 peer,
                                 self.transport.as_mut(),
+                                &self.local_fate_routes,
+                                &self.downstream_fates,
                                 update,
                             )?;
                             if let Some((subscription, receipt)) = receipt {
@@ -3821,10 +3846,12 @@ where
                                     "subscriber send group delta {}",
                                     summarize_sync_message(&update)
                                 ));
-                                send_with_sync_context(
+                                send_subscriber_with_sync_context(
                                     &self.node,
                                     peer,
                                     self.transport.as_mut(),
+                                    &self.local_fate_routes,
+                                    &self.downstream_fates,
                                     update,
                                 )?;
                                 if let Some((subscription, receipt)) = receipt {
@@ -3847,10 +3874,12 @@ where
                             peer.current_rows_update(&mut node, table).await?
                         };
                         if !view_update_is_empty(&update) {
-                            send_with_sync_context(
+                            send_subscriber_with_sync_context(
                                 &self.node,
                                 peer,
                                 self.transport.as_mut(),
+                                &self.local_fate_routes,
+                                &self.downstream_fates,
                                 update,
                             )?;
                             sent_view_update = true;
@@ -4825,6 +4854,38 @@ where
         summarize_sync_message(&message)
     ));
     send_sync_message_chunked(transport, message)
+}
+
+fn send_subscriber_with_sync_context<S>(
+    node: &SharedNodeState<S>,
+    peer: &mut PeerState,
+    transport: &mut dyn Transport,
+    local_fate_routes: &LocalFateRoutes,
+    downstream_fates: &PendingDownstreamFates,
+    message: SyncMessage,
+) -> Result<(), Error>
+where
+    S: OrderedKvStorage + ReopenableStorage + 'static,
+{
+    let mut pending_tx_ids = BTreeSet::new();
+    if let SyncMessage::ViewUpdate(payload) = &message {
+        for carrier in &payload.version_carriers {
+            for bundle in carrier
+                .bundle_refs()
+                .map_err(|_| Error::new(ErrorCode::Protocol, "malformed version-bundle run"))?
+            {
+                if matches!(bundle.fate, Fate::Pending) {
+                    pending_tx_ids.insert(bundle.tx.tx_id);
+                }
+            }
+        }
+    }
+
+    send_with_sync_context(node, peer, transport, message)?;
+    for tx_id in pending_tx_ids {
+        register_local_fate_observer(local_fate_routes, tx_id, downstream_fates);
+    }
+    Ok(())
 }
 
 /// Deliver terminal/local fate updates in FIFO order without letting a bounded

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -1139,6 +1139,66 @@ describe("SharedWorker bridge with IndexedDB", () => {
     expect(todosAfterRevert.length).toBe(0);
   });
 
+  /**
+   * 1. Two in-memory `Db`s attach to the same persistent browser worker.
+   * 2. One DB inserts a row.
+   * 3. The other DB receives the optimistic row through its subscription.
+   * 4. The server rejects the transaction.
+   * 5. The persistent worker rolls back.
+   * 6. The writer DB rolls back.
+   * 7. The other in-memory DB rolls back as well.
+   */
+  it("rejected write from one live peer reverts every attached peer", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "sync-cross-peer-rejection",
+      readOnlyPermissions,
+    );
+    const secret = generateAuthSecret();
+    const dbName = uniqueDbName("sync-cross-peer-rejection");
+    const config = {
+      appId: syncServer.appId,
+      serverUrl: syncServer.serverUrl,
+      secret,
+      driver: { type: "persistent" as const, dbName },
+      schema: app,
+    };
+    // Both `Db`s attach to the same persistent worker
+    const appPeer = track(await createDb(config));
+    const writerPeer = track(await createDb(config));
+
+    await Promise.all([
+      appPeer.all(allTodos, { tier: "edge" }),
+      writerPeer.all(allTodos, { tier: "edge" }),
+    ]);
+    // Disconnect from server so both in-memory `Db`s receive the optimistic insert
+    // before the server rejection
+    await appPeer.disconnect();
+
+    const rejected = writerPeer.insert(todos, {
+      title: "Rejected from the other peer",
+      done: false,
+    });
+    await rejected.wait({ tier: "local" });
+    await waitForCondition(
+      async () => (await appPeer.all(allTodos, { tier: "local" })).length === 1,
+      5000,
+      "non-originating app peer should observe the optimistic insert",
+    );
+
+    await appPeer.reconnect();
+    await expect(rejected.wait({ tier: "edge" })).rejects.toMatchObject({
+      name: "PersistedWriteRejectedError",
+      code: "permission_denied",
+    });
+    expect(await writerPeer.all(allTodos, { tier: "local" })).toEqual([]);
+    expect(await appPeer.all(allTodos, { tier: "edge" })).toEqual([]);
+    await waitForCondition(
+      async () => (await appPeer.all(allTodos, { tier: "local" })).length === 0,
+      5000,
+      "non-originating app peer should receive the rejection rollback",
+    );
+  });
+
   it("server permissions check rejects client optimistic insert - onMutationError notification", async () => {
     const syncServer = await publishSyncServerSchemaAndPermissions(
       "sync-wait-edge",


### PR DESCRIPTION
## Stack

1. #2315 — inspector reads and CI coverage
2. #2316 — remove the duplicate `ViewUpdate.version_bundles` wire field
3. **This PR** — propagate rejected optimistic writes to every attached in-memory DB

Depends on #2316. Review and land this stack from the bottom up.

## Problem

When two in-memory `Db` clients were attached to the same persistent browser worker, an optimistic write from one client was delivered to both clients, but the shared runtime remembered a terminal-fate route only for the client that originated the `CommitUnit`.

If server authorization later rejected the write:

- the persistent worker rolled it back;
- the writer DB received `FateUpdate::Rejected` and rolled it back; but
- a sibling DB that had observed the optimistic transaction through a `ViewUpdate` never received the rejection and retained the row in local queries until restart.

A result-membership removal was insufficient: the sibling's in-memory node still retained the pending transaction/version state and needed the terminal fate to remove it correctly.

## Solution

Whenever a subscriber successfully receives a `ViewUpdate`, inspect its `version_carriers` and register that subscriber as an observer of each `Fate::Pending` transaction it was shown. The existing local fate router then fans a later rejection out to the originating peer and every observing peer.

Observer routes start with local durability already acknowledged because the `ViewUpdate` represented that local state. Registration happens only after the transport accepts the update, so fate routing cannot reveal a transaction to a peer that never observed it.

## Governing invariants

- Every live peer that observes a pending transaction receives its terminal rejection.
- Only peers that were actually sent the transaction are registered as observers.
- The originating writer retains the existing local-acknowledgement behavior; observer registration does not emit a duplicate local acknowledgement.
- Only `Fate::Pending` transactions need observer routes: an accepted transaction cannot later transition to rejected under the fate state machine.
- Terminal rejection still removes the optimistic edit; this PR does not restore rejected inserts, updates, or deletes to the inspector/editor.

## Worked examples

### Rejected insert

App DB A and inspector DB B share one persistent worker. B inserts a row while offline from the server, and A receives it optimistically. After reconnect, the server rejects the insert. The worker routes the rejection to both A and B, and both local queries remove the row immediately.

### Unobserved peer

DB C attaches only after the transaction has already been rejected and was never sent its pending payload. C is not registered as an observer and receives no stale live rejection; it simply hydrates the authoritative post-rejection state.

## Testing

The retained browser regression `rejected write from one live peer reverts every attached peer` now passes unchanged.

Focused receipts from development:

- Target cross-peer rejection regression: passed.
- Related rejection, notification, and restart group: 11/11 passed.
- Rust focused configuration check: passed.
- Correctness NAPI/WASM artifact rebuild: passed.
- Formatting and diff checks: passed.

A full `worker-bridge.test.ts` run also exposed separate pre-existing A→B/B→A ordinary server-propagation timeouts; those are not changed or masked by this PR.
