### PR TITLE
Build a full browser Jazz storage compatibility corpus

### DIFF
--- a/packages/jazz-tools/tests/browser/indexeddb-jazz-compat.test.ts
+++ b/packages/jazz-tools/tests/browser/indexeddb-jazz-compat.test.ts
@@ -14,7 +14,14 @@ import { schema as s } from "../../src/index.js";
 import { deploy } from "../../src/dev/catalogue.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import { createDb, type Db } from "../../src/runtime/db.js";
-import { IndexedDbPageStore } from "../../src/runtime/indexeddb-page-store.js";
+import {
+  INDEXEDDB_BTREE_METADATA_STORE,
+  INDEXEDDB_BTREE_PAGES_STORE,
+  INDEXEDDB_STORAGE_MANIFEST,
+  INDEXEDDB_STORAGE_MANIFEST_KEY,
+  INDEXEDDB_STORAGE_MANIFEST_STORE,
+  IndexedDbPageStore,
+} from "../../src/runtime/indexeddb-page-store.js";
 import { getJazzServerInfo } from "./testing-server.js";
 import { uniqueDbName, waitForQuery, withTimeout } from "./support.js";
 
@@ -117,6 +124,7 @@ describe("browser Jazz storage compatibility corpus", () => {
 
     await db.shutdown();
     openDbs.splice(openDbs.indexOf(db), 1);
+    const rawBeforeReadOnlyInspection = await rawRecords(dbName);
 
     db = await openPersistentDb(dbName, secret, server);
     const reopenedMain = await db.one(app.documents.where({ id: document.id }), { branch: "main" });
@@ -137,6 +145,39 @@ describe("browser Jazz storage compatibility corpus", () => {
       projectId: project.id,
       body: "large value ".repeat(20_000),
     });
+    await db.shutdown();
+    openDbs.splice(openDbs.indexOf(db), 1);
+    expect(await rawRecords(dbName)).toEqual(rawBeforeReadOnlyInspection);
+  }, 90_000);
+
+  it("rejects a corrupt durable epoch before handing a public Jazz handle to the app", async () => {
+    const server = await getJazzServerInfo(uniqueDbName("storage-compat-corruption-server"));
+    await deploy({
+      appId: server.appId,
+      serverUrl: server.serverUrl,
+      adminSecret: server.adminSecret,
+      schema: app.wasmSchema,
+      permissions,
+    });
+
+    const dbName = databaseName();
+    const secret = generateAuthSecret();
+    const db = await openPersistentDb(dbName, secret, server);
+    await withTimeout(
+      db.insert(app.projects, { name: "corruption sentinel" }).wait({ tier: "global" }),
+      20_000,
+      "corruption fixture did not settle",
+    );
+    await db.shutdown();
+    openDbs.splice(openDbs.indexOf(db), 1);
+
+    await replaceManifest(dbName, { ...INDEXEDDB_STORAGE_MANIFEST, storageEpoch: 2 });
+    const rawBeforeRejectedOpen = await rawRecords(dbName);
+    await expect(openPersistentDb(dbName, secret, server)).rejects.toThrow(
+      "Missing or invalid IndexedDB storage epoch manifest",
+    );
+    expect(openDbs).toHaveLength(0);
+    expect(await rawRecords(dbName)).toEqual(rawBeforeRejectedOpen);
   }, 90_000);
 
   function databaseName(): string {
@@ -160,3 +201,72 @@ describe("browser Jazz storage compatibility corpus", () => {
     return db;
   }
 });
