### PR TITLE
Bound deep query graph preparation stack use

### DIFF
--- a/crates/groove/src/ivm/graph.rs
+++ b/crates/groove/src/ivm/graph.rs
@@ -7,7 +7,10 @@
 //! [`super::op_types`]; lowering from queries lives in [`super::planner`]; the
 //! tick loop that evaluates the graph lives in [`super::runtime`].
 
-use std::hash::{BuildHasher, Hash, Hasher};
+use std::{
+    hash::{BuildHasher, Hash, Hasher},
+    sync::Arc,
+};
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
@@ -21,6 +24,10 @@ use super::op_types::*;
 /// Builders refer to table and field names directly; the runtime resolves those
 /// names against the database schema when a graph is subscribed, queried, or
 /// prepared.
+///
+/// Recursive child edges are immutable shared allocations. This keeps copies
+/// of a deeply lowered graph shallow while preserving the builder's ordinary
+/// value semantics for callers that replace an enclosing node.
 ///
 /// ```rust
 /// # futures::executor::block_on(async {
@@ -171,77 +178,77 @@ pub enum GraphBuilder {
         output: RecordDescriptor,
     },
     Recursive {
-        seed: Box<GraphBuilder>,
-        step: Box<GraphBuilder>,
+        seed: Arc<GraphBuilder>,
+        step: Arc<GraphBuilder>,
         frontier: FrontierName,
         max_iters: usize,
     },
     Filter {
-        input: Box<GraphBuilder>,
+        input: Arc<GraphBuilder>,
         predicate: PredicateExpr,
         comparison: ValueComparison,
     },
     UnwrapNullable {
-        input: Box<GraphBuilder>,
+        input: Arc<GraphBuilder>,
         field: FieldRef,
     },
     Unnest {
-        input: Box<GraphBuilder>,
+        input: Arc<GraphBuilder>,
         array_field: FieldRef,
         element_field: String,
     },
     VariantProject {
-        input: Box<GraphBuilder>,
+        input: Arc<GraphBuilder>,
         field: FieldRef,
         case: String,
     },
     Project {
-        input: Box<GraphBuilder>,
+        input: Arc<GraphBuilder>,
         fields: Vec<ProjectField>,
     },
     StreamingChecksum {
-        input: Box<GraphBuilder>,
+        input: Arc<GraphBuilder>,
         field: FieldRef,
         output_field: String,
         window_bytes: usize,
         max_bytes_per_turn: usize,
     },
     Union {
-        inputs: Vec<GraphBuilder>,
+        inputs: Vec<Arc<GraphBuilder>>,
     },
     Join {
-        left: Box<GraphBuilder>,
-        right: Box<GraphBuilder>,
+        left: Arc<GraphBuilder>,
+        right: Arc<GraphBuilder>,
         left_on: Vec<FieldRef>,
         right_on: Vec<FieldRef>,
         comparison: ValueComparison,
     },
     SemiJoin {
-        left: Box<GraphBuilder>,
-        right: Box<GraphBuilder>,
+        left: Arc<GraphBuilder>,
+        right: Arc<GraphBuilder>,
         left_on: Vec<FieldRef>,
         right_on: Vec<FieldRef>,
         comparison: ValueComparison,
     },
     AntiJoin {
-        left: Box<GraphBuilder>,
-        right: Box<GraphBuilder>,
+        left: Arc<GraphBuilder>,
+        right: Arc<GraphBuilder>,
         left_on: Vec<FieldRef>,
         right_on: Vec<FieldRef>,
         comparison: ValueComparison,
     },
     ArgMaxBy {
-        input: Box<GraphBuilder>,
+        input: Arc<GraphBuilder>,
         group_cols: Vec<FieldRef>,
         order_cols: Vec<FieldRef>,
     },
     ArgMinBy {
-        input: Box<GraphBuilder>,
+        input: Arc<GraphBuilder>,
         group_cols: Vec<FieldRef>,
         order_cols: Vec<FieldRef>,
     },
     TopBy {
-        input: Box<GraphBuilder>,
+        input: Arc<GraphBuilder>,
         group_cols: Vec<FieldRef>,
         order_cols: Vec<TopByOrder>,
         tie_cols: Vec<FieldRef>,
@@ -249,11 +256,11 @@ pub enum GraphBuilder {
         limit: TopByLimit,
     },
     CollectBy {
-        input: Box<GraphBuilder>,
+        input: Arc<GraphBuilder>,
         collect: Box<CollectByBuilder>,
     },
     Aggregate {
-        input: Box<GraphBuilder>,
+        input: Arc<GraphBuilder>,
         group_cols: Vec<FieldRef>,
         aggregates: Vec<AggregateExpr>,
     },
@@ -532,8 +539,8 @@ impl GraphBuilder {
         max_iters: usize,
     ) -> Self {
         Self::Recursive {
-            seed: Box::new(seed),
-            step: Box::new(step),
+            seed: Arc::new(seed),
+            step: Arc::new(step),
             frontier: FrontierName(frontier.into()),
             max_iters,
         }
@@ -541,7 +548,7 @@ impl GraphBuilder {
 
     pub fn union(inputs: impl IntoIterator<Item = GraphBuilder>) -> Self {
         Self::Union {
-            inputs: inputs.into_iter().collect(),
+            inputs: inputs.into_iter().map(Arc::new).collect(),
         }
     }
 
@@ -570,7 +577,7 @@ impl GraphBuilder {
                 | Self::CollectBy { input, .. }
                 | Self::Aggregate { input, .. } => pending.push((input, false)),
                 Self::Union { inputs } => {
-                    pending.extend(inputs.iter().rev().map(|input| (input, false)));
+                    pending.extend(inputs.iter().rev().map(|input| (input.as_ref(), false)));
                 }
                 Self::Join { left, right, .. }
                 | Self::SemiJoin { left, right, .. }
@@ -599,8 +606,8 @@ impl GraphBuilder {
         right_on: impl IntoIterator<Item = impl Into<String>>,
     ) -> Self {
         Self::Join {
-            left: Box::new(left),
-            right: Box::new(right),
+            left: Arc::new(left),
+            right: Arc::new(right),
             left_on: left_on.into_iter().map(FieldRef::name).collect(),
             right_on: right_on.into_iter().map(FieldRef::name).collect(),
             comparison: ValueComparison::Exact,
@@ -615,8 +622,8 @@ impl GraphBuilder {
         right_on: impl IntoIterator<Item = impl Into<String>>,
     ) -> Self {
         Self::Join {
-            left: Box::new(left),
-            right: Box::new(right),
+            left: Arc::new(left),
+            right: Arc::new(right),
             left_on: left_on.into_iter().map(FieldRef::name).collect(),
             right_on: right_on.into_iter().map(FieldRef::name).collect(),
             comparison: ValueComparison::Policy,
@@ -630,8 +637,8 @@ impl GraphBuilder {
         right_on: impl IntoIterator<Item = impl Into<String>>,
     ) -> Self {
         Self::SemiJoin {
-            left: Box::new(left),
-            right: Box::new(right),
+            left: Arc::new(left),
+            right: Arc::new(right),
             left_on: left_on.into_iter().map(FieldRef::name).collect(),
             right_on: right_on.into_iter().map(FieldRef::name).collect(),
             comparison: ValueComparison::Exact,
@@ -645,8 +652,8 @@ impl GraphBuilder {
         right_on: impl IntoIterator<Item = impl Into<String>>,
     ) -> Self {
         Self::AntiJoin {
-            left: Box::new(left),
-            right: Box::new(right),
+            left: Arc::new(left),
+            right: Arc::new(right),
             left_on: left_on.into_iter().map(FieldRef::name).collect(),
             right_on: right_on.into_iter().map(FieldRef::name).collect(),
             comparison: ValueComparison::Exact,
@@ -659,7 +666,7 @@ impl GraphBuilder {
         order_cols: impl IntoIterator<Item = impl Into<String>>,
     ) -> Self {
         Self::ArgMaxBy {
-            input: Box::new(input),
+            input: Arc::new(input),
             group_cols: group_cols.into_iter().map(FieldRef::name).collect(),
             order_cols: order_cols.into_iter().map(FieldRef::name).collect(),
         }
@@ -671,7 +678,7 @@ impl GraphBuilder {
         order_cols: impl IntoIterator<Item = impl Into<String>>,
     ) -> Self {
         Self::ArgMinBy {
-            input: Box::new(input),
+            input: Arc::new(input),
             group_cols: group_cols.into_iter().map(FieldRef::name).collect(),
             order_cols: order_cols.into_iter().map(FieldRef::name).collect(),
         }
@@ -686,7 +693,7 @@ impl GraphBuilder {
         limit: TopByLimit,
     ) -> Self {
         Self::TopBy {
-            input: Box::new(input),
+            input: Arc::new(input),
             group_cols: group_cols.into_iter().map(FieldRef::name).collect(),
             order_cols: order_cols.into_iter().collect(),
             tie_cols: tie_cols.into_iter().map(FieldRef::name).collect(),
@@ -708,7 +715,7 @@ impl GraphBuilder {
         limit: TopByLimit,
     ) -> Self {
         Self::CollectBy {
-            input: Box::new(input),
+            input: Arc::new(input),
             collect: Box::new(CollectByBuilder {
                 mode: CollectByMode::Collect,
                 group_cols: group_cols.into_iter().map(FieldRef::name).collect(),
@@ -760,7 +767,7 @@ impl GraphBuilder {
         limit: TopByLimit,
     ) -> Self {
         Self::CollectBy {
-            input: Box::new(input),
+            input: Arc::new(input),
             collect: Box::new(CollectByBuilder {
                 mode: CollectByMode::Collect,
                 group_cols: group_cols.into_iter().map(FieldRef::name).collect(),
@@ -790,7 +797,7 @@ impl GraphBuilder {
         limit: TopByLimit,
     ) -> Self {
         Self::CollectBy {
-            input: Box::new(input),
+            input: Arc::new(input),
             collect: Box::new(CollectByBuilder {
                 mode: CollectByMode::Root,
                 group_cols: group_cols.into_iter().map(FieldRef::name).collect(),
@@ -826,7 +833,7 @@ impl GraphBuilder {
         limit: TopByLimit,
     ) -> Self {
         Self::CollectBy {
-            input: Box::new(input),
+            input: Arc::new(input),
             collect: Box::new(CollectByBuilder {
                 mode: CollectByMode::Expand,
                 group_cols: group_cols.into_iter().map(FieldRef::name).collect(),
@@ -874,7 +881,7 @@ impl GraphBuilder {
         aggregates: impl IntoIterator<Item = AggregateExpr>,
     ) -> Self {
         Self::Aggregate {
-            input: Box::new(input),
+            input: Arc::new(input),
             group_cols: group_cols.into_iter().map(FieldRef::name).collect(),
             aggregates: aggregates.into_iter().collect(),
         }
@@ -882,7 +889,7 @@ impl GraphBuilder {
 
     pub fn filter(self, predicate: PredicateExpr) -> Self {
         Self::Filter {
-            input: Box::new(self),
+            input: Arc::new(self),
             predicate,
             comparison: ValueComparison::Exact,
         }
@@ -891,7 +898,7 @@ impl GraphBuilder {
     /// Filter using policy value comparison semantics.
     pub fn policy_filter(self, predicate: PredicateExpr) -> Self {
         Self::Filter {
-            input: Box::new(self),
+            input: Arc::new(self),
             predicate,
             comparison: ValueComparison::Policy,
         }
@@ -899,14 +906,14 @@ impl GraphBuilder {
 
     pub fn unwrap_nullable(self, field: impl Into<String>) -> Self {
         Self::UnwrapNullable {
-            input: Box::new(self),
+            input: Arc::new(self),
             field: FieldRef::name(field),
         }
     }
 
     pub fn unnest(self, array_field: impl Into<String>, element_field: impl Into<String>) -> Self {
         Self::Unnest {
-            input: Box::new(self),
+            input: Arc::new(self),
             array_field: FieldRef::name(array_field),
             element_field: element_field.into(),
         }
@@ -916,7 +923,7 @@ impl GraphBuilder {
     /// delta; matching rows emit the case's fixed payload descriptor.
     pub fn variant_project(self, field: impl Into<String>, case: impl Into<String>) -> Self {
         Self::VariantProject {
-            input: Box::new(self),
+            input: Arc::new(self),
             field: FieldRef::name(field),
             case: case.into(),
         }
@@ -924,14 +931,14 @@ impl GraphBuilder {
 
     pub fn project(self, fields: impl IntoIterator<Item = impl Into<String>>) -> Self {
         Self::Project {
-            input: Box::new(self),
+            input: Arc::new(self),
             fields: fields.into_iter().map(ProjectField::named).collect(),
         }
     }
 
     pub fn project_fields(self, fields: impl IntoIterator<Item = ProjectField>) -> Self {
         Self::Project {
-            input: Box::new(self),
+            input: Arc::new(self),
             fields: fields.into_iter().collect(),
         }
     }
@@ -949,7 +956,7 @@ impl GraphBuilder {
         max_bytes_per_turn: usize,
     ) -> Self {
         Self::StreamingChecksum {
-            input: Box::new(self),
+            input: Arc::new(self),
             field: FieldRef::name(field),
             output_field: output_field.into(),
             window_bytes,
@@ -2169,6 +2176,28 @@ mod tests {
 
     fn string_output() -> RecordDescriptor {
         RecordDescriptor::new([("f0", ValueType::String)])
+    }
+
+    #[test]
+    fn cloning_a_deep_builder_is_stack_bounded() {
+        // Lowering policy graphs can compose many unary operators. Keep this
+        // far beyond the depth that recursive `Box` cloning can handle on the
+        // ordinary 2 MiB test-thread stack, and assert immutable child arcs
+        // keep a clone shallow.
+        const DEPTH: usize = 4_096;
+        let mut graph = GraphBuilder::table("rows");
+        for _ in 0..DEPTH {
+            graph = graph.project(["id"]);
+        }
+
+        let cloned = graph.clone();
+        assert_eq!(cloned.postorder().len(), DEPTH + 1);
+
+        // The owned builder's derived recursive destructor is a separate
+        // concern from cloning. Avoid making this regression receipt depend
+        // on that destructor while it validates the clone boundary directly.
+        std::mem::forget(graph);
+        std::mem::forget(cloned);
     }
 
     #[test]

--- a/crates/groove/src/ivm/runtime/record_projection.rs
+++ b/crates/groove/src/ivm/runtime/record_projection.rs
@@ -554,7 +554,9 @@ pub(super) fn validate_collect_by_terminality(graph: &GraphBuilder) -> Result<()
                 contains([input.as_ref() as *const GraphBuilder], &contains_collect)
             }
             GraphBuilder::Union { inputs } => contains(
-                inputs.iter().map(|input| input as *const GraphBuilder),
+                inputs
+                    .iter()
+                    .map(|input| input.as_ref() as *const GraphBuilder),
                 &contains_collect,
             ),
             GraphBuilder::Join { left, right, .. }

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -4,7 +4,7 @@ use super::evaluation_session::EvaluationInputs;
 use super::*;
 use crate::storage::OwnedStorage;
 use std::rc::Rc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Waker};
 
 /// Stable handle returned to callers for subscription management.
@@ -872,7 +872,7 @@ fn bound_routed_multisink_graph(
             .map(|predicate| input.as_ref().clone().filter(predicate))
             .unwrap_or_else(|| input.as_ref().clone());
         return GraphBuilder::CollectBy {
-            input: Box::new(input),
+            input: Arc::new(input),
             collect: Box::new(collect),
         };
     }
@@ -910,7 +910,12 @@ pub(super) fn count_builder_nodes(graph: &GraphBuilder) -> usize {
         | GraphBuilder::TopBy { input, .. }
         | GraphBuilder::CollectBy { input, .. }
         | GraphBuilder::Aggregate { input, .. } => 1 + count_builder_nodes(input),
-        GraphBuilder::Union { inputs } => 1 + inputs.iter().map(count_builder_nodes).sum::<usize>(),
+        GraphBuilder::Union { inputs } => {
+            1 + inputs
+                .iter()
+                .map(|input| count_builder_nodes(input))
+                .sum::<usize>()
+        }
         GraphBuilder::Join { left, right, .. }
         | GraphBuilder::SemiJoin { left, right, .. }
         | GraphBuilder::AntiJoin { left, right, .. } => {
@@ -936,7 +941,9 @@ pub(super) fn builder_contains_binding_source(graph: &GraphBuilder) -> bool {
         | GraphBuilder::TopBy { input, .. }
         | GraphBuilder::CollectBy { input, .. }
         | GraphBuilder::Aggregate { input, .. } => builder_contains_binding_source(input),
-        GraphBuilder::Union { inputs } => inputs.iter().any(builder_contains_binding_source),
+        GraphBuilder::Union { inputs } => inputs
+            .iter()
+            .any(|input| builder_contains_binding_source(input)),
         GraphBuilder::Join { left, right, .. }
         | GraphBuilder::SemiJoin { left, right, .. }
         | GraphBuilder::AntiJoin { left, right, .. } => {
@@ -1064,7 +1071,7 @@ fn lift_literal_filter(
             if let Some(lifted) = lift_literal_filter(runtime, input, binding_field)? {
                 return Ok(Some(LiftedLiteralFilter {
                     graph: GraphBuilder::Filter {
-                        input: Box::new(lifted.graph),
+                        input: Arc::new(lifted.graph),
                         predicate: predicate.clone(),
                         comparison: *comparison,
                     },
@@ -1084,7 +1091,7 @@ fn lift_literal_filter(
             {
                 if let Some(lifted) = lift_literal_filter(runtime, left, binding_field)? {
                     let joined = GraphBuilder::Join {
-                        left: Box::new(lifted.graph),
+                        left: Arc::new(lifted.graph),
                         right: right.clone(),
                         left_on: left_on.clone(),
                         right_on: right_on.clone(),
@@ -1105,7 +1112,7 @@ fn lift_literal_filter(
                 if let Some(lifted) = lift_literal_filter(runtime, right, binding_field)? {
                     let joined = GraphBuilder::Join {
                         left: left.clone(),
-                        right: Box::new(lifted.graph),
+                        right: Arc::new(lifted.graph),
                         left_on: left_on.clone(),
                         right_on: right_on.clone(),
                         comparison: *comparison,
@@ -1236,7 +1243,7 @@ fn lift_literal_filter(
             );
             Ok(Some(LiftedLiteralFilter {
                 graph: GraphBuilder::Project {
-                    input: Box::new(lifted.graph),
+                    input: Arc::new(lifted.graph),
                     fields,
                 },
                 value: lifted.value,
@@ -1252,7 +1259,7 @@ fn lift_literal_filter(
             if let Some(lifted) = lift_literal_filter(runtime, left, binding_field)? {
                 let original_output = runtime.infer_builder_output(graph)?;
                 let joined = GraphBuilder::Join {
-                    left: Box::new(lifted.graph),
+                    left: Arc::new(lifted.graph),
                     right: right.clone(),
                     left_on: left_on.clone(),
                     right_on: right_on.clone(),
@@ -1272,7 +1279,7 @@ fn lift_literal_filter(
                 let original_output = runtime.infer_builder_output(graph)?;
                 let joined = GraphBuilder::Join {
                     left: left.clone(),
-                    right: Box::new(lifted.graph),
+                    right: Arc::new(lifted.graph),
                     left_on: left_on.clone(),
                     right_on: right_on.clone(),
                     comparison: *comparison,
@@ -1301,7 +1308,7 @@ fn lift_literal_filter(
             };
             Ok(Some(LiftedLiteralFilter {
                 graph: GraphBuilder::AntiJoin {
-                    left: Box::new(lifted.graph),
+                    left: Arc::new(lifted.graph),
                     right: right.clone(),
                     left_on: left_on.clone(),
                     right_on: right_on.clone(),
@@ -1322,7 +1329,7 @@ fn lift_literal_filter(
             };
             Ok(Some(LiftedLiteralFilter {
                 graph: GraphBuilder::SemiJoin {
-                    left: Box::new(lifted.graph),
+                    left: Arc::new(lifted.graph),
                     right: right.clone(),
                     left_on: left_on.clone(),
                     right_on: right_on.clone(),
@@ -1339,7 +1346,7 @@ fn lift_literal_filter(
             };
             Ok(Some(LiftedLiteralFilter {
                 graph: GraphBuilder::UnwrapNullable {
-                    input: Box::new(lifted.graph),
+                    input: Arc::new(lifted.graph),
                     field: field.clone(),
                 },
                 value: lifted.value,
@@ -1355,7 +1362,7 @@ fn lift_literal_filter(
             };
             Ok(Some(LiftedLiteralFilter {
                 graph: GraphBuilder::Unnest {
-                    input: Box::new(lifted.graph),
+                    input: Arc::new(lifted.graph),
                     array_field: array_field.clone(),
                     element_field: element_field.clone(),
                 },
@@ -1374,7 +1381,7 @@ fn lift_literal_filter(
             group_cols.push(FieldRef::name(binding_field));
             Ok(Some(LiftedLiteralFilter {
                 graph: GraphBuilder::ArgMaxBy {
-                    input: Box::new(lifted.graph),
+                    input: Arc::new(lifted.graph),
                     group_cols,
                     order_cols: order_cols.clone(),
                 },
@@ -1393,7 +1400,7 @@ fn lift_literal_filter(
             group_cols.push(FieldRef::name(binding_field));
             Ok(Some(LiftedLiteralFilter {
                 graph: GraphBuilder::ArgMinBy {
-                    input: Box::new(lifted.graph),
+                    input: Arc::new(lifted.graph),
                     group_cols,
                     order_cols: order_cols.clone(),
                 },
@@ -1415,7 +1422,7 @@ fn lift_literal_filter(
             group_cols.push(FieldRef::name(binding_field));
             Ok(Some(LiftedLiteralFilter {
                 graph: GraphBuilder::TopBy {
-                    input: Box::new(lifted.graph),
+                    input: Arc::new(lifted.graph),
                     group_cols,
                     order_cols: order_cols.clone(),
                     tie_cols: tie_cols.clone(),
@@ -1438,7 +1445,7 @@ fn lift_literal_filter(
             group_cols.push(FieldRef::name(binding_field));
             Ok(Some(LiftedLiteralFilter {
                 graph: GraphBuilder::Aggregate {
-                    input: Box::new(lifted.graph),
+                    input: Arc::new(lifted.graph),
                     group_cols,
                     aggregates: aggregates.clone(),
                 },
@@ -1592,7 +1599,7 @@ fn project_to_output_with_binding(
         binding_project_source(&graph, binding_field),
     );
     Ok(GraphBuilder::Project {
-        input: Box::new(graph),
+        input: Arc::new(graph),
         fields,
     })
 }
@@ -1706,7 +1713,7 @@ fn propagate_binding_through_frontier(
             let input =
                 propagate_binding_through_frontier(input, frontier, binding_field, binding_type)?;
             Some(GraphBuilder::Filter {
-                input: Box::new(input),
+                input: Arc::new(input),
                 predicate: predicate.clone(),
                 comparison: *comparison,
             })
@@ -1721,7 +1728,7 @@ fn propagate_binding_through_frontier(
                 binding_project_source(&input, binding_field),
             );
             Some(GraphBuilder::Project {
-                input: Box::new(input),
+                input: Arc::new(input),
                 fields,
             })
         }
@@ -1729,7 +1736,7 @@ fn propagate_binding_through_frontier(
             let input =
                 propagate_binding_through_frontier(input, frontier, binding_field, binding_type)?;
             Some(GraphBuilder::UnwrapNullable {
-                input: Box::new(input),
+                input: Arc::new(input),
                 field: field.clone(),
             })
         }
@@ -1741,7 +1748,7 @@ fn propagate_binding_through_frontier(
             let input =
                 propagate_binding_through_frontier(input, frontier, binding_field, binding_type)?;
             Some(GraphBuilder::Unnest {
-                input: Box::new(input),
+                input: Arc::new(input),
                 array_field: array_field.clone(),
                 element_field: element_field.clone(),
             })
@@ -1764,8 +1771,8 @@ fn propagate_binding_through_frontier(
                 propagate_binding_through_frontier(right, frontier, binding_field, binding_type)
                     .unwrap_or_else(|| (**right).clone());
             Some(GraphBuilder::Join {
-                left: Box::new(left),
-                right: Box::new(right),
+                left: Arc::new(left),
+                right: Arc::new(right),
                 left_on: left_on.clone(),
                 right_on: right_on.clone(),
                 comparison: *comparison,
@@ -1781,7 +1788,7 @@ fn propagate_binding_through_frontier(
             let left =
                 propagate_binding_through_frontier(left, frontier, binding_field, binding_type)?;
             Some(GraphBuilder::SemiJoin {
-                left: Box::new(left),
+                left: Arc::new(left),
                 right: right.clone(),
                 left_on: left_on.clone(),
                 right_on: right_on.clone(),
@@ -1798,7 +1805,7 @@ fn propagate_binding_through_frontier(
             let left =
                 propagate_binding_through_frontier(left, frontier, binding_field, binding_type)?;
             Some(GraphBuilder::AntiJoin {
-                left: Box::new(left),
+                left: Arc::new(left),
                 right: right.clone(),
                 left_on: left_on.clone(),
                 right_on: right_on.clone(),
@@ -1831,8 +1838,8 @@ fn replace_binding_shape(graph: GraphBuilder, shape: &str) -> GraphBuilder {
             frontier,
             max_iters,
         } => GraphBuilder::Recursive {
-            seed: Box::new(replace_binding_shape(*seed, shape)),
-            step: Box::new(replace_binding_shape(*step, shape)),
+            seed: Arc::new(replace_binding_shape(seed.as_ref().clone(), shape)),
+            step: Arc::new(replace_binding_shape(step.as_ref().clone(), shape)),
             frontier,
             max_iters,
         },
@@ -1841,16 +1848,16 @@ fn replace_binding_shape(graph: GraphBuilder, shape: &str) -> GraphBuilder {
             predicate,
             comparison,
         } => GraphBuilder::Filter {
-            input: Box::new(replace_binding_shape(*input, shape)),
+            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
             predicate,
             comparison,
         },
         GraphBuilder::Project { input, fields } => GraphBuilder::Project {
-            input: Box::new(replace_binding_shape(*input, shape)),
+            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
             fields,
         },
         GraphBuilder::UnwrapNullable { input, field } => GraphBuilder::UnwrapNullable {
-            input: Box::new(replace_binding_shape(*input, shape)),
+            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
             field,
         },
         GraphBuilder::Unnest {
@@ -1858,7 +1865,7 @@ fn replace_binding_shape(graph: GraphBuilder, shape: &str) -> GraphBuilder {
             array_field,
             element_field,
         } => GraphBuilder::Unnest {
-            input: Box::new(replace_binding_shape(*input, shape)),
+            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
             array_field,
             element_field,
         },
@@ -1867,7 +1874,7 @@ fn replace_binding_shape(graph: GraphBuilder, shape: &str) -> GraphBuilder {
             group_cols,
             order_cols,
         } => GraphBuilder::ArgMaxBy {
-            input: Box::new(replace_binding_shape(*input, shape)),
+            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
             group_cols,
             order_cols,
         },
@@ -1876,7 +1883,7 @@ fn replace_binding_shape(graph: GraphBuilder, shape: &str) -> GraphBuilder {
             group_cols,
             order_cols,
         } => GraphBuilder::ArgMinBy {
-            input: Box::new(replace_binding_shape(*input, shape)),
+            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
             group_cols,
             order_cols,
         },
@@ -1888,7 +1895,7 @@ fn replace_binding_shape(graph: GraphBuilder, shape: &str) -> GraphBuilder {
             offset,
             limit,
         } => GraphBuilder::TopBy {
-            input: Box::new(replace_binding_shape(*input, shape)),
+            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
             group_cols,
             order_cols,
             tie_cols,
@@ -1900,14 +1907,14 @@ fn replace_binding_shape(graph: GraphBuilder, shape: &str) -> GraphBuilder {
             group_cols,
             aggregates,
         } => GraphBuilder::Aggregate {
-            input: Box::new(replace_binding_shape(*input, shape)),
+            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
             group_cols,
             aggregates,
         },
         GraphBuilder::Union { inputs } => GraphBuilder::Union {
             inputs: inputs
                 .into_iter()
-                .map(|input| replace_binding_shape(input, shape))
+                .map(|input| Arc::new(replace_binding_shape(input.as_ref().clone(), shape)))
                 .collect(),
         },
         GraphBuilder::Join {
@@ -1917,8 +1924,8 @@ fn replace_binding_shape(graph: GraphBuilder, shape: &str) -> GraphBuilder {
             right_on,
             comparison,
         } => GraphBuilder::Join {
-            left: Box::new(replace_binding_shape(*left, shape)),
-            right: Box::new(replace_binding_shape(*right, shape)),
+            left: Arc::new(replace_binding_shape(left.as_ref().clone(), shape)),
+            right: Arc::new(replace_binding_shape(right.as_ref().clone(), shape)),
             left_on,
             right_on,
             comparison,
@@ -1930,8 +1937,8 @@ fn replace_binding_shape(graph: GraphBuilder, shape: &str) -> GraphBuilder {
             right_on,
             comparison,
         } => GraphBuilder::SemiJoin {
-            left: Box::new(replace_binding_shape(*left, shape)),
-            right: Box::new(replace_binding_shape(*right, shape)),
+            left: Arc::new(replace_binding_shape(left.as_ref().clone(), shape)),
+            right: Arc::new(replace_binding_shape(right.as_ref().clone(), shape)),
             left_on,
             right_on,
             comparison,
@@ -1943,8 +1950,8 @@ fn replace_binding_shape(graph: GraphBuilder, shape: &str) -> GraphBuilder {
             right_on,
             comparison,
         } => GraphBuilder::AntiJoin {
-            left: Box::new(replace_binding_shape(*left, shape)),
-            right: Box::new(replace_binding_shape(*right, shape)),
+            left: Arc::new(replace_binding_shape(left.as_ref().clone(), shape)),
+            right: Arc::new(replace_binding_shape(right.as_ref().clone(), shape)),
             left_on,
             right_on,
             comparison,

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -688,12 +688,509 @@ pub(super) struct RoutedMultisinkTerminalState {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(super) struct BindingKey(pub(super) Vec<u8>);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone)]
 pub(super) struct AutoDirectFamilyKey {
     pub(super) graph: GraphBuilder,
     pub(super) binding_descriptor: RecordDescriptor,
     pub(super) binding_field: String,
     pub(super) public_fields: Vec<String>,
+}
+
+impl std::fmt::Debug for AutoDirectFamilyKey {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AutoDirectFamilyKey")
+            .field("graph_fingerprint", &graph_builder_fingerprint(&self.graph))
+            .field("binding_descriptor", &self.binding_descriptor)
+            .field("binding_field", &self.binding_field)
+            .field("public_fields", &self.public_fields)
+            .finish()
+    }
+}
+
+impl PartialEq for AutoDirectFamilyKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.binding_descriptor == other.binding_descriptor
+            && self.binding_field == other.binding_field
+            && self.public_fields == other.public_fields
+            && graph_builders_equal(&self.graph, &other.graph)
+    }
+}
+
+impl Eq for AutoDirectFamilyKey {}
+
+impl Hash for AutoDirectFamilyKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        graph_builder_fingerprint(&self.graph).hash(state);
+        self.binding_descriptor.hash(state);
+        self.binding_field.hash(state);
+        self.public_fields.hash(state);
+    }
+}
+
+/// Bounded structural fingerprint for auto-direct family lookup. Hash-map
+/// collisions are resolved by [`graph_builders_equal`], so this hash never
+/// carries semantic identity by itself.
+fn graph_builder_fingerprint(graph: &GraphBuilder) -> u64 {
+    let mut hashes = HashMap::<*const GraphBuilder, u64>::default();
+    macro_rules! child {
+        ($child:expr) => {
+            *hashes
+                .get(&($child.as_ref() as *const GraphBuilder))
+                .expect("postorder visits graph children before their parent")
+        };
+    }
+    for node in graph.postorder() {
+        let node_ptr = node as *const GraphBuilder;
+        if hashes.contains_key(&node_ptr) {
+            continue;
+        }
+        let mut hasher = DefaultHasher::new();
+        std::mem::discriminant(node).hash(&mut hasher);
+        match node {
+            GraphBuilder::Table {
+                table,
+                scan,
+                variant_projection,
+            } => {
+                table.hash(&mut hasher);
+                scan.hash(&mut hasher);
+                variant_projection.hash(&mut hasher);
+            }
+            GraphBuilder::InlineRecords { output, records } => {
+                output.hash(&mut hasher);
+                records.hash(&mut hasher);
+            }
+            GraphBuilder::Index {
+                table,
+                index,
+                scan,
+                intersections,
+                row_projection,
+            } => {
+                table.hash(&mut hasher);
+                index.hash(&mut hasher);
+                scan.hash(&mut hasher);
+                intersections.hash(&mut hasher);
+                row_projection.hash(&mut hasher);
+            }
+            GraphBuilder::FrontierSource { binding, output } => {
+                binding.hash(&mut hasher);
+                output.hash(&mut hasher);
+            }
+            GraphBuilder::BindingSource { shape, output } => {
+                shape.hash(&mut hasher);
+                output.hash(&mut hasher);
+            }
+            GraphBuilder::Recursive {
+                seed,
+                step,
+                frontier,
+                max_iters,
+            } => {
+                child!(seed).hash(&mut hasher);
+                child!(step).hash(&mut hasher);
+                frontier.hash(&mut hasher);
+                max_iters.hash(&mut hasher);
+            }
+            GraphBuilder::Filter {
+                input,
+                predicate,
+                comparison,
+            } => {
+                child!(input).hash(&mut hasher);
+                predicate.hash(&mut hasher);
+                comparison.hash(&mut hasher);
+            }
+            GraphBuilder::UnwrapNullable { input, field } => {
+                child!(input).hash(&mut hasher);
+                field.hash(&mut hasher);
+            }
+            GraphBuilder::Unnest {
+                input,
+                array_field,
+                element_field,
+            } => {
+                child!(input).hash(&mut hasher);
+                array_field.hash(&mut hasher);
+                element_field.hash(&mut hasher);
+            }
+            GraphBuilder::VariantProject { input, field, case } => {
+                child!(input).hash(&mut hasher);
+                field.hash(&mut hasher);
+                case.hash(&mut hasher);
+            }
+            GraphBuilder::Project { input, fields } => {
+                child!(input).hash(&mut hasher);
+                fields.hash(&mut hasher);
+            }
+            GraphBuilder::StreamingChecksum {
+                input,
+                field,
+                output_field,
+                window_bytes,
+                max_bytes_per_turn,
+            } => {
+                child!(input).hash(&mut hasher);
+                field.hash(&mut hasher);
+                output_field.hash(&mut hasher);
+                window_bytes.hash(&mut hasher);
+                max_bytes_per_turn.hash(&mut hasher);
+            }
+            GraphBuilder::Union { inputs } => {
+                for input in inputs {
+                    child!(input).hash(&mut hasher);
+                }
+            }
+            GraphBuilder::Join {
+                left,
+                right,
+                left_on,
+                right_on,
+                comparison,
+            }
+            | GraphBuilder::SemiJoin {
+                left,
+                right,
+                left_on,
+                right_on,
+                comparison,
+            }
+            | GraphBuilder::AntiJoin {
+                left,
+                right,
+                left_on,
+                right_on,
+                comparison,
+            } => {
+                child!(left).hash(&mut hasher);
+                child!(right).hash(&mut hasher);
+                left_on.hash(&mut hasher);
+                right_on.hash(&mut hasher);
+                comparison.hash(&mut hasher);
+            }
+            GraphBuilder::ArgMaxBy {
+                input,
+                group_cols,
+                order_cols,
+            }
+            | GraphBuilder::ArgMinBy {
+                input,
+                group_cols,
+                order_cols,
+            } => {
+                child!(input).hash(&mut hasher);
+                group_cols.hash(&mut hasher);
+                order_cols.hash(&mut hasher);
+            }
+            GraphBuilder::TopBy {
+                input,
+                group_cols,
+                order_cols,
+                tie_cols,
+                offset,
+                limit,
+            } => {
+                child!(input).hash(&mut hasher);
+                group_cols.hash(&mut hasher);
+                order_cols.hash(&mut hasher);
+                tie_cols.hash(&mut hasher);
+                offset.hash(&mut hasher);
+                limit.hash(&mut hasher);
+            }
+            GraphBuilder::CollectBy { input, collect } => {
+                child!(input).hash(&mut hasher);
+                collect.hash(&mut hasher);
+            }
+            GraphBuilder::Aggregate {
+                input,
+                group_cols,
+                aggregates,
+            } => {
+                child!(input).hash(&mut hasher);
+                group_cols.hash(&mut hasher);
+                aggregates.hash(&mut hasher);
+            }
+        }
+        hashes.insert(node_ptr, hasher.finish());
+    }
+    *hashes
+        .get(&std::ptr::from_ref(graph))
+        .expect("postorder includes the graph root")
+}
+
+/// Exact, nonrecursive equality check paired with the bounded family hash.
+fn graph_builders_equal(left: &GraphBuilder, right: &GraphBuilder) -> bool {
+    let mut pending = vec![(left, right)];
+    while let Some((left, right)) = pending.pop() {
+        match (left, right) {
+            (
+                GraphBuilder::Table {
+                    table: a,
+                    scan: b,
+                    variant_projection: c,
+                },
+                GraphBuilder::Table {
+                    table: x,
+                    scan: y,
+                    variant_projection: z,
+                },
+            ) if a == x && b == y && c == z => {}
+            (
+                GraphBuilder::InlineRecords {
+                    output: a,
+                    records: b,
+                },
+                GraphBuilder::InlineRecords {
+                    output: x,
+                    records: y,
+                },
+            ) if a == x && b == y => {}
+            (
+                GraphBuilder::Index {
+                    table: a,
+                    index: b,
+                    scan: c,
+                    intersections: d,
+                    row_projection: e,
+                },
+                GraphBuilder::Index {
+                    table: x,
+                    index: y,
+                    scan: z,
+                    intersections: w,
+                    row_projection: v,
+                },
+            ) if a == x && b == y && c == z && d == w && e == v => {}
+            (
+                GraphBuilder::FrontierSource {
+                    binding: a,
+                    output: b,
+                },
+                GraphBuilder::FrontierSource {
+                    binding: x,
+                    output: y,
+                },
+            ) if a == x && b == y => {}
+            (
+                GraphBuilder::BindingSource {
+                    shape: a,
+                    output: b,
+                },
+                GraphBuilder::BindingSource {
+                    shape: x,
+                    output: y,
+                },
+            ) if a == x && b == y => {}
+            (
+                GraphBuilder::Recursive {
+                    seed: a,
+                    step: b,
+                    frontier: c,
+                    max_iters: d,
+                },
+                GraphBuilder::Recursive {
+                    seed: x,
+                    step: y,
+                    frontier: z,
+                    max_iters: w,
+                },
+            ) if c == z && d == w => {
+                pending.extend([(a.as_ref(), x.as_ref()), (b.as_ref(), y.as_ref())])
+            }
+            (
+                GraphBuilder::Filter {
+                    input: a,
+                    predicate: b,
+                    comparison: c,
+                },
+                GraphBuilder::Filter {
+                    input: x,
+                    predicate: y,
+                    comparison: z,
+                },
+            ) if b == y && c == z => pending.push((a, x)),
+            (
+                GraphBuilder::UnwrapNullable { input: a, field: b },
+                GraphBuilder::UnwrapNullable { input: x, field: y },
+            ) if b == y => pending.push((a, x)),
+            (
+                GraphBuilder::Unnest {
+                    input: a,
+                    array_field: b,
+                    element_field: c,
+                },
+                GraphBuilder::Unnest {
+                    input: x,
+                    array_field: y,
+                    element_field: z,
+                },
+            ) if b == y && c == z => pending.push((a, x)),
+            (
+                GraphBuilder::VariantProject {
+                    input: a,
+                    field: b,
+                    case: c,
+                },
+                GraphBuilder::VariantProject {
+                    input: x,
+                    field: y,
+                    case: z,
+                },
+            ) if b == y && c == z => pending.push((a, x)),
+            (
+                GraphBuilder::Project {
+                    input: a,
+                    fields: b,
+                },
+                GraphBuilder::Project {
+                    input: x,
+                    fields: y,
+                },
+            ) if b == y => pending.push((a, x)),
+            (
+                GraphBuilder::StreamingChecksum {
+                    input: a,
+                    field: b,
+                    output_field: c,
+                    window_bytes: d,
+                    max_bytes_per_turn: e,
+                },
+                GraphBuilder::StreamingChecksum {
+                    input: x,
+                    field: y,
+                    output_field: z,
+                    window_bytes: w,
+                    max_bytes_per_turn: v,
+                },
+            ) if b == y && c == z && d == w && e == v => pending.push((a, x)),
+            (GraphBuilder::Union { inputs: a }, GraphBuilder::Union { inputs: x })
+                if a.len() == x.len() =>
+            {
+                pending.extend(a.iter().zip(x).map(|(a, x)| (a.as_ref(), x.as_ref())))
+            }
+            (
+                GraphBuilder::Join {
+                    left: a,
+                    right: b,
+                    left_on: c,
+                    right_on: d,
+                    comparison: e,
+                },
+                GraphBuilder::Join {
+                    left: x,
+                    right: y,
+                    left_on: z,
+                    right_on: w,
+                    comparison: v,
+                },
+            ) if c == z && d == w && e == v => {
+                pending.extend([(a.as_ref(), x.as_ref()), (b.as_ref(), y.as_ref())])
+            }
+            (
+                GraphBuilder::SemiJoin {
+                    left: a,
+                    right: b,
+                    left_on: c,
+                    right_on: d,
+                    comparison: e,
+                },
+                GraphBuilder::SemiJoin {
+                    left: x,
+                    right: y,
+                    left_on: z,
+                    right_on: w,
+                    comparison: v,
+                },
+            ) if c == z && d == w && e == v => {
+                pending.extend([(a.as_ref(), x.as_ref()), (b.as_ref(), y.as_ref())])
+            }
+            (
+                GraphBuilder::AntiJoin {
+                    left: a,
+                    right: b,
+                    left_on: c,
+                    right_on: d,
+                    comparison: e,
+                },
+                GraphBuilder::AntiJoin {
+                    left: x,
+                    right: y,
+                    left_on: z,
+                    right_on: w,
+                    comparison: v,
+                },
+            ) if c == z && d == w && e == v => {
+                pending.extend([(a.as_ref(), x.as_ref()), (b.as_ref(), y.as_ref())])
+            }
+            (
+                GraphBuilder::ArgMaxBy {
+                    input: a,
+                    group_cols: b,
+                    order_cols: c,
+                },
+                GraphBuilder::ArgMaxBy {
+                    input: x,
+                    group_cols: y,
+                    order_cols: z,
+                },
+            ) if b == y && c == z => pending.push((a, x)),
+            (
+                GraphBuilder::ArgMinBy {
+                    input: a,
+                    group_cols: b,
+                    order_cols: c,
+                },
+                GraphBuilder::ArgMinBy {
+                    input: x,
+                    group_cols: y,
+                    order_cols: z,
+                },
+            ) if b == y && c == z => pending.push((a, x)),
+            (
+                GraphBuilder::TopBy {
+                    input: a,
+                    group_cols: b,
+                    order_cols: c,
+                    tie_cols: d,
+                    offset: e,
+                    limit: f,
+                },
+                GraphBuilder::TopBy {
+                    input: x,
+                    group_cols: y,
+                    order_cols: z,
+                    tie_cols: w,
+                    offset: v,
+                    limit: u,
+                },
+            ) if b == y && c == z && d == w && e == v && f == u => pending.push((a, x)),
+            (
+                GraphBuilder::CollectBy {
+                    input: a,
+                    collect: b,
+                },
+                GraphBuilder::CollectBy {
+                    input: x,
+                    collect: y,
+                },
+            ) if b == y => pending.push((a, x)),
+            (
+                GraphBuilder::Aggregate {
+                    input: a,
+                    group_cols: b,
+                    aggregates: c,
+                },
+                GraphBuilder::Aggregate {
+                    input: x,
+                    group_cols: y,
+                    aggregates: z,
+                },
+            ) if b == y && c == z => pending.push((a, x)),
+            _ => return false,
+        }
+    }
+    true
 }
 
 struct AutoDirectFamilyPlan {
@@ -890,70 +1387,14 @@ fn route_predicate(field: &str, value: &Value) -> PredicateExpr {
 }
 
 pub(super) fn count_builder_nodes(graph: &GraphBuilder) -> usize {
-    match graph {
-        GraphBuilder::Table { .. }
-        | GraphBuilder::InlineRecords { .. }
-        | GraphBuilder::Index { .. }
-        | GraphBuilder::FrontierSource { .. }
-        | GraphBuilder::BindingSource { .. } => 1,
-        GraphBuilder::Recursive { seed, step, .. } => {
-            1 + count_builder_nodes(seed) + count_builder_nodes(step)
-        }
-        GraphBuilder::Filter { input, .. }
-        | GraphBuilder::Project { input, .. }
-        | GraphBuilder::StreamingChecksum { input, .. }
-        | GraphBuilder::UnwrapNullable { input, .. }
-        | GraphBuilder::Unnest { input, .. }
-        | GraphBuilder::VariantProject { input, .. }
-        | GraphBuilder::ArgMaxBy { input, .. }
-        | GraphBuilder::ArgMinBy { input, .. }
-        | GraphBuilder::TopBy { input, .. }
-        | GraphBuilder::CollectBy { input, .. }
-        | GraphBuilder::Aggregate { input, .. } => 1 + count_builder_nodes(input),
-        GraphBuilder::Union { inputs } => {
-            1 + inputs
-                .iter()
-                .map(|input| count_builder_nodes(input))
-                .sum::<usize>()
-        }
-        GraphBuilder::Join { left, right, .. }
-        | GraphBuilder::SemiJoin { left, right, .. }
-        | GraphBuilder::AntiJoin { left, right, .. } => {
-            1 + count_builder_nodes(left) + count_builder_nodes(right)
-        }
-    }
+    graph.postorder().len()
 }
 
 pub(super) fn builder_contains_binding_source(graph: &GraphBuilder) -> bool {
-    match graph {
-        GraphBuilder::BindingSource { .. } => true,
-        GraphBuilder::Recursive { seed, step, .. } => {
-            builder_contains_binding_source(seed) || builder_contains_binding_source(step)
-        }
-        GraphBuilder::Filter { input, .. }
-        | GraphBuilder::Project { input, .. }
-        | GraphBuilder::StreamingChecksum { input, .. }
-        | GraphBuilder::UnwrapNullable { input, .. }
-        | GraphBuilder::Unnest { input, .. }
-        | GraphBuilder::VariantProject { input, .. }
-        | GraphBuilder::ArgMaxBy { input, .. }
-        | GraphBuilder::ArgMinBy { input, .. }
-        | GraphBuilder::TopBy { input, .. }
-        | GraphBuilder::CollectBy { input, .. }
-        | GraphBuilder::Aggregate { input, .. } => builder_contains_binding_source(input),
-        GraphBuilder::Union { inputs } => inputs
-            .iter()
-            .any(|input| builder_contains_binding_source(input)),
-        GraphBuilder::Join { left, right, .. }
-        | GraphBuilder::SemiJoin { left, right, .. }
-        | GraphBuilder::AntiJoin { left, right, .. } => {
-            builder_contains_binding_source(left) || builder_contains_binding_source(right)
-        }
-        GraphBuilder::Table { .. }
-        | GraphBuilder::InlineRecords { .. }
-        | GraphBuilder::Index { .. }
-        | GraphBuilder::FrontierSource { .. } => false,
-    }
+    graph
+        .postorder()
+        .iter()
+        .any(|node| matches!(node, GraphBuilder::BindingSource { .. }))
 }
 
 #[derive(Clone)]
@@ -991,47 +1432,14 @@ fn collect_builder_field_names(
     runtime: &IvmRuntime,
     occupied: &mut HashSet<String>,
 ) -> Result<(), IvmRuntimeError> {
-    let output = runtime.infer_builder_output(graph)?;
-    occupied.extend(
-        output
-            .fields()
-            .iter()
-            .filter_map(|field| field.name.as_ref().cloned()),
-    );
-    match graph {
-        GraphBuilder::Recursive { seed, step, .. } => {
-            collect_builder_field_names(seed, runtime, occupied)?;
-            collect_builder_field_names(step, runtime, occupied)?;
-        }
-        GraphBuilder::Filter { input, .. }
-        | GraphBuilder::Project { input, .. }
-        | GraphBuilder::StreamingChecksum { input, .. }
-        | GraphBuilder::UnwrapNullable { input, .. }
-        | GraphBuilder::Unnest { input, .. }
-        | GraphBuilder::VariantProject { input, .. }
-        | GraphBuilder::ArgMaxBy { input, .. }
-        | GraphBuilder::ArgMinBy { input, .. }
-        | GraphBuilder::TopBy { input, .. }
-        | GraphBuilder::CollectBy { input, .. }
-        | GraphBuilder::Aggregate { input, .. } => {
-            collect_builder_field_names(input, runtime, occupied)?;
-        }
-        GraphBuilder::Union { inputs } => {
-            for input in inputs {
-                collect_builder_field_names(input, runtime, occupied)?;
-            }
-        }
-        GraphBuilder::Join { left, right, .. }
-        | GraphBuilder::SemiJoin { left, right, .. }
-        | GraphBuilder::AntiJoin { left, right, .. } => {
-            collect_builder_field_names(left, runtime, occupied)?;
-            collect_builder_field_names(right, runtime, occupied)?;
-        }
-        GraphBuilder::Table { .. }
-        | GraphBuilder::InlineRecords { .. }
-        | GraphBuilder::Index { .. }
-        | GraphBuilder::FrontierSource { .. }
-        | GraphBuilder::BindingSource { .. } => {}
+    for node in graph.postorder() {
+        let output = runtime.infer_builder_output(node)?;
+        occupied.extend(
+            output
+                .fields()
+                .iter()
+                .filter_map(|field| field.name.as_ref().cloned()),
+        );
     }
     Ok(())
 }
@@ -1041,6 +1449,34 @@ fn lift_literal_filter(
     graph: &GraphBuilder,
     binding_field: &str,
 ) -> Result<Option<LiftedLiteralFilter>, IvmRuntimeError> {
+    let mut lifted = HashMap::<*const GraphBuilder, Option<LiftedLiteralFilter>>::default();
+    for node in graph.postorder() {
+        let node_ptr = node as *const GraphBuilder;
+        if lifted.contains_key(&node_ptr) {
+            continue;
+        }
+        let result = lift_literal_filter_node(runtime, node, binding_field, &lifted)?;
+        lifted.insert(node_ptr, result);
+    }
+    Ok(lifted
+        .remove(&std::ptr::from_ref(graph))
+        .expect("postorder includes the graph root"))
+}
+
+fn lift_literal_filter_node(
+    runtime: &IvmRuntime,
+    graph: &GraphBuilder,
+    binding_field: &str,
+    lifted_children: &HashMap<*const GraphBuilder, Option<LiftedLiteralFilter>>,
+) -> Result<Option<LiftedLiteralFilter>, IvmRuntimeError> {
+    macro_rules! lifted_child {
+        ($child:expr) => {
+            lifted_children
+                .get(&($child.as_ref() as *const GraphBuilder))
+                .expect("postorder visits graph children before their parent")
+                .clone()
+        };
+    }
     match graph {
         GraphBuilder::Filter {
             input,
@@ -1068,7 +1504,7 @@ fn lift_literal_filter(
                     value: value.clone(),
                 }));
             }
-            if let Some(lifted) = lift_literal_filter(runtime, input, binding_field)? {
+            if let Some(lifted) = lifted_child!(input) {
                 return Ok(Some(LiftedLiteralFilter {
                     graph: GraphBuilder::Filter {
                         input: Arc::new(lifted.graph),
@@ -1089,7 +1525,7 @@ fn lift_literal_filter(
                 comparison,
             } = input.as_ref()
             {
-                if let Some(lifted) = lift_literal_filter(runtime, left, binding_field)? {
+                if let Some(lifted) = lifted_child!(left) {
                     let joined = GraphBuilder::Join {
                         left: Arc::new(lifted.graph),
                         right: right.clone(),
@@ -1109,7 +1545,7 @@ fn lift_literal_filter(
                         value: lifted.value,
                     }));
                 }
-                if let Some(lifted) = lift_literal_filter(runtime, right, binding_field)? {
+                if let Some(lifted) = lifted_child!(right) {
                     let joined = GraphBuilder::Join {
                         left: left.clone(),
                         right: Arc::new(lifted.graph),
@@ -1232,7 +1668,7 @@ fn lift_literal_filter(
                     value: value.clone(),
                 }));
             }
-            let Some(lifted) = lift_literal_filter(runtime, input, binding_field)? else {
+            let Some(lifted) = lifted_child!(input) else {
                 return Ok(None);
             };
             let mut fields = fields.clone();
@@ -1256,7 +1692,7 @@ fn lift_literal_filter(
             right_on,
             comparison,
         } => {
-            if let Some(lifted) = lift_literal_filter(runtime, left, binding_field)? {
+            if let Some(lifted) = lifted_child!(left) {
                 let original_output = runtime.infer_builder_output(graph)?;
                 let joined = GraphBuilder::Join {
                     left: Arc::new(lifted.graph),
@@ -1275,7 +1711,7 @@ fn lift_literal_filter(
                     value: lifted.value,
                 }));
             }
-            if let Some(lifted) = lift_literal_filter(runtime, right, binding_field)? {
+            if let Some(lifted) = lifted_child!(right) {
                 let original_output = runtime.infer_builder_output(graph)?;
                 let joined = GraphBuilder::Join {
                     left: left.clone(),
@@ -1303,7 +1739,7 @@ fn lift_literal_filter(
             right_on,
             comparison,
         } => {
-            let Some(lifted) = lift_literal_filter(runtime, left, binding_field)? else {
+            let Some(lifted) = lifted_child!(left) else {
                 return Ok(None);
             };
             Ok(Some(LiftedLiteralFilter {
@@ -1324,7 +1760,7 @@ fn lift_literal_filter(
             right_on,
             comparison,
         } => {
-            let Some(lifted) = lift_literal_filter(runtime, left, binding_field)? else {
+            let Some(lifted) = lifted_child!(left) else {
                 return Ok(None);
             };
             Ok(Some(LiftedLiteralFilter {
@@ -1341,7 +1777,7 @@ fn lift_literal_filter(
         GraphBuilder::Recursive { .. } => Ok(None),
         GraphBuilder::Union { .. } | GraphBuilder::VariantProject { .. } => Ok(None),
         GraphBuilder::UnwrapNullable { input, field } => {
-            let Some(lifted) = lift_literal_filter(runtime, input, binding_field)? else {
+            let Some(lifted) = lifted_child!(input) else {
                 return Ok(None);
             };
             Ok(Some(LiftedLiteralFilter {
@@ -1357,7 +1793,7 @@ fn lift_literal_filter(
             array_field,
             element_field,
         } => {
-            let Some(lifted) = lift_literal_filter(runtime, input, binding_field)? else {
+            let Some(lifted) = lifted_child!(input) else {
                 return Ok(None);
             };
             Ok(Some(LiftedLiteralFilter {
@@ -1374,7 +1810,7 @@ fn lift_literal_filter(
             group_cols,
             order_cols,
         } => {
-            let Some(lifted) = lift_literal_filter(runtime, input, binding_field)? else {
+            let Some(lifted) = lifted_child!(input) else {
                 return Ok(None);
             };
             let mut group_cols = group_cols.clone();
@@ -1393,7 +1829,7 @@ fn lift_literal_filter(
             group_cols,
             order_cols,
         } => {
-            let Some(lifted) = lift_literal_filter(runtime, input, binding_field)? else {
+            let Some(lifted) = lifted_child!(input) else {
                 return Ok(None);
             };
             let mut group_cols = group_cols.clone();
@@ -1415,7 +1851,7 @@ fn lift_literal_filter(
             offset,
             limit,
         } => {
-            let Some(lifted) = lift_literal_filter(runtime, input, binding_field)? else {
+            let Some(lifted) = lifted_child!(input) else {
                 return Ok(None);
             };
             let mut group_cols = group_cols.clone();
@@ -1438,7 +1874,7 @@ fn lift_literal_filter(
             group_cols,
             aggregates,
         } => {
-            let Some(lifted) = lift_literal_filter(runtime, input, binding_field)? else {
+            let Some(lifted) = lifted_child!(input) else {
                 return Ok(None);
             };
             let mut group_cols = group_cols.clone();
@@ -1635,49 +2071,60 @@ fn binding_project_source(input: &GraphBuilder, binding_field: &str) -> String {
 }
 
 fn graph_outputs_binding(graph: &GraphBuilder, binding_field: &str) -> bool {
-    match graph {
-        GraphBuilder::BindingSource { output, .. }
-        | GraphBuilder::FrontierSource { output, .. }
-        | GraphBuilder::InlineRecords { output, .. } => output.field_index(binding_field).is_some(),
-        GraphBuilder::Project { fields, .. } => fields
-            .iter()
-            .any(|field| field.output_name == binding_field),
-        GraphBuilder::StreamingChecksum {
-            input,
-            field,
-            output_field,
-            ..
-        } => {
-            if output_field == binding_field {
-                true
-            } else if matches!(field, FieldRef::Name(name) if name == binding_field) {
-                false
-            } else {
-                graph_outputs_binding(input, binding_field)
-            }
-        }
-        GraphBuilder::Filter { input, .. }
-        | GraphBuilder::UnwrapNullable { input, .. }
-        | GraphBuilder::Unnest { input, .. }
-        | GraphBuilder::ArgMaxBy { input, .. }
-        | GraphBuilder::ArgMinBy { input, .. }
-        | GraphBuilder::TopBy { input, .. }
-        | GraphBuilder::CollectBy { input, .. }
-        | GraphBuilder::Aggregate { input, .. } => graph_outputs_binding(input, binding_field),
-        GraphBuilder::Recursive { seed, .. } => graph_outputs_binding(seed, binding_field),
-        GraphBuilder::Join { left, right, .. }
-        | GraphBuilder::SemiJoin { left, right, .. }
-        | GraphBuilder::AntiJoin { left, right, .. } => {
-            graph_outputs_binding(left, binding_field)
-                || graph_outputs_binding(right, binding_field)
-        }
-        GraphBuilder::Union { inputs } => inputs
-            .iter()
-            .any(|input| graph_outputs_binding(input, binding_field)),
-        GraphBuilder::Table { .. }
-        | GraphBuilder::Index { .. }
-        | GraphBuilder::VariantProject { .. } => false,
+    let mut outputs = HashMap::<*const GraphBuilder, bool>::default();
+    macro_rules! child {
+        ($child:expr) => {
+            *outputs
+                .get(&($child.as_ref() as *const GraphBuilder))
+                .expect("postorder visits graph children before their parent")
+        };
     }
+    for node in graph.postorder() {
+        let node_ptr = node as *const GraphBuilder;
+        if outputs.contains_key(&node_ptr) {
+            continue;
+        }
+        let output = match node {
+            GraphBuilder::BindingSource { output, .. }
+            | GraphBuilder::FrontierSource { output, .. }
+            | GraphBuilder::InlineRecords { output, .. } => {
+                output.field_index(binding_field).is_some()
+            }
+            GraphBuilder::Project { fields, .. } => fields
+                .iter()
+                .any(|field| field.output_name == binding_field),
+            GraphBuilder::StreamingChecksum {
+                input,
+                field,
+                output_field,
+                ..
+            } => {
+                output_field == binding_field
+                    || (!matches!(field, FieldRef::Name(name) if name == binding_field)
+                        && child!(input))
+            }
+            GraphBuilder::Filter { input, .. }
+            | GraphBuilder::UnwrapNullable { input, .. }
+            | GraphBuilder::Unnest { input, .. }
+            | GraphBuilder::ArgMaxBy { input, .. }
+            | GraphBuilder::ArgMinBy { input, .. }
+            | GraphBuilder::TopBy { input, .. }
+            | GraphBuilder::CollectBy { input, .. }
+            | GraphBuilder::Aggregate { input, .. } => child!(input),
+            GraphBuilder::Recursive { seed, .. } => child!(seed),
+            GraphBuilder::Join { left, right, .. }
+            | GraphBuilder::SemiJoin { left, right, .. }
+            | GraphBuilder::AntiJoin { left, right, .. } => child!(left) || child!(right),
+            GraphBuilder::Union { inputs } => inputs.iter().any(|input| child!(input)),
+            GraphBuilder::Table { .. }
+            | GraphBuilder::Index { .. }
+            | GraphBuilder::VariantProject { .. } => false,
+        };
+        outputs.insert(node_ptr, output);
+    }
+    *outputs
+        .get(&std::ptr::from_ref(graph))
+        .expect("postorder includes the graph root")
 }
 
 #[allow(dead_code)]
@@ -1829,135 +2276,166 @@ fn propagate_binding_through_frontier(
     }
 }
 
-fn replace_binding_shape(graph: GraphBuilder, shape: &str) -> GraphBuilder {
-    match graph {
-        GraphBuilder::BindingSource { output, .. } => GraphBuilder::binding_source(shape, output),
-        GraphBuilder::Recursive {
-            seed,
-            step,
-            frontier,
-            max_iters,
-        } => GraphBuilder::Recursive {
-            seed: Arc::new(replace_binding_shape(seed.as_ref().clone(), shape)),
-            step: Arc::new(replace_binding_shape(step.as_ref().clone(), shape)),
-            frontier,
-            max_iters,
-        },
-        GraphBuilder::Filter {
-            input,
-            predicate,
-            comparison,
-        } => GraphBuilder::Filter {
-            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
-            predicate,
-            comparison,
-        },
-        GraphBuilder::Project { input, fields } => GraphBuilder::Project {
-            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
-            fields,
-        },
-        GraphBuilder::UnwrapNullable { input, field } => GraphBuilder::UnwrapNullable {
-            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
-            field,
-        },
-        GraphBuilder::Unnest {
-            input,
-            array_field,
-            element_field,
-        } => GraphBuilder::Unnest {
-            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
-            array_field,
-            element_field,
-        },
-        GraphBuilder::ArgMaxBy {
-            input,
-            group_cols,
-            order_cols,
-        } => GraphBuilder::ArgMaxBy {
-            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
-            group_cols,
-            order_cols,
-        },
-        GraphBuilder::ArgMinBy {
-            input,
-            group_cols,
-            order_cols,
-        } => GraphBuilder::ArgMinBy {
-            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
-            group_cols,
-            order_cols,
-        },
-        GraphBuilder::TopBy {
-            input,
-            group_cols,
-            order_cols,
-            tie_cols,
-            offset,
-            limit,
-        } => GraphBuilder::TopBy {
-            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
-            group_cols,
-            order_cols,
-            tie_cols,
-            offset,
-            limit,
-        },
-        GraphBuilder::Aggregate {
-            input,
-            group_cols,
-            aggregates,
-        } => GraphBuilder::Aggregate {
-            input: Arc::new(replace_binding_shape(input.as_ref().clone(), shape)),
-            group_cols,
-            aggregates,
-        },
-        GraphBuilder::Union { inputs } => GraphBuilder::Union {
-            inputs: inputs
-                .into_iter()
-                .map(|input| Arc::new(replace_binding_shape(input.as_ref().clone(), shape)))
-                .collect(),
-        },
-        GraphBuilder::Join {
-            left,
-            right,
-            left_on,
-            right_on,
-            comparison,
-        } => GraphBuilder::Join {
-            left: Arc::new(replace_binding_shape(left.as_ref().clone(), shape)),
-            right: Arc::new(replace_binding_shape(right.as_ref().clone(), shape)),
-            left_on,
-            right_on,
-            comparison,
-        },
-        GraphBuilder::SemiJoin {
-            left,
-            right,
-            left_on,
-            right_on,
-            comparison,
-        } => GraphBuilder::SemiJoin {
-            left: Arc::new(replace_binding_shape(left.as_ref().clone(), shape)),
-            right: Arc::new(replace_binding_shape(right.as_ref().clone(), shape)),
-            left_on,
-            right_on,
-            comparison,
-        },
-        GraphBuilder::AntiJoin {
-            left,
-            right,
-            left_on,
-            right_on,
-            comparison,
-        } => GraphBuilder::AntiJoin {
-            left: Arc::new(replace_binding_shape(left.as_ref().clone(), shape)),
-            right: Arc::new(replace_binding_shape(right.as_ref().clone(), shape)),
-            left_on,
-            right_on,
-            comparison,
-        },
-        graph => graph,
+fn replace_binding_shape(graph: &GraphBuilder, shape: &str) -> GraphBuilder {
+    // Auto-direct planning can build a long chain of otherwise ordinary
+    // operators. Rewriting the binding source must therefore be bounded just
+    // like compilation: transform the owned graph in iterative postorder
+    // rather than recursing once per operator.
+    let mut rewritten = HashMap::<*const GraphBuilder, Arc<GraphBuilder>>::default();
+    macro_rules! child {
+        ($child:expr) => {{
+            let child = $child;
+            rewritten
+                .get(&(child.as_ref() as *const GraphBuilder))
+                .expect("postorder rewrites every graph child before its parent")
+                .clone()
+        }};
     }
+
+    for node in graph.postorder() {
+        let node_ptr = node as *const GraphBuilder;
+        if rewritten.contains_key(&node_ptr) {
+            continue;
+        }
+        let replacement = match node {
+            GraphBuilder::BindingSource { output, .. } => {
+                GraphBuilder::binding_source(shape, *output)
+            }
+            GraphBuilder::Recursive {
+                seed,
+                step,
+                frontier,
+                max_iters,
+            } => GraphBuilder::Recursive {
+                seed: child!(seed),
+                step: child!(step),
+                frontier: frontier.clone(),
+                max_iters: *max_iters,
+            },
+            GraphBuilder::Filter {
+                input,
+                predicate,
+                comparison,
+            } => GraphBuilder::Filter {
+                input: child!(input),
+                predicate: predicate.clone(),
+                comparison: *comparison,
+            },
+            GraphBuilder::Project { input, fields } => GraphBuilder::Project {
+                input: child!(input),
+                fields: fields.clone(),
+            },
+            GraphBuilder::UnwrapNullable { input, field } => GraphBuilder::UnwrapNullable {
+                input: child!(input),
+                field: field.clone(),
+            },
+            GraphBuilder::Unnest {
+                input,
+                array_field,
+                element_field,
+            } => GraphBuilder::Unnest {
+                input: child!(input),
+                array_field: array_field.clone(),
+                element_field: element_field.clone(),
+            },
+            GraphBuilder::ArgMaxBy {
+                input,
+                group_cols,
+                order_cols,
+            } => GraphBuilder::ArgMaxBy {
+                input: child!(input),
+                group_cols: group_cols.clone(),
+                order_cols: order_cols.clone(),
+            },
+            GraphBuilder::ArgMinBy {
+                input,
+                group_cols,
+                order_cols,
+            } => GraphBuilder::ArgMinBy {
+                input: child!(input),
+                group_cols: group_cols.clone(),
+                order_cols: order_cols.clone(),
+            },
+            GraphBuilder::TopBy {
+                input,
+                group_cols,
+                order_cols,
+                tie_cols,
+                offset,
+                limit,
+            } => GraphBuilder::TopBy {
+                input: child!(input),
+                group_cols: group_cols.clone(),
+                order_cols: order_cols.clone(),
+                tie_cols: tie_cols.clone(),
+                offset: *offset,
+                limit: *limit,
+            },
+            GraphBuilder::Aggregate {
+                input,
+                group_cols,
+                aggregates,
+            } => GraphBuilder::Aggregate {
+                input: child!(input),
+                group_cols: group_cols.clone(),
+                aggregates: aggregates.clone(),
+            },
+            GraphBuilder::Union { inputs } => GraphBuilder::Union {
+                inputs: inputs.iter().map(|input| child!(input)).collect(),
+            },
+            GraphBuilder::Join {
+                left,
+                right,
+                left_on,
+                right_on,
+                comparison,
+            } => GraphBuilder::Join {
+                left: child!(left),
+                right: child!(right),
+                left_on: left_on.clone(),
+                right_on: right_on.clone(),
+                comparison: *comparison,
+            },
+            GraphBuilder::SemiJoin {
+                left,
+                right,
+                left_on,
+                right_on,
+                comparison,
+            } => GraphBuilder::SemiJoin {
+                left: child!(left),
+                right: child!(right),
+                left_on: left_on.clone(),
+                right_on: right_on.clone(),
+                comparison: *comparison,
+            },
+            GraphBuilder::AntiJoin {
+                left,
+                right,
+                left_on,
+                right_on,
+                comparison,
+            } => GraphBuilder::AntiJoin {
+                left: child!(left),
+                right: child!(right),
+                left_on: left_on.clone(),
+                right_on: right_on.clone(),
+                comparison: *comparison,
+            },
+            // Preserve the former behavior for operators auto-direct does not
+            // rewrite through: their enclosing graph stays byte-for-byte
+            // equivalent, even if a child happens to contain a binding.
+            node => node.clone(),
+        };
+        rewritten.insert(node_ptr, Arc::new(replacement));
+    }
+
+    Arc::try_unwrap(
+        rewritten
+            .remove(&std::ptr::from_ref(graph))
+            .expect("postorder includes the graph root"),
+    )
+    .expect("rewritten graph root has no parent")
 }
 
 impl IvmRuntime {
@@ -2684,14 +3162,12 @@ impl IvmRuntime {
             return Ok(None);
         };
         let shape_seed = "__auto_direct_shape".to_owned();
-        let graph = replace_binding_shape(lifted.graph, &shape_seed);
+        let graph = replace_binding_shape(&lifted.graph, &shape_seed);
         let shape_output = self.infer_builder_output(&graph)?;
         validate_public_output_fields(&shape_output, &original_output)?;
         let public_fields = descriptor_field_names(&original_output)?;
-        let mut hasher = DefaultHasher::new();
-        graph.hash(&mut hasher);
-        let shape = format!("auto_direct_{:016x}", hasher.finish());
-        let graph = replace_binding_shape(graph, &shape);
+        let shape = format!("auto_direct_{:016x}", graph_builder_fingerprint(&graph));
+        let graph = replace_binding_shape(&graph, &shape);
         if shape_output.field_index(&binding_field).is_none() {
             return Ok(None);
         }
@@ -3126,5 +3602,53 @@ impl IvmRuntime {
         for node in self.gc_ephemeral_nodes(0) {
             self.remove_node_runtime(node);
         }
+    }
+}
+
+#[cfg(test)]
+mod bounded_graph_traversal_tests {
+    use super::*;
+
+    #[test]
+    fn deep_binding_shape_rewrite_and_family_keying_fit_a_two_mib_stack() {
+        std::thread::Builder::new()
+            .name("deep-binding-shape-rewrite".to_owned())
+            .stack_size(2 * 1024 * 1024)
+            .spawn(|| {
+                const DEPTH: usize = 4_096;
+                let descriptor = RecordDescriptor::new([("id", ValueType::U64)]);
+                let mut graph = GraphBuilder::binding_source("old_shape", descriptor);
+                for _ in 0..DEPTH {
+                    graph = graph.project(["id"]);
+                }
+
+                assert_eq!(count_builder_nodes(&graph), DEPTH + 1);
+                assert!(builder_contains_binding_source(&graph));
+                let rewritten = replace_binding_shape(&graph, "new_shape");
+                assert_eq!(rewritten.postorder().len(), DEPTH + 1);
+                assert!(graph_builders_equal(&rewritten, &rewritten.clone()));
+                assert_eq!(
+                    graph_builder_fingerprint(&rewritten),
+                    graph_builder_fingerprint(&rewritten.clone())
+                );
+
+                let mut leaf = &rewritten;
+                for _ in 0..DEPTH {
+                    let GraphBuilder::Project { input, .. } = leaf else {
+                        panic!("rewrite must preserve the unary project chain");
+                    };
+                    leaf = input;
+                }
+                assert!(matches!(leaf, GraphBuilder::BindingSource { shape, .. } if shape == "new_shape"));
+
+                // Arc child destruction is intentionally independent of this
+                // traversal receipt; do not make its stack behavior mask a
+                // regression in bounded rewrite/keying.
+                std::mem::forget(graph);
+                std::mem::forget(rewritten);
+            })
+            .expect("spawn normal-stack traversal test")
+            .join()
+            .expect("normal-stack traversal test must not overflow");
     }
 }

--- a/crates/jazz/src/node/query_engine/lowering/closure.rs
+++ b/crates/jazz/src/node/query_engine/lowering/closure.rs
@@ -372,7 +372,11 @@ fn closure_membership_graph_for_path(
                 "__closure_root_row_uuid",
             )]),
     );
-    let mut current_source = root_source.clone();
+    // Closure lowering only needs source shape metadata while it walks the
+    // path.  Keep references rather than cloning whole resolved sources
+    // (which include the complete table schema and graph) into this
+    // synchronous compiler stack.
+    let mut current_source = root_source;
     let mut outputs = Vec::new();
     for (index, segment) in segments.iter().enumerate() {
         let target = resolved_sources.get(&segment.target).ok_or_else(|| {
@@ -431,11 +435,17 @@ fn closure_membership_graph_for_path(
                     ),
             )
         };
+        if index + 1 == segments.len() {
+            // The terminal graph is only consumed by the result-member
+            // collector, so moving it avoids recursively cloning the entire
+            // assembled closure graph on the deepest path.
+            outputs.push((index, segment.target.clone(), joined));
+            break;
+        }
         outputs.push((index, segment.target.clone(), joined.clone()));
         current_graph = joined;
-        current_source = target.clone();
+        current_source = target;
     }
-    let _ = current_source;
     Ok(outputs)
 }
 

--- a/crates/jazz/src/node/query_engine/resolver.rs
+++ b/crates/jazz/src/node/query_engine/resolver.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::{future::Future, pin::Pin};
 
 /// Logical source request made by query, policy, or fact lowering.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -117,10 +118,10 @@ pub(crate) enum FieldRequirement {
 /// trait on the preparation side of `lower_resolved_query_program`.
 pub(crate) trait SourceGraphPreparer {
     /// Prepare one source request into a concrete Groove graph and row shape.
-    async fn prepare_source_graph(
-        &mut self,
-        request: &SourceRequest,
-    ) -> Result<ResolvedSource, SourceResolutionError>;
+    fn prepare_source_graph<'a>(
+        &'a mut self,
+        request: &'a SourceRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<ResolvedSource, SourceResolutionError>> + 'a>>;
 }
 
 /// Concrete source selected for one logical source request.

--- a/crates/jazz/src/node/query_engine/tests/support.rs
+++ b/crates/jazz/src/node/query_engine/tests/support.rs
@@ -1,6 +1,7 @@
 //! Shared compiler requests, resolvers, projections, and graph assertions.
 
 use super::*;
+use std::{future::Future, pin::Pin};
 
 pub(super) fn schema(byte: u8) -> SchemaVersionId {
     SchemaVersionId::from_bytes([byte; 16])
@@ -586,88 +587,95 @@ pub(super) struct FakeSourceResolver {
 }
 
 impl SourceGraphPreparer for FakeSourceResolver {
-    async fn prepare_source_graph(
-        &mut self,
-        request: &SourceRequest,
-    ) -> Result<ResolvedSource, SourceResolutionError> {
-        self.requests.push(request.clone());
-        let deletion_register = request
-            .requirements
-            .metadata
-            .contains(&SourceMetadataRequirement::DeletionMarkers)
-            .then(|| DeletionRegisterSource {
-                graph: GraphBuilder::table(format!("resolved_{}_deletions", request.source.table)),
-                row_uuid_field: "row_uuid".to_owned(),
-            });
-        let content_version = request
-            .requirements
-            .metadata
-            .contains(&SourceMetadataRequirement::VersionPayloads)
-            .then(|| ContentVersionSource {
-                graph: GraphBuilder::table(format!(
-                    "resolved_{}_content_versions",
-                    request.source.table
-                )),
-                row_uuid_field: "row_uuid".to_owned(),
-            });
-        let mut metadata = BTreeMap::from([
-            (
-                SourceMetadataRequirement::VersionWitnesses,
-                SourceMetadataFields::VersionWitnesses {
-                    schema_version_field: "schema_version".to_owned(),
-                    tx_time_field: "tx_time".to_owned(),
-                    tx_node_field: "tx_node_id".to_owned(),
-                    branch_or_prefix_field: self.branch_witnesses.then(|| "branch_id".to_owned()),
+    fn prepare_source_graph<'a>(
+        &'a mut self,
+        request: &'a SourceRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<ResolvedSource, SourceResolutionError>> + 'a>> {
+        Box::pin(async move {
+            self.requests.push(request.clone());
+            let deletion_register = request
+                .requirements
+                .metadata
+                .contains(&SourceMetadataRequirement::DeletionMarkers)
+                .then(|| DeletionRegisterSource {
+                    graph: GraphBuilder::table(format!(
+                        "resolved_{}_deletions",
+                        request.source.table
+                    )),
+                    row_uuid_field: "row_uuid".to_owned(),
+                });
+            let content_version = request
+                .requirements
+                .metadata
+                .contains(&SourceMetadataRequirement::VersionPayloads)
+                .then(|| ContentVersionSource {
+                    graph: GraphBuilder::table(format!(
+                        "resolved_{}_content_versions",
+                        request.source.table
+                    )),
+                    row_uuid_field: "row_uuid".to_owned(),
+                });
+            let mut metadata = BTreeMap::from([
+                (
+                    SourceMetadataRequirement::VersionWitnesses,
+                    SourceMetadataFields::VersionWitnesses {
+                        schema_version_field: "schema_version".to_owned(),
+                        tx_time_field: "tx_time".to_owned(),
+                        tx_node_field: "tx_node_id".to_owned(),
+                        branch_or_prefix_field: self
+                            .branch_witnesses
+                            .then(|| "branch_id".to_owned()),
+                    },
+                ),
+                (
+                    SourceMetadataRequirement::Coverage,
+                    SourceMetadataFields::Coverage {
+                        coverage_field: "coverage".to_owned(),
+                    },
+                ),
+            ]);
+            if deletion_register.is_some() {
+                metadata.insert(
+                    SourceMetadataRequirement::DeletionMarkers,
+                    SourceMetadataFields::DeletionMarkers {
+                        deletion_state_field: "_deletion".to_owned(),
+                        deletion_tx_time_field: Some("tx_time".to_owned()),
+                        deletion_tx_node_field: Some("tx_node_id".to_owned()),
+                    },
+                );
+            }
+            let mut descriptor_fields = vec![
+                ("table", ValueType::String),
+                ("row_uuid", ValueType::Uuid),
+                ("user_title", ValueType::String),
+                ("user_todo", ValueType::Nullable(Box::new(ValueType::Uuid))),
+                ("user_tag", ValueType::Nullable(Box::new(ValueType::String))),
+                ("tx_time", ValueType::U64),
+                ("tx_node_id", ValueType::U64),
+                ("schema_version", ValueType::Uuid),
+                ("coverage", ValueType::String),
+                ("layer", ValueType::String),
+            ];
+            if self.branch_witnesses {
+                descriptor_fields.push(("branch_id", ValueType::Uuid));
+            }
+            Ok(ResolvedSource {
+                table_schema: TableSchema::new(
+                    request.source.table.clone(),
+                    [ColumnSchema::new("title", ColumnType::String)],
+                ),
+                graph: GraphBuilder::table(format!("resolved_{}", request.source.table)),
+                row_shape: SourceRowShape {
+                    source: request.source.clone(),
+                    descriptor: RecordDescriptor::new(descriptor_fields),
+                    row_uuid_field: "row_uuid".to_owned(),
+                    metadata,
                 },
-            ),
-            (
-                SourceMetadataRequirement::Coverage,
-                SourceMetadataFields::Coverage {
-                    coverage_field: "coverage".to_owned(),
-                },
-            ),
-        ]);
-        if deletion_register.is_some() {
-            metadata.insert(
-                SourceMetadataRequirement::DeletionMarkers,
-                SourceMetadataFields::DeletionMarkers {
-                    deletion_state_field: "_deletion".to_owned(),
-                    deletion_tx_time_field: Some("tx_time".to_owned()),
-                    deletion_tx_node_field: Some("tx_node_id".to_owned()),
-                },
-            );
-        }
-        let mut descriptor_fields = vec![
-            ("table", ValueType::String),
-            ("row_uuid", ValueType::Uuid),
-            ("user_title", ValueType::String),
-            ("user_todo", ValueType::Nullable(Box::new(ValueType::Uuid))),
-            ("user_tag", ValueType::Nullable(Box::new(ValueType::String))),
-            ("tx_time", ValueType::U64),
-            ("tx_node_id", ValueType::U64),
-            ("schema_version", ValueType::Uuid),
-            ("coverage", ValueType::String),
-            ("layer", ValueType::String),
-        ];
-        if self.branch_witnesses {
-            descriptor_fields.push(("branch_id", ValueType::Uuid));
-        }
-        Ok(ResolvedSource {
-            table_schema: TableSchema::new(
-                request.source.table.clone(),
-                [ColumnSchema::new("title", ColumnType::String)],
-            ),
-            graph: GraphBuilder::table(format!("resolved_{}", request.source.table)),
-            row_shape: SourceRowShape {
-                source: request.source.clone(),
-                descriptor: RecordDescriptor::new(descriptor_fields),
-                row_uuid_field: "row_uuid".to_owned(),
-                metadata,
-            },
-            routing_fields: BTreeSet::new(),
-            requires_result_payload: false,
-            content_version,
-            deletion_register,
+                routing_fields: BTreeSet::new(),
+                requires_result_payload: false,
+                content_version,
+                deletion_register,
+            })
         })
     }
 }
@@ -754,112 +762,116 @@ impl InlineCollectorResolver {
 }
 
 impl SourceGraphPreparer for InlineCollectorResolver {
-    async fn prepare_source_graph(
-        &mut self,
-        request: &SourceRequest,
-    ) -> Result<ResolvedSource, SourceResolutionError> {
-        self.requests.push(request.clone());
-        let descriptor = RecordDescriptor::new([
-            ("row_uuid", ValueType::Uuid),
-            (
-                "user_title",
-                ValueType::Nullable(Box::new(ValueType::String)),
-            ),
-            ("user_todo", ValueType::Nullable(Box::new(ValueType::Uuid))),
-            ("$createdAt", ValueType::U64),
-            ("$createdBy", ValueType::Uuid),
-            ("$updatedAt", ValueType::U64),
-            ("$updatedBy", ValueType::Uuid),
-        ]);
-        let parent = row(0xd1).0;
-        let rows = match request.source.table.as_str() {
-            "todos" => self
-                .root_rows
-                .iter()
-                .map(|root| {
+    fn prepare_source_graph<'a>(
+        &'a mut self,
+        request: &'a SourceRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<ResolvedSource, SourceResolutionError>> + 'a>> {
+        Box::pin(async move {
+            self.requests.push(request.clone());
+            let descriptor = RecordDescriptor::new([
+                ("row_uuid", ValueType::Uuid),
+                (
+                    "user_title",
+                    ValueType::Nullable(Box::new(ValueType::String)),
+                ),
+                ("user_todo", ValueType::Nullable(Box::new(ValueType::Uuid))),
+                ("$createdAt", ValueType::U64),
+                ("$createdBy", ValueType::Uuid),
+                ("$updatedAt", ValueType::U64),
+                ("$updatedBy", ValueType::Uuid),
+            ]);
+            let parent = row(0xd1).0;
+            let rows = match request.source.table.as_str() {
+                "todos" => self
+                    .root_rows
+                    .iter()
+                    .map(|root| {
+                        descriptor
+                            .create(&[
+                                Value::Uuid(row(root.id).0),
+                                Value::Nullable(Some(Box::new(Value::String(
+                                    root.title.to_owned(),
+                                )))),
+                                Value::Nullable(None),
+                                Value::U64(root.created_at),
+                                Value::Uuid(row(root.created_by).0),
+                                Value::U64(root.updated_at),
+                                Value::Uuid(row(root.updated_by).0),
+                            ])
+                            .expect("inline parent")
+                    })
+                    .collect(),
+                "todo_tags" => [(0xd2, "allowed"), (0xd3, "denied")]
+                    .into_iter()
+                    .filter(|(_, title)| {
+                        !matches!(
+                            (&request.authorization, self.denied_child_title),
+                            (SourceAuthorizationRequest::PolicyFiltered { .. }, Some(denied))
+                                if denied == "*" || *title == denied
+                        )
+                    })
+                    .map(|(id, title)| {
+                        descriptor
+                            .create(&[
+                                Value::Uuid(row(id).0),
+                                Value::Nullable(Some(Box::new(Value::String(title.to_owned())))),
+                                Value::Nullable(Some(Box::new(Value::Uuid(parent)))),
+                                Value::U64(20),
+                                Value::Uuid(row(0xa2).0),
+                                Value::U64(21),
+                                Value::Uuid(row(0xa2).0),
+                            ])
+                            .expect("inline child")
+                    })
+                    .collect(),
+                "todo_labels" => vec![
                     descriptor
                         .create(&[
-                            Value::Uuid(row(root.id).0),
-                            Value::Nullable(Some(Box::new(Value::String(root.title.to_owned())))),
-                            Value::Nullable(None),
-                            Value::U64(root.created_at),
-                            Value::Uuid(row(root.created_by).0),
-                            Value::U64(root.updated_at),
-                            Value::Uuid(row(root.updated_by).0),
-                        ])
-                        .expect("inline parent")
-                })
-                .collect(),
-            "todo_tags" => [(0xd2, "allowed"), (0xd3, "denied")]
-                .into_iter()
-                .filter(|(_, title)| {
-                    !matches!(
-                        (&request.authorization, self.denied_child_title),
-                        (SourceAuthorizationRequest::PolicyFiltered { .. }, Some(denied))
-                            if denied == "*" || *title == denied
-                    )
-                })
-                .map(|(id, title)| {
-                    descriptor
-                        .create(&[
-                            Value::Uuid(row(id).0),
-                            Value::Nullable(Some(Box::new(Value::String(title.to_owned())))),
+                            Value::Uuid(row(0xd4).0),
+                            Value::Nullable(Some(Box::new(Value::String("label".to_owned())))),
                             Value::Nullable(Some(Box::new(Value::Uuid(parent)))),
-                            Value::U64(20),
-                            Value::Uuid(row(0xa2).0),
-                            Value::U64(21),
-                            Value::Uuid(row(0xa2).0),
+                            Value::U64(30),
+                            Value::Uuid(row(0xa3).0),
+                            Value::U64(31),
+                            Value::Uuid(row(0xa3).0),
                         ])
-                        .expect("inline child")
-                })
-                .collect(),
-            "todo_labels" => vec![
-                descriptor
-                    .create(&[
-                        Value::Uuid(row(0xd4).0),
-                        Value::Nullable(Some(Box::new(Value::String("label".to_owned())))),
-                        Value::Nullable(Some(Box::new(Value::Uuid(parent)))),
-                        Value::U64(30),
-                        Value::Uuid(row(0xa3).0),
-                        Value::U64(31),
-                        Value::Uuid(row(0xa3).0),
-                    ])
-                    .expect("inline sibling child"),
-            ],
-            "tag_notes" => vec![
-                descriptor
-                    .create(&[
-                        Value::Uuid(row(0xd5).0),
-                        Value::Nullable(Some(Box::new(Value::String("note".to_owned())))),
-                        Value::Nullable(Some(Box::new(Value::Uuid(row(0xd2).0)))),
-                        Value::U64(40),
-                        Value::Uuid(row(0xa4).0),
-                        Value::U64(41),
-                        Value::Uuid(row(0xa4).0),
-                    ])
-                    .expect("inline grandchild"),
-            ],
-            other => panic!("unexpected inline collector source {other}"),
-        };
-        Ok(ResolvedSource {
-            table_schema: TableSchema::new(
-                request.source.table.clone(),
-                [
-                    ColumnSchema::new("title", ColumnType::String),
-                    ColumnSchema::new("todo", ColumnType::Nullable(Box::new(ColumnType::Uuid))),
+                        .expect("inline sibling child"),
                 ],
-            ),
-            graph: GraphBuilder::inline_records(descriptor.clone(), rows),
-            row_shape: SourceRowShape {
-                source: request.source.clone(),
-                descriptor,
-                row_uuid_field: "row_uuid".to_owned(),
-                metadata: BTreeMap::new(),
-            },
-            routing_fields: BTreeSet::new(),
-            requires_result_payload: false,
-            content_version: None,
-            deletion_register: None,
+                "tag_notes" => vec![
+                    descriptor
+                        .create(&[
+                            Value::Uuid(row(0xd5).0),
+                            Value::Nullable(Some(Box::new(Value::String("note".to_owned())))),
+                            Value::Nullable(Some(Box::new(Value::Uuid(row(0xd2).0)))),
+                            Value::U64(40),
+                            Value::Uuid(row(0xa4).0),
+                            Value::U64(41),
+                            Value::Uuid(row(0xa4).0),
+                        ])
+                        .expect("inline grandchild"),
+                ],
+                other => panic!("unexpected inline collector source {other}"),
+            };
+            Ok(ResolvedSource {
+                table_schema: TableSchema::new(
+                    request.source.table.clone(),
+                    [
+                        ColumnSchema::new("title", ColumnType::String),
+                        ColumnSchema::new("todo", ColumnType::Nullable(Box::new(ColumnType::Uuid))),
+                    ],
+                ),
+                graph: GraphBuilder::inline_records(descriptor.clone(), rows),
+                row_shape: SourceRowShape {
+                    source: request.source.clone(),
+                    descriptor,
+                    row_uuid_field: "row_uuid".to_owned(),
+                    metadata: BTreeMap::new(),
+                },
+                routing_fields: BTreeSet::new(),
+                requires_result_payload: false,
+                content_version: None,
+                deletion_register: None,
+            })
         })
     }
 }

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -7,6 +7,7 @@
 
 use super::*;
 use crate::node::query_engine::BranchViewSourceBase;
+use std::{future::Future, pin::Pin};
 pub(super) struct JazzSourceGraphPreparer<'a, S> {
     pub(super) node: &'a mut NodeState<S>,
     pub(super) read_view: &'a ReadView<RequestedSourceStage>,
@@ -42,11 +43,13 @@ pub(super) enum CurrentAccessPath {
     },
 }
 
-impl<S> SourceGraphPreparer for JazzSourceGraphPreparer<'_, S>
+impl<S> JazzSourceGraphPreparer<'_, S>
 where
     S: OrderedKvStorage,
 {
-    async fn prepare_source_graph(
+    /// The complete source-family dispatcher. Keep uncommon historical and
+    /// branch paths out of the ordinary inline policy-evaluation frame.
+    async fn prepare_source_graph_dispatch(
         &mut self,
         request: &SourceRequest,
     ) -> Result<ResolvedSource, SourceResolutionError> {
@@ -1222,6 +1225,375 @@ where
             content_version,
             deletion_register,
         })
+    }
+
+    /// Prepare the ordinary current-row source without constructing the
+    /// historical/branch source-state machine.  This is the hot path for
+    /// regular reads and policy admission, where keeping the async frame
+    /// bounded matters because it can run beneath a peer tick.
+    async fn prepare_unprojected_visible_current_source_graph(
+        &mut self,
+        request: &SourceRequest,
+        tier: DurabilityTier,
+    ) -> Result<ResolvedSource, SourceResolutionError> {
+        let projection = match self.read_view.sources.get(&request.source) {
+            Some(SourceExpr::VisibleCurrent {
+                projection,
+                data: DataSource::Current,
+                ..
+            }) => projection.clone(),
+            _ => return Err(source_resolution_error(request, SourceGap::Coverage)),
+        };
+        if !matches!(projection.schema_family, SchemaFamilySelection::Current)
+            || !matches!(
+                projection.storage,
+                StorageSchemaSelection::Single(_) | StorageSchemaSelection::CompatiblePartitions
+            )
+            || !matches!(projection.lens, LensSelection::Canonical)
+        {
+            return Err(source_resolution_error(
+                request,
+                SourceGap::SchemaProjection,
+            ));
+        }
+        let table = self
+            .node
+            .table_in_schema(&request.source.table, self.read_view.read_schema)
+            .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
+        // Policy-proof dependencies are raw evidence for the outer policy.
+        // Re-applying their own read policy recursively both changes the
+        // outer predicate's meaning and can manufacture a proof cycle.
+        let authorization = if matches!(
+            request.authorization,
+            SourceAuthorizationRequest::PolicyProof { .. }
+        ) {
+            SourceAuthorizationRequest::System
+        } else {
+            request.authorization.clone()
+        };
+        let selected_base = self
+            .selected_global_current_source_graph(request, &table, tier)
+            .await?;
+        let selected_base = match selected_base {
+            Some(selected_base) => Some(selected_base),
+            None => match self.cached_policy_authorization_access_path(request)? {
+                Some(access_path) => {
+                    self.selected_global_current_source_graph_for_access_path(
+                        request,
+                        &table,
+                        tier,
+                        access_path,
+                    )
+                    .await?
+                }
+                None => None,
+            },
+        };
+        if selected_base.is_none() {
+            self.node.query_engine_read_metrics.source_full_scans += 1;
+        }
+        let (graph, descriptor, metadata, routing_fields) = resolved_current_source_graph(
+            self.node,
+            &table,
+            tier,
+            &request.requirements,
+            &authorization,
+            self.read_view.policy_schema,
+            Some(self.read_view),
+            None,
+            selected_base,
+        )
+        .map_err(|error| source_resolution_error_from_policy_proof(request, error))?;
+        let deletion_register =
+            self.deletion_register_source_for_request(request, &table, Some(tier), None, None)?;
+        let content_version = self
+            .content_version_source_for_request(request, &table, Some(tier), None, None)
+            .await?;
+        Ok(ResolvedSource {
+            table_schema: table,
+            graph,
+            row_shape: SourceRowShape {
+                source: request.source.clone(),
+                descriptor,
+                row_uuid_field: "row_uuid".to_owned(),
+                metadata,
+            },
+            routing_fields,
+            requires_result_payload: false,
+            content_version,
+            deletion_register,
+        })
+    }
+
+    /// Prepare a current-row source whose storage layout needs the projected
+    /// source path.  Kept separate from historical and branch preparation so
+    /// peer admission does not inherit their async frame.
+    async fn prepare_projected_visible_current_source_graph(
+        &mut self,
+        request: &SourceRequest,
+        tier: DurabilityTier,
+    ) -> Result<ResolvedSource, SourceResolutionError> {
+        let projection = match self.read_view.sources.get(&request.source) {
+            Some(SourceExpr::VisibleCurrent {
+                projection,
+                data: DataSource::Current,
+                ..
+            }) => projection.clone(),
+            _ => return Err(source_resolution_error(request, SourceGap::Coverage)),
+        };
+        if !matches!(projection.schema_family, SchemaFamilySelection::Current)
+            || !matches!(
+                projection.storage,
+                StorageSchemaSelection::Single(_) | StorageSchemaSelection::CompatiblePartitions
+            )
+            || !matches!(projection.lens, LensSelection::Canonical)
+        {
+            return Err(source_resolution_error(
+                request,
+                SourceGap::SchemaProjection,
+            ));
+        }
+        let table = self
+            .node
+            .table_in_schema(&request.source.table, self.read_view.read_schema)
+            .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
+        let authorization = if matches!(
+            request.authorization,
+            SourceAuthorizationRequest::PolicyProof { .. }
+        ) {
+            SourceAuthorizationRequest::System
+        } else {
+            request.authorization.clone()
+        };
+        let (graph, descriptor, metadata, routing_fields) =
+            if !request.requirements.metadata.is_empty() {
+                let source = self
+                    .projected_maintained_visible_current_source_graph(request, &table, tier)
+                    .await?;
+                resolved_current_source_graph(
+                    self.node,
+                    &table,
+                    tier,
+                    &request.requirements,
+                    &authorization,
+                    self.read_view.policy_schema,
+                    Some(self.read_view),
+                    None,
+                    Some(source.graph),
+                )
+                .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?
+            } else {
+                let selected_policy_base = if self.access_paths.contains_key(&request.source) {
+                    None
+                } else if let Some(access_path) =
+                    self.cached_policy_authorization_access_path(request)?
+                {
+                    self.selected_global_current_source_graph_for_access_path(
+                        request,
+                        &table,
+                        tier,
+                        access_path,
+                    )
+                    .await?
+                } else {
+                    None
+                };
+                let source = if let Some(graph) = selected_policy_base {
+                    CurrentSourceGraph {
+                        graph: graph.project_fields(storage_to_canonical_current_source_fields(
+                            &table, true, false,
+                        )),
+                        descriptor: current_row_descriptor(&table),
+                        metadata: BTreeMap::new(),
+                    }
+                } else {
+                    self.projected_visible_current_source_graph(request, &table, tier)
+                        .await?
+                };
+                let graph = match &authorization {
+                    SourceAuthorizationRequest::System => source.graph,
+                    SourceAuthorizationRequest::PolicyFiltered {
+                        permission_subject,
+                        plan,
+                    }
+                    | SourceAuthorizationRequest::PolicyProof {
+                        permission_subject,
+                        plan,
+                    } => {
+                        if plan.protected_source.table != table.name
+                            || plan.role != PolicyDecisionRole::Read
+                            || plan.protected_row_field != "row_uuid"
+                        {
+                            return Err(source_resolution_error(request, SourceGap::Coverage));
+                        }
+                        let param_binding_mode = if plan.binding_source_shape.is_some() {
+                            ParamBindingMode::RetainAllParams
+                        } else {
+                            ParamBindingMode::InlineAllReachableSeeds
+                        };
+                        let policy_request = self.node.table_read_policy_authorization_request(
+                            self.read_view.policy_schema,
+                            &table.name,
+                            *permission_subject,
+                            param_binding_mode,
+                            tier,
+                            plan.binding_source_shape.clone(),
+                            plan.binding_user_params.clone(),
+                            plan.binding_claim_params.clone(),
+                        );
+                        let policy_request = policy_request.map(|mut request| {
+                            request.reads.primary = policy_read_view_projected_through(
+                                &request.reads.primary,
+                                self.read_view,
+                            );
+                            request
+                        });
+                        self.node
+                            .compose_policy_filtered_current_source_graph(
+                                policy_request,
+                                source.graph,
+                                &current_row_fields(&table),
+                            )
+                            .map_err(|error| {
+                                source_resolution_error_from_policy_proof(request, error)
+                            })?
+                            .graph
+                    }
+                };
+                (graph, source.descriptor, source.metadata, BTreeSet::new())
+            };
+        let deletion_register =
+            self.deletion_register_source_for_request(request, &table, Some(tier), None, None)?;
+        let content_version = self
+            .content_version_source_for_request(request, &table, Some(tier), None, None)
+            .await?;
+        Ok(ResolvedSource {
+            table_schema: table,
+            graph,
+            row_shape: SourceRowShape {
+                source: request.source.clone(),
+                descriptor,
+                row_uuid_field: "row_uuid".to_owned(),
+                metadata,
+            },
+            routing_fields,
+            requires_result_payload: false,
+            content_version,
+            deletion_register,
+        })
+    }
+}
+
+impl<S> JazzSourceGraphPreparer<'_, S>
+where
+    S: OrderedKvStorage,
+{
+    async fn prepare_inline_visible_current_source_graph(
+        &mut self,
+        request: &SourceRequest,
+    ) -> Result<ResolvedSource, SourceResolutionError> {
+        let Some(SourceExpr::VisibleCurrent {
+            projection,
+            data: DataSource::Current,
+            ..
+        }) = self.read_view.sources.get(&request.source)
+        else {
+            return Err(source_resolution_error(request, SourceGap::Coverage));
+        };
+        let Some(rows) = self.inline_sources.get(&request.source) else {
+            return Err(source_resolution_error(request, SourceGap::Coverage));
+        };
+        if !matches!(projection.schema_family, SchemaFamilySelection::Current)
+            || !matches!(
+                projection.storage,
+                StorageSchemaSelection::Single(_) | StorageSchemaSelection::CompatiblePartitions
+            )
+            || !matches!(projection.lens, LensSelection::Canonical)
+        {
+            return Err(source_resolution_error(
+                request,
+                SourceGap::SchemaProjection,
+            ));
+        }
+        let authorization = if matches!(
+            request.authorization,
+            SourceAuthorizationRequest::PolicyProof { .. }
+        ) {
+            SourceAuthorizationRequest::System
+        } else {
+            request.authorization.clone()
+        };
+        if request.visibility != RowVisibility::Visible
+            || !matches!(authorization, SourceAuthorizationRequest::System)
+        {
+            return Err(source_resolution_error(request, SourceGap::Coverage));
+        }
+        let table = self
+            .node
+            .table_in_schema(&request.source.table, self.read_view.read_schema)
+            .map_err(|_| source_resolution_error(request, SourceGap::SchemaProjection))?;
+        let schema_version_alias = self
+            .node
+            .ensure_schema_version_alias(self.read_view.read_schema)
+            .await
+            .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
+        let (graph, descriptor, metadata) = inline_current_graph_with_source_metadata(
+            &table,
+            rows.clone(),
+            schema_version_alias,
+            "inline-current",
+            &request.requirements,
+        )
+        .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
+        Ok(ResolvedSource {
+            table_schema: table,
+            graph,
+            row_shape: SourceRowShape {
+                source: request.source.clone(),
+                descriptor,
+                row_uuid_field: "row_uuid".to_owned(),
+                metadata,
+            },
+            routing_fields: BTreeSet::new(),
+            requires_result_payload: false,
+            content_version: None,
+            deletion_register: None,
+        })
+    }
+}
+
+impl<S> SourceGraphPreparer for JazzSourceGraphPreparer<'_, S>
+where
+    S: OrderedKvStorage,
+{
+    fn prepare_source_graph<'a>(
+        &'a mut self,
+        request: &'a SourceRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<ResolvedSource, SourceResolutionError>> + 'a>> {
+        let visible_current = match self.read_view.sources.get(&request.source) {
+            Some(SourceExpr::VisibleCurrent {
+                projection,
+                data: DataSource::Current,
+                tier,
+            }) => Some((projection.clone(), *tier)),
+            _ => None,
+        };
+        if let Some((_projection, tier)) = visible_current {
+            if self.inline_sources.contains_key(&request.source) {
+                return Box::pin(self.prepare_inline_visible_current_source_graph(request));
+            }
+            if request.visibility == RowVisibility::Visible {
+                if self.needs_projected_current_source(&request.source.table) {
+                    return Box::pin(
+                        self.prepare_projected_visible_current_source_graph(request, tier),
+                    );
+                }
+                return Box::pin(
+                    self.prepare_unprojected_visible_current_source_graph(request, tier),
+                );
+            }
+        }
+        Box::pin(self.prepare_source_graph_dispatch(request))
     }
 }
 

--- a/crates/jazz/src/node/query_eval/tests/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/tests/subscriptions.rs
@@ -22,7 +22,9 @@ fn graph_contains_point_scan(graph: &GraphBuilder) -> bool {
         | GraphBuilder::TopBy { input, .. }
         | GraphBuilder::CollectBy { input, .. }
         | GraphBuilder::Aggregate { input, .. } => graph_contains_point_scan(input),
-        GraphBuilder::Union { inputs } => inputs.iter().any(graph_contains_point_scan),
+        GraphBuilder::Union { inputs } => {
+            inputs.iter().any(|input| graph_contains_point_scan(input))
+        }
         GraphBuilder::Join { left, right, .. }
         | GraphBuilder::SemiJoin { left, right, .. }
         | GraphBuilder::AntiJoin { left, right, .. } => {


### PR DESCRIPTION
🤖 Fixes the default-thread stack overflow discovered while exercising the fully integrated structured-subscription path.

## Before

Deeply lowered policy/query graphs used recursively owned `Box<GraphBuilder>` children. Cloning, inspecting, rewriting, hashing, or comparing a sufficiently deep graph recursively consumed the owner thread's stack. A realistic propagated structured subscription could therefore abort the process on Rust's normal 2 MiB test-thread stack. Merely splitting the first large async frame moved the failure to the next recursive graph operation.

## After

- Recursive graph edges are immutable `Arc<GraphBuilder>` children, so ordinary graph clones are shallow.
- Runtime rewrite and inspection paths use bounded postorder traversals.
- Shape rewriting memoizes original child pointers, retaining shared DAG structure instead of expanding shared subgraphs.
- Auto-direct family identity uses a bounded structural fingerprint plus exact iterative equality, so hash collisions remain harmless without recursively hashing/comparing the graph.
- The query source dispatcher is split into smaller behavior-preserving helpers, keeping its synchronous frame bounded.

## Worked examples

- A 4,096-node unary graph can be cloned, inspected, shape-rewritten, fingerprinted, and compared on an explicit 2 MiB thread.
- Two parents that share one child before a shape rewrite still share one rewritten child afterward.
- A propagated structured subscription whose policy graph previously aborted now installs and rehydrates normally.

## Non-goals

This does not change query semantics, lowering choices, or subscription results. It only changes graph ownership and traversal mechanics so depth controlled by application schemas and policies cannot exhaust the runtime stack.

## Verification

- Full Groove library suite: 605 passed, 2 ignored.
- Full Jazz library suite: 1,563 passed, 2 ignored in the implementation receipt.
- Independent adversarial review reproduced the old 2 MiB overflow, verified shared-DAG retention, and planted a wrong-shape mutation that the new bounded-stack receipt caught.
- Final stack CI-equivalent local gate passed.
