### PR TITLE
Restore permanent catalogue identity retirement

### DIFF
--- a/crates/jazz/fixtures/persistent_codec_family_registry.json
+++ b/crates/jazz/fixtures/persistent_codec_family_registry.json
@@ -481,24 +481,24 @@
       ]
     },
     {
-      "id": "jazz.idb-page.v2",
+      "id": "jazz.idb-page.v1",
       "boundary": "durable-storage",
       "spec": {
         "path": "crates/groove/SPEC/2_storage_model.md",
         "anchor": "### IndexedDB page-store physical format"
       },
       "semantic_fixture": {
-        "path": "crates/idb-tree/fixtures/page-v2-leaf.hex",
+        "path": "crates/idb-tree/fixtures/page-v1-leaf.hex",
         "anchor": "49444254524545"
       },
       "rejection_receipt": {
         "path": "crates/idb-tree/src/page.rs",
-        "anchor": "page_v2_decoder_rejects_noncanonical_or_malformed_payloads"
+        "anchor": "page_v1_decoder_rejects_noncanonical_or_malformed_payloads"
       },
       "evidence": [
         {
           "path": "packages/jazz-tools/tests/browser/indexeddb-physical-epoch.test.ts",
-          "anchor": "opens a manually committed epoch-one page-v2 fixture read-only, writes current data, and reopens"
+          "anchor": "opens a manually committed epoch-one page-v1 fixture read-only, writes current data, and reopens"
         }
       ]
     },

--- a/crates/jazz/src/node/ingest/catalogue.rs
+++ b/crates/jazz/src/node/ingest/catalogue.rs
@@ -489,6 +489,27 @@ where
         } else {
             if let Some(source) = self.catalogue.catalogue_schemas.get(&lens.source) {
                 Self::validate_migration_lens_between(lens, source, schema)?;
+                let identity_history = self.physical_identity_history_for_candidate(
+                    publication.schema.id,
+                    Some(publication.id),
+                );
+                let source_identities = &self
+                    .catalogue
+                    .physical_mappings
+                    .get(&lens.source)
+                    .ok_or(Error::InvalidCatalogueUpdate(
+                        "source physical identity manifest missing",
+                    ))?
+                    .identities;
+                source_identities
+                    .validate_evolution_to_with_history(
+                        &source.schema,
+                        &publication.physical_identities,
+                        &schema.schema,
+                        lens,
+                        identity_history,
+                    )
+                    .map_err(Error::InvalidCatalogueUpdate)?;
                 Self::validate_lineage_table_partition(
                     &source.schema,
                     &schema.schema,
@@ -578,6 +599,27 @@ where
                     &publication.new_tables,
                     &publication.dropped_tables,
                 )
+            })
+            .and_then(|()| {
+                let identity_history = self.physical_identity_history_for_candidate(
+                    publication.schema.id,
+                    Some(publication.id),
+                );
+                self.catalogue
+                    .physical_mappings
+                    .get(&publication.lens.source)
+                    .ok_or(Error::InvalidCatalogueUpdate(
+                        "source physical identity manifest missing",
+                    ))?
+                    .identities
+                    .validate_evolution_to_with_history(
+                        &source.schema,
+                        &publication.physical_identities,
+                        &publication.schema.schema,
+                        &publication.lens,
+                        identity_history,
+                    )
+                    .map_err(Error::InvalidCatalogueUpdate)
             });
             if validation.is_err() {
                 self.remove_pending_schema_lineage(next, publication.id)
@@ -1246,6 +1288,10 @@ where
                 "schema lineage publication id mismatch",
             ));
         }
+        publication
+            .physical_identities
+            .validate_for_schema(&publication.schema.schema)
+            .map_err(Error::InvalidCatalogueUpdate)?;
         if publication.schema.id != publication.schema.schema.version_id() {
             return Err(Error::InvalidCatalogueUpdate(
                 "schema id does not match schema payload",

--- a/crates/jazz/tests/persistent_codec_family_registry.rs
+++ b/crates/jazz/tests/persistent_codec_family_registry.rs
@@ -201,7 +201,7 @@ fn validate_registry_with_profiles(
         "jazz.history-version-current.v1",
         "jazz.contribution-provenance.v1",
         "jazz.merge-heads.v1",
-        "jazz.idb-page.v2",
+        "jazz.idb-page.v1",
         "jazz.wire-frame.v1",
         "jazz.binding-abi.v1",
         "jazz.local-auth-secret.v1",


### PR DESCRIPTION
🤖 Restore two fail-closed guarantees exposed by the final integrated Rust workspace gate.

## Before

A later catalogue refactor stopped invoking permanent physical-identity retirement validation at two publication boundaries:

- immediate trusted catalogue admission; and
- deferred activation of a previously pending lineage.

A forged later schema could therefore reuse a table, column, or nested enum-occurrence UUID retired earlier in the same durable lineage. Two existing adversarial receipts caught this on the final stack.

The persistent-codec registry also still named the pre-settlement IndexedDB page-v2 fixture after #2295 correctly froze the sole page codec as V1.

## After

- Live admission and deferred pending activation both call `validate_evolution_to_with_history` against durable lineage history.
- Structural publication validation applies the same manifest constraints before mutation.
- Reopen continues validating active, staged, and source-resolved pending mappings.
- The codec registry names `jazz.idb-page.v1` and points to the exact V1 fixture, decoder rejection receipt, and browser raw-IDB evidence.

## Worked examples

A table UUID used in schema A, retired in schema B, and assigned to an unrelated table in schema C now rejects both when C arrives live and when C was parked pending a missing parent. The catalogue remains unchanged.

A scalar enum UUID likewise cannot later be reused as an unrelated nested enum occurrence.

## Verification

- exact five failing CI receipts now pass;
- full Jazz crate suite: 1,705 passed, 4 skipped;
- idb-tree: 19/19;
- multihop, scalar/nested-enum, parked/reopen, malformed-deferred, and registry planted tests;
- independent adversarial review with a planted retirement-validation bypass.
