### PR TITLE
Share embedded server shutdown completion

### DIFF
--- a/.changeset/clear-moths-stop.md
+++ b/.changeset/clear-moths-stop.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reject embedded server stop calls when shutdown finalization fails.

--- a/.changeset/clear-moths-stop.md
+++ b/.changeset/clear-moths-stop.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Reject embedded server stop calls when shutdown finalization fails.
+Make concurrent and repeated embedded server stop calls share the same successful or failed terminal shutdown result.

--- a/crates/jazz-napi/Cargo.toml
+++ b/crates/jazz-napi/Cargo.toml
@@ -16,7 +16,7 @@ jazz-server = { path = "../jazz-server", features = ["embedded-server"] }
 jazz-native-transport = { path = "../jazz-native-transport" }
 jazz-storage-rocksdb = { workspace = true, optional = true }
 jazz-otel.workspace = true
-tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync"] }
 futures = "0.3"
 base64 = "0.22"
 napi = { version = "3", features = ["napi6", "serde-json", "async"] }

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -43,14 +43,16 @@ pub type JsonValue = serde_json::Value;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::future::Future;
+use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::rc::Rc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Waker};
 use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use futures::FutureExt;
 use futures::future::LocalBoxFuture;
 use futures::lock::Mutex as LocalMutex;
 use futures::task::{ArcWake, waker};
