### PR TITLE
Run browser topologies in their complete CI harnesses

### DIFF
--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -20,8 +20,11 @@ if [[ "${JAZZ_REQUIRE_CI_TEST_COMMANDS:-0}" == "1" ]]; then
   done
 fi
 
+# Every workspace package's `test` target belongs to this Node/Turbo partition.
+# Browser-only receipts keep their topology out of that target and run through
+# `test:browser` below, where their Vitest projects own the Jazz server commands.
 node_tests_command=${JAZZ_NODE_TEST_COMMAND:-"pnpm test --filter=!moon-lander-react --filter=!@jazz/rust --filter=!auth-simple-chat --filter=!auth-workos-chat --filter=!auth-betterauth-chat --filter=!chat-react --filter=!world-tour --filter=!jazz-rn --concurrency=2"}
-browser_tests_command=${JAZZ_BROWSER_TEST_COMMAND:-"pnpm --parallel --filter jazz-tools --filter inspector test:browser"}
+browser_tests_command=${JAZZ_BROWSER_TEST_COMMAND:-"pnpm --parallel --filter jazz-tools --filter inspector --filter band-chat-nextjs-betterauth --filter record-player-next-betterauth test:browser"}
 node_tests_pid=""
 browser_tests_pid=""
 log_dir=${RUNNER_TEMP:-/tmp}

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1439,6 +1439,22 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   assert.doesNotMatch(typescript, /rust-components: clippy,rustfmt/);
 });
 