+
+/**
+ * Snapshot the production adapter's complete physical surface after it has
+ * closed.  This is a deliberately raw inspection: if a future read-only open
+ * rewrites a page, metadata, or manifest, the receipt exposes it rather than
+ * hiding it behind a decoded logical value.
+ */
+async function rawRecords(name: string): Promise<Record<string, string>> {
+  const database = await requestResult(indexedDB.open(name));
+  const storeNames = [
+    INDEXEDDB_BTREE_PAGES_STORE,
+    INDEXEDDB_BTREE_METADATA_STORE,
+    INDEXEDDB_STORAGE_MANIFEST_STORE,
+  ];
+  const transaction = database.transaction(storeNames, "readonly");
+  const records = Object.fromEntries(
+    await Promise.all(
+      storeNames.map(async (storeName) => {
+        const store = transaction.objectStore(storeName);
+        const [keys, values] = await Promise.all([
+          requestResult(store.getAllKeys()),
+          requestResult(store.getAll()),
+        ]);
+        return [
+          storeName,
+          JSON.stringify(keys.map((key, index) => [key, serializeRawRecord(values[index])])),
+        ] as const;
+      }),
+    ),
+  );
+  await transactionDone(transaction);
+  database.close();
+  return records;
+}
+
+async function replaceManifest(name: string, manifest: unknown): Promise<void> {
+  const database = await requestResult(indexedDB.open(name));
+  const transaction = database.transaction(INDEXEDDB_STORAGE_MANIFEST_STORE, "readwrite");
+  transaction
+    .objectStore(INDEXEDDB_STORAGE_MANIFEST_STORE)
+    .put(manifest, INDEXEDDB_STORAGE_MANIFEST_KEY);
+  await transactionDone(transaction);
+  database.close();
+}
+
+function serializeRawRecord(value: unknown): unknown {
+  if (value instanceof ArrayBuffer) return Array.from(new Uint8Array(value));
+  if (ArrayBuffer.isView(value)) {
+    return Array.from(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
+  }
+  return value;
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () =>
+      reject(transaction.error ?? new Error("IndexedDB transaction failed"));
+    transaction.onabort = () =>
+      reject(transaction.error ?? new Error("IndexedDB transaction aborted"));
+  });
+}

--- a/packages/jazz-tools/tests/browser/indexeddb-jazz-compat.test.ts
+++ b/packages/jazz-tools/tests/browser/indexeddb-jazz-compat.test.ts
@@ -23,7 +23,7 @@ import {
   IndexedDbPageStore,
 } from "../../src/runtime/indexeddb-page-store.js";
 import { getJazzServerInfo } from "./testing-server.js";