@@ -4535,7 +4537,18 @@ impl TestJwtIssuer {
 
 #[napi]
 pub struct JazzServer {
-    inner: Mutex<Option<JazzServerInner>>,
+    lifecycle: Arc<JazzServerLifecycle>,
+}
+
+struct JazzServerLifecycle {
+    state: Mutex<JazzServerState>,
+    changed: tokio::sync::watch::Sender<()>,
+}
+
+enum JazzServerState {
+    Running(JazzServerInner),
+    Stopping,
+    Stopped(std::result::Result<(), String>),
 }
 
 enum JazzServerInner {
@@ -4629,9 +4642,7 @@ impl JazzServer {
         )
         .await;
 
-        Ok(Self {
-            inner: Mutex::new(Some(JazzServerInner::Core(server))),
-        })
+        Ok(Self::from_inner(JazzServerInner::Core(server)))
     }
 
     #[napi(getter, js_name = "appId")]
@@ -4678,35 +4689,103 @@ impl JazzServer {
 
     #[napi]
     pub async fn stop(&self) -> napi::Result<()> {
-        let server = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("lock"))?
-            .take();
-
-        if let Some(server) = server {
-            let phase = match server {
-                JazzServerInner::Core(server) => server.shutdown().await,
-            };
-            if phase != jazz_server::ShutdownPhase::StorageClosed {
-                return Err(napi::Error::from_reason(format!(
-                    "JazzServer shutdown failed during phase {phase:?}"
-                )));
+        let mut changes = self.lifecycle.changed.subscribe();
+        let shutdown_owner = {
+            let mut state = self
+                .lifecycle
+                .state
+                .lock()
+                .map_err(|_| napi::Error::from_reason("lock"))?;
+            match &*state {
+                JazzServerState::Running(_) => {
+                    let JazzServerState::Running(server) =
+                        std::mem::replace(&mut *state, JazzServerState::Stopping)
+                    else {
+                        unreachable!("running state changed while locked")
+                    };
+                    Some(server)
+                }
+                JazzServerState::Stopping | JazzServerState::Stopped(_) => None,
             }
+        };
+
+        if let Some(server) = shutdown_owner {
+            let lifecycle = Arc::clone(&self.lifecycle);
+            tokio::spawn(async move {
+                let result = AssertUnwindSafe(shutdown_jazz_server(server))
+                    .catch_unwind()
+                    .await
+                    .unwrap_or_else(|_| Err("JazzServer shutdown task panicked".to_owned()));
+                let mut state = lifecycle
+                    .state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                *state = JazzServerState::Stopped(result);
+                drop(state);
+                lifecycle.changed.send_replace(());
+            });
         }
 
-        Ok(())
+        loop {
+            let result = {
+                let state = self
+                    .lifecycle
+                    .state
+                    .lock()
+                    .map_err(|_| napi::Error::from_reason("lock"))?;
+                match &*state {
+                    JazzServerState::Running(_) => {
+                        return Err(napi::Error::from_reason(
+                            "JazzServer shutdown state returned to running",
+                        ));
+                    }
+                    JazzServerState::Stopping => None,
+                    JazzServerState::Stopped(result) => Some(result.clone()),
+                }
+            };
+            if let Some(result) = result {
+                return result.map_err(napi::Error::from_reason);
+            }
+            changes.changed().await.map_err(|_| {
+                napi::Error::from_reason("JazzServer shutdown state closed unexpectedly")
+            })?;
+        }
+    }
+
+    fn from_inner(inner: JazzServerInner) -> Self {
+        let (changed, _) = tokio::sync::watch::channel(());
+        Self {
+            lifecycle: Arc::new(JazzServerLifecycle {
+                state: Mutex::new(JazzServerState::Running(inner)),
+                changed,
+            }),
+        }
     }
 
     fn with_server<T>(&self, f: impl FnOnce(&JazzServerInner) -> T) -> napi::Result<T> {
-        let server = self
-            .inner
+        let state = self
+            .lifecycle
+            .state
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
-        let server = server
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("JazzServer has been stopped"))?;
-        Ok(f(server))
+        match &*state {
+            JazzServerState::Running(server) => Ok(f(server)),
+            JazzServerState::Stopping => Err(napi::Error::from_reason("JazzServer is stopping")),
+            JazzServerState::Stopped(_) => {
+                Err(napi::Error::from_reason("JazzServer has been stopped"))
+            }
+        }
+    }
+}
+
+async fn shutdown_jazz_server(server: JazzServerInner) -> std::result::Result<(), String> {
+    let phase = match server {
+        JazzServerInner::Core(server) => server.shutdown().await,
+    };
+    if phase == jazz_server::ShutdownPhase::StorageClosed {
+        Ok(())
+    } else {
+        Err(format!("JazzServer shutdown failed during phase {phase:?}"))
     }
 }
 
@@ -4783,21 +4862,23 @@ pub fn verify_local_first_identity_proof_napi(
 mod tests {
     use base64::Engine;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-    use std::collections::{BTreeMap, VecDeque};
+    use std::collections::{BTreeMap, HashSet, VecDeque};
     use std::rc::Rc;
+    use std::time::Duration;
 
     use futures::channel::oneshot;
 
     use crate::{
-        CoreOpenDbConfig, CoreSelfSignedClientProof, InsertOptions, NapiDb, NapiDbInnerStorage,
-        NapiTxKind, PendingNativeRead, PendingNativeSubscriptionBatch,
+        CoreOpenDbConfig, CoreSelfSignedClientProof, InsertOptions, JazzServer, JazzServerInner,
+        NapiDb, NapiDbInnerStorage, NapiTxKind, PendingNativeRead, PendingNativeSubscriptionBatch,
         PendingSubscriptionBatchOutcome, PendingSubscriptionBatchPoll, PreparedQuery,
         RestoreOptions, Tx, UpdateOptions, UpsertOptions, authority_epoch_from_bigint,
         core_author_id_from_bytes, core_block_on, core_claim_value_from_json, core_insert_options,
         core_open_backend_identity, core_open_identity, core_read_opts_from_json,
         core_read_tier_from_str, core_restore_options, core_subscription_event_to_napi,
         core_update_options, core_upsert_options, encode_core_subscription_delta,
-        requeue_retryable_subscription_batch, unknown_transaction_kind_message,
+        requeue_retryable_subscription_batch, terminal_bytes_to_numbers,
+        unknown_transaction_kind_message,
     };
 
     #[test]
@@ -4900,6 +4981,86 @@ mod tests {
             unknown_transaction_kind_message("invalid"),
             "unknown transaction kind invalid"
         );
+    }
+
+    async fn jazz_server_binding(
+        built: jazz_server::BuiltServer,
+        app_id: jazz::tools::AppId,
+    ) -> JazzServer {
+        let server = jazz_server::JazzServer::from_built(
+            built,
+            None,
+            app_id,
+            jazz_server::ServerDataDir::in_memory(),
+            "napi-stop-test-admin".to_owned(),
+            "napi-stop-test-backend".to_owned(),
+        )
+        .await;
+        JazzServer::from_inner(JazzServerInner::Core(server))
+    }
+
+    #[tokio::test]
+    async fn jazz_server_stop_shares_success_with_concurrent_and_later_callers() {
+        let app_id = jazz::tools::AppId::from_name("napi-stop-success");
+        let built = jazz_server::ServerBuilder::new(app_id)
+            .with_storage(jazz_server::StorageBackend::InMemory)
+            .build()
+            .await
+            .expect("build NAPI test server");
+        let server = jazz_server_binding(built, app_id).await;
+
+        let (first, second) = tokio::join!(server.stop(), server.stop());
+        assert!(first.is_ok(), "shutdown owner succeeds: {first:?}");
+        assert!(
+            second.is_ok(),
+            "concurrent waiter shares success: {second:?}"
+        );
+        assert!(
+            server.stop().await.is_ok(),
+            "later caller replays terminal success"
+        );
+    }
+
+    #[tokio::test]
+    async fn jazz_server_stop_shares_failure_with_concurrent_and_later_callers() {
+        let app_id = jazz::tools::AppId::from_name("napi-stop-failure");
+        let built = jazz_server::ServerBuilder::new(app_id)
+            .with_storage(jazz_server::StorageBackend::InMemory)
+            .with_shutdown_timeout(Duration::from_millis(1))
+            .build()
+            .await
+            .expect("build NAPI test server");
+        let active_request = built
+            .state
+            .shutdown
+            .try_enter_app_request()
+            .expect("hold request through shutdown timeout");
+        let server = jazz_server_binding(built, app_id).await;
+
+        let (first, second) = tokio::join!(server.stop(), server.stop());
+        let first = first
+            .expect_err("shutdown owner reports failure")
+            .reason
+            .clone();
+        let second = second
+            .expect_err("concurrent waiter reports failure")
+            .reason
+            .clone();
+        assert_eq!(second, first);
+        assert_eq!(
+            first, "JazzServer shutdown failed during phase Failed",
+            "binding preserves the embedded host's terminal failure"
+        );
+        assert_eq!(
+            server
+                .stop()
+                .await
+                .expect_err("later caller replays failure")
+                .reason
+                .clone(),
+            first
+        );
+        drop(active_request);
     }
     use jazz::db::{
         Db as CoreDb, DbConfig as CoreDbConfig, DbIdentity as CoreDbIdentity, ExclusiveTxOps,

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -4862,8 +4862,9 @@ pub fn verify_local_first_identity_proof_napi(
 mod tests {
     use base64::Engine;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-    use std::collections::{BTreeMap, HashSet, VecDeque};
+    use std::collections::{BTreeMap, VecDeque};
     use std::rc::Rc;
+    use std::task::{Context, Poll, Waker};
     use std::time::Duration;
 
     use futures::channel::oneshot;
@@ -4877,8 +4878,7 @@ mod tests {
         core_open_backend_identity, core_open_identity, core_read_opts_from_json,
         core_read_tier_from_str, core_restore_options, core_subscription_event_to_napi,
         core_update_options, core_upsert_options, encode_core_subscription_delta,
-        requeue_retryable_subscription_batch, terminal_bytes_to_numbers,
-        unknown_transaction_kind_message,
+        requeue_retryable_subscription_batch, unknown_transaction_kind_message,
     };
 
     #[test]
@@ -5018,6 +5018,38 @@ mod tests {
         assert!(
             server.stop().await.is_ok(),
             "later caller replays terminal success"
+        );
+    }
+
+    #[tokio::test]
+    async fn jazz_server_stop_finalization_outlives_the_initiating_future() {
+        let app_id = jazz::tools::AppId::from_name("napi-stop-cancelled-initiator");
+        let built = jazz_server::ServerBuilder::new(app_id)
+            .with_storage(jazz_server::StorageBackend::InMemory)
+            .build()
+            .await
+            .expect("build NAPI test server");
+        let server = jazz_server_binding(built, app_id).await;
+
+        // The first poll synchronously transfers Running -> Stopping and
+        // launches the independently owned finalizer. Dropping this future
+        // models cancellation of the Promise which initiated `stop`.
+        let mut initiator = Box::pin(server.stop());
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        assert!(matches!(
+            initiator.as_mut().poll(&mut context),
+            Poll::Pending
+        ));
+        drop(initiator);
+
+        assert!(
+            server.stop().await.is_ok(),
+            "waiter completes the finalization detached from its initiator"
+        );
+        assert!(
+            server.stop().await.is_ok(),
+            "later caller replays the same completed outcome"
         );
     }
 

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -4685,8 +4685,13 @@ impl JazzServer {
             .take();
 
         if let Some(server) = server {
-            match server {
+            let phase = match server {
                 JazzServerInner::Core(server) => server.shutdown().await,
+            };
+            if phase != jazz_server::ShutdownPhase::StorageClosed {
+                return Err(napi::Error::from_reason(format!(
+                    "JazzServer shutdown failed during phase {phase:?}"
+                )));
             }
         }
 

--- a/crates/jazz-server/src/server/testing.rs
+++ b/crates/jazz-server/src/server/testing.rs
@@ -15,7 +15,7 @@ use jazz::tools::AppContext;
 use jazz::tools::AppId;
 use jazz::tools::public_schema::Schema;
 
-use super::{BuiltServer, ServerBuilder, ServerState, StorageBackend};
+use super::{BuiltServer, ServerBuilder, ServerState, ShutdownPhase, StorageBackend};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
@@ -237,8 +237,8 @@ impl Drop for TestJwtIssuer {
 
 pub struct JazzServer {
     state: Arc<ServerState>,
-    task: Option<JoinHandle<()>>,
-    shutdown_task: Option<JoinHandle<()>>,
+    task: Option<JoinHandle<std::io::Result<()>>>,
+    shutdown_task: Option<JoinHandle<ShutdownPhase>>,
     port: u16,
     app_id: AppId,
     data_dir: ServerDataDir,
@@ -363,8 +363,9 @@ impl JazzServer {
         let shutdown_task = tokio::spawn(async move {
             shutdown_state.shutdown.wait_requested().await;
             tokio::time::sleep(Duration::from_millis(50)).await;
-            shutdown_state.run_shutdown_finalization().await;
+            let phase = shutdown_state.run_shutdown_finalization().await;
             let _ = serve_shutdown_tx.send(());
+            phase
         });
         let task = tokio::spawn(async move {
             axum::serve(listener, built.app)
@@ -372,7 +373,6 @@ impl JazzServer {
                     let _ = serve_shutdown_rx.await;
                 })
                 .await
-                .expect("serve jazz server");
         });
 
         let server = Self {
@@ -474,31 +474,50 @@ impl JazzServer {
         self.data_dir.path()
     }
 
-    pub async fn shutdown(mut self) {
+    pub async fn shutdown(mut self) -> ShutdownPhase {
         self.state.shutdown.request_shutdown();
         let shutdown_budget = self.state.shutdown.timeout() * 2 + Duration::from_secs(5);
 
-        let mut finalization_completed = false;
-        if let Some(mut shutdown_task) = self.shutdown_task.take()
-            && tokio::time::timeout(shutdown_budget, &mut shutdown_task)
-                .await
-                .is_ok()
-        {
-            finalization_completed = true;
+        let phase = if let Some(mut shutdown_task) = self.shutdown_task.take() {
+            match tokio::time::timeout(shutdown_budget, &mut shutdown_task).await {
+                Ok(Ok(phase)) => phase,
+                Ok(Err(error)) => {
+                    tracing::error!(%error, "embedded shutdown finalization task failed");
+                    return ShutdownPhase::Failed;
+                }
+                Err(_) => {
+                    shutdown_task.abort();
+                    tracing::error!("embedded shutdown finalization timed out");
+                    return ShutdownPhase::Failed;
+                }
+            }
+        } else {
+            self.state.shutdown.phase()
+        };
+        if phase != ShutdownPhase::StorageClosed {
+            return phase;
         }
 
-        if !finalization_completed {
-            return;
+        if let Some(mut task) = self.task.take() {
+            match tokio::time::timeout(shutdown_budget, &mut task).await {
+                Ok(Ok(Ok(()))) => {}
+                Ok(Ok(Err(error))) => {
+                    tracing::error!(%error, "embedded server task failed during shutdown");
+                    return ShutdownPhase::Failed;
+                }
+                Ok(Err(error)) => {
+                    tracing::error!(%error, "embedded server task join failed during shutdown");
+                    return ShutdownPhase::Failed;
+                }
+                Err(_) => {
+                    task.abort();
+                    let _ = tokio::time::timeout(Duration::from_millis(50), task).await;
+                    tracing::error!("embedded server task timed out during shutdown");
+                    return ShutdownPhase::Failed;
+                }
+            }
         }
-
-        if let Some(mut task) = self.task.take()
-            && tokio::time::timeout(shutdown_budget, &mut task)
-                .await
-                .is_err()
-        {
-            task.abort();
-            let _ = tokio::time::timeout(Duration::from_millis(50), task).await;
-        }
+        ShutdownPhase::StorageClosed
     }
 
     async fn wait_ready(&self) {
@@ -682,7 +701,7 @@ mod tests {
         assert!(context.jwt_token.is_some());
         assert!(context.admin_secret.is_none());
 
-        server.shutdown().await;
+        assert_eq!(server.shutdown().await, ShutdownPhase::StorageClosed);
     }
 
     #[tokio::test]
@@ -716,6 +735,34 @@ mod tests {
             "JazzServer uses an external JWKS URL; built-in JWT helpers are unavailable. Mint JWTs from your external JWKS test fixture instead."
         );
 
-        server.shutdown().await;
+        assert_eq!(server.shutdown().await, ShutdownPhase::StorageClosed);
+    }
+
+    #[tokio::test]
+    async fn embedded_shutdown_reports_finalization_failure() {
+        let app_id = JazzServer::default_app_id();
+        let built = ServerBuilder::new(app_id)
+            .with_storage(StorageBackend::InMemory)
+            .with_shutdown_timeout(Duration::from_millis(1))
+            .build()
+            .await
+            .expect("build embedded server");
+        let active_request = built
+            .state
+            .shutdown
+            .try_enter_app_request()
+            .expect("enter active request");
+        let server = JazzServer::from_built(
+            built,
+            None,
+            app_id,
+            ServerDataDir::in_memory(),
+            JazzServer::ADMIN_SECRET.to_owned(),
+            JazzServer::BACKEND_SECRET.to_owned(),
+        )
+        .await;
+
+        assert_eq!(server.shutdown().await, ShutdownPhase::Failed);
+        drop(active_request);
     }
 }

--- a/packages/jazz-tools/src/dev/dev-server.test.ts
+++ b/packages/jazz-tools/src/dev/dev-server.test.ts
@@ -1,4 +1,5 @@
 import { access } from "node:fs/promises";
+import { JazzServer } from "jazz-napi";
 import { afterEach, describe, expect, it } from "vitest";
 import { startLocalJazzServer, type LocalJazzServerHandle } from "./dev-server.js";
 import { getAvailablePort } from "./test-helpers.js";
@@ -59,6 +60,28 @@ describe("startLocalJazzServer via JazzServer", () => {
     handle = null;
 
     await expect(fetch(`${url}/health`).then((r) => r.ok)).rejects.toThrow();
+  }, 30_000);
+
+  it("shares native stop completion with concurrent and repeated callers", async () => {
+    const port = await getAvailablePort();
+    const server = await JazzServer.start({
+      appId: "00000000-0000-0000-0000-000000000002",
+      port,
+      inMemory: true,
+      adminSecret: "concurrent-stop-admin",
+      backendSecret: "concurrent-stop-backend",
+    });
+
+    try {
+      const results = await Promise.allSettled([server.stop(), server.stop()]);
+      expect(results).toEqual([
+        { status: "fulfilled", value: undefined },
+        { status: "fulfilled", value: undefined },
+      ]);
+      await expect(server.stop()).resolves.toBeUndefined();
+    } finally {
+      await server.stop().catch(() => undefined);
+    }
   }, 30_000);
 
   it("passes edge upstream options through JazzServer with admin secret only", async () => {


### PR DESCRIPTION
🤖 Replaces merged-in-stack #2268 at the earliest layer whose native-artifact corpus exercises embedded-server shutdown.

## Before

The first `JazzServer.stop()` caller took ownership of the native server. Concurrent or later callers could resolve without observing whether native finalization succeeded, and test cleanup could race a still-open RocksDB directory.

## After

Shutdown is one shared `Running → Stopping → Stopped` transition. Every concurrent and repeated caller observes the same immutable success or failure, and success requires native storage to be closed.

```ts
const first = server.stop();
const second = server.stop();
await Promise.all([first, second]);
await server.stop(); // replays the same terminal result
```

If finalization fails, times out, or panics, every waiter rejects with that terminal result.

## Non-goals

This does not change client database shutdown, durability semantics, or add shutdown retries.

## Verification

- Concurrent/repeated NAPI stop receipts pass.
- Embedded finalization-failure receipt passes.
- Jazz Tools dev-server tests pass.
- The final CI-equivalent stack gate passes.