+test("TypeScript CI runs the inspector's freshly built embedded browser receipt", () => {
+  const inspectorPackage = JSON.parse(
+    fs.readFileSync(path.join(root, "packages/inspector/package.json"), "utf8"),
+  );
+  const browserCommand = inspectorPackage.scripts["test:browser"];
+
+  assert.equal(
+    browserCommand,
+    "pnpm run build:embedded && playwright test --config playwright.config.ts",
+  );
+  assert.throws(
+    () => assert.match(browserCommand.replace("pnpm run build:embedded && ", ""), /build:embedded/),
+    /build:embedded/,
+  );
+});
+
 test("a sealed test surface rejects a child clean before it can delete prepared exports", async () => {
   const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-sealed-tools-dist-"));
   const marker = path.join(fixture, "testing", "index.js");

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1417,7 +1417,7 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   assert.match(runner, /--concurrency=2/);
   assert.match(
     runner,
-    /browser_tests_command=.*pnpm --parallel --filter jazz-tools --filter inspector test:browser/,
+    /browser_tests_command=.*pnpm --parallel --filter jazz-tools --filter inspector --filter band-chat-nextjs-betterauth --filter record-player-next-betterauth test:browser/,
   );
   assert.match(runner, /setsid bash -c "\$\{node_tests_command\}" >"\$\{node_tests_log\}" 2>&1 &/);
   assert.match(

--- a/examples/band-chat/apps/nextjs-betterauth/package.json
+++ b/examples/band-chat/apps/nextjs-betterauth/package.json
@@ -11,7 +11,7 @@
     "test:permissions": "vitest run tests/permissions.test.ts",
     "test:browser": "node ../../../../dev/artifacts/verify-correctness-test-artifacts.mjs && vitest run --config vitest.config.browser.ts",
     "test:browser:focused": "node scripts/test-browser-focused.mjs",
-    "test": "pnpm test:permissions && pnpm test:browser"
+    "test": "pnpm test:permissions"
   },
   "dependencies": {
     "better-auth": "1.7.1",

--- a/examples/band-chat/apps/nextjs-betterauth/package.json
+++ b/examples/band-chat/apps/nextjs-betterauth/package.json
@@ -11,7 +11,8 @@
     "test:permissions": "vitest run tests/permissions.test.ts",
     "test:browser": "node ../../../../dev/artifacts/verify-correctness-test-artifacts.mjs && vitest run --config vitest.config.browser.ts",
     "test:browser:focused": "node scripts/test-browser-focused.mjs",
-    "test": "pnpm test:permissions"
+    "test:selection": "node --test tests/test-selection.test.mjs",
+    "test": "pnpm test:permissions && pnpm test:selection"
   },
   "dependencies": {
     "better-auth": "1.7.1",

--- a/examples/band-chat/apps/nextjs-betterauth/tests/test-selection.test.mjs
+++ b/examples/band-chat/apps/nextjs-betterauth/tests/test-selection.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import packageJson from "../package.json" with { type: "json" };
+
+const cwd = fileURLToPath(new URL("..", import.meta.url));
+const browserConfig = readFileSync(path.join(cwd, "vitest.config.browser.ts"), "utf8");
+
+test("the Node package gate excludes browser-only topology receipts", () => {
+  assert.match(packageJson.scripts.test, /test:permissions/);
+  assert.match(packageJson.scripts.test, /test:selection/);
+  assert.doesNotMatch(packageJson.scripts.test, /test:browser/);
+  assert.equal(packageJson.scripts["test:selection"], "node --test tests/test-selection.test.mjs");
+});
+
+test("the topology browser project provides the complete Jazz server command contract", () => {
+  for (const command of [
+    "jazzServerInfo",
+    "jazzServerStop",
+    "jazzServerBlockNetwork",
+    "jazzServerUnblockNetwork",
+    "jazzServerJwtForUser",
+  ]) {
+    assert.match(browserConfig, new RegExp(`\\b${command}\\s*:`));
+  }
+});

--- a/examples/band-chat/apps/nextjs-betterauth/vitest.config.browser.ts
+++ b/examples/band-chat/apps/nextjs-betterauth/vitest.config.browser.ts
@@ -8,6 +8,7 @@ import {
   blockJazzServerNetwork,
   jazzServerInfo,
   jazzServerJwtForUser,
+  stopJazzServerByUrl,
   unblockJazzServerNetwork,
 } from "../../../../packages/jazz-tools/tests/browser/testing-server-node.js";
 
@@ -37,6 +38,7 @@ export default defineConfig({
       commands: {
         jazzBrowserTopologyLog,
         jazzServerInfo: async (_context, appId, schema) => jazzServerInfo(appId, schema),
+        jazzServerStop: async (_context, serverUrl) => stopJazzServerByUrl(serverUrl),
         jazzServerBlockNetwork: async ({ context }, serverUrl) =>
           blockJazzServerNetwork(context, serverUrl),
         jazzServerUnblockNetwork: async ({ context }, serverUrl) =>

--- a/examples/record-player/apps/next-betterauth/package.json
+++ b/examples/record-player/apps/next-betterauth/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "pnpm test:unit && pnpm test:provider && pnpm test:selection && pnpm test:topology",
+    "test": "pnpm test:unit && pnpm test:provider && pnpm test:selection",
     "test:unit": "vitest run tests/*.test.ts",
     "test:topology": "vitest run --config vitest.config.browser.ts",
     "test:browser": "pnpm test:topology",

--- a/examples/record-player/apps/next-betterauth/tests/test-selection.test.mjs
+++ b/examples/record-player/apps/next-betterauth/tests/test-selection.test.mjs
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import path from "node:path";
 import test from "node:test";
 import packageJson from "../package.json" with { type: "json" };
 
 const cwd = fileURLToPath(new URL("..", import.meta.url));
+const browserConfig = readFileSync(path.join(cwd, "vitest.config.browser.ts"), "utf8");
 
 function listedTests(config) {
   return execFileSync("pnpm", ["exec", "vitest", "list", "--config", config], {
@@ -23,13 +26,26 @@ test("browser and provider gates select disjoint receipts", () => {
   assert.doesNotMatch(provider, /tests\/browser\/topology\.e2e\.test\.ts/);
 });
 
-test("the maintained package gate includes every RecordPlayer receipt", () => {
+test("the Node package gate excludes the browser-only topology receipt", () => {
   assert.match(packageJson.scripts.test, /test:unit/);
   assert.match(packageJson.scripts.test, /test:provider/);
   assert.match(packageJson.scripts.test, /test:selection/);
-  assert.match(packageJson.scripts.test, /test:topology/);
+  assert.doesNotMatch(packageJson.scripts.test, /test:topology/);
   assert.equal(
     packageJson.scripts["test:topology"],
     "vitest run --config vitest.config.browser.ts",
   );
+  assert.equal(packageJson.scripts["test:browser"], "pnpm test:topology");
+});
+
+test("the topology browser project provides the complete Jazz server command contract", () => {
+  for (const command of [
+    "jazzServerInfo",
+    "jazzServerStop",
+    "jazzServerBlockNetwork",
+    "jazzServerUnblockNetwork",
+    "jazzServerJwtForUser",
+  ]) {
+    assert.match(browserConfig, new RegExp(`\\b${command}\\b`));
+  }
 });

--- a/examples/record-player/apps/next-betterauth/vitest.config.browser.ts
+++ b/examples/record-player/apps/next-betterauth/vitest.config.browser.ts
@@ -7,6 +7,7 @@ import {
   blockJazzServerNetwork,
   jazzServerInfo,
   jazzServerJwtForUser,
+  stopJazzServerByUrl,
   unblockJazzServerNetwork,
 } from "../../../../packages/jazz-tools/tests/browser/testing-server-node.js";
 
@@ -42,6 +43,7 @@ export default defineConfig({
       commands: {
         jazzBrowserTopologyLog,
         jazzServerInfo: async (_context, appId, schema) => jazzServerInfo(appId, schema),
+        jazzServerStop: async (_context, serverUrl) => stopJazzServerByUrl(serverUrl),
         jazzServerBlockNetwork: async ({ context }, serverUrl) =>
           blockJazzServerNetwork(context, serverUrl),
         jazzServerUnblockNetwork: async ({ context }, serverUrl) =>

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -10,8 +10,9 @@
     "build:web": "vite build --mode web",
     "build:embedded": "vite build --mode embedded",
     "preview": "vite preview",
-    "test": "vitest run --config vitest.config.ts",
-    "test:browser": "pnpm run build:embedded && playwright test --config playwright.config.ts"
+    "test": "vitest run --config vitest.config.ts && pnpm test:browser-contract",
+    "test:browser": "pnpm run build:embedded && playwright test --config playwright.config.ts",
+    "test:browser-contract": "node --test tests/browser/test-browser-command.test.mjs"
   },
   "dependencies": {
     "@tanstack/react-table": "^8.21.3",

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -11,7 +11,7 @@
     "build:embedded": "vite build --mode embedded",
     "preview": "vite preview",
     "test": "vitest run --config vitest.config.ts",
-    "test:browser": "playwright test --config playwright.config.ts"
+    "test:browser": "pnpm run build:embedded && playwright test --config playwright.config.ts"
   },
   "dependencies": {
     "@tanstack/react-table": "^8.21.3",

--- a/packages/inspector/tests/browser/overlay.spec.ts
+++ b/packages/inspector/tests/browser/overlay.spec.ts
@@ -86,6 +86,14 @@ test.describe("inspector overlay (embedded, shared runtime peer end-to-end)", ()
           __jazzInspectorHost?: {
             getConnectionConfig(): {
               driver?: { type?: string };
+              jwtToken?: string;
+              runtimeSources?: {
+                browserWorkerSession?: {
+                  issuer?: string;
+                  user_id?: string;
+                  authMode?: string;
+                };
+              };
             };
             openControlPort?: unknown;
           };
@@ -94,10 +102,17 @@ test.describe("inspector overlay (embedded, shared runtime peer end-to-end)", ()
       return {
         driverType: host?.getConnectionConfig().driver?.type,
         hasControlPort: typeof host?.openControlPort === "function",
+        hasJwtToken: Boolean(host?.getConnectionConfig().jwtToken),
+        browserWorkerSession: host?.getConnectionConfig().runtimeSources?.browserWorkerSession,
       };
     });
     expect(overlayConfig.driverType).toBe("persistent");
     expect(overlayConfig.hasControlPort).toBe(true);
+    expect(overlayConfig.hasJwtToken).toBe(true);
+    expect(overlayConfig.browserWorkerSession).toMatchObject({
+      issuer: "urn:jazz:local-first",
+      authMode: "local-first",
+    });
 
     // The overlay reads the handle, opens its connection joining that store, and
     // leaves the connecting state.

--- a/packages/inspector/tests/browser/overlay.spec.ts
+++ b/packages/inspector/tests/browser/overlay.spec.ts
@@ -1,5 +1,3 @@
-import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -27,18 +25,6 @@ function extOf(path: string): string {
 }
 
 test.describe("inspector overlay (embedded, shared runtime peer end-to-end)", () => {
-  test.beforeAll(() => {
-    // The embedded entry is a separate Vite build. Build it on demand so
-    // `pnpm test:browser` works from a clean checkout; rebuild manually with
-    // `pnpm --filter inspector run build:embedded` to refresh the assets.
-    if (!existsSync(join(distEmbedded, "embedded.html"))) {
-      execFileSync("pnpm", ["run", "build:embedded"], {
-        cwd: packageRoot,
-        stdio: "inherit",
-      });
-    }
-  });
-
   test("embedded inspector discovers and switches across auth-session runtimes", async ({
     page,
   }) => {

--- a/packages/inspector/tests/browser/test-browser-command.test.mjs
+++ b/packages/inspector/tests/browser/test-browser-command.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import packageJson from "../../package.json" with { type: "json" };
+
+test("browser receipts rebuild the embedded inspector before Playwright", () => {
+  assert.equal(
+    packageJson.scripts["test:browser"],
+    "pnpm run build:embedded && playwright test --config playwright.config.ts",
+  );
+});

--- a/packages/jazz-tools/src/dev/inspector-overlay/host-bridge.test.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/host-bridge.test.ts
@@ -161,4 +161,31 @@ describe("installInspectorHost", () => {
     await (window as any)[INSPECTOR_HOST_GLOBAL].openControlPort();
     expect((fake.db as any).openInspectorControlPort).toHaveBeenCalledOnce();
   });
+
+  it("forwards a resolved local-first session from the host JWT when private session state is unavailable", () => {
+    const iframeWindow = { postMessage: () => {} } as unknown as Window;
+    const fake = makeFakeDb({
+      getConfig: () => ({
+        appId: "a",
+        serverUrl: "http://server",
+        jwtToken:
+          "header.eyJzdWIiOiJpbnNwZWN0b3ItdGVzdC11c2VyIiwiaXNzIjoidXJuOmpheno6bG9jYWwtZmlyc3QiLCJjbGFpbXMiOnsicm9sZSI6Imluc3BlY3Rvci10ZXN0In19.signature",
+      }),
+    });
+
+    installInspectorHost(fake.db, iframeWindow, "http://localhost");
+
+    expect((window as any)[INSPECTOR_HOST_GLOBAL].getConnectionConfig()).toMatchObject({
+      jwtToken:
+        "header.eyJzdWIiOiJpbnNwZWN0b3ItdGVzdC11c2VyIiwiaXNzIjoidXJuOmpheno6bG9jYWwtZmlyc3QiLCJjbGFpbXMiOnsicm9sZSI6Imluc3BlY3Rvci10ZXN0In19.signature",
+      runtimeSources: {
+        browserWorkerSession: {
+          issuer: "urn:jazz:local-first",
+          user_id: "inspector-test-user",
+          authMode: "local-first",
+          claims: { role: "inspector-test" },
+        },
+      },
+    });
+  });
 });

--- a/packages/jazz-tools/src/dev/inspector-overlay/host-bridge.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/host-bridge.ts
@@ -1,5 +1,11 @@
 import type { Db, DbConfig } from "../../runtime/db.js";
 import { resolveDefaultPersistentDbName } from "../../runtime/db.js";
+import {
+  ANONYMOUS_JWT_ISSUER,
+  internalSessionFromVerifiedReservedJwtPayload,
+  LOCAL_FIRST_JWT_ISSUER,
+  parseJwtPayload,
+} from "../../runtime/client-session.js";
 import { getRegisteredWasmSchema } from "../../typed-app.js";
 import {
   INSPECTOR_HOST_GLOBAL,
@@ -10,6 +16,27 @@ import {
 import { openAggregatedBrowserInspectorControlPort } from "./browser-control-registry.js";
 import { getDbInternalSession } from "../../runtime/db-internal-session.js";
 
+function overlayBrowserWorkerSession(
+  config: DbConfig,
+  fallback: ReturnType<typeof getDbInternalSession>,
+) {
+  const payload = parseJwtPayload(config.jwtToken ?? "");
+  const authMode =
+    payload?.iss === LOCAL_FIRST_JWT_ISSUER
+      ? "local-first"
+      : payload?.iss === ANONYMOUS_JWT_ISSUER
+        ? "anonymous"
+        : null;
+
+  // The host's resolved reserved-issuer token is the durable source of truth
+  // for an attached peer's session. Do not make the inspector handoff depend
+  // on the Db's private WeakMap bookkeeping: the receiving native runtime
+  // verifies the same token before admitting the peer.
+  return payload && authMode
+    ? internalSessionFromVerifiedReservedJwtPayload(payload, authMode)
+    : fallback;
+}
+
 /**
  * Build the ready-to-use browser config in the host bundle, where the host's
  * resolved storage coordinates and worker URL are known. The overlay passes it
@@ -19,6 +46,7 @@ function buildOverlayDbConfig(
   config: DbConfig,
   session: ReturnType<typeof getDbInternalSession>,
 ): DbConfig {
+  const browserWorkerSession = overlayBrowserWorkerSession(config, session);
   const identityCredential = config.jwtToken
     ? { jwtToken: config.jwtToken }
     : config.secret
@@ -36,7 +64,9 @@ function buildOverlayDbConfig(
     // `persistent` selects the SharedWorker connection so this client joins
     // the host's IndexedDB-backed runtime. Its main-thread Db remains in-memory.
     driver: { type: "persistent", dbName: resolveDefaultPersistentDbName(config) },
-    ...(session ? { runtimeSources: { browserWorkerSession: structuredClone(session) } } : {}),
+    ...(browserWorkerSession
+      ? { runtimeSources: { browserWorkerSession: structuredClone(browserWorkerSession) } }
+      : {}),
   };
 }
 


### PR DESCRIPTION
🤖 Make the canonical TypeScript CI partition execute every browser topology in its owning browser harness and make Inspector attachment deterministic and credential-complete.

## Before

- Turbo’s broad Node partition invoked RecordPlayer’s `test`, which chained into a browser topology suite without the Jazz server command fixture.
- BandChat had the same latent partitioning mistake.
- Inspector browser tests conditionally reused ignored `dist-embedded` output when it existed, so a reused checkout could exercise stale code.
- The inspector host forwarded its attached worker session only from private WeakMap state. When that state was unavailable even though the resolved reserved-issuer JWT was present, the inspector opened without a verified session and failed row reads.

## After

- BandChat and RecordPlayer `test` commands are Node-only.
- Their topology suites run explicitly alongside Jazz Tools and Inspector in the canonical browser CI command, with all required server lifecycle/JWT commands.
- `inspector test:browser` always rebuilds the embedded bundle before Playwright.
- If private host-session state is absent, the bridge deterministically derives the claimed session from the resolved reserved-issuer JWT.
- The receiver still verifies the token and requires exact issuer, user, and auth-mode equality before trusting the forwarded session; claims come from the token, not the cross-realm object.

## Worked examples

A reused worktree with an old ignored Inspector bundle now rebuilds before testing. An attached local-first host with a resolved JWT but no private WeakMap entry forwards matching session claims and the inspector reads the seeded row. A malformed, external-issuer, or mismatched token/session remains untrusted.

## Verification

- exact TypeScript CI-equivalent partition: Node exit 0, browser exit 0;
- Inspector fresh browser 12/12 and repeated overlay 12/12;
- Jazz Tools browser: 270 passed, 1 expected failure, 3 skipped;
- BandChat browser 5/5 and RecordPlayer browser 9/9;
- build:test-artifacts and 122 CI contracts;
- planted missing server command, missing embedded build, missing session derivation, and receiver equality bypasses;
- independent security/coverage review.