-import { uniqueDbName, waitForQuery, withTimeout } from "./support.js";
+import { sleep, TestCleanup, uniqueDbName, withTimeout } from "./support.js";
 
 const app = s.defineApp({
   projects: s.table({
@@ -49,6 +49,16 @@ const permissions = s.definePermissions(app, ({ policy }) => [
   policy.documents.allowUpdate.always(),
   policy.documents.allowDelete.always(),
 ]);
+
+// Keep the corrupt-open receipt deliberately small. The broader corpus above
+// exercises branches and large values; this isolates storage admission from
+// any schema-level query work that cannot run after an invalid epoch anyway.
+const corruptionApp = s.defineApp({
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+  }),
+});
 
 describe("browser Jazz storage compatibility corpus", () => {
   const databaseNames: string[] = [];
@@ -77,29 +87,34 @@ describe("browser Jazz storage compatibility corpus", () => {
     const dbName = databaseName();
     const secret = generateAuthSecret();
     let db = await openPersistentDb(dbName, secret, server);
-    const project = db.insert(app.projects, { name: "compat project" }).value;
-    await withTimeout(
-      db
-        .insert(app.documents, {
+    const initialFixture = await db.transaction((tx) => {
+      const project = tx.insert(app.projects, { name: "compat project" });
+      const document = tx.insert(
+        app.documents,
+        {
           branch: "main",
           title: "first title",
           projectId: project.id,
           body: "large value ".repeat(20_000),
-        })
-        .wait({ tier: "global" }),
+        },
+        { branch: "main" },
+      );
+      return { project, document };
+    });
+    await withTimeout(
+      initialFixture.wait({ tier: "global" }),
       20_000,
       "initial compatibility fixture did not settle",
     );
+    const { project, document } = initialFixture.value;
 
-    const main = await waitForQuery(
-      db,
-      app.documents.where({ branch: "main" }),
-      (rows) => rows.length === 1,
-      "main branch fixture did not become readable",
+    const main = await withTimeout(
+      db.all(app.documents, { branch: "main", tier: "edge" }),
       20_000,
-      "edge",
+      "main branch fixture did not become readable",
     );
-    const document = main[0]!;
+    expect(main).toHaveLength(1);
+    expect(main[0]!.id).toBe(document.id);
     await withTimeout(
       db
         .update(app.documents, document.id, { title: "current title" }, { branch: "main" })
@@ -124,6 +139,7 @@ describe("browser Jazz storage compatibility corpus", () => {
 
     await db.shutdown();
     openDbs.splice(openDbs.indexOf(db), 1);
+    await sleep(100);
     const rawBeforeReadOnlyInspection = await rawRecords(dbName);
 
     db = await openPersistentDb(dbName, secret, server);
@@ -147,37 +163,47 @@ describe("browser Jazz storage compatibility corpus", () => {
     });
     await db.shutdown();
     openDbs.splice(openDbs.indexOf(db), 1);
+    await sleep(100);
     expect(await rawRecords(dbName)).toEqual(rawBeforeReadOnlyInspection);
   }, 90_000);
 
   it("rejects a corrupt durable epoch before handing a public Jazz handle to the app", async () => {
-    const server = await getJazzServerInfo(uniqueDbName("storage-compat-corruption-server"));
-    await deploy({
-      appId: server.appId,
-      serverUrl: server.serverUrl,
-      adminSecret: server.adminSecret,
-      schema: app.wasmSchema,
-      permissions,
-    });
-
+    const cleanup = new TestCleanup();
     const dbName = databaseName();
-    const secret = generateAuthSecret();
-    const db = await openPersistentDb(dbName, secret, server);
+    const appId = "browser-storage-compat-corruption";
+    const db = cleanup.track(await createDb({ appId, driver: { type: "persistent", dbName } }));
     await withTimeout(
-      db.insert(app.projects, { name: "corruption sentinel" }).wait({ tier: "global" }),
-      20_000,
+      db
+        .insert(corruptionApp.todos, { title: "corruption sentinel", done: false })
+        .wait({ tier: "local" }),
+      5_000,
       "corruption fixture did not settle",
     );
     await db.shutdown();
-    openDbs.splice(openDbs.indexOf(db), 1);
+    cleanup.untrack(db);
+    await sleep(100);
 
     await replaceManifest(dbName, { ...INDEXEDDB_STORAGE_MANIFEST, storageEpoch: 2 });
-    const rawBeforeRejectedOpen = await rawRecords(dbName);
-    await expect(openPersistentDb(dbName, secret, server)).rejects.toThrow(
-      "Missing or invalid IndexedDB storage epoch manifest",
-    );
-    expect(openDbs).toHaveLength(0);
-    expect(await rawRecords(dbName)).toEqual(rawBeforeRejectedOpen);
+    const rawBeforeRejectedRead = await rawRecords(dbName);
+    // Db construction is schema-lazy, so it returns the typed façade before a
+    // public operation supplies `app.wasmSchema`. That first operation is the
+    // admission boundary: it must reject rather than leak a worker error or
+    // read a row from the corrupt durable replica.
+    try {
+      const corruptedDb = cleanup.track(
+        await createDb({ appId, driver: { type: "persistent", dbName } }),
+      );
+      await expect(
+        withTimeout(
+          corruptedDb.all(corruptionApp.todos, { tier: "local" }),
+          5_000,
+          "corrupt epoch query did not reject",
+        ),
+      ).rejects.toThrow("Missing or invalid IndexedDB storage epoch manifest");
+      expect(await rawRecords(dbName)).toEqual(rawBeforeRejectedRead);
+    } finally {
+      await cleanup.cleanup();
+    }
   }, 90_000);
 
   function databaseName(): string {

--- a/packages/jazz-tools/tests/browser/indexeddb-jazz-compat.test.ts
+++ b/packages/jazz-tools/tests/browser/indexeddb-jazz-compat.test.ts
@@ -1,0 +1,162 @@
+/**
+ * A real-Chromium, public-Jazz compatibility receipt for a durable browser
+ * replica.  The companion raw-page receipt proves the adapter's epoch/page
+ * framing; this file deliberately drives that adapter through `createDb`, the
+ * SharedWorker, and the released WASM runtime instead.
+ *
+ * Keep this corpus on the canonical browser test project.  It is intentionally
+ * not a second fake-IDB or MemoryPageStore harness: a durable fixture must be
+ * readable by the same public path an application uses.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { schema as s } from "../../src/index.js";
+import { deploy } from "../../src/dev/catalogue.js";
+import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
+import { createDb, type Db } from "../../src/runtime/db.js";
+import { IndexedDbPageStore } from "../../src/runtime/indexeddb-page-store.js";
+import { getJazzServerInfo } from "./testing-server.js";
+import { uniqueDbName, waitForQuery, withTimeout } from "./support.js";
+
+const app = s.defineApp({
+  projects: s.table({
+    name: s.string(),
+  }),
+  documents: s
+    .table({
+      branch: s.string(),
+      title: s.string(),
+      projectId: s.ref("projects"),
+      body: s.string(),
+    })
+    .branchBy("branch"),
+});
+
+const permissions = s.definePermissions(app, ({ policy }) => [
+  policy.projects.allowRead.always(),
+  policy.projects.allowInsert.always(),
+  policy.projects.allowUpdate.always(),
+  policy.projects.allowDelete.always(),
+  policy.documents.allowRead.always(),
+  policy.documents.allowInsert.always(),
+  policy.documents.allowUpdate.always(),
+  policy.documents.allowDelete.always(),
+]);
+
+describe("browser Jazz storage compatibility corpus", () => {
+  const databaseNames: string[] = [];
+  const openDbs: Db[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      openDbs
+        .splice(0)
+        .reverse()
+        .map((db) => db.shutdown()),
+    );
+    await Promise.all(databaseNames.splice(0).map((name) => IndexedDbPageStore.destroy(name)));
+  });
+
+  it("persists a catalogue-backed current/history/branch/large-value replica through the public browser path", async () => {
+    const server = await getJazzServerInfo(uniqueDbName("storage-compat-server"));
+    await deploy({
+      appId: server.appId,
+      serverUrl: server.serverUrl,
+      adminSecret: server.adminSecret,
+      schema: app.wasmSchema,
+      permissions,
+    });
+
+    const dbName = databaseName();
+    const secret = generateAuthSecret();
+    let db = await openPersistentDb(dbName, secret, server);
+    const project = db.insert(app.projects, { name: "compat project" }).value;
+    await withTimeout(
+      db
+        .insert(app.documents, {
+          branch: "main",
+          title: "first title",
+          projectId: project.id,
+          body: "large value ".repeat(20_000),
+        })
+        .wait({ tier: "global" }),
+      20_000,
+      "initial compatibility fixture did not settle",
+    );
+
+    const main = await waitForQuery(
+      db,
+      app.documents.where({ branch: "main" }),
+      (rows) => rows.length === 1,
+      "main branch fixture did not become readable",
+      20_000,
+      "edge",
+    );
+    const document = main[0]!;
+    await withTimeout(
+      db
+        .update(app.documents, document.id, { title: "current title" }, { branch: "main" })
+        .wait({ tier: "global" }),
+      20_000,
+      "current history update did not settle",
+    );
+    await withTimeout(
+      db
+        .update(
+          app.documents,
+          document.id,
+          {
+            title: "draft override",
+          },
+          { branch: "draft", base: "main" },
+        )
+        .wait({ tier: "global" }),
+      20_000,
+      "draft branch update did not settle",
+    );
+
+    await db.shutdown();
+    openDbs.splice(openDbs.indexOf(db), 1);
+
+    db = await openPersistentDb(dbName, secret, server);
+    const reopenedMain = await db.one(app.documents.where({ id: document.id }), { branch: "main" });
+    const reopenedDraft = await db.one(app.documents.where({ id: document.id }), {
+      branch: "draft",
+    });
+    expect(reopenedMain).toMatchObject({
+      id: document.id,
+      branch: "main",
+      title: "current title",
+      projectId: project.id,
+      body: "large value ".repeat(20_000),
+    });
+    expect(reopenedDraft).toMatchObject({
+      id: document.id,
+      branch: "draft",
+      title: "draft override",
+      projectId: project.id,
+      body: "large value ".repeat(20_000),
+    });
+  }, 90_000);
+
+  function databaseName(): string {
+    const name = uniqueDbName("jazz-storage-compat");
+    databaseNames.push(name);
+    return name;
+  }
+
+  async function openPersistentDb(
+    dbName: string,
+    secret: string,
+    server: Awaited<ReturnType<typeof getJazzServerInfo>>,
+  ): Promise<Db> {
+    const db = await createDb({
+      appId: server.appId,
+      serverUrl: server.serverUrl,
+      secret,
+      driver: { type: "persistent", dbName },
+    });
+    openDbs.push(db);
+    return db;
+  }
+});


### PR DESCRIPTION
🤖 Draft implementation of #2308: a complete browser Jazz storage compatibility corpus.

## Before

The browser compatibility receipt froze raw IndexedDB page framing, but did not open and extend a complete historical Jazz root through the public browser runtime.

## Current slice

The canonical real-Chromium project now exercises the production path from createDb through SharedWorker and WasmDb into IndexedDB.

It persists deployed catalogue permissions, application rows, main and draft branch state, an updated history/current row, and a large text value, then shuts down and reopens the database through the public API.

## Still in progress

- pin the producer fixture and checksums;
- prove read-only inspection preserves raw IndexedDB records;
- add manifest, page, and authoritative-payload corruption receipts;
- register the complete historical corpus in canonical storage-compat CI and specs.

### Example

A browser store with a historical row, its draft-branch edit, and a referenced large text value is reopened by the current runtime. Both branch views and the large value must remain readable; a corrupt authoritative record must fail before a usable handle or mutation is published.

Tracks #2308 and contributes to #2160.
