### PR TITLE
Prevent browser foreground transaction identity aliasing

### DIFF
--- a/packages/jazz-tools/src/runtime/default-runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/default-runtime-source.ts
@@ -208,14 +208,12 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
     const session = sessionFromConfig(config);
     const selfSignedClientProof = selfSignedClientProofFromConfig(config, session);
     const backendMode = isBackendRuntime(config);
-    const identitySeed = persistentIdentitySeed(config, session);
-    // A persistent worker may replay a main-thread-authored transaction after
-    // the page has reopened. Keep that logical client's node identity stable
-    // for the persistence namespace so the fresh in-memory runtime still owns
-    // the transaction's eventual rejection/settlement notifications.
-    const node = isPersistentBrowserConfig(config)
-      ? deterministicBytes(`${identitySeed}:${resolveDefaultPersistentDbName(config)}:main-node`)
-      : randomBytes();
+    // The persistent worker owns durable recovery. A foreground runtime owns
+    // only its live optimistic writes, so every new runtime needs a fresh node
+    // identity. Reusing a deterministic node across independently opened tabs
+    // would let their fresh HLC registers mint the same TxId before either has
+    // observed the other's first commit.
+    const node = randomBytes();
     const author = authorBytesForSession(runtimeAuthorFromConfig(config));
     const flushEvery = initialSyncFlushEvery(config);
     const browserMode = isPersistentBrowserConfig(config);

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -113,6 +113,31 @@ const app: s.App<AppSchema> = s.defineApp(schema);
 const { projects, todos } = app;
 type Todo = s.RowOf<typeof todos>;
 
+const transactionIdentitySchema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  documents: s
+    .table({
+      branch: s.string(),
+      title: s.string(),
+      projectId: s.ref("projects"),
+      body: s.string(),
+    })
+    .branchBy("branch"),
+};
+const transactionIdentityApp = s.defineApp(transactionIdentitySchema);
+const transactionIdentityPermissions = s.definePermissions(transactionIdentityApp, ({ policy }) => [
+  policy.projects.allowRead.always(),
+  policy.projects.allowInsert.always(),
+  policy.projects.allowUpdate.always(),
+  policy.projects.allowDelete.always(),
+  policy.documents.allowRead.always(),
+  policy.documents.allowInsert.always(),
+  policy.documents.allowUpdate.always(),
+  policy.documents.allowDelete.always(),
+]);
+
 const readOnlyPermissions = s.definePermissions(app, ({ policy }) => [
   policy.projects.allowRead.always(),
   policy.projects.allowInsert.never(),
@@ -1218,6 +1243,64 @@ describe("SharedWorker bridge with IndexedDB", () => {
     );
     expect(rowsOnA.some((row) => row.title === title)).toBe(true);
   }, 60000);
+
+  /**
+   * Two fresh foreground runtimes can share a persistent worker. Each runtime
+   * starts with an empty HLC register, so their first writes must not alias
+   * one transaction identity when the browser gives both writes the same
+   * millisecond.
+   *
+   * alice tab A ──insert project────────────► shared worker ──► server
+   * alice tab B ──insert large branch doc───► shared worker ──► server
+   */
+  it("prevents foreground transaction identity aliasing in one millisecond", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "distinct-client-tx-ids",
+      transactionIdentityPermissions,
+      transactionIdentityApp.wasmSchema,
+    );
+    const secret = generateAuthSecret();
+    const dbName = uniqueDbName("distinct-client-tx-ids");
+    const config = {
+      appId: syncServer.appId,
+      serverUrl: syncServer.serverUrl,
+      secret,
+      driver: { type: "persistent" as const, dbName },
+      schema: transactionIdentityApp,
+    };
+    const first = track(await createDb(config));
+    const second = track(await createDb(config));
+    const fixedNow = Date.now();
+    const now = vi.spyOn(Date, "now").mockReturnValue(fixedNow);
+    const { project, document } = (() => {
+      try {
+        const project = first.insert(transactionIdentityApp.projects, {
+          name: "shared-worker project",
+        });
+        const document = second.insert(
+          transactionIdentityApp.documents,
+          {
+            branch: "main",
+            title: "first title",
+            projectId: project.value.id,
+            body: "large browser value ".repeat(20_000),
+          },
+          { branch: "main" },
+        );
+        return { project, document };
+      } finally {
+        now.mockRestore();
+      }
+    })();
+    const projectTxId = await project.txId;
+    const documentTxId = await document.txId;
+    expect(documentTxId).not.toBe(projectTxId);
+    await withTimeout(
+      Promise.all([project.wait({ tier: "global" }), document.wait({ tier: "global" })]),
+      20_000,
+      "aliased foreground transactions did not both settle globally",
+    );
+  }, 60_000);
 
   it("resolves insert wait at edge tier through the worker bridge", async () => {
     const syncServer = await publishSyncServerSchemaAndPermissions("sync-wait-edge");


### PR DESCRIPTION
🤖 Prevent transaction-identity aliasing between fresh browser foreground runtimes.

## Before

Every persistent browser foreground runtime deterministically reused `main-node`, while each disposable in-memory runtime began with an empty HLC register. Two fresh runtimes attached to the same persistent worker could therefore mint the same first transaction ID when their clocks matched. Public behavior could lose liveness rather than reliably surface the internal conflict.

## After

Each foreground runtime receives a fresh random node identity. The persistent worker remains deterministic and owns durable recovery; disposable foreground identities do not need to survive tab lifecycle.

### Example

Two tabs attach to one worker. Their first writes observe the same fixed millisecond. Previously both could produce the same public `txId`; now their IDs differ and both project/document writes reach global settlement.

## Receipt

A real Chromium + SharedWorker + server test creates two fresh foreground runtimes, pins `Date.now()` only around their first writes, asserts distinct transaction IDs, and awaits both global settlements with no sleep or retry. Restoring deterministic `main-node` produces equal IDs and a liveness failure.

This fixes the proven cross-foreground aliasing. The distinct full-server single-runtime sequence still under investigation in #2335 is intentionally not claimed fixed here.
