### PR TITLE
Gate browser local subscriptions on storage readiness

### DIFF
--- a/crates/groove/src/db/commit.rs
+++ b/crates/groove/src/db/commit.rs
@@ -268,6 +268,15 @@ impl Database {
                 return Err(Error::IvmRuntime(error));
             }
         };
+        // The public direct write APIs are themselves the runtime owner for
+        // CPU-only continuations which this tick scheduled.  In particular,
+        // a bounded recursive evaluation may yield after making resident
+        // progress and self-wake for another slice.  Finish those slices
+        // before returning the publication so its subscription output is
+        // observable in the same direct write turn.  A genuinely cold input
+        // never self-wakes here, so it remains pending for an external owner
+        // rather than making a write wait on storage.
+        self.drain_self_scheduled_resident_progress()?;
         let ivm_tick_time = tick_start.elapsed();
         // The IVM's resident observer uses the staged overlay. It takes the
         // lifecycle lock itself only when another resident publication does

--- a/crates/groove/src/db/commit.rs
+++ b/crates/groove/src/db/commit.rs
@@ -273,9 +273,9 @@ impl Database {
         // a bounded recursive evaluation may yield after making resident
         // progress and self-wake for another slice.  Finish those slices
         // before returning the publication so its subscription output is
-        // observable in the same direct write turn.  A genuinely cold input
-        // never self-wakes here, so it remains pending for an external owner
-        // rather than making a write wait on storage.
+        // observable in the same direct write turn. A genuinely cold input
+        // remains pending for an external owner even if its storage future
+        // eagerly wakes, rather than making a write wait on storage.
         self.drain_self_scheduled_resident_progress()?;
         let ivm_tick_time = tick_start.elapsed();
         // The IVM's resident observer uses the staged overlay. It takes the

--- a/crates/groove/src/db/query.rs
+++ b/crates/groove/src/db/query.rs
@@ -1,20 +1,4 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-
-use futures::task::{ArcWake, waker};
-
 use super::*;
-
-/// Counts immediate, in-memory continuation requests while a direct Database
-/// API call owns progress.  This deliberately does not retain an executor
-/// wake: cold storage must stay pending for a real runtime owner instead.
-struct DirectProgressWake(AtomicUsize);
-
-impl ArcWake for DirectProgressWake {
-    fn wake_by_ref(arc_self: &Arc<Self>) {
-        arc_self.0.fetch_add(1, Ordering::AcqRel);
-    }
-}
 
 impl Database {
     /// Drain continuation turns which the IVM itself has explicitly scheduled
@@ -22,21 +6,25 @@ impl Database {
     /// genuinely pending: this direct API has no durable owner waker to retain
     /// for external readiness, and callers may install one with
     /// [`Self::drive_ready_progress_with_waker`] or [`Self::poll_subscription`].
-    pub(super) fn drive_resident_progress_now(
-        &mut self,
-        progress_waker: &std::task::Waker,
-        wake_count: &AtomicUsize,
-    ) -> Result<(), Error> {
+    pub(super) fn drive_resident_progress_now(&mut self) -> Result<(), Error> {
+        // Never use a new direct call as an excuse to poll an already-cold
+        // evaluation again. A storage future is permitted to self-wake before
+        // it is ready; only the owner that installed its durable waker may
+        // resume it.
+        if self.ivm_runtime.has_pending_incremental()
+            && !self.ivm_runtime.has_resident_continuation()
+        {
+            return Ok(());
+        }
         loop {
-            let before = wake_count.load(Ordering::Acquire);
-            let mut cx = std::task::Context::from_waker(progress_waker);
+            let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
             match self.poll_progress(&mut cx) {
                 std::task::Poll::Ready(result) => return result,
-                // Cooperative resident work explicitly self-wakes before it
-                // yields, so keep draining it synchronously. A real cold
-                // request does not wake until external readiness and remains
-                // pending for the caller's actual runtime owner.
-                std::task::Poll::Pending if wake_count.load(Ordering::Acquire) != before => {}
+                // The runtime records an explicit resident continuation when
+                // a bounded CPU slice yields. Storage may self-wake before it
+                // is ready, so it remains pending even if it woke this no-op
+                // waker.
+                std::task::Poll::Pending if self.ivm_runtime.has_resident_continuation() => {}
                 std::task::Poll::Pending => return Ok(()),
             }
         }
@@ -47,14 +35,7 @@ impl Database {
     /// turn a cold storage request into a blocking call without a runtime
     /// owner to resume it later.
     pub(super) fn drain_self_scheduled_resident_progress(&mut self) -> Result<(), Error> {
-        let (wake_count, progress_waker) = Self::direct_progress_waker();
-        self.drive_resident_progress_now(&progress_waker, &wake_count.0)
-    }
-
-    fn direct_progress_waker() -> (Arc<DirectProgressWake>, std::task::Waker) {
-        let wake_count = Arc::new(DirectProgressWake(AtomicUsize::new(0)));
-        let progress_waker = waker(Arc::clone(&wake_count));
-        (wake_count, progress_waker)
+        self.drive_resident_progress_now()
     }
 
     /// Whether a suspended IVM evaluation still needs a future owner turn.
@@ -311,17 +292,15 @@ impl Database {
             overlay,
             Rc::clone(&self.storage_read_metrics),
         ));
-        let wake_count = Arc::new(DirectProgressWake(AtomicUsize::new(0)));
-        let progress_waker = waker(Arc::clone(&wake_count));
         let subscription = self
             .ivm_runtime
-            .subscribe_one_sink_with_waker(graph, &storage, Some(&progress_waker))
+            .subscribe_one_sink_with_waker(graph, &storage, None)
             .await
             .map_err(Error::IvmRuntime)?;
         // A direct async opening owns the immediately-resident continuation
         // chain, but it must not await a cold read with no durable owner to
         // resume it. Drain only self-scheduled cooperative slices here.
-        self.drive_resident_progress_now(&progress_waker, &wake_count.0)?;
+        self.drive_resident_progress_now()?;
         Ok(subscription)
     }
 
@@ -334,9 +313,8 @@ impl Database {
         I: IntoIterator<Item = (K, GraphBuilder)>,
         K: Into<String>,
     {
-        let (wake_count, progress_waker) = Self::direct_progress_waker();
-        let subscription = self.subscribe_with_waker(sinks, Some(&progress_waker))?;
-        self.drive_resident_progress_now(&progress_waker, &wake_count.0)?;
+        let subscription = self.subscribe_with_waker(sinks, None)?;
+        self.drive_resident_progress_now()?;
         Ok(subscription)
     }
 
@@ -546,7 +524,6 @@ impl Database {
             overlay,
             Rc::clone(&self.storage_read_metrics),
         ));
-        let (wake_count, progress_waker) = Self::direct_progress_waker();
         let subscription = self
             .ivm_runtime
             .bind_shape_one_sink_with_output_and_waker(
@@ -554,10 +531,10 @@ impl Database {
                 &values,
                 prepared.output,
                 &storage,
-                Some(&progress_waker),
+                None,
             )
             .map_err(Error::IvmRuntime)?;
-        self.drive_resident_progress_now(&progress_waker, &wake_count.0)?;
+        self.drive_resident_progress_now()?;
         Ok(subscription)
     }
 
@@ -702,12 +679,11 @@ impl Database {
             overlay,
             Rc::clone(&self.storage_read_metrics),
         ));
-        let (wake_count, progress_waker) = Self::direct_progress_waker();
         let subscription = self
             .ivm_runtime
-            .bind_shape_one_sink_with_waker(shape, binding_values, &storage, Some(&progress_waker))
+            .bind_shape_one_sink_with_waker(shape, binding_values, &storage, None)
             .map_err(Error::IvmRuntime)?;
-        self.drive_resident_progress_now(&progress_waker, &wake_count.0)?;
+        self.drive_resident_progress_now()?;
         Ok(subscription)
     }
 
@@ -733,7 +709,6 @@ impl Database {
             overlay,
             Rc::clone(&self.storage_read_metrics),
         ));
-        let (wake_count, progress_waker) = Self::direct_progress_waker();
         let subscription = self
             .ivm_runtime
             .bind_shape_one_sink_with_output_and_waker(
@@ -741,10 +716,10 @@ impl Database {
                 binding_values,
                 public_output,
                 &storage,
-                Some(&progress_waker),
+                None,
             )
             .map_err(Error::IvmRuntime)?;
-        self.drive_resident_progress_now(&progress_waker, &wake_count.0)?;
+        self.drive_resident_progress_now()?;
         Ok(subscription)
     }
 
@@ -754,11 +729,10 @@ impl Database {
         shape: PreparedShapeId,
         binding_values: &[Value],
     ) -> Result<MultisinkSubscription, Error> {
-        let (wake_count, progress_waker) = Self::direct_progress_waker();
         let subscription = self
-            .bind_shape_with_waker(shape, binding_values, Some(&progress_waker))
+            .bind_shape_with_waker(shape, binding_values, None)
             .await?;
-        self.drive_resident_progress_now(&progress_waker, &wake_count.0)?;
+        self.drive_resident_progress_now()?;
         Ok(subscription)
     }
 

--- a/crates/groove/src/db/query.rs
+++ b/crates/groove/src/db/query.rs
@@ -255,10 +255,18 @@ impl Database {
             overlay,
             Rc::clone(&self.storage_read_metrics),
         ));
-        self.ivm_runtime
+        let subscription = self
+            .ivm_runtime
             .subscribe_one_sink(graph, &storage)
             .await
-            .map_err(Error::IvmRuntime)
+            .map_err(Error::IvmRuntime)?;
+        // `Database` is the runtime owner for its direct async API. A
+        // resident recursive hydration can intentionally yield between
+        // bounded traversal slices; unlike a browser/node owner loop there is
+        // no external continuation to consume a noop wake here. Drive that
+        // owned initial work to completion before exposing the subscription.
+        self.drive_progress().await?;
+        Ok(subscription)
     }
 
     /// Subscribe to several named IVM graph outputs as one logical stream.

--- a/crates/groove/src/db/query.rs
+++ b/crates/groove/src/db/query.rs
@@ -270,6 +270,22 @@ impl Database {
         I: IntoIterator<Item = (K, GraphBuilder)>,
         K: Into<String>,
     {
+        self.subscribe_with_waker(sinks, None)
+    }
+
+    /// Internal owner-loop subscription entrypoint.  A bounded opening poll
+    /// may encounter cold storage; `progress_waker` remains its continuation
+    /// instead of the transient opening task's waker.
+    #[doc(hidden)]
+    pub fn subscribe_with_waker<I, K>(
+        &mut self,
+        sinks: I,
+        progress_waker: Option<&std::task::Waker>,
+    ) -> Result<MultisinkSubscription, Error>
+    where
+        I: IntoIterator<Item = (K, GraphBuilder)>,
+        K: Into<String>,
+    {
         self.ensure_not_poisoned()?;
         let overlay = Rc::new(StagedWriteOverlay::new_owned(
             Rc::clone(&self.storage),
@@ -280,7 +296,7 @@ impl Database {
             Rc::clone(&self.storage_read_metrics),
         ));
         self.ivm_runtime
-            .subscribe(sinks, &storage)
+            .subscribe_with_waker(sinks, &storage, progress_waker)
             .map_err(Error::IvmRuntime)
     }
 
@@ -647,6 +663,18 @@ impl Database {
         shape: PreparedShapeId,
         binding_values: &[Value],
     ) -> Result<MultisinkSubscription, Error> {
+        self.bind_shape_with_waker(shape, binding_values, None)
+            .await
+    }
+
+    /// Internal owner-loop binding entrypoint; see [`Self::subscribe_with_waker`].
+    #[doc(hidden)]
+    pub async fn bind_shape_with_waker(
+        &mut self,
+        shape: PreparedShapeId,
+        binding_values: &[Value],
+        progress_waker: Option<&std::task::Waker>,
+    ) -> Result<MultisinkSubscription, Error> {
         self.ensure_not_poisoned()?;
         let overlay = Rc::new(StagedWriteOverlay::new_owned(
             Rc::clone(&self.storage),
@@ -657,7 +685,7 @@ impl Database {
             Rc::clone(&self.storage_read_metrics),
         ));
         self.ivm_runtime
-            .bind_shape(shape, binding_values, &storage)
+            .bind_shape_with_waker(shape, binding_values, &storage, progress_waker)
             .map_err(Error::IvmRuntime)
     }
 

--- a/crates/groove/src/db/query.rs
+++ b/crates/groove/src/db/query.rs
@@ -1,6 +1,44 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use futures::task::{ArcWake, waker};
+
 use super::*;
 
+struct DirectSubscriptionWake(AtomicUsize);
+
+impl ArcWake for DirectSubscriptionWake {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.0.fetch_add(1, Ordering::AcqRel);
+    }
+}
+
 impl Database {
+    /// Drain continuation turns which the IVM itself has explicitly scheduled
+    /// for already-resident work. Stop as soon as a storage/chunk request is
+    /// genuinely pending: this direct API has no durable owner waker to retain
+    /// for external readiness, and callers may install one with
+    /// [`Self::drive_ready_progress_with_waker`] or [`Self::poll_subscription`].
+    fn drive_resident_progress_now(
+        &mut self,
+        progress_waker: &std::task::Waker,
+        wake_count: &AtomicUsize,
+    ) -> Result<(), Error> {
+        loop {
+            let before = wake_count.load(Ordering::Acquire);
+            let mut cx = std::task::Context::from_waker(progress_waker);
+            match self.poll_progress(&mut cx) {
+                std::task::Poll::Ready(result) => return result,
+                // Cooperative resident work explicitly self-wakes before it
+                // yields, so keep draining it synchronously. A real cold
+                // request does not wake until external readiness and remains
+                // pending for the caller's actual runtime owner.
+                std::task::Poll::Pending if wake_count.load(Ordering::Acquire) != before => {}
+                std::task::Poll::Pending => return Ok(()),
+            }
+        }
+    }
+
     /// Whether a suspended IVM evaluation still needs a future owner turn.
     ///
     /// An external chunk completion can wake an evaluation which then starts a
@@ -255,17 +293,17 @@ impl Database {
             overlay,
             Rc::clone(&self.storage_read_metrics),
         ));
+        let wake_count = Arc::new(DirectSubscriptionWake(AtomicUsize::new(0)));
+        let progress_waker = waker(Arc::clone(&wake_count));
         let subscription = self
             .ivm_runtime
-            .subscribe_one_sink(graph, &storage)
+            .subscribe_one_sink_with_waker(graph, &storage, Some(&progress_waker))
             .await
             .map_err(Error::IvmRuntime)?;
-        // `Database` is the runtime owner for its direct async API. A
-        // resident recursive hydration can intentionally yield between
-        // bounded traversal slices; unlike a browser/node owner loop there is
-        // no external continuation to consume a noop wake here. Drive that
-        // owned initial work to completion before exposing the subscription.
-        self.drive_progress().await?;
+        // A direct async opening owns the immediately-resident continuation
+        // chain, but it must not await a cold read with no durable owner to
+        // resume it. Drain only self-scheduled cooperative slices here.
+        self.drive_resident_progress_now(&progress_waker, &wake_count.0)?;
         Ok(subscription)
     }
 

--- a/crates/groove/src/db/query.rs
+++ b/crates/groove/src/db/query.rs
@@ -5,9 +5,12 @@ use futures::task::{ArcWake, waker};
 
 use super::*;
 
-struct DirectSubscriptionWake(AtomicUsize);
+/// Counts immediate, in-memory continuation requests while a direct Database
+/// API call owns progress.  This deliberately does not retain an executor
+/// wake: cold storage must stay pending for a real runtime owner instead.
+struct DirectProgressWake(AtomicUsize);
 
-impl ArcWake for DirectSubscriptionWake {
+impl ArcWake for DirectProgressWake {
     fn wake_by_ref(arc_self: &Arc<Self>) {
         arc_self.0.fetch_add(1, Ordering::AcqRel);
     }
@@ -19,7 +22,7 @@ impl Database {
     /// genuinely pending: this direct API has no durable owner waker to retain
     /// for external readiness, and callers may install one with
     /// [`Self::drive_ready_progress_with_waker`] or [`Self::poll_subscription`].
-    fn drive_resident_progress_now(
+    pub(super) fn drive_resident_progress_now(
         &mut self,
         progress_waker: &std::task::Waker,
         wake_count: &AtomicUsize,
@@ -37,6 +40,21 @@ impl Database {
                 std::task::Poll::Pending => return Ok(()),
             }
         }
+    }
+
+    /// A direct Database API call owns CPU-only continuations that it starts.
+    /// It must publish their terminal output before returning, but it must not
+    /// turn a cold storage request into a blocking call without a runtime
+    /// owner to resume it later.
+    pub(super) fn drain_self_scheduled_resident_progress(&mut self) -> Result<(), Error> {
+        let (wake_count, progress_waker) = Self::direct_progress_waker();
+        self.drive_resident_progress_now(&progress_waker, &wake_count.0)
+    }
+
+    fn direct_progress_waker() -> (Arc<DirectProgressWake>, std::task::Waker) {
+        let wake_count = Arc::new(DirectProgressWake(AtomicUsize::new(0)));
+        let progress_waker = waker(Arc::clone(&wake_count));
+        (wake_count, progress_waker)
     }
 
     /// Whether a suspended IVM evaluation still needs a future owner turn.
@@ -293,7 +311,7 @@ impl Database {
             overlay,
             Rc::clone(&self.storage_read_metrics),
         ));
-        let wake_count = Arc::new(DirectSubscriptionWake(AtomicUsize::new(0)));
+        let wake_count = Arc::new(DirectProgressWake(AtomicUsize::new(0)));
         let progress_waker = waker(Arc::clone(&wake_count));
         let subscription = self
             .ivm_runtime
@@ -316,7 +334,10 @@ impl Database {
         I: IntoIterator<Item = (K, GraphBuilder)>,
         K: Into<String>,
     {
-        self.subscribe_with_waker(sinks, None)
+        let (wake_count, progress_waker) = Self::direct_progress_waker();
+        let subscription = self.subscribe_with_waker(sinks, Some(&progress_waker))?;
+        self.drive_resident_progress_now(&progress_waker, &wake_count.0)?;
+        Ok(subscription)
     }
 
     /// Internal owner-loop subscription entrypoint.  A bounded opening poll
@@ -525,9 +546,19 @@ impl Database {
             overlay,
             Rc::clone(&self.storage_read_metrics),
         ));
-        self.ivm_runtime
-            .bind_shape_one_sink_with_output(prepared.id, &values, prepared.output, &storage)
-            .map_err(Error::IvmRuntime)
+        let (wake_count, progress_waker) = Self::direct_progress_waker();
+        let subscription = self
+            .ivm_runtime
+            .bind_shape_one_sink_with_output_and_waker(
+                prepared.id,
+                &values,
+                prepared.output,
+                &storage,
+                Some(&progress_waker),
+            )
+            .map_err(Error::IvmRuntime)?;
+        self.drive_resident_progress_now(&progress_waker, &wake_count.0)?;
+        Ok(subscription)
     }
 
     /// Prepare a one-sink parameterized graph shape directly.
@@ -671,9 +702,13 @@ impl Database {
             overlay,
             Rc::clone(&self.storage_read_metrics),
         ));
-        self.ivm_runtime
-            .bind_shape_one_sink(shape, binding_values, &storage)
-            .map_err(Error::IvmRuntime)
+        let (wake_count, progress_waker) = Self::direct_progress_waker();
+        let subscription = self
+            .ivm_runtime
+            .bind_shape_one_sink_with_waker(shape, binding_values, &storage, Some(&progress_waker))
+            .map_err(Error::IvmRuntime)?;
+        self.drive_resident_progress_now(&progress_waker, &wake_count.0)?;
+        Ok(subscription)
     }
 
     /// Bind a prepared one-sink graph shape while projecting subscriber-visible
@@ -698,9 +733,19 @@ impl Database {
             overlay,
             Rc::clone(&self.storage_read_metrics),
         ));
-        self.ivm_runtime
-            .bind_shape_one_sink_with_output(shape, binding_values, public_output, &storage)
-            .map_err(Error::IvmRuntime)
+        let (wake_count, progress_waker) = Self::direct_progress_waker();
+        let subscription = self
+            .ivm_runtime
+            .bind_shape_one_sink_with_output_and_waker(
+                shape,
+                binding_values,
+                public_output,
+                &storage,
+                Some(&progress_waker),
+            )
+            .map_err(Error::IvmRuntime)?;
+        self.drive_resident_progress_now(&progress_waker, &wake_count.0)?;
+        Ok(subscription)
     }
 
     /// Bind a routed multisink shape by positional values.
@@ -709,8 +754,12 @@ impl Database {
         shape: PreparedShapeId,
         binding_values: &[Value],
     ) -> Result<MultisinkSubscription, Error> {
-        self.bind_shape_with_waker(shape, binding_values, None)
-            .await
+        let (wake_count, progress_waker) = Self::direct_progress_waker();
+        let subscription = self
+            .bind_shape_with_waker(shape, binding_values, Some(&progress_waker))
+            .await?;
+        self.drive_resident_progress_now(&progress_waker, &wake_count.0)?;
+        Ok(subscription)
     }
 
     /// Internal owner-loop binding entrypoint; see [`Self::subscribe_with_waker`].

--- a/crates/groove/src/db/query.rs
+++ b/crates/groove/src/db/query.rs
@@ -7,18 +7,15 @@ impl Database {
     /// for external readiness, and callers may install one with
     /// [`Self::drive_ready_progress_with_waker`] or [`Self::poll_subscription`].
     pub(super) fn drive_resident_progress_now(&mut self) -> Result<(), Error> {
-        // Never use a new direct call as an excuse to poll an already-cold
-        // evaluation again. A storage future is permitted to self-wake before
-        // it is ready; only the owner that installed its durable waker may
-        // resume it.
-        if self.ivm_runtime.has_pending_incremental()
-            && !self.ivm_runtime.has_resident_continuation()
-        {
-            return Ok(());
-        }
         loop {
+            // Never use a new direct call as an excuse to poll a cold
+            // evaluation again. Scan the runtime's per-evaluation signals so
+            // an older cold hydration cannot hide later resident work.
+            if !self.ivm_runtime.has_resident_continuation() {
+                return Ok(());
+            }
             let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
-            match self.poll_progress(&mut cx) {
+            match self.poll_resident_progress(&mut cx) {
                 std::task::Poll::Ready(result) => return result,
                 // The runtime records an explicit resident continuation when
                 // a bounded CPU slice yields. Storage may self-wake before it
@@ -63,6 +60,29 @@ impl Database {
             return std::task::Poll::Ready(Err(error));
         }
         let progress = self.ivm_runtime.poll_pending_incremental(cx);
+        self.refresh_resident_writes();
+        match progress {
+            std::task::Poll::Ready(Ok(())) => std::task::Poll::Ready(Ok(())),
+            std::task::Poll::Ready(Err(error)) => {
+                self.poisoned = true;
+                std::task::Poll::Ready(Err(Error::IvmRuntime(error)))
+            }
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
+    }
+
+    /// Poll only explicitly runnable CPU continuations. This is the direct
+    /// API counterpart to [`Self::poll_progress`]: it must never repoll a
+    /// storage-pending evaluation merely because another direct operation
+    /// started later.
+    fn poll_resident_progress(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Error>> {
+        if let Err(error) = self.ensure_not_poisoned() {
+            return std::task::Poll::Ready(Err(error));
+        }
+        let progress = self.ivm_runtime.poll_resident_incremental(cx);
         self.refresh_resident_writes();
         match progress {
             std::task::Poll::Ready(Ok(())) => std::task::Poll::Ready(Ok(())),

--- a/crates/groove/src/db/storage_helpers.rs
+++ b/crates/groove/src/db/storage_helpers.rs
@@ -476,6 +476,10 @@ impl<S> OrderedKvStorage for MeteredStorage<'_, S>
 where
     S: OrderedKvStorage,
 {
+    fn permits_eager_read_retry(&self) -> bool {
+        self.storage.permits_eager_read_retry()
+    }
+
     fn scan(
         &self,
         request: crate::storage::ScanRequest,

--- a/crates/groove/src/db/tests/graphs/recursion.rs
+++ b/crates/groove/src/db/tests/graphs/recursion.rs
@@ -70,8 +70,10 @@ async fn deep_recursive_step_evaluates_with_constant_stack() {
         step = step.filter(PredicateExpr::gt("src", Value::U64(0)));
     }
     let subscription = database
-        .subscribe_one_sink(GraphBuilder::recursive(seed, step, "frontier", 16))
-        .await
+        .subscribe([(
+            "result",
+            GraphBuilder::recursive(seed, step, "frontier", 16),
+        )])
         .unwrap();
 
     let mut batch = database.open_batch();
@@ -79,7 +81,13 @@ async fn deep_recursive_step_evaluates_with_constant_stack() {
     database.commit_batch(batch).await.unwrap();
 
     assert_eq!(
-        expect_recv_vals(&subscription),
+        subscription
+            .recv()
+            .unwrap()
+            .get("result")
+            .unwrap()
+            .to_values()
+            .unwrap(),
         vec![(vec![Value::U64(1), Value::U64(2)], 1)]
     );
 }
@@ -126,13 +134,17 @@ async fn deep_recursive_hydration_yields_and_preserves_its_snapshot() {
     for _ in 0..48 {
         step = step.filter(PredicateExpr::gt("src", Value::U64(0)));
     }
-    let subscription = database
-        .subscribe_one_sink(GraphBuilder::recursive(seed, step, "frontier", 16))
-        .await
-        .unwrap();
-
     let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
     let owner_waker = waker(Arc::clone(&wakes));
+    let subscription = database
+        .subscribe_with_waker(
+            [(
+                "result",
+                GraphBuilder::recursive(seed, step, "frontier", 16),
+            )],
+            Some(&owner_waker),
+        )
+        .unwrap();
     let mut previous_wakes = 0;
     let mut yielded = false;
     for _ in 0..128 {
@@ -161,7 +173,13 @@ async fn deep_recursive_hydration_yields_and_preserves_its_snapshot() {
         "the retained traversal converges without a hot-loop"
     );
     assert_eq!(
-        expect_recv_vals(&subscription),
+        subscription
+            .recv()
+            .unwrap()
+            .get("result")
+            .unwrap()
+            .to_values()
+            .unwrap(),
         vec![(vec![Value::U64(1), Value::U64(2)], 1)]
     );
 }
@@ -189,12 +207,11 @@ async fn recursive_hydration_retains_frontiers_until_the_full_closure_is_ready()
     insert_edge(&mut batch, 3, 3, 4);
     database.commit_batch(batch).await.unwrap();
 
-    let subscription = database
-        .subscribe_one_sink(reachability_graph(16))
-        .await
-        .unwrap();
     let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
     let owner_waker = waker(Arc::clone(&wakes));
+    let subscription = database
+        .subscribe_with_waker([("result", reachability_graph(16))], Some(&owner_waker))
+        .unwrap();
     for _ in 0..128 {
         database
             .drive_ready_progress_with_waker(Some(&owner_waker))
@@ -213,7 +230,13 @@ async fn recursive_hydration_retains_frontiers_until_the_full_closure_is_ready()
         "frontier phases hand their continuation back to the runtime owner"
     );
 
-    let mut values = expect_recv_vals(&subscription);
+    let mut values = subscription
+        .recv()
+        .unwrap()
+        .get("result")
+        .unwrap()
+        .to_values()
+        .unwrap();
     sort_pairs_by_value(&mut values);
     assert_eq!(
         values,
@@ -896,6 +919,27 @@ async fn recursive_graph_subscriptions_converge_on_self_cycles() {
     let values = subscription.recv().unwrap().to_values().unwrap();
 
     assert_eq!(values, [(vec![Value::U64(1), Value::U64(1)], 1)]);
+}
+
+/// The direct async Database API is itself the runtime owner. A resident
+/// recursive snapshot may use several cooperative IVM turns, but callers must
+/// not need to provide an external wake loop before they can consume it.
+#[futures_test::test]
+async fn direct_recursive_subscription_open_drives_resident_snapshot() {
+    let storage = MemoryStorage::new(&["edges"]).expect("valid memory storage families");
+    let mut database = Database::new(edges_schema(), storage).await.unwrap();
+    let mut batch = database.open_batch();
+    insert_edge(&mut batch, 1, 1, 2);
+    database.commit_batch(batch).await.unwrap();
+
+    let subscription = database
+        .subscribe_one_sink(reachability_graph(16))
+        .await
+        .expect("direct subscription opening drives the recursive snapshot");
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
 }
 
 #[futures_test::test]

--- a/crates/groove/src/db/tests/graphs/recursion.rs
+++ b/crates/groove/src/db/tests/graphs/recursion.rs
@@ -228,6 +228,48 @@ async fn recursive_hydration_retains_frontiers_until_the_full_closure_is_ready()
     );
 }
 
+/// Retractions force a full recursive snapshot during a live tick. That path
+/// shares the same bounded postorder continuation as initial hydration: a
+/// delete must not trade a correct retraction for an owner-turn monopoly.
+#[futures_test::test]
+async fn recursive_live_recompute_retains_traversal_through_retraction() {
+    let storage = MemoryStorage::new(&["edges"]).expect("valid memory storage families");
+    let mut database = Database::new(edges_schema(), storage).await.unwrap();
+    let subscription = database
+        .subscribe_one_sink(reachability_graph(16))
+        .await
+        .unwrap();
+    for _ in 0..128 {
+        database.drive_ready_progress().await.unwrap();
+        if !database.has_pending_progress() {
+            break;
+        }
+    }
+    assert!(!database.has_pending_progress());
+
+    let mut batch = database.open_batch();
+    insert_edge(&mut batch, 1, 1, 2);
+    insert_edge(&mut batch, 2, 2, 3);
+    insert_edge(&mut batch, 3, 3, 4);
+    database.commit_batch(batch).await.unwrap();
+    let _initial = expect_recv_vals(&subscription);
+
+    let mut batch = database.open_batch();
+    batch.delete("edges", PrimaryKeyValue::U64(2));
+    database.commit_batch(batch).await.unwrap();
+    let mut values = expect_recv_vals(&subscription);
+    sort_pairs_by_value(&mut values);
+    assert_eq!(
+        values,
+        [
+            (vec![Value::U64(1), Value::U64(3)], -1),
+            (vec![Value::U64(1), Value::U64(4)], -1),
+            (vec![Value::U64(2), Value::U64(3)], -1),
+            (vec![Value::U64(2), Value::U64(4)], -1),
+        ]
+    );
+}
+
 #[futures_test::test]
 async fn recursive_graph_subscriptions_settle_transitive_closure_in_one_tick() {
     let storage = MemoryStorage::new(&["edges"]).expect("valid memory storage families");

--- a/crates/groove/src/db/tests/graphs/recursion.rs
+++ b/crates/groove/src/db/tests/graphs/recursion.rs
@@ -84,6 +84,150 @@ async fn deep_recursive_step_evaluates_with_constant_stack() {
     );
 }
 
+/// A resident recursive subscription can contain a much deeper graph than the
+/// outer IVM work queue sees: the recursive snapshot walks its seed/step graph
+/// privately. That walk must yield through the runtime owner while retaining
+/// its postorder continuation, so it neither blocks unrelated runtime work nor
+/// replays already-evaluated shared children on every turn.
+#[futures_test::test]
+async fn deep_recursive_hydration_yields_and_preserves_its_snapshot() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::task::{ArcWake, waker};
+
+    struct WakeCount(AtomicUsize);
+
+    impl ArcWake for WakeCount {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    let storage = MemoryStorage::new(&["edges"]).expect("valid memory storage families");
+    let mut database = Database::new(edges_schema(), storage).await.unwrap();
+    let mut batch = database.open_batch();
+    insert_edge(&mut batch, 1, 1, 2);
+    database.commit_batch(batch).await.unwrap();
+
+    let seed = GraphBuilder::table("edges").project(["src", "dst"]);
+    let frontier = GraphBuilder::frontier_source(
+        "frontier",
+        RecordDescriptor::new([
+            ("src", ColumnType::U64.clone()),
+            ("dst", ColumnType::U64.clone()),
+        ]),
+    );
+    let edge_pairs = GraphBuilder::table("edges").project(["src", "dst"]);
+    let mut step = GraphBuilder::join(frontier, edge_pairs, ["dst"], ["src"]).project_fields([
+        ProjectField::renamed("left.src", "src"),
+        ProjectField::renamed("right.dst", "dst"),
+    ]);
+    for _ in 0..48 {
+        step = step.filter(PredicateExpr::gt("src", Value::U64(0)));
+    }
+    let subscription = database
+        .subscribe_one_sink(GraphBuilder::recursive(seed, step, "frontier", 16))
+        .await
+        .unwrap();
+
+    let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+    let owner_waker = waker(Arc::clone(&wakes));
+    let mut previous_wakes = 0;
+    let mut yielded = false;
+    for _ in 0..128 {
+        database
+            .drive_ready_progress_with_waker(Some(&owner_waker))
+            .await
+            .unwrap();
+        if !database.has_pending_progress() {
+            break;
+        }
+        yielded = true;
+        let wakes_now = wakes.0.load(Ordering::Acquire);
+        assert!(
+            wakes_now > previous_wakes,
+            "each bounded recursive owner turn schedules exactly one continuation"
+        );
+        previous_wakes = wakes_now;
+    }
+
+    assert!(
+        yielded,
+        "the deep private recursion must not complete in one turn"
+    );
+    assert!(
+        !database.has_pending_progress(),
+        "the retained traversal converges without a hot-loop"
+    );
+    assert_eq!(
+        expect_recv_vals(&subscription),
+        vec![(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+}
+
+#[futures_test::test]
+async fn recursive_hydration_retains_frontiers_until_the_full_closure_is_ready() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::task::{ArcWake, waker};
+
+    struct WakeCount(AtomicUsize);
+
+    impl ArcWake for WakeCount {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    let storage = MemoryStorage::new(&["edges"]).expect("valid memory storage families");
+    let mut database = Database::new(edges_schema(), storage).await.unwrap();
+    let mut batch = database.open_batch();
+    insert_edge(&mut batch, 1, 1, 2);
+    insert_edge(&mut batch, 2, 2, 3);
+    insert_edge(&mut batch, 3, 3, 4);
+    database.commit_batch(batch).await.unwrap();
+
+    let subscription = database
+        .subscribe_one_sink(reachability_graph(16))
+        .await
+        .unwrap();
+    let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+    let owner_waker = waker(Arc::clone(&wakes));
+    for _ in 0..128 {
+        database
+            .drive_ready_progress_with_waker(Some(&owner_waker))
+            .await
+            .unwrap();
+        if !database.has_pending_progress() {
+            break;
+        }
+    }
+    assert!(
+        !database.has_pending_progress(),
+        "all retained recursive frontiers eventually settle"
+    );
+    assert!(
+        wakes.0.load(Ordering::Acquire) > 0,
+        "frontier phases hand their continuation back to the runtime owner"
+    );
+
+    let mut values = expect_recv_vals(&subscription);
+    sort_pairs_by_value(&mut values);
+    assert_eq!(
+        values,
+        [
+            (vec![Value::U64(1), Value::U64(2)], 1),
+            (vec![Value::U64(1), Value::U64(3)], 1),
+            (vec![Value::U64(1), Value::U64(4)], 1),
+            (vec![Value::U64(2), Value::U64(3)], 1),
+            (vec![Value::U64(2), Value::U64(4)], 1),
+            (vec![Value::U64(3), Value::U64(4)], 1),
+        ]
+    );
+}
+
 #[futures_test::test]
 async fn recursive_graph_subscriptions_settle_transitive_closure_in_one_tick() {
     let storage = MemoryStorage::new(&["edges"]).expect("valid memory storage families");

--- a/crates/groove/src/db/tests/graphs/recursion.rs
+++ b/crates/groove/src/db/tests/graphs/recursion.rs
@@ -49,8 +49,12 @@ impl Future for YieldOnce {
     }
 }
 
+/// Direct writes own resident recursive continuation turns.  The bounded
+/// evaluator may yield repeatedly, but `commit_batch` must publish its output
+/// before it returns; only genuinely cold storage is allowed to remain pending
+/// for a runtime owner.
 #[futures_test::test]
-async fn deep_recursive_step_evaluates_with_constant_stack() {
+async fn direct_recursive_write_drains_resident_continuations() {
     let storage = MemoryStorage::new(&["edges"]).expect("valid memory storage families");
     let mut database = Database::new(edges_schema(), storage).await.unwrap();
     let seed = GraphBuilder::table("edges").project(["src", "dst"]);
@@ -70,24 +74,22 @@ async fn deep_recursive_step_evaluates_with_constant_stack() {
         step = step.filter(PredicateExpr::gt("src", Value::U64(0)));
     }
     let subscription = database
-        .subscribe([(
-            "result",
-            GraphBuilder::recursive(seed, step, "frontier", 16),
-        )])
+        .subscribe_one_sink(GraphBuilder::recursive(seed, step, "frontier", 16))
+        .await
         .unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
 
     let mut batch = database.open_batch();
     insert_edge(&mut batch, 1, 1, 2);
     database.commit_batch(batch).await.unwrap();
 
+    assert!(
+        !database.has_pending_progress(),
+        "a direct resident write drains its self-scheduled recursive slices before returning"
+    );
+
     assert_eq!(
-        subscription
-            .recv()
-            .unwrap()
-            .get("result")
-            .unwrap()
-            .to_values()
-            .unwrap(),
+        subscription.recv().unwrap().to_values().unwrap(),
         vec![(vec![Value::U64(1), Value::U64(2)], 1)]
     );
 }
@@ -465,6 +467,10 @@ async fn prepared_recursive_binding_skips_recompute_for_unrelated_table_delta() 
     insert_edge(&mut batch, 1, 1, 2);
     insert_edge(&mut batch, 2, 2, 3);
     database.commit_batch(batch).await.unwrap();
+    assert!(
+        !database.has_pending_progress(),
+        "prepared recursive direct writes drain their resident continuation turns"
+    );
     let mut initial = expect_recv_vals(&subscription);
     sort_pairs_by_value(&mut initial);
     assert_eq!(

--- a/crates/groove/src/db/tests/graphs/recursion.rs
+++ b/crates/groove/src/db/tests/graphs/recursion.rs
@@ -94,6 +94,203 @@ async fn direct_recursive_write_drains_resident_continuations() {
     );
 }
 
+/// Direct work scans every pending evaluation for an explicitly runnable CPU
+/// continuation. Older cold subscriptions stay parked, including more than
+/// one cold queue head, but they must not prevent a later independent
+/// recursive write from publishing its resident result.
+#[futures_test::test]
+async fn direct_recursive_write_drains_behind_multiple_cold_hydrations() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::task::{ArcWake, waker};
+
+    struct WakeCount(AtomicUsize);
+
+    impl ArcWake for WakeCount {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    let schema = DatabaseSchema::new([
+        TableSchema::new(
+            "edges",
+            [
+                ColumnSchema::new("id", ColumnType::U64),
+                ColumnSchema::new("src", ColumnType::U64),
+                ColumnSchema::new("dst", ColumnType::U64),
+            ],
+        )
+        .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64)),
+        TableSchema::new(
+            "docs",
+            [
+                ColumnSchema::new("id", ColumnType::U64),
+                ColumnSchema::new("team", ColumnType::U64),
+            ],
+        )
+        .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64)),
+        TableSchema::new(
+            "notes",
+            [
+                ColumnSchema::new("id", ColumnType::U64),
+                ColumnSchema::new("team", ColumnType::U64),
+            ],
+        )
+        .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64)),
+    ]);
+    let (storage, control) = TestStorage::controlled(&["edges", "docs", "notes"]);
+    let mut database = Database::new(schema, storage.clone()).await.unwrap();
+    let mut seed = database.open_batch();
+    insert_edge(&mut seed, 1, 1, 2);
+    seed.insert("docs", vec![Value::U64(1), Value::U64(7)]);
+    seed.insert("notes", vec![Value::U64(1), Value::U64(8)]);
+    database.commit_batch(seed).await.unwrap();
+
+    let deep_recursive_graph = || {
+        let seed = GraphBuilder::table("edges").project(["src", "dst"]);
+        let frontier = GraphBuilder::frontier_source(
+            "frontier",
+            RecordDescriptor::new([
+                ("src", ColumnType::U64.clone()),
+                ("dst", ColumnType::U64.clone()),
+            ]),
+        );
+        let edge_pairs = GraphBuilder::table("edges").project(["src", "dst"]);
+        let mut step = GraphBuilder::join(frontier, edge_pairs, ["dst"], ["src"]).project_fields([
+            ProjectField::renamed("left.src", "src"),
+            ProjectField::renamed("right.dst", "dst"),
+        ]);
+        for _ in 0..48 {
+            step = step.filter(PredicateExpr::gt("src", Value::U64(0)));
+        }
+        GraphBuilder::recursive(seed, step, "frontier", 16)
+    };
+    let edges = database
+        .subscribe_one_sink(deep_recursive_graph())
+        .await
+        .unwrap();
+    for _ in 0..32 {
+        database.drive_ready_progress().await.unwrap();
+        if !database.has_pending_progress() {
+            break;
+        }
+    }
+    assert!(!database.has_pending_progress());
+    assert_eq!(
+        expect_recv_vals(&edges),
+        vec![(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+
+    control.take_observed();
+    let first_docs = database
+        .subscribe_one_sink(GraphBuilder::table("docs"))
+        .await
+        .unwrap();
+    let second_notes = database
+        .subscribe_one_sink(GraphBuilder::table("notes"))
+        .await
+        .unwrap();
+    assert!(database.has_pending_progress());
+    assert_eq!(
+        control
+            .observed()
+            .into_iter()
+            .filter(|operation| *operation == TestStorageOperation::ScanOpen)
+            .count(),
+        1,
+        "the older docs hydration owns the first cold turn; the later notes hydration remains queued behind it"
+    );
+    assert!(first_docs.try_recv().is_err());
+    assert!(second_notes.try_recv().is_err());
+
+    // The edges scan is already resident. Its no-owner direct opening is
+    // queued behind the older cold requests, so this receipt fails if direct
+    // progress looks only at the queue head instead of every evaluation.
+    let resident_tail = database
+        .subscribe_one_sink(deep_recursive_graph())
+        .await
+        .unwrap();
+    assert_eq!(
+        expect_try_recv_vals(&resident_tail),
+        vec![(vec![Value::U64(1), Value::U64(2)], 1)],
+        "a resident direct opening drains behind older cold queue entries"
+    );
+
+    let mut write = database.open_batch();
+    insert_edge(&mut write, 2, 2, 3);
+    let applied = database.apply_batch(write).await.unwrap();
+    assert_eq!(
+        edges.recv().unwrap().to_values().unwrap(),
+        vec![
+            (vec![Value::U64(1), Value::U64(3)], 1),
+            (vec![Value::U64(2), Value::U64(3)], 1),
+        ],
+        "the later resident recursive write publishes despite older cold queue entries"
+    );
+    assert_eq!(
+        resident_tail.recv().unwrap().to_values().unwrap(),
+        vec![
+            (vec![Value::U64(1), Value::U64(3)], 1),
+            (vec![Value::U64(2), Value::U64(3)], 1),
+        ]
+    );
+    assert!(database.has_pending_progress());
+    assert!(first_docs.try_recv().is_err());
+    assert!(second_notes.try_recv().is_err());
+
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+    let owner_waker = waker(Arc::clone(&wakes));
+    database
+        .drive_ready_progress_with_waker(Some(&owner_waker))
+        .await
+        .unwrap();
+    let mut wakes_before_paused_poll = wakes.0.load(Ordering::Acquire);
+    let mut paused = false;
+    for _ in 0..8 {
+        database
+            .drive_ready_progress_with_waker(Some(&owner_waker))
+            .await
+            .unwrap();
+        let wakes_now = wakes.0.load(Ordering::Acquire);
+        if wakes_now == wakes_before_paused_poll {
+            paused = true;
+            break;
+        }
+        wakes_before_paused_poll = wakes_now;
+    }
+    assert!(
+        paused,
+        "each queued cold opening may self-wake once, but the owner eventually retains the paused request"
+    );
+    control.resume_operation(TestStorageOperation::ScanOpen);
+    assert!(
+        wakes.0.load(Ordering::Acquire) > wakes_before_paused_poll,
+        "the owner that observed the cold request receives its later readiness wake"
+    );
+    for _ in 0..32 {
+        database
+            .drive_ready_progress_with_waker(Some(&owner_waker))
+            .await
+            .unwrap();
+        if !database.has_pending_progress() {
+            break;
+        }
+    }
+    assert!(!database.has_pending_progress());
+    assert_eq!(
+        expect_recv_vals(&first_docs),
+        vec![(vec![Value::U64(1), Value::U64(7)], 1)]
+    );
+    assert_eq!(
+        expect_recv_vals(&second_notes),
+        vec![(vec![Value::U64(1), Value::U64(8)], 1)]
+    );
+    drop(applied);
+}
+
 /// A resident recursive subscription can contain a much deeper graph than the
 /// outer IVM work queue sees: the recursive snapshot walks its seed/step graph
 /// privately. That walk must yield through the runtime owner while retaining

--- a/crates/groove/src/db/tests/subscriptions/mod.rs
+++ b/crates/groove/src/db/tests/subscriptions/mod.rs
@@ -38,6 +38,10 @@ async fn cold_hydration_wakes_the_supplied_owner_once_without_polling() {
         .subscribe_one_sink(GraphBuilder::table("albums"))
         .await
         .unwrap();
+    assert!(
+        database.has_pending_progress(),
+        "a direct opening returns while its controlled ScanOpen is cold instead of awaiting it"
+    );
     let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
     let owner_waker = waker(Arc::clone(&wakes));
     database

--- a/crates/groove/src/db/tests/subscriptions/mod.rs
+++ b/crates/groove/src/db/tests/subscriptions/mod.rs
@@ -364,6 +364,141 @@ async fn deep_resident_hydration_yields_without_changing_its_snapshot() {
     );
 }
 
+/// Cold storage is permitted to self-wake after its first poll. That wake is
+/// not an IVM CPU continuation: a direct opening must leave the request
+/// pending, and only a later owner turn may attach and receive its durable
+/// wake route.
+#[futures_test::test]
+async fn direct_cold_self_wake_waits_for_a_later_owner_turn() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::task::{ArcWake, waker};
+
+    struct WakeCount(AtomicUsize);
+
+    impl ArcWake for WakeCount {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    let (storage, control) = TestStorage::controlled(&["albums"]);
+    let mut database = Database::new(albums_schema(), storage.clone())
+        .await
+        .unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(1), Value::String("cold wake".to_owned())],
+    );
+    database.commit_batch(batch).await.unwrap();
+    storage.evict_all();
+    control.take_observed();
+
+    let subscription = database
+        .subscribe_one_sink(GraphBuilder::table("albums"))
+        .await
+        .unwrap();
+    assert!(database.has_pending_progress());
+    assert_eq!(
+        control
+            .observed()
+            .into_iter()
+            .filter(|operation| *operation == TestStorageOperation::ScanOpen)
+            .count(),
+        1,
+        "the direct opening polls the cold scan once but must not consume its self-wake"
+    );
+    assert!(
+        subscription.try_recv().is_err(),
+        "a self-woken cold scan must not publish during the direct opening"
+    );
+
+    // The direct call has returned. Install a real owner waker before letting
+    // the retained storage operation become ready.
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+    let owner_waker = waker(Arc::clone(&wakes));
+    database
+        .drive_ready_progress_with_waker(Some(&owner_waker))
+        .await
+        .unwrap();
+    assert!(database.has_pending_progress());
+    assert_eq!(wakes.0.load(Ordering::Acquire), 0);
+
+    control.resume_operation(TestStorageOperation::ScanOpen);
+    assert_eq!(
+        wakes.0.load(Ordering::Acquire),
+        1,
+        "the resumed cold operation wakes the owner that actually retained it"
+    );
+    for _ in 0..32 {
+        database
+            .drive_ready_progress_with_waker(Some(&owner_waker))
+            .await
+            .unwrap();
+        if !database.has_pending_progress() {
+            break;
+        }
+    }
+    assert!(!database.has_pending_progress());
+    assert_eq!(
+        expect_try_recv_vals(&subscription),
+        vec![(
+            vec![Value::U64(1), Value::String("cold wake".to_owned())],
+            1
+        )]
+    );
+}
+
+/// A later direct write may create resident work, but it cannot use that call
+/// to poll an earlier cold subscription past its self-wake.
+#[futures_test::test]
+async fn direct_write_does_not_consume_an_earlier_cold_subscription() {
+    let (storage, control) = TestStorage::controlled(&["albums"]);
+    let mut database = Database::new(albums_schema(), storage.clone())
+        .await
+        .unwrap();
+    let mut seed = database.open_batch();
+    seed.insert(
+        "albums",
+        vec![Value::U64(1), Value::String("seed".to_owned())],
+    );
+    database.commit_batch(seed).await.unwrap();
+    storage.evict_all();
+    control.take_observed();
+
+    let subscription = database
+        .subscribe_one_sink(GraphBuilder::table("albums"))
+        .await
+        .unwrap();
+    assert!(database.has_pending_progress());
+    assert!(subscription.try_recv().is_err());
+
+    let mut write = database.open_batch();
+    write.insert(
+        "albums",
+        vec![Value::U64(2), Value::String("later write".to_owned())],
+    );
+    let applied = database.apply_batch(write).await.unwrap();
+    assert_eq!(
+        control
+            .observed()
+            .into_iter()
+            .filter(|operation| *operation == TestStorageOperation::ScanOpen)
+            .count(),
+        1,
+        "the write must not repoll the self-woken cold scan synchronously"
+    );
+    assert!(database.has_pending_progress());
+    assert!(
+        subscription.try_recv().is_err(),
+        "the cold subscription cannot publish as a side effect of an unrelated direct write"
+    );
+    drop(applied);
+}
+
 #[futures_test::test]
 async fn subscribe_sends_empty_hydration_snapshot_without_writes() {
     let storage = MemoryStorage::new(&["albums"]).expect("valid memory storage families");

--- a/crates/groove/src/db/tests/subscriptions/mod.rs
+++ b/crates/groove/src/db/tests/subscriptions/mod.rs
@@ -262,6 +262,75 @@ async fn cold_hydration_yields_before_later_subscription_work() {
     );
 }
 
+/// A large entirely resident graph is CPU work, not a storage wait. Hydration
+/// must therefore schedule bounded owner turns and still produce the same
+/// snapshot as the equivalent shallow subscription.
+#[futures_test::test]
+async fn deep_resident_hydration_yields_without_changing_its_snapshot() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::task::{ArcWake, waker};
+
+    struct WakeCount(AtomicUsize);
+
+    impl ArcWake for WakeCount {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    let storage = MemoryStorage::new(&["albums"]).expect("valid memory storage families");
+    let mut database = Database::new(albums_schema(), storage).await.unwrap();
+    let mut batch = database.open_batch();
+    for id in 1..=3 {
+        batch.insert(
+            "albums",
+            vec![Value::U64(id), Value::String(format!("resident {id}"))],
+        );
+    }
+    database.commit_batch(batch).await.unwrap();
+
+    let mut deep_graph = GraphBuilder::table("albums");
+    // Deliberately far larger than one cooperative session slice.
+    for _ in 0..128 {
+        deep_graph = deep_graph.filter(PredicateExpr::gt("id", Value::U64(0)));
+    }
+    let deep = database.subscribe_one_sink(deep_graph).await.unwrap();
+    let shallow = database
+        .subscribe_one_sink(GraphBuilder::table("albums"))
+        .await
+        .unwrap();
+
+    let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+    let owner_waker = waker(Arc::clone(&wakes));
+    database
+        .drive_ready_progress_with_waker(Some(&owner_waker))
+        .await
+        .unwrap();
+    assert!(database.has_pending_progress());
+    assert!(
+        wakes.0.load(Ordering::Acquire) > 0,
+        "resident graph work schedules a cooperative owner turn"
+    );
+
+    for _ in 0..32 {
+        database
+            .drive_ready_progress_with_waker(Some(&owner_waker))
+            .await
+            .unwrap();
+        if !database.has_pending_progress() {
+            break;
+        }
+    }
+    assert!(!database.has_pending_progress());
+    assert_eq!(
+        expect_try_recv_vals(&deep),
+        expect_try_recv_vals(&shallow),
+        "bounded deep hydration preserves the shallow graph's snapshot"
+    );
+}
+
 #[futures_test::test]
 async fn subscribe_sends_empty_hydration_snapshot_without_writes() {
     let storage = MemoryStorage::new(&["albums"]).expect("valid memory storage families");

--- a/crates/groove/src/db/tests/subscriptions/mod.rs
+++ b/crates/groove/src/db/tests/subscriptions/mod.rs
@@ -266,9 +266,10 @@ async fn cold_hydration_yields_before_later_subscription_work() {
     );
 }
 
-/// A large entirely resident graph is CPU work, not a storage wait. Hydration
-/// must therefore schedule bounded owner turns and still produce the same
-/// snapshot as the equivalent shallow subscription.
+/// A large entirely resident graph is CPU work, not a storage wait. The direct
+/// async API owns and drains that resident continuation chain before returning;
+/// the owner-loop API instead yields bounded turns and wakes its owner. Both
+/// paths must produce the same stable snapshot.
 #[futures_test::test]
 async fn deep_resident_hydration_yields_without_changing_its_snapshot() {
     use std::sync::Arc;
@@ -295,30 +296,27 @@ async fn deep_resident_hydration_yields_without_changing_its_snapshot() {
     }
     database.commit_batch(batch).await.unwrap();
 
-    let mut deep_graph = GraphBuilder::table("albums");
+    let mut owner_deep_graph = GraphBuilder::table("albums");
     // Deliberately far larger than one cooperative session slice.
     for _ in 0..128 {
-        deep_graph = deep_graph.filter(PredicateExpr::gt("id", Value::U64(0)));
+        owner_deep_graph = owner_deep_graph.filter(PredicateExpr::gt("id", Value::U64(0)));
     }
-    let deep = database.subscribe_one_sink(deep_graph).await.unwrap();
-    let shallow = database
-        .subscribe_one_sink(GraphBuilder::table("albums"))
-        .await
-        .unwrap();
 
     let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
     let owner_waker = waker(Arc::clone(&wakes));
-    database
-        .drive_ready_progress_with_waker(Some(&owner_waker))
-        .await
+    let owner_deep = database
+        .subscribe_with_waker([("deep", owner_deep_graph)], Some(&owner_waker))
         .unwrap();
     assert!(database.has_pending_progress());
-    assert!(
-        wakes.0.load(Ordering::Acquire) > 0,
-        "resident graph work schedules a cooperative owner turn"
-    );
 
+    let mut previous_wakes = 0;
     for _ in 0..32 {
+        let wakes_now = wakes.0.load(Ordering::Acquire);
+        assert!(
+            wakes_now > previous_wakes,
+            "each bounded resident owner turn schedules its continuation rather than relying on polling"
+        );
+        previous_wakes = wakes_now;
         database
             .drive_ready_progress_with_waker(Some(&owner_waker))
             .await
@@ -328,10 +326,41 @@ async fn deep_resident_hydration_yields_without_changing_its_snapshot() {
         }
     }
     assert!(!database.has_pending_progress());
+    let owner_snapshot = owner_deep
+        .try_recv()
+        .expect("owner-loop hydration publishes its completed initial snapshot")
+        .get("deep")
+        .expect("the deep sink is present")
+        .to_values()
+        .unwrap();
+    let mut owner_snapshot = owner_snapshot;
+    owner_snapshot.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
+
+    let mut direct_deep_graph = GraphBuilder::table("albums");
+    for _ in 0..128 {
+        direct_deep_graph = direct_deep_graph.filter(PredicateExpr::gt("id", Value::U64(0)));
+    }
+    let direct_deep = database
+        .subscribe_one_sink(direct_deep_graph)
+        .await
+        .unwrap();
+    let shallow = database
+        .subscribe_one_sink(GraphBuilder::table("albums"))
+        .await
+        .unwrap();
+    assert!(
+        !database.has_pending_progress(),
+        "the direct async API drains all self-scheduled resident slices before returning"
+    );
+    let direct_snapshot = expect_try_recv_vals(&direct_deep);
     assert_eq!(
-        expect_try_recv_vals(&deep),
+        direct_snapshot,
         expect_try_recv_vals(&shallow),
-        "bounded deep hydration preserves the shallow graph's snapshot"
+        "direct resident hydration returns a complete stable deep snapshot"
+    );
+    assert_eq!(
+        owner_snapshot, direct_snapshot,
+        "bounded owner-loop hydration preserves the deep snapshot"
     );
 }
 

--- a/crates/groove/src/db/tests/subscriptions/mod.rs
+++ b/crates/groove/src/db/tests/subscriptions/mod.rs
@@ -173,6 +173,95 @@ async fn cold_subscription_open_retains_the_supplied_owner_waker() {
     );
 }
 
+/// A cold hydration cannot monopolize the IVM worklist while a second
+/// subscription is being registered. The owner must return after the first
+/// pending evaluation, leaving storage to wake it before any later work is
+/// advanced.
+#[futures_test::test]
+async fn cold_hydration_yields_before_later_subscription_work() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::task::{ArcWake, waker};
+
+    struct WakeCount(AtomicUsize);
+
+    impl ArcWake for WakeCount {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    let (storage, control) = TestStorage::controlled(&["albums", "artists"]);
+    let mut database = Database::new(albums_artists_schema(), storage.clone())
+        .await
+        .unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![
+            Value::U64(1),
+            Value::U64(1),
+            Value::String("owner-turn album".to_owned()),
+        ],
+    );
+    batch.insert(
+        "artists",
+        vec![Value::U64(1), Value::String("owner-turn artist".to_owned())],
+    );
+    database.commit_batch(batch).await.unwrap();
+    storage.evict_all();
+    control.pause_on(TestStorageOperation::ScanOpen);
+
+    let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+    let owner_waker = waker(Arc::clone(&wakes));
+    let albums = database
+        .subscribe([("albums", GraphBuilder::table("albums"))])
+        .unwrap();
+    let artists = database
+        .subscribe([("artists", GraphBuilder::table("artists"))])
+        .unwrap();
+
+    // The first owner turn has a cooperative IVM yield; the second reaches
+    // the paused album scan. The artist scan must remain untouched.
+    database
+        .drive_ready_progress_with_waker(Some(&owner_waker))
+        .await
+        .unwrap();
+    database
+        .drive_ready_progress_with_waker(Some(&owner_waker))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        control
+            .observed()
+            .into_iter()
+            .filter(|operation| *operation == TestStorageOperation::ScanOpen)
+            .count(),
+        1,
+        "the first cold scan yields the worklist before the later hydration can open its scan"
+    );
+    assert!(database.has_pending_progress());
+
+    control.resume_operation(TestStorageOperation::ScanOpen);
+    for _ in 0..32 {
+        database
+            .drive_ready_progress_with_waker(Some(&owner_waker))
+            .await
+            .unwrap();
+        if !database.has_pending_progress() {
+            break;
+        }
+    }
+    assert!(!database.has_pending_progress());
+    assert!(albums.try_recv().is_ok(), "the cold hydration completes");
+    assert!(
+        artists.try_recv().is_ok(),
+        "later independent work also completes"
+    );
+}
+
 #[futures_test::test]
 async fn subscribe_sends_empty_hydration_snapshot_without_writes() {
     let storage = MemoryStorage::new(&["albums"]).expect("valid memory storage families");

--- a/crates/groove/src/db/tests/subscriptions/mod.rs
+++ b/crates/groove/src/db/tests/subscriptions/mod.rs
@@ -89,6 +89,90 @@ async fn cold_hydration_wakes_the_supplied_owner_once_without_polling() {
     );
 }
 
+/// Subscription opening performs one bounded incremental poll to publish
+/// resident rows without another owner turn.  That opening poll must retain
+/// the host's durable continuation when it discovers cold storage: otherwise
+/// a worker can render its initial empty view yet never receive the wake that
+/// lets it process a later local write or shutdown.
+#[futures_test::test]
+async fn cold_subscription_open_retains_the_supplied_owner_waker() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::task::{ArcWake, waker};
+
+    struct WakeCount(AtomicUsize);
+
+    impl ArcWake for WakeCount {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    let (storage, control) = TestStorage::controlled(&["albums"]);
+    let mut database = Database::new(albums_schema(), storage.clone())
+        .await
+        .unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![
+            Value::U64(1),
+            Value::String("opening wake bridge".to_owned()),
+        ],
+    );
+    database.commit_batch(batch).await.unwrap();
+    storage.evict_all();
+    control.pause_on(TestStorageOperation::ScanOpen);
+
+    let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+    let owner_waker = waker(Arc::clone(&wakes));
+    let subscription = database
+        .subscribe_with_waker(
+            [("albums", GraphBuilder::table("albums"))],
+            Some(&owner_waker),
+        )
+        .unwrap();
+    assert!(database.has_pending_progress());
+    assert_eq!(
+        wakes.0.load(Ordering::Acquire),
+        1,
+        "the opening poll uses the supplied owner waker rather than Waker::noop"
+    );
+
+    // Simulate the owner turn that the opening poll just requested. It starts
+    // the controlled storage operation and leaves the same durable wake route
+    // attached to that cold operation.
+    database
+        .drive_ready_progress_with_waker(Some(&owner_waker))
+        .await
+        .unwrap();
+    assert!(database.has_pending_progress());
+    let wakes_before_resume = wakes.0.load(Ordering::Acquire);
+
+    control.resume_operation(TestStorageOperation::ScanOpen);
+    assert_eq!(
+        wakes.0.load(Ordering::Acquire),
+        wakes_before_resume + 1,
+        "cold work opened by a subscription schedules its runtime owner"
+    );
+
+    for _ in 0..32 {
+        database
+            .drive_ready_progress_with_waker(Some(&owner_waker))
+            .await
+            .unwrap();
+        if !database.has_pending_progress() {
+            break;
+        }
+    }
+    assert!(!database.has_pending_progress());
+    assert!(
+        subscription.try_recv().is_ok(),
+        "the resumed subscription publishes its seeded snapshot"
+    );
+}
+
 #[futures_test::test]
 async fn subscribe_sends_empty_hydration_snapshot_without_writes() {
     let storage = MemoryStorage::new(&["albums"]).expect("valid memory storage families");

--- a/crates/groove/src/ivm/runtime/evaluation_session.rs
+++ b/crates/groove/src/ivm/runtime/evaluation_session.rs
@@ -181,8 +181,13 @@ impl EvaluationInputs {
     }
 }
 
-type PendingRequest<'a> =
+type PendingRequestFuture<'a> =
     StorageFuture<'a, Result<EvaluationRequestOutput, EvaluationRequestFailure>>;
+
+struct PendingRequest<'a> {
+    future: PendingRequestFuture<'a>,
+    eager_retry_safe: bool,
+}
 
 #[derive(Debug)]
 pub(super) struct EvaluationRequestFailure {
@@ -233,6 +238,8 @@ impl<'a> EvaluationRequests<'a> {
         if self.pending.contains_key(&key) || self.ready.contains_key(&key) {
             return false;
         }
+        let eager_retry_safe = matches!(key, EvaluationRequestKey::Storage(_))
+            && storage.as_ref().permits_eager_read_retry();
         let future = match &key {
             EvaluationRequestKey::Storage(StorageRequestKey::Get { family, key }) => {
                 let future = storage.get(family.clone(), key.clone());
@@ -242,7 +249,7 @@ impl<'a> EvaluationRequests<'a> {
                         .map(StorageRequestOutput::Value)
                         .map(EvaluationRequestOutput::Storage)
                         .map_err(Into::into)
-                }) as PendingRequest<'a>
+                }) as PendingRequestFuture<'a>
             }
             EvaluationRequestKey::Storage(StorageRequestKey::ScanRange { family, start, end }) => {
                 let future = storage.scan(ScanRequest::range(
@@ -256,7 +263,7 @@ impl<'a> EvaluationRequests<'a> {
                         .map(StorageRequestOutput::Rows)
                         .map(EvaluationRequestOutput::Storage)
                         .map_err(Into::into)
-                }) as PendingRequest<'a>
+                }) as PendingRequestFuture<'a>
             }
             EvaluationRequestKey::Storage(StorageRequestKey::ScanPrefix { family, prefix }) => {
                 let future = storage.scan(ScanRequest::prefix(family.clone(), prefix.clone()));
@@ -266,7 +273,7 @@ impl<'a> EvaluationRequests<'a> {
                         .map(StorageRequestOutput::Rows)
                         .map(EvaluationRequestOutput::Storage)
                         .map_err(Into::into)
-                }) as PendingRequest<'a>
+                }) as PendingRequestFuture<'a>
             }
             EvaluationRequestKey::Storage(StorageRequestKey::ScanPrefixLimit {
                 family,
@@ -282,7 +289,7 @@ impl<'a> EvaluationRequests<'a> {
                         .map(StorageRequestOutput::Rows)
                         .map(EvaluationRequestOutput::Storage)
                         .map_err(Into::into)
-                }) as PendingRequest<'a>
+                }) as PendingRequestFuture<'a>
             }
             EvaluationRequestKey::Storage(StorageRequestKey::IndexedRowsPrefix {
                 table,
@@ -451,17 +458,23 @@ impl<'a> EvaluationRequests<'a> {
                                     })
                                 }
                             }
-                        }) as PendingRequest<'a>
+                        }) as PendingRequestFuture<'a>
                     }
                     None => Box::pin(async {
                         Err(EvaluationRequestFailure::from(
                             super::IvmRuntimeError::Chunk(crate::chunks::ChunkError::Unavailable),
                         ))
-                    }) as PendingRequest<'a>,
+                    }) as PendingRequestFuture<'a>,
                 }
             }
         };
-        self.pending.insert(key, future);
+        self.pending.insert(
+            key,
+            PendingRequest {
+                future,
+                eager_retry_safe,
+            },
+        );
         true
     }
 
@@ -470,8 +483,30 @@ impl<'a> EvaluationRequests<'a> {
     pub(super) fn poll(&mut self, cx: &mut Context<'_>) -> usize {
         let mut completed = Vec::new();
         for (key, request) in &mut self.pending {
-            if let Poll::Ready(result) = Pin::new(request).poll(cx) {
+            if let Poll::Ready(result) = Pin::new(&mut request.future).poll(cx) {
                 completed.push((key.clone(), result));
+            }
+        }
+        let count = completed.len();
+        for (key, result) in completed {
+            self.pending.remove(&key);
+            self.ready.insert(key, result);
+        }
+        count
+    }
+
+    /// Re-poll only requests whose storage backend explicitly guarantees that
+    /// an eager retry cannot wait for external I/O. A self-woken cold request
+    /// remains pending for its owner rather than being mistaken for resident
+    /// work.
+    pub(super) fn poll_eager_retry(&mut self, cx: &mut Context<'_>) -> usize {
+        let mut completed = Vec::new();
+        for (key, request) in &mut self.pending {
+            if request.eager_retry_safe {
+                let result = Pin::new(&mut request.future).poll(cx);
+                if let Poll::Ready(result) = result {
+                    completed.push((key.clone(), result));
+                }
             }
         }
         let count = completed.len();

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -2343,7 +2343,8 @@ impl TickEvaluator<'_> {
             return Err(IvmRuntimeError::NodeStateOperatorMismatch(node));
         };
         if self.context.eval_mode == EvalMode::Hydrate {
-            if recursive_as_of.value().step_arrangements_hydrated()
+            if !recursive_as_of.value().has_pending_hydration()
+                && recursive_as_of.value().step_arrangements_hydrated()
                 && recursive_as_of.as_of() == Some(Tick(self.current_tick))
                 && recursive_as_of.value().hydrated_input_generation() == Some(input_generation)
             {
@@ -2357,26 +2358,64 @@ impl TickEvaluator<'_> {
                 });
             }
             let scope = self.context.scope.child(node);
-            let next = recompute_recursive(
-                self.schema,
-                self.graph,
-                self.variant_projections,
-                Some(self.table_deltas),
-                self.evaluation_inputs.as_deref_mut(),
-                node,
-                recursive,
-                output_desc,
-                step,
-                storage,
-                self.binding_snapshots,
-                self.current_tick,
-                scope,
-            )
-            .await?;
-            recursive_as_of.value_mut().replace_with(next);
-            let accumulated = RecordDeltas {
-                descriptor: output_desc,
-                deltas: recursive_as_of.value().accumulated_deltas(),
+            let accumulated = if let Some(inputs) = self.evaluation_inputs.as_deref_mut() {
+                let progress = super::recursion::resume_inputs_hydration_recompute(
+                    recursive_as_of.value_mut(),
+                    super::recursion::HydrationRecomputeContext {
+                        schema: self.schema,
+                        graph: self.graph,
+                        variant_projections: self.variant_projections,
+                        inputs,
+                        storage,
+                        binding_snapshots: self.binding_snapshots,
+                        scope,
+                        input_generation,
+                    },
+                    node,
+                    recursive,
+                    output_desc,
+                    seed,
+                    step,
+                )
+                .await;
+                match progress {
+                    Ok(super::recursion::HydrationRecomputeProgress::Yield) => {
+                        self.operator_states.insert(operator_key, operator);
+                        cooperative_operator_yield().await;
+                        unreachable!("retained recursive hydration yields through operator state")
+                    }
+                    Ok(
+                        super::recursion::HydrationRecomputeProgress::ReadyForArrangementHydration,
+                    ) => recursive_as_of
+                        .value()
+                        .pending_hydration_accumulated_deltas(output_desc),
+                    Err(error) => {
+                        self.operator_states.insert(operator_key, operator);
+                        return Err(error);
+                    }
+                }
+            } else {
+                let next = recompute_recursive(
+                    self.schema,
+                    self.graph,
+                    self.variant_projections,
+                    Some(self.table_deltas),
+                    None,
+                    node,
+                    recursive,
+                    output_desc,
+                    step,
+                    storage,
+                    self.binding_snapshots,
+                    self.current_tick,
+                    scope,
+                )
+                .await?;
+                recursive_as_of.value_mut().replace_with(next);
+                RecordDeltas {
+                    descriptor: output_desc,
+                    deltas: recursive_as_of.value().accumulated_deltas(),
+                }
             };
             let mut runtime = graph_runtime_view(
                 self.schema,
@@ -2402,6 +2441,10 @@ impl TickEvaluator<'_> {
             );
             hydrate_recursive_arrangements(&mut runtime, recursive, step, accumulated.clone())
                 .await?;
+            if recursive_as_of.value().has_pending_hydration() {
+                let next = recursive_as_of.value_mut().finish_hydration_recompute();
+                recursive_as_of.value_mut().replace_with(next);
+            }
             recursive_as_of
                 .value_mut()
                 .mark_step_arrangements_hydrated();

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -2358,63 +2358,40 @@ impl TickEvaluator<'_> {
                 });
             }
             let scope = self.context.scope.child(node);
-            let accumulated = if let Some(inputs) = self.evaluation_inputs.as_deref_mut() {
-                let progress = super::recursion::resume_inputs_hydration_recompute(
-                    recursive_as_of.value_mut(),
-                    super::recursion::HydrationRecomputeContext {
-                        schema: self.schema,
-                        graph: self.graph,
-                        variant_projections: self.variant_projections,
-                        inputs,
-                        storage,
-                        binding_snapshots: self.binding_snapshots,
-                        scope,
-                        input_generation,
-                    },
-                    node,
-                    recursive,
-                    output_desc,
-                    seed,
-                    step,
-                )
-                .await;
-                match progress {
-                    Ok(super::recursion::HydrationRecomputeProgress::Yield) => {
-                        self.operator_states.insert(operator_key, operator);
-                        cooperative_operator_yield().await;
-                        unreachable!("retained recursive hydration yields through operator state")
-                    }
-                    Ok(
-                        super::recursion::HydrationRecomputeProgress::ReadyForArrangementHydration,
-                    ) => recursive_as_of
-                        .value()
-                        .pending_hydration_accumulated_deltas(output_desc),
-                    Err(error) => {
-                        self.operator_states.insert(operator_key, operator);
-                        return Err(error);
-                    }
-                }
-            } else {
-                let next = recompute_recursive(
-                    self.schema,
-                    self.graph,
-                    self.variant_projections,
-                    Some(self.table_deltas),
-                    None,
-                    node,
-                    recursive,
-                    output_desc,
-                    step,
+            let progress = super::recursion::resume_inputs_hydration_recompute(
+                recursive_as_of.value_mut(),
+                super::recursion::HydrationRecomputeContext {
+                    schema: self.schema,
+                    graph: self.graph,
+                    variant_projections: self.variant_projections,
+                    inputs: self.evaluation_inputs.as_deref_mut(),
+                    table_deltas: Some(self.table_deltas),
                     storage,
-                    self.binding_snapshots,
-                    self.current_tick,
+                    binding_snapshots: self.binding_snapshots,
                     scope,
-                )
-                .await?;
-                recursive_as_of.value_mut().replace_with(next);
-                RecordDeltas {
-                    descriptor: output_desc,
-                    deltas: recursive_as_of.value().accumulated_deltas(),
+                    input_generation,
+                },
+                node,
+                recursive,
+                output_desc,
+                seed,
+                step,
+            )
+            .await;
+            let accumulated = match progress {
+                Ok(super::recursion::HydrationRecomputeProgress::Yield) => {
+                    self.operator_states.insert(operator_key, operator);
+                    cooperative_operator_yield().await;
+                    unreachable!("retained recursive hydration yields through operator state")
+                }
+                Ok(super::recursion::HydrationRecomputeProgress::ReadyForArrangementHydration) => {
+                    recursive_as_of
+                        .value()
+                        .pending_hydration_accumulated_deltas(output_desc)
+                }
+                Err(error) => {
+                    self.operator_states.insert(operator_key, operator);
+                    return Err(error);
                 }
             };
             let mut runtime = graph_runtime_view(
@@ -2487,7 +2464,12 @@ impl TickEvaluator<'_> {
         )
         .await;
         let deltas = match deltas {
-            Ok(deltas) => deltas,
+            Ok(super::recursion::RecursiveDeltaProgress::Ready(deltas)) => deltas,
+            Ok(super::recursion::RecursiveDeltaProgress::Yield) => {
+                self.operator_states.insert(operator_key, operator);
+                cooperative_operator_yield().await;
+                unreachable!("retained recursive tick yields through operator state")
+            }
             Err(error) => {
                 self.operator_states.insert(operator_key, operator);
                 return Err(error);

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -365,6 +365,8 @@ pub enum IvmRuntimeError {
     GraphInputMissing(NodeId),
     #[error("graph node not found: {0:?}")]
     GraphNodeNotFound(NodeId),
+    #[error("graph contains a dependency cycle at node: {0:?}")]
+    GraphCycle(NodeId),
     #[error("graph output descriptors do not match")]
     GraphOutputMismatch,
     #[error("enum tag {tag} is absent from this projection target")]

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -53,8 +53,8 @@ use aggregate::{aggregate_row_from_records, records_before_from_deltas, resolve_
 use join::{AntiJoinState, ArrangementState, JoinState, touched_join_keys};
 use persist::apply_persist_delta;
 use recursion::{
-    RecursiveState, hydrate_recursive_arrangements, recompute_recursive, recursive_delta,
-    recursive_read_tables, require_snapshot_inputs, snapshot_requirement,
+    RecursiveState, hydrate_recursive_arrangements, recursive_delta, recursive_read_tables,
+    require_snapshot_inputs, snapshot_requirement,
 };
 use state::{
     ArrangementKey, ArrangementUpdateMode, AsOf, EvalContext, EvalMemoEntry, EvalMemoKey, EvalMode,

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -100,11 +100,22 @@ pub(super) enum HydrationRecomputeProgress {
     ReadyForArrangementHydration,
 }
 
+/// A live recursive tick either has its public delta ready or has saved its
+/// snapshot traversal in [`RecursiveState`] and must yield to the owner.
+pub(super) enum RecursiveDeltaProgress {
+    Yield,
+    Ready(Vec<RecordDelta>),
+}
+
 pub(super) struct HydrationRecomputeContext<'a> {
     pub(super) schema: &'a crate::schema::DatabaseSchema,
     pub(super) graph: &'a IvmGraph,
     pub(super) variant_projections: &'a HashMap<VariantProjectionKey, VariantProjection>,
-    pub(super) inputs: &'a mut EvaluationInputs,
+    /// `Some` routes source reads through the session request registry; `None`
+    /// is the direct-storage path used by a live tick that must still retain
+    /// its bounded graph traversal across cooperative yields.
+    pub(super) inputs: Option<&'a mut EvaluationInputs>,
+    pub(super) table_deltas: Option<&'a [TableDelta]>,
     pub(super) storage: &'a dyn OrderedKvStorage,
     pub(super) binding_snapshots: &'a HashMap<String, RecordDeltas>,
     pub(super) scope: ScopeId,
@@ -145,6 +156,12 @@ impl RecursiveState {
 
     pub(super) fn has_pending_hydration(&self) -> bool {
         self.pending_hydration.is_some()
+    }
+
+    pub(super) fn has_pending_hydration_for(&self, generation: u64) -> bool {
+        self.pending_hydration
+            .as_ref()
+            .is_some_and(|pending| pending.input_generation == generation)
     }
 
     fn begin_hydration_recompute(&mut self, input_generation: u64) {
@@ -279,12 +296,7 @@ impl HydrationTraversal {
 
     async fn poll(
         &mut self,
-        schema: &crate::schema::DatabaseSchema,
-        graph: &IvmGraph,
-        variant_projections: &HashMap<VariantProjectionKey, VariantProjection>,
-        inputs: &mut EvaluationInputs,
-        storage: &dyn OrderedKvStorage,
-        binding_snapshots: &HashMap<String, RecordDeltas>,
+        context: &mut HydrationRecomputeContext<'_>,
     ) -> Result<HydrationTraversalProgress, IvmRuntimeError> {
         let mut remaining = MAX_HYDRATION_TRAVERSAL_NODES_PER_POLL;
         while remaining > 0 {
@@ -299,7 +311,8 @@ impl HydrationTraversal {
                             continue;
                         }
                         self.visiting.insert(node);
-                        let graph_node = graph
+                        let graph_node = context
+                            .graph
                             .node(node)
                             .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
                         self.discovery.push(HydrationTraversalFrame::Evaluate(node));
@@ -325,13 +338,13 @@ impl HydrationTraversal {
             };
             remaining -= 1;
             let mut evaluator = HydrationEvaluator {
-                schema,
-                graph,
-                variant_projections,
-                table_deltas: Some(&[]),
-                evaluation_inputs: Some(inputs),
-                storage,
-                binding_snapshots,
+                schema: context.schema,
+                graph: context.graph,
+                variant_projections: context.variant_projections,
+                table_deltas: context.table_deltas,
+                evaluation_inputs: context.inputs.as_deref_mut(),
+                storage: context.storage,
+                binding_snapshots: context.binding_snapshots,
                 context: self.context.clone(),
                 memo: std::mem::take(&mut self.memo),
             };
@@ -350,7 +363,7 @@ impl HydrationTraversal {
 /// retained postorder traversal or moves the fixpoint frontier forward.
 pub(super) async fn resume_inputs_hydration_recompute(
     recursive_state: &mut RecursiveState,
-    context: HydrationRecomputeContext<'_>,
+    mut context: HydrationRecomputeContext<'_>,
     node: NodeId,
     recursive: &RecursiveOp,
     output_desc: RecordDescriptor,
@@ -373,17 +386,7 @@ pub(super) async fn resume_inputs_hydration_recompute(
                 .take()
                 .unwrap_or_else(|| HydrationTraversal::new(seed, EvalContext::root()));
             let mut traversal = traversal;
-            let progress = match traversal
-                .poll(
-                    context.schema,
-                    context.graph,
-                    context.variant_projections,
-                    context.inputs,
-                    context.storage,
-                    context.binding_snapshots,
-                )
-                .await
-            {
+            let progress = match traversal.poll(&mut context).await {
                 Ok(progress) => progress,
                 // The session owns request registration, but this operator
                 // owns traversal continuation. Keep the exact postorder
@@ -442,17 +445,7 @@ pub(super) async fn resume_inputs_hydration_recompute(
                 .take()
                 .unwrap_or_else(|| HydrationTraversal::new(step, eval_context));
             let mut traversal = traversal;
-            let progress = match traversal
-                .poll(
-                    context.schema,
-                    context.graph,
-                    context.variant_projections,
-                    context.inputs,
-                    context.storage,
-                    context.binding_snapshots,
-                )
-                .await
-            {
+            let progress = match traversal.poll(&mut context).await {
                 Ok(progress) => progress,
                 Err(IvmRuntimeError::EvaluationBlocked) => {
                     recursive_state.pending_hydration_mut().traversal = Some(traversal);
@@ -502,7 +495,7 @@ pub(super) async fn recursive_delta(
     output_desc: RecordDescriptor,
     seed: NodeId,
     step: NodeId,
-) -> Result<Vec<RecordDelta>, IvmRuntimeError> {
+) -> Result<RecursiveDeltaProgress, IvmRuntimeError> {
     let has_recompute_table_delta = has_recompute_table_delta_for_recursion(&runtime, seed, step)?;
     let has_table_delta = has_table_delta_for_cached_tables(&runtime, recursive);
     let has_recompute_binding_delta =
@@ -515,7 +508,9 @@ pub(super) async fn recursive_delta(
     {
         // Retractions are handled by full recompute + diff until we implement
         // DRed or DBSP-style nested negative deltas.
-        runtime.metrics.recursive_recomputes += 1;
+        if !recursive_state.has_pending_hydration_for(runtime.current_tick) {
+            runtime.metrics.recursive_recomputes += 1;
+        }
         if std::env::var_os("JAZZ_CLOSURE_TRACE").is_some() {
             eprintln!(
                 "CLOSURE_TRACE event=recursive_recompute node={node:?} scope={:?} has_recompute_table_delta={has_recompute_table_delta} has_table_delta={has_table_delta} has_recompute_binding_delta={has_recompute_binding_delta} has_binding_deltas={has_binding_deltas} state_empty={} step_hydrated={} total_recomputes={}",
@@ -525,22 +520,33 @@ pub(super) async fn recursive_delta(
                 runtime.metrics.recursive_recomputes,
             );
         }
-        let next = recompute_recursive(
-            runtime.schema,
-            runtime.graph,
-            runtime.variant_projections,
-            None,
-            runtime.evaluation_inputs.as_deref_mut(),
+        let progress = resume_inputs_hydration_recompute(
+            recursive_state,
+            HydrationRecomputeContext {
+                schema: runtime.schema,
+                graph: runtime.graph,
+                variant_projections: runtime.variant_projections,
+                inputs: runtime.evaluation_inputs.as_deref_mut(),
+                table_deltas: None,
+                storage: runtime.storage,
+                binding_snapshots: runtime.binding_snapshots,
+                scope: runtime.scope,
+                // The live tick's inputs are immutable while it is driven.
+                // Retrying after a cooperative yield can resume its exact
+                // traversal; a later tick restarts with a fresh snapshot.
+                input_generation: runtime.current_tick,
+            },
             node,
             recursive,
             output_desc,
+            seed,
             step,
-            runtime.storage,
-            runtime.binding_snapshots,
-            runtime.current_tick,
-            runtime.scope,
         )
         .await?;
+        if progress == HydrationRecomputeProgress::Yield {
+            return Ok(RecursiveDeltaProgress::Yield);
+        }
+        let next = recursive_state.finish_hydration_recompute();
         let accumulated = RecordDeltas {
             descriptor: output_desc,
             deltas: next
@@ -556,7 +562,7 @@ pub(super) async fn recursive_delta(
         let emitted = recursive_state.replace_with(next);
         hydrate_recursive_arrangements(&mut runtime, recursive, step, accumulated).await?;
         recursive_state.mark_step_arrangements_hydrated();
-        return Ok(emitted);
+        return Ok(RecursiveDeltaProgress::Ready(emitted));
     }
 
     let mut emitted = Vec::new();
@@ -649,7 +655,7 @@ pub(super) async fn recursive_delta(
         sub_tick += 1;
     }
 
-    Ok(consolidate_deltas(emitted))
+    Ok(RecursiveDeltaProgress::Ready(consolidate_deltas(emitted)))
 }
 
 fn has_table_delta_for_cached_tables(
@@ -1047,79 +1053,6 @@ fn walk_input_graph(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-pub(super) async fn recompute_recursive(
-    schema: &crate::schema::DatabaseSchema,
-    graph: &IvmGraph,
-    variant_projections: &HashMap<VariantProjectionKey, VariantProjection>,
-    table_deltas: Option<&[TableDelta]>,
-    mut evaluation_inputs: Option<&mut EvaluationInputs>,
-    node: NodeId,
-    recursive: &RecursiveOp,
-    output_desc: RecordDescriptor,
-    step: NodeId,
-    storage: &dyn OrderedKvStorage,
-    binding_snapshots: &HashMap<String, RecordDeltas>,
-    _current_tick: u64,
-    scope: ScopeId,
-) -> Result<HashMap<Bytes, i64>, IvmRuntimeError> {
-    let recursive_node = graph
-        .node(node)
-        .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
-    let [seed, _] = recursive_node.descriptor.inputs.as_slice() else {
-        return Err(IvmRuntimeError::GraphInputArityMismatch(recursive_node.id));
-    };
-
-    let mut snapshot = HydrationEvaluator {
-        schema,
-        graph,
-        variant_projections,
-        table_deltas,
-        evaluation_inputs: evaluation_inputs.as_deref_mut(),
-        storage,
-        binding_snapshots,
-        context: EvalContext::root(),
-        memo: HashMap::default(),
-    };
-    let mut accumulated = HashMap::<Bytes, i64>::default();
-    let mut frontier = snapshot.eval_node(*seed).await?;
-    if frontier.descriptor != output_desc {
-        return Err(IvmRuntimeError::GraphOutputMismatch);
-    }
-    frontier.deltas = accept_positive_into_set(&mut accumulated, frontier.deltas)?;
-
-    let mut sub_tick = 1;
-    while !frontier.is_empty() {
-        if sub_tick > recursive.max_iters {
-            return Err(IvmRuntimeError::RecursiveIterationLimit {
-                node: recursive_node.id,
-                max_iters: recursive.max_iters,
-            });
-        }
-        let context =
-            EvalContext::with_binding(scope, sub_tick as u64, recursive.frontier.clone(), frontier);
-        let mut snapshot = HydrationEvaluator {
-            schema,
-            graph,
-            variant_projections,
-            table_deltas,
-            evaluation_inputs: evaluation_inputs.as_deref_mut(),
-            storage,
-            binding_snapshots,
-            context,
-            memo: HashMap::default(),
-        };
-        frontier = snapshot.eval_node(step).await?;
-        if frontier.descriptor != output_desc {
-            return Err(IvmRuntimeError::GraphOutputMismatch);
-        }
-        frontier.deltas = accept_positive_into_set(&mut accumulated, frontier.deltas)?;
-        sub_tick += 1;
-    }
-
-    Ok(accumulated)
-}
-
 fn accept_positive_into_set(
     multiset: &mut HashMap<Bytes, i64>,
     deltas: Vec<RecordDelta>,
@@ -1464,34 +1397,10 @@ impl HydrationEvaluator<'_> {
                         deltas,
                     })
                 }
-                OpType::Recursive(recursive) => {
-                    let [_, step] = graph_node.descriptor.inputs.as_slice() else {
-                        return Err(IvmRuntimeError::GraphInputArityMismatch(node));
-                    };
-                    let accumulated = recompute_recursive(
-                        self.schema,
-                        self.graph,
-                        self.variant_projections,
-                        self.table_deltas,
-                        self.evaluation_inputs.as_deref_mut(),
-                        node,
-                        recursive,
-                        output_desc,
-                        *step,
-                        self.storage,
-                        self.binding_snapshots,
-                        0,
-                        self.context.scope.child(node),
-                    )
-                    .await?;
-                    Ok(RecordDeltas {
-                        descriptor: output_desc,
-                        deltas: accumulated
-                            .into_iter()
-                            .map(|(record, weight)| RecordDelta { record, weight })
-                            .collect(),
-                    })
-                }
+                // A nested recursive graph needs its own persisted frontier
+                // state. v0 deliberately rejects it rather than falling back
+                // to an unbounded private DFS inside this traversal.
+                OpType::Recursive(_) => Err(IvmRuntimeError::UnsupportedNestedRecursion),
                 OpType::Persist(_)
                 | OpType::StreamingChecksum(_)
                 | OpType::Distinct

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -38,6 +38,77 @@ pub(super) struct RecursiveState {
     /// not capture same-tick binding changes made while installing a prepared
     /// subscription.
     hydrated_input_generation: Option<u64>,
+    /// A retained, inputs-backed snapshot recomputation. Subscription opening
+    /// owns a disposable operator future, so recursive hydration must keep its
+    /// postorder traversal and frontier outside that future when it yields.
+    pending_hydration: Option<Box<PendingHydrationRecompute>>,
+}
+
+const MAX_HYDRATION_TRAVERSAL_NODES_PER_POLL: usize = 32;
+
+#[derive(Clone, Debug)]
+struct PendingHydrationRecompute {
+    /// A pending snapshot is tied to the exact input generation that started
+    /// it. A later binding/table generation must restart from a coherent
+    /// snapshot rather than blend old memoized subgraphs into new inputs.
+    input_generation: u64,
+    accumulated: HashMap<Bytes, i64>,
+    phase: PendingHydrationPhase,
+    traversal: Option<HydrationTraversal>,
+}
+
+#[derive(Clone, Debug)]
+enum PendingHydrationPhase {
+    Seed,
+    Step {
+        frontier: RecordDeltas,
+        sub_tick: usize,
+    },
+    ReadyForArrangementHydration,
+}
+
+/// A postorder walk over one immutable graph/context snapshot. Discovering and
+/// evaluating are both explicitly bounded; `memo` makes a hash-consed child
+/// run once even when several parents reference it.
+#[derive(Clone, Debug)]
+struct HydrationTraversal {
+    root: NodeId,
+    context: EvalContext,
+    discovery: Vec<HydrationTraversalFrame>,
+    discovered: HashSet<NodeId>,
+    visiting: HashSet<NodeId>,
+    order: Vec<NodeId>,
+    next_evaluation: usize,
+    memo: HashMap<NodeId, RecordDeltas>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum HydrationTraversalFrame {
+    Visit(NodeId),
+    Evaluate(NodeId),
+}
+
+#[derive(Clone, Debug)]
+enum HydrationTraversalProgress {
+    Yield,
+    Ready(RecordDeltas),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum HydrationRecomputeProgress {
+    Yield,
+    ReadyForArrangementHydration,
+}
+
+pub(super) struct HydrationRecomputeContext<'a> {
+    pub(super) schema: &'a crate::schema::DatabaseSchema,
+    pub(super) graph: &'a IvmGraph,
+    pub(super) variant_projections: &'a HashMap<VariantProjectionKey, VariantProjection>,
+    pub(super) inputs: &'a mut EvaluationInputs,
+    pub(super) storage: &'a dyn OrderedKvStorage,
+    pub(super) binding_snapshots: &'a HashMap<String, RecordDeltas>,
+    pub(super) scope: ScopeId,
+    pub(super) input_generation: u64,
 }
 
 impl RecursiveState {
@@ -70,6 +141,61 @@ impl RecursiveState {
 
     pub(super) fn mark_hydrated_input_generation(&mut self, generation: u64) {
         self.hydrated_input_generation = Some(generation);
+    }
+
+    pub(super) fn has_pending_hydration(&self) -> bool {
+        self.pending_hydration.is_some()
+    }
+
+    fn begin_hydration_recompute(&mut self, input_generation: u64) {
+        self.pending_hydration = Some(Box::new(PendingHydrationRecompute {
+            input_generation,
+            accumulated: HashMap::default(),
+            phase: PendingHydrationPhase::Seed,
+            traversal: None,
+        }));
+    }
+
+    fn pending_hydration_mut(&mut self) -> &mut PendingHydrationRecompute {
+        self.pending_hydration
+            .as_mut()
+            .expect("hydration recompute was initialized")
+    }
+
+    pub(super) fn pending_hydration_accumulated_deltas(
+        &self,
+        descriptor: RecordDescriptor,
+    ) -> RecordDeltas {
+        let pending = self
+            .pending_hydration
+            .as_ref()
+            .expect("hydration recompute was initialized");
+        RecordDeltas {
+            descriptor,
+            deltas: pending
+                .accumulated
+                .iter()
+                .filter_map(|(record, weight)| {
+                    (*weight > 0).then_some(RecordDelta {
+                        record: record.clone(),
+                        weight: *weight,
+                    })
+                })
+                .collect(),
+        }
+    }
+
+    pub(super) fn finish_hydration_recompute(&mut self) -> HashMap<Bytes, i64> {
+        let pending = self
+            .pending_hydration
+            .take()
+            .expect("hydration recompute was initialized");
+        debug_assert!(matches!(
+            pending.phase,
+            PendingHydrationPhase::ReadyForArrangementHydration
+        ));
+        debug_assert!(pending.traversal.is_none());
+        pending.accumulated
     }
 
     pub(super) fn accumulated_deltas(&self) -> Vec<RecordDelta> {
@@ -132,7 +258,239 @@ impl RecursiveState {
         }
         self.accumulated = Rc::new(next);
         self.step_arrangements_hydrated = false;
+        self.pending_hydration = None;
         consolidate_deltas(deltas)
+    }
+}
+
+impl HydrationTraversal {
+    fn new(root: NodeId, context: EvalContext) -> Self {
+        Self {
+            root,
+            context,
+            discovery: vec![HydrationTraversalFrame::Visit(root)],
+            discovered: HashSet::default(),
+            visiting: HashSet::default(),
+            order: Vec::new(),
+            next_evaluation: 0,
+            memo: HashMap::default(),
+        }
+    }
+
+    async fn poll(
+        &mut self,
+        schema: &crate::schema::DatabaseSchema,
+        graph: &IvmGraph,
+        variant_projections: &HashMap<VariantProjectionKey, VariantProjection>,
+        inputs: &mut EvaluationInputs,
+        storage: &dyn OrderedKvStorage,
+        binding_snapshots: &HashMap<String, RecordDeltas>,
+    ) -> Result<HydrationTraversalProgress, IvmRuntimeError> {
+        let mut remaining = MAX_HYDRATION_TRAVERSAL_NODES_PER_POLL;
+        while remaining > 0 {
+            if let Some(frame) = self.discovery.pop() {
+                remaining -= 1;
+                match frame {
+                    HydrationTraversalFrame::Visit(node) => {
+                        if !self.discovered.insert(node) {
+                            if self.visiting.contains(&node) {
+                                return Err(IvmRuntimeError::GraphCycle(node));
+                            }
+                            continue;
+                        }
+                        self.visiting.insert(node);
+                        let graph_node = graph
+                            .node(node)
+                            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+                        self.discovery.push(HydrationTraversalFrame::Evaluate(node));
+                        for input in graph_node.descriptor.inputs.iter().rev() {
+                            self.discovery.push(HydrationTraversalFrame::Visit(*input));
+                        }
+                    }
+                    HydrationTraversalFrame::Evaluate(node) => {
+                        debug_assert!(self.visiting.remove(&node));
+                        self.order.push(node);
+                    }
+                }
+                continue;
+            }
+
+            let Some(node) = self.order.get(self.next_evaluation).copied() else {
+                return self
+                    .memo
+                    .get(&self.root)
+                    .cloned()
+                    .map(HydrationTraversalProgress::Ready)
+                    .ok_or(IvmRuntimeError::GraphNodeNotFound(self.root));
+            };
+            remaining -= 1;
+            let mut evaluator = HydrationEvaluator {
+                schema,
+                graph,
+                variant_projections,
+                table_deltas: Some(&[]),
+                evaluation_inputs: Some(inputs),
+                storage,
+                binding_snapshots,
+                context: self.context.clone(),
+                memo: std::mem::take(&mut self.memo),
+            };
+            let result = evaluator.eval_node(node).await;
+            self.memo = evaluator.memo;
+            let result = result?;
+            self.memo.insert(node, result);
+            self.next_evaluation += 1;
+        }
+        Ok(HydrationTraversalProgress::Yield)
+    }
+}
+
+/// Resume one bounded phase of an inputs-backed recursive snapshot. The caller
+/// owns the operator-state save/yield boundary; this helper only advances the
+/// retained postorder traversal or moves the fixpoint frontier forward.
+pub(super) async fn resume_inputs_hydration_recompute(
+    recursive_state: &mut RecursiveState,
+    context: HydrationRecomputeContext<'_>,
+    node: NodeId,
+    recursive: &RecursiveOp,
+    output_desc: RecordDescriptor,
+    seed: NodeId,
+    step: NodeId,
+) -> Result<HydrationRecomputeProgress, IvmRuntimeError> {
+    if recursive_state
+        .pending_hydration
+        .as_ref()
+        .is_none_or(|pending| pending.input_generation != context.input_generation)
+    {
+        recursive_state.begin_hydration_recompute(context.input_generation);
+    }
+    let phase = recursive_state.pending_hydration_mut().phase.clone();
+    match phase {
+        PendingHydrationPhase::Seed => {
+            let traversal = recursive_state
+                .pending_hydration_mut()
+                .traversal
+                .take()
+                .unwrap_or_else(|| HydrationTraversal::new(seed, EvalContext::root()));
+            let mut traversal = traversal;
+            let progress = match traversal
+                .poll(
+                    context.schema,
+                    context.graph,
+                    context.variant_projections,
+                    context.inputs,
+                    context.storage,
+                    context.binding_snapshots,
+                )
+                .await
+            {
+                Ok(progress) => progress,
+                // The session owns request registration, but this operator
+                // owns traversal continuation. Keep the exact postorder
+                // stack/memo across a cold source instead of replaying every
+                // resident ancestor once the request is ready.
+                Err(IvmRuntimeError::EvaluationBlocked) => {
+                    recursive_state.pending_hydration_mut().traversal = Some(traversal);
+                    return Err(IvmRuntimeError::EvaluationBlocked);
+                }
+                Err(error) => return Err(error),
+            };
+            match progress {
+                HydrationTraversalProgress::Yield => {
+                    recursive_state.pending_hydration_mut().traversal = Some(traversal);
+                    Ok(HydrationRecomputeProgress::Yield)
+                }
+                HydrationTraversalProgress::Ready(frontier) => {
+                    if frontier.descriptor != output_desc {
+                        return Err(IvmRuntimeError::GraphOutputMismatch);
+                    }
+                    let accepted = accept_positive_into_set(
+                        &mut recursive_state.pending_hydration_mut().accumulated,
+                        frontier.deltas,
+                    )?;
+                    recursive_state.pending_hydration_mut().phase = if accepted.is_empty() {
+                        PendingHydrationPhase::ReadyForArrangementHydration
+                    } else {
+                        PendingHydrationPhase::Step {
+                            frontier: RecordDeltas {
+                                descriptor: output_desc,
+                                deltas: accepted,
+                            },
+                            sub_tick: 1,
+                        }
+                    };
+                    Ok(HydrationRecomputeProgress::Yield)
+                }
+            }
+        }
+        PendingHydrationPhase::Step { frontier, sub_tick } => {
+            if sub_tick > recursive.max_iters {
+                return Err(IvmRuntimeError::RecursiveIterationLimit {
+                    node,
+                    max_iters: recursive.max_iters,
+                });
+            }
+            let eval_context = EvalContext::with_binding(
+                context.scope,
+                sub_tick as u64,
+                recursive.frontier.clone(),
+                frontier,
+            );
+            let traversal = recursive_state
+                .pending_hydration_mut()
+                .traversal
+                .take()
+                .unwrap_or_else(|| HydrationTraversal::new(step, eval_context));
+            let mut traversal = traversal;
+            let progress = match traversal
+                .poll(
+                    context.schema,
+                    context.graph,
+                    context.variant_projections,
+                    context.inputs,
+                    context.storage,
+                    context.binding_snapshots,
+                )
+                .await
+            {
+                Ok(progress) => progress,
+                Err(IvmRuntimeError::EvaluationBlocked) => {
+                    recursive_state.pending_hydration_mut().traversal = Some(traversal);
+                    return Err(IvmRuntimeError::EvaluationBlocked);
+                }
+                Err(error) => return Err(error),
+            };
+            match progress {
+                HydrationTraversalProgress::Yield => {
+                    recursive_state.pending_hydration_mut().traversal = Some(traversal);
+                    Ok(HydrationRecomputeProgress::Yield)
+                }
+                HydrationTraversalProgress::Ready(step_delta) => {
+                    if step_delta.descriptor != output_desc {
+                        return Err(IvmRuntimeError::GraphOutputMismatch);
+                    }
+                    let accepted = accept_positive_into_set(
+                        &mut recursive_state.pending_hydration_mut().accumulated,
+                        step_delta.deltas,
+                    )?;
+                    recursive_state.pending_hydration_mut().phase = if accepted.is_empty() {
+                        PendingHydrationPhase::ReadyForArrangementHydration
+                    } else {
+                        PendingHydrationPhase::Step {
+                            frontier: RecordDeltas {
+                                descriptor: output_desc,
+                                deltas: accepted,
+                            },
+                            sub_tick: sub_tick + 1,
+                        }
+                    };
+                    Ok(HydrationRecomputeProgress::Yield)
+                }
+            }
+        }
+        PendingHydrationPhase::ReadyForArrangementHydration => {
+            Ok(HydrationRecomputeProgress::ReadyForArrangementHydration)
+        }
     }
 }
 
@@ -721,6 +1079,7 @@ pub(super) async fn recompute_recursive(
         storage,
         binding_snapshots,
         context: EvalContext::root(),
+        memo: HashMap::default(),
     };
     let mut accumulated = HashMap::<Bytes, i64>::default();
     let mut frontier = snapshot.eval_node(*seed).await?;
@@ -748,6 +1107,7 @@ pub(super) async fn recompute_recursive(
             storage,
             binding_snapshots,
             context,
+            memo: HashMap::default(),
         };
         frontier = snapshot.eval_node(step).await?;
         if frontier.descriptor != output_desc {
@@ -801,6 +1161,7 @@ struct HydrationEvaluator<'a> {
     storage: &'a dyn OrderedKvStorage,
     binding_snapshots: &'a HashMap<String, RecordDeltas>,
     context: EvalContext,
+    memo: HashMap<NodeId, RecordDeltas>,
 }
 
 impl HydrationEvaluator<'_> {
@@ -809,6 +1170,9 @@ impl HydrationEvaluator<'_> {
         node: NodeId,
     ) -> StorageFuture<'_, Result<RecordDeltas, IvmRuntimeError>> {
         Box::pin(async move {
+            if let Some(records) = self.memo.get(&node) {
+                return Ok(records.clone());
+            }
             let graph_node = self
                 .graph
                 .node(node)

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -117,16 +117,6 @@ struct PendingIncrementalState {
     order: VecDeque<u64>,
     waiters_by_node: HashMap<NodeId, VecDeque<u64>>,
     next_id: u64,
-    /// Why the current queue head yielded. This is runtime state rather than
-    /// an inference from a caller's waker: storage futures may wake eagerly
-    /// while they are still cold.
-    pending_progress: Option<PendingProgress>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum PendingProgress {
-    ResidentContinuation,
-    Storage,
 }
 
 enum PendingEvaluation {
@@ -158,6 +148,10 @@ impl PendingEvaluation {
             Self::SubscriptionHydration(evaluation) => &evaluation.session.work_queue,
         }
     }
+
+    fn has_resident_continuation(&self) -> bool {
+        self.work_queue().has_resident_continuation()
+    }
 }
 
 #[derive(Default)]
@@ -184,7 +178,11 @@ impl PendingIncrementalEvaluation {
     }
 
     fn has_resident_continuation(&self) -> bool {
-        self.0.borrow().pending_progress == Some(PendingProgress::ResidentContinuation)
+        self.0
+            .borrow()
+            .evaluations
+            .values()
+            .any(PendingEvaluation::has_resident_continuation)
     }
 }
 
@@ -539,7 +537,10 @@ impl IncrementalEvaluation<'_> {
         runtime: &mut IvmRuntime,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), EvaluationFailure>> {
-        self.requests.poll(cx);
+        let ready = self.requests.poll(cx);
+        if ready == 0 {
+            self.requests.poll_eager_retry(cx);
+        }
         let ready = match self.requests.drain_ready() {
             Ok(ready) => ready,
             Err(error) => {
@@ -623,11 +624,18 @@ impl IncrementalEvaluation<'_> {
                 }
             }
         }
-        let immediately_ready = if registered_requests {
+        let mut immediately_ready = if registered_requests {
             self.requests.poll(cx)
         } else {
             0
         };
+        if registered_requests && immediately_ready == 0 {
+            // A backend may explicitly attest that a yielded read is still
+            // executor-local (for example, the in-memory cursor path). Retry
+            // only those requests; opaque cold storage keeps ownership of its
+            // self-wake and remains pending for the real runtime owner.
+            immediately_ready = self.requests.poll_eager_retry(cx);
+        }
         if immediately_ready > 0 {
             // Resident requests completed synchronously. Install their results
             // and resume the queue within this same public poll so resident
@@ -731,10 +739,10 @@ impl IncrementalEvaluation<'_> {
                         drop(evaluator);
                         let mut ready = self.requests.poll(cx);
                         if ready == 0 {
-                            // A provider may deliberately yield once on a cold
-                            // resident request. Advance that retained future a
-                            // second time before yielding the whole commit.
-                            ready = self.requests.poll(cx);
+                            // Retry only a backend that explicitly attests its
+                            // reads are executor-local. A cold self-wake is
+                            // not a resident continuation.
+                            ready = self.requests.poll_eager_retry(cx);
                         }
                         if ready > 0 {
                             return self.poll(runtime, cx);
@@ -1042,7 +1050,10 @@ impl<'a> EvaluationSession<'a> {
     ) -> Poll<Result<(), IvmRuntimeError>> {
         let mut remaining_runnable_nodes = MAX_HYDRATION_RUNNABLE_NODES_PER_POLL;
         'owner_turn: loop {
-            self.requests.poll(cx);
+            let ready = self.requests.poll(cx);
+            if ready == 0 {
+                self.requests.poll_eager_retry(cx);
+            }
             let ready = match self.requests.drain_ready() {
                 Ok(ready) => ready,
                 Err(error) => return Poll::Ready(Err(error.1.error)),
@@ -1138,7 +1149,10 @@ impl<'a> EvaluationSession<'a> {
                                 // Every newly retained future must be polled once
                                 // before returning Pending so it can install the
                                 // caller's waker.
-                                if self.requests.poll(cx) > 0 {
+                                let ready = self.requests.poll(cx);
+                                if ready > 0
+                                    || (ready == 0 && self.requests.poll_eager_retry(cx) > 0)
+                                {
                                     continue 'owner_turn;
                                 }
                                 if self.requests.has_pending() {
@@ -1169,9 +1183,11 @@ impl<'a> EvaluationSession<'a> {
                             );
                         }
                         self.work_queue.wait_for_requests(node, requests);
-                        if (registered || self.requests.has_pending()) && self.requests.poll(cx) > 0
-                        {
-                            continue 'owner_turn;
+                        if registered || self.requests.has_pending() {
+                            let ready = self.requests.poll(cx);
+                            if ready > 0 || (ready == 0 && self.requests.poll_eager_retry(cx) > 0) {
+                                continue 'owner_turn;
+                            }
                         }
                         if self.requests.has_pending() {
                             // A request was polled with this owner's durable
@@ -1544,19 +1560,41 @@ impl IvmRuntime {
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), IvmRuntimeError>> {
+        self.poll_incremental(cx, false)
+    }
+
+    /// Poll only evaluations that have retained an explicit in-memory
+    /// continuation. Cold evaluations are left entirely untouched: their
+    /// storage futures may have self-woken, but only a runtime owner may poll
+    /// them again with a durable waker.
+    pub(crate) fn poll_resident_incremental(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), IvmRuntimeError>> {
+        self.poll_incremental(cx, true)
+    }
+
+    fn poll_incremental(
+        &mut self,
+        cx: &mut Context<'_>,
+        resident_only: bool,
+    ) -> Poll<Result<(), IvmRuntimeError>> {
         let slot = Rc::clone(&self.pending_incremental.0);
         let mut state = std::mem::take(&mut *slot.borrow_mut());
         if state.order.is_empty() {
-            state.pending_progress = None;
             return Poll::Ready(Ok(()));
         }
-        state.pending_progress = None;
         let mut retained_order = VecDeque::new();
         while let Some(evaluation_id) = state.order.pop_front() {
             let mut evaluation = state
                 .evaluations
                 .remove(&evaluation_id)
                 .expect("pending evaluation order references a live session");
+            if resident_only && !evaluation.has_resident_continuation() {
+                state.evaluations.insert(evaluation_id, evaluation);
+                retained_order.push_back(evaluation_id);
+                continue;
+            }
             let progress = match &mut evaluation {
                 PendingEvaluation::Incremental(incremental) => incremental.poll(self, cx),
                 PendingEvaluation::SubscriptionHydration(hydration) => hydration
@@ -1666,13 +1704,15 @@ impl IvmRuntime {
                     }
                 }
                 Poll::Pending => {
-                    let pending_progress = if evaluation.work_queue().has_resident_continuation() {
-                        PendingProgress::ResidentContinuation
-                    } else {
-                        PendingProgress::Storage
-                    };
                     state.evaluations.insert(evaluation_id, evaluation);
                     retained_order.push_back(evaluation_id);
+                    if resident_only {
+                        // A resident slice can discover cold storage. It has
+                        // installed only this direct call's no-op waker, so
+                        // leave it parked and continue looking for unrelated
+                        // resident work later in the queue.
+                        continue;
+                    }
                     // One owner turn advances at most one suspended
                     // evaluation. In particular, a cold subscription
                     // hydration must hand control back to the runtime owner
@@ -1682,7 +1722,6 @@ impl IvmRuntime {
                     // waker; cooperative in-memory yields wake it directly.
                     retained_order.append(&mut state.order);
                     state.order = retained_order;
-                    state.pending_progress = Some(pending_progress);
                     *slot.borrow_mut() = state;
                     return Poll::Pending;
                 }
@@ -1690,7 +1729,6 @@ impl IvmRuntime {
         }
         let done = retained_order.is_empty();
         state.order = retained_order;
-        state.pending_progress = None;
         *slot.borrow_mut() = state;
         if done {
             Poll::Ready(Ok(()))

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -13,6 +13,12 @@ use super::evaluation_session::{
 use super::*;
 use crate::storage::OwnedStorage;
 
+/// Hydration can discover a large resident graph in one poll. Keep every
+/// owner turn bounded so a browser worker returns to transport ingress between
+/// CPU-only graph slices. Cold storage takes the separate request-pending path
+/// below and intentionally does not self-wake.
+const MAX_HYDRATION_RUNNABLE_NODES_PER_POLL: usize = 32;
+
 /// Owned preparation state for one interruptible evaluation.
 ///
 /// Storage suspension and dependency ordering live in `EvaluationWorkQueue`.
@@ -1019,145 +1025,157 @@ impl<'a> EvaluationSession<'a> {
         metrics: &mut TickMetrics,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), IvmRuntimeError>> {
-        self.requests.poll(cx);
-        let ready = match self.requests.drain_ready() {
-            Ok(ready) => ready,
-            Err(error) => return Poll::Ready(Err(error.1.error)),
-        };
-        self.work_queue.requests_ready(ready.keys().cloned());
-        self.evaluation_inputs.install(ready);
-
-        while let Some(node) = self.work_queue.runnable.pop_front() {
-            let context = if hydrate_arrangements {
-                EvalContext::root_subscription_snapshot()
-            } else {
-                EvalContext::root_snapshot()
+        let mut remaining_runnable_nodes = MAX_HYDRATION_RUNNABLE_NODES_PER_POLL;
+        'owner_turn: loop {
+            self.requests.poll(cx);
+            let ready = match self.requests.drain_ready() {
+                Ok(ready) => ready,
+                Err(error) => return Poll::Ready(Err(error.1.error)),
             };
-            let result = if let Some(records) = self.pending_outputs.remove(&node) {
-                Ok(records)
-            } else {
-                let mut evaluator = TickEvaluator {
-                    schema: &runtime.schema,
-                    graph: &runtime.graph,
-                    variant_projections: &runtime.variant_projections,
-                    table_deltas: &[],
-                    binding_deltas: &[],
-                    binding_snapshots,
-                    current_tick: runtime.current_tick,
-                    operator_states: &mut self.operator_states,
-                    arrangement_states: &mut self.arrangement_states,
-                    arrangement_keys_by_input: &mut self.arrangement_keys_by_input,
-                    eval_memo: &mut self.eval_memo,
-                    eval_memo_bytes: &mut self.eval_memo_bytes,
-                    table_frontiers: &runtime.table_frontiers,
-                    binding_frontiers: &self.binding_frontiers,
-                    memo_use_clock: &mut self.memo_use_clock,
-                    node_meta: &mut self.node_meta,
-                    storage: Some(self.storage.as_ref()),
-                    evaluation_inputs: Some(&mut self.evaluation_inputs),
-                    context,
-                    metrics,
-                    terminal_deltas: HashMap::default(),
-                    root_ordering_windows: HashMap::default(),
+            self.work_queue.requests_ready(ready.keys().cloned());
+            self.evaluation_inputs.install(ready);
+
+            while let Some(node) = self.work_queue.runnable.pop_front() {
+                if remaining_runnable_nodes == 0 {
+                    self.work_queue.requeue_yielded(node);
+                    // This is a resident CPU budget yield, not an external
+                    // dependency. Arrange exactly one fresh owner turn.
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+                remaining_runnable_nodes -= 1;
+                let context = if hydrate_arrangements {
+                    EvalContext::root_subscription_snapshot()
+                } else {
+                    EvalContext::root_snapshot()
                 };
-                let mut evaluation = evaluator.update_node(node);
-                match Pin::new(&mut evaluation).poll(cx) {
-                    Poll::Ready(result) => result.map(|records| records.as_ref().clone()),
-                    Poll::Pending => {
-                        self.work_queue.requeue_yielded(node);
-                        cx.waker().wake_by_ref();
-                        return Poll::Pending;
-                    }
-                }
-            };
-            match result {
-                Ok(mut records) => {
-                    if self.work_queue.is_root(node) {
-                        let mut materialized = Vec::with_capacity(records.deltas.len());
-                        let mut blocked = false;
-                        for delta in &records.deltas {
-                            match crate::large_values::materialize_record_attempt(
-                                &records.descriptor,
-                                delta.raw(),
-                                &mut self.evaluation_inputs,
-                            ) {
-                                Ok(record) => materialized.push(RecordDelta {
-                                    record: record.into(),
-                                    weight: delta.weight,
-                                }),
-                                Err(IvmRuntimeError::EvaluationBlocked) => blocked = true,
-                                Err(error) => return Poll::Ready(Err(error)),
-                            }
+                let result = if let Some(records) = self.pending_outputs.remove(&node) {
+                    Ok(records)
+                } else {
+                    let mut evaluator = TickEvaluator {
+                        schema: &runtime.schema,
+                        graph: &runtime.graph,
+                        variant_projections: &runtime.variant_projections,
+                        table_deltas: &[],
+                        binding_deltas: &[],
+                        binding_snapshots,
+                        current_tick: runtime.current_tick,
+                        operator_states: &mut self.operator_states,
+                        arrangement_states: &mut self.arrangement_states,
+                        arrangement_keys_by_input: &mut self.arrangement_keys_by_input,
+                        eval_memo: &mut self.eval_memo,
+                        eval_memo_bytes: &mut self.eval_memo_bytes,
+                        table_frontiers: &runtime.table_frontiers,
+                        binding_frontiers: &self.binding_frontiers,
+                        memo_use_clock: &mut self.memo_use_clock,
+                        node_meta: &mut self.node_meta,
+                        storage: Some(self.storage.as_ref()),
+                        evaluation_inputs: Some(&mut self.evaluation_inputs),
+                        context,
+                        metrics,
+                        terminal_deltas: HashMap::default(),
+                        root_ordering_windows: HashMap::default(),
+                    };
+                    let mut evaluation = evaluator.update_node(node);
+                    match Pin::new(&mut evaluation).poll(cx) {
+                        Poll::Ready(result) => result.map(|records| records.as_ref().clone()),
+                        Poll::Pending => {
+                            self.work_queue.requeue_yielded(node);
+                            cx.waker().wake_by_ref();
+                            return Poll::Pending;
                         }
-                        if blocked {
-                            let requests = self.evaluation_inputs.take_missing();
-                            if requests.is_empty() {
-                                return Poll::Ready(Err(IvmRuntimeError::EvaluationBlocked));
+                    }
+                };
+                match result {
+                    Ok(mut records) => {
+                        if self.work_queue.is_root(node) {
+                            let mut materialized = Vec::with_capacity(records.deltas.len());
+                            let mut blocked = false;
+                            for delta in &records.deltas {
+                                match crate::large_values::materialize_record_attempt(
+                                    &records.descriptor,
+                                    delta.raw(),
+                                    &mut self.evaluation_inputs,
+                                ) {
+                                    Ok(record) => materialized.push(RecordDelta {
+                                        record: record.into(),
+                                        weight: delta.weight,
+                                    }),
+                                    Err(IvmRuntimeError::EvaluationBlocked) => blocked = true,
+                                    Err(error) => return Poll::Ready(Err(error)),
+                                }
                             }
-                            for request in requests.iter().cloned() {
-                                self.requests.request(
-                                    request,
-                                    &self.storage,
-                                    Some(&runtime.chunk_provider),
-                                    &runtime.schema,
-                                );
+                            if blocked {
+                                let requests = self.evaluation_inputs.take_missing();
+                                if requests.is_empty() {
+                                    return Poll::Ready(Err(IvmRuntimeError::EvaluationBlocked));
+                                }
+                                for request in requests.iter().cloned() {
+                                    self.requests.request(
+                                        request,
+                                        &self.storage,
+                                        Some(&runtime.chunk_provider),
+                                        &runtime.schema,
+                                    );
+                                }
+                                self.pending_outputs.insert(node, records);
+                                self.work_queue.wait_for_requests(node, requests);
+                                // Every newly retained future must be polled once
+                                // before returning Pending so it can install the
+                                // caller's waker.
+                                if self.requests.poll(cx) > 0 {
+                                    continue 'owner_turn;
+                                }
+                                if self.requests.has_pending() {
+                                    // Cold storage owns the continuation now.
+                                    // Do not spin through unrelated runnable
+                                    // graph nodes in this owner turn.
+                                    return Poll::Pending;
+                                }
+                                continue;
                             }
-                            self.pending_outputs.insert(node, records);
-                            self.work_queue.wait_for_requests(node, requests);
-                            // Every newly retained future must be polled once
-                            // before returning Pending so it can install the
-                            // caller's waker.
-                            if self.requests.poll(cx) > 0 {
-                                return self.poll(
-                                    runtime,
-                                    binding_snapshots,
-                                    hydrate_arrangements,
-                                    metrics,
-                                    cx,
-                                );
-                            }
-                            continue;
+                            records.deltas = materialized;
+                            self.outputs.insert(node, records);
                         }
-                        records.deltas = materialized;
-                        self.outputs.insert(node, records);
+                        self.work_queue.complete(node);
                     }
-                    self.work_queue.complete(node);
+                    Err(IvmRuntimeError::EvaluationBlocked) => {
+                        let requests = self.evaluation_inputs.take_missing();
+                        if requests.is_empty() {
+                            return Poll::Ready(Err(IvmRuntimeError::EvaluationBlocked));
+                        }
+                        let mut registered = false;
+                        for request in requests.iter().cloned() {
+                            registered |= self.requests.request(
+                                request,
+                                &self.storage,
+                                Some(&runtime.chunk_provider),
+                                &runtime.schema,
+                            );
+                        }
+                        self.work_queue.wait_for_requests(node, requests);
+                        if (registered || self.requests.has_pending()) && self.requests.poll(cx) > 0
+                        {
+                            continue 'owner_turn;
+                        }
+                        if self.requests.has_pending() {
+                            // A request was polled with this owner's durable
+                            // waker. Yield to it rather than scanning the rest of
+                            // a potentially huge graph while it is cold.
+                            return Poll::Pending;
+                        }
+                    }
+                    Err(error) => return Poll::Ready(Err(error)),
                 }
-                Err(IvmRuntimeError::EvaluationBlocked) => {
-                    let requests = self.evaluation_inputs.take_missing();
-                    if requests.is_empty() {
-                        return Poll::Ready(Err(IvmRuntimeError::EvaluationBlocked));
-                    }
-                    let mut registered = false;
-                    for request in requests.iter().cloned() {
-                        registered |= self.requests.request(
-                            request,
-                            &self.storage,
-                            Some(&runtime.chunk_provider),
-                            &runtime.schema,
-                        );
-                    }
-                    self.work_queue.wait_for_requests(node, requests);
-                    if registered && self.requests.poll(cx) > 0 {
-                        return self.poll(
-                            runtime,
-                            binding_snapshots,
-                            hydrate_arrangements,
-                            metrics,
-                            cx,
-                        );
-                    }
-                }
-                Err(error) => return Poll::Ready(Err(error)),
             }
-        }
 
-        if self.outputs.len() == self.roots.len() {
-            Poll::Ready(Ok(()))
-        } else if self.requests.has_pending() {
-            Poll::Pending
-        } else {
-            Poll::Ready(Err(IvmRuntimeError::EvaluationBlocked))
+            if self.outputs.len() == self.roots.len() {
+                return Poll::Ready(Ok(()));
+            }
+            if self.requests.has_pending() {
+                return Poll::Pending;
+            }
+            return Poll::Ready(Err(IvmRuntimeError::EvaluationBlocked));
         }
     }
 

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -1633,6 +1633,17 @@ impl IvmRuntime {
                 Poll::Pending => {
                     state.evaluations.insert(evaluation_id, evaluation);
                     retained_order.push_back(evaluation_id);
+                    // One owner turn advances at most one suspended
+                    // evaluation. In particular, a cold subscription
+                    // hydration must hand control back to the runtime owner
+                    // before it can drain unrelated queued work (such as
+                    // transport ingress and local write fates). The pending
+                    // storage future has just received this poll's durable
+                    // waker; cooperative in-memory yields wake it directly.
+                    retained_order.append(&mut state.order);
+                    state.order = retained_order;
+                    *slot.borrow_mut() = state;
+                    return Poll::Pending;
                 }
             }
         }

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -16,7 +16,7 @@ use crate::storage::OwnedStorage;
 /// Hydration can discover a large resident graph in one poll. Keep every
 /// owner turn bounded so a browser worker returns to transport ingress between
 /// CPU-only graph slices. Cold storage takes the separate request-pending path
-/// below and intentionally does not self-wake.
+/// below; its waker is intentionally not used to classify the pending reason.
 const MAX_HYDRATION_RUNNABLE_NODES_PER_POLL: usize = 32;
 
 /// Owned preparation state for one interruptible evaluation.
@@ -117,6 +117,16 @@ struct PendingIncrementalState {
     order: VecDeque<u64>,
     waiters_by_node: HashMap<NodeId, VecDeque<u64>>,
     next_id: u64,
+    /// Why the current queue head yielded. This is runtime state rather than
+    /// an inference from a caller's waker: storage futures may wake eagerly
+    /// while they are still cold.
+    pending_progress: Option<PendingProgress>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PendingProgress {
+    ResidentContinuation,
+    Storage,
 }
 
 enum PendingEvaluation {
@@ -171,6 +181,10 @@ impl std::fmt::Debug for PendingIncrementalEvaluation {
 impl PendingIncrementalEvaluation {
     pub(super) fn is_pending(&self) -> bool {
         !self.0.borrow().order.is_empty()
+    }
+
+    fn has_resident_continuation(&self) -> bool {
+        self.0.borrow().pending_progress == Some(PendingProgress::ResidentContinuation)
     }
 }
 
@@ -383,6 +397,13 @@ impl EvaluationWorkQueue {
     fn requeue_yielded(&mut self, node: NodeId) {
         self.entries.insert(node, EvaluationEntry::Runnable);
         self.runnable.push_front(node);
+    }
+
+    /// A runnable node is an explicit in-memory evaluator continuation.
+    /// Requests are represented separately as `Waiting`, so an eager cold
+    /// storage wake cannot be mistaken for CPU work.
+    fn has_resident_continuation(&self) -> bool {
+        !self.runnable.is_empty()
     }
 
     fn is_root(&self, node: NodeId) -> bool {
@@ -602,17 +623,11 @@ impl IncrementalEvaluation<'_> {
                 }
             }
         }
-        let mut immediately_ready = if registered_requests {
+        let immediately_ready = if registered_requests {
             self.requests.poll(cx)
         } else {
             0
         };
-        if registered_requests && immediately_ready == 0 {
-            // Test and memory providers may deliberately yield once on a cold
-            // resident lookup. Match terminal materialization by advancing
-            // that retained request future once more before detaching the tick.
-            immediately_ready = self.requests.poll(cx);
-        }
         if immediately_ready > 0 {
             // Resident requests completed synchronously. Install their results
             // and resume the queue within this same public poll so resident
@@ -1532,8 +1547,10 @@ impl IvmRuntime {
         let slot = Rc::clone(&self.pending_incremental.0);
         let mut state = std::mem::take(&mut *slot.borrow_mut());
         if state.order.is_empty() {
+            state.pending_progress = None;
             return Poll::Ready(Ok(()));
         }
+        state.pending_progress = None;
         let mut retained_order = VecDeque::new();
         while let Some(evaluation_id) = state.order.pop_front() {
             let mut evaluation = state
@@ -1649,6 +1666,11 @@ impl IvmRuntime {
                     }
                 }
                 Poll::Pending => {
+                    let pending_progress = if evaluation.work_queue().has_resident_continuation() {
+                        PendingProgress::ResidentContinuation
+                    } else {
+                        PendingProgress::Storage
+                    };
                     state.evaluations.insert(evaluation_id, evaluation);
                     retained_order.push_back(evaluation_id);
                     // One owner turn advances at most one suspended
@@ -1660,6 +1682,7 @@ impl IvmRuntime {
                     // waker; cooperative in-memory yields wake it directly.
                     retained_order.append(&mut state.order);
                     state.order = retained_order;
+                    state.pending_progress = Some(pending_progress);
                     *slot.borrow_mut() = state;
                     return Poll::Pending;
                 }
@@ -1667,6 +1690,7 @@ impl IvmRuntime {
         }
         let done = retained_order.is_empty();
         state.order = retained_order;
+        state.pending_progress = None;
         *slot.borrow_mut() = state;
         if done {
             Poll::Ready(Ok(()))
@@ -1677,6 +1701,12 @@ impl IvmRuntime {
 
     pub(crate) fn has_pending_incremental(&self) -> bool {
         self.pending_incremental.is_pending()
+    }
+
+    /// Whether the last suspended owner turn retained a cooperative CPU
+    /// continuation rather than a cold storage request.
+    pub(crate) fn has_resident_continuation(&self) -> bool {
+        self.pending_incremental.has_resident_continuation()
     }
 
     /// Drop an uninstalled hydration when its subscription is cancelled.

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -2480,7 +2480,7 @@ impl IvmRuntime {
         }
         let multisink = self.subscribe_staged(vec![(DEFAULT_SINK.to_owned(), graph)], storage)?;
         let subscription = self.single_sink_subscription(multisink, DEFAULT_SINK)?;
-        self.poll_ready_subscription_work_now()?;
+        self.poll_ready_subscription_work_now_with_waker(None)?;
         Ok(subscription)
     }
 
@@ -2494,20 +2494,38 @@ impl IvmRuntime {
         K: Into<String>,
         S: OrderedKvStorage + 'static,
     {
+        self.subscribe_with_waker(sinks, storage, None)
+    }
+
+    /// Internal owner-loop counterpart to [`Self::subscribe`].
+    pub(crate) fn subscribe_with_waker<I, K, S>(
+        &mut self,
+        sinks: I,
+        storage: &Rc<S>,
+        progress_waker: Option<&Waker>,
+    ) -> Result<MultisinkSubscription, IvmRuntimeError>
+    where
+        I: IntoIterator<Item = (K, GraphBuilder)>,
+        K: Into<String>,
+        S: OrderedKvStorage + 'static,
+    {
         let sinks = sinks
             .into_iter()
             .map(|(sink, graph)| (sink.into(), graph))
             .collect::<Vec<_>>();
         let subscription = self.subscribe_staged(sinks, storage)?;
-        self.poll_ready_subscription_work_now()?;
+        self.poll_ready_subscription_work_now_with_waker(progress_waker)?;
         Ok(subscription)
     }
 
     /// Publish all subscription work that can complete from resident inputs
     /// before returning control to the caller. Cold inputs remain queued for
     /// the runtime owner to resume when storage wakes them.
-    fn poll_ready_subscription_work_now(&mut self) -> Result<(), IvmRuntimeError> {
-        let mut cx = Context::from_waker(Waker::noop());
+    fn poll_ready_subscription_work_now_with_waker(
+        &mut self,
+        progress_waker: Option<&Waker>,
+    ) -> Result<(), IvmRuntimeError> {
+        let mut cx = Context::from_waker(progress_waker.unwrap_or(Waker::noop()));
         match self.poll_pending_incremental(&mut cx) {
             Poll::Ready(result) => result,
             Poll::Pending => Ok(()),
@@ -2702,7 +2720,27 @@ impl IvmRuntime {
     where
         S: OrderedKvStorage + 'static,
     {
-        self.bind_shape_with_public_fields(shape_id, binding_values, BTreeMap::new(), storage)
+        self.bind_shape_with_public_fields(shape_id, binding_values, BTreeMap::new(), storage, None)
+    }
+
+    /// Internal owner-loop counterpart to [`Self::bind_shape`].
+    pub(crate) fn bind_shape_with_waker<S>(
+        &mut self,
+        shape_id: PreparedShapeId,
+        binding_values: &[Value],
+        storage: &Rc<S>,
+        progress_waker: Option<&Waker>,
+    ) -> Result<MultisinkSubscription, IvmRuntimeError>
+    where
+        S: OrderedKvStorage + 'static,
+    {
+        self.bind_shape_with_public_fields(
+            shape_id,
+            binding_values,
+            BTreeMap::new(),
+            storage,
+            progress_waker,
+        )
     }
 
     fn bind_shape_with_public_fields<S>(
@@ -2711,6 +2749,7 @@ impl IvmRuntime {
         binding_values: &[Value],
         public_fields: BTreeMap<String, Vec<String>>,
         storage: &Rc<S>,
+        progress_waker: Option<&Waker>,
     ) -> Result<MultisinkSubscription, IvmRuntimeError>
     where
         S: OrderedKvStorage + 'static,
@@ -2721,7 +2760,7 @@ impl IvmRuntime {
             public_fields,
             storage,
         )?;
-        self.poll_ready_subscription_work_now()?;
+        self.poll_ready_subscription_work_now_with_waker(progress_waker)?;
         Ok(subscription)
     }
 
@@ -2923,7 +2962,7 @@ impl IvmRuntime {
             storage,
         )?;
         let subscription = self.single_sink_subscription(multisink, DEFAULT_SINK)?;
-        self.poll_ready_subscription_work_now()?;
+        self.poll_ready_subscription_work_now_with_waker(None)?;
         Ok(subscription)
     }
 
@@ -2952,7 +2991,7 @@ impl IvmRuntime {
             storage,
         )?;
         let subscription = self.single_sink_subscription(multisink, DEFAULT_SINK)?;
-        self.poll_ready_subscription_work_now()?;
+        self.poll_ready_subscription_work_now_with_waker(None)?;
         Ok(subscription)
     }
 

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -2447,6 +2447,23 @@ impl IvmRuntime {
     where
         S: OrderedKvStorage + 'static,
     {
+        self.subscribe_one_sink_with_waker(graph, storage, None)
+            .await
+    }
+
+    /// Internal direct-subscription opening with an optional continuation
+    /// waker. Runtime owners use the multi-sink entrypoint; this exists for
+    /// the database convenience API to drain only its resident continuation
+    /// chain without losing a cold-storage wake.
+    pub(crate) async fn subscribe_one_sink_with_waker<S>(
+        &mut self,
+        graph: GraphBuilder,
+        storage: &Rc<S>,
+        progress_waker: Option<&Waker>,
+    ) -> Result<Subscription, IvmRuntimeError>
+    where
+        S: OrderedKvStorage + 'static,
+    {
         if builder_contains_binding_source(&graph) {
             return Err(IvmRuntimeError::BindingSourceRequiresPrepare);
         }
@@ -2476,11 +2493,16 @@ impl IvmRuntime {
                     .insert(plan.key.clone(), shape.id());
                 shape.id()
             };
-            return self.bind_shape_one_sink(shape_id, &[plan.binding_value], storage);
+            return self.bind_shape_one_sink_with_waker(
+                shape_id,
+                &[plan.binding_value],
+                storage,
+                progress_waker,
+            );
         }
         let multisink = self.subscribe_staged(vec![(DEFAULT_SINK.to_owned(), graph)], storage)?;
         let subscription = self.single_sink_subscription(multisink, DEFAULT_SINK)?;
-        self.poll_ready_subscription_work_now_with_waker(None)?;
+        self.poll_ready_subscription_work_now_with_waker(progress_waker)?;
         Ok(subscription)
     }
 
@@ -2955,6 +2977,19 @@ impl IvmRuntime {
     where
         S: OrderedKvStorage + 'static,
     {
+        self.bind_shape_one_sink_with_waker(shape_id, binding_values, storage, None)
+    }
+
+    fn bind_shape_one_sink_with_waker<S>(
+        &mut self,
+        shape_id: PreparedShapeId,
+        binding_values: &[Value],
+        storage: &Rc<S>,
+        progress_waker: Option<&Waker>,
+    ) -> Result<Subscription, IvmRuntimeError>
+    where
+        S: OrderedKvStorage + 'static,
+    {
         let multisink = self.bind_shape_with_public_fields_staged(
             shape_id,
             binding_values,
@@ -2962,7 +2997,7 @@ impl IvmRuntime {
             storage,
         )?;
         let subscription = self.single_sink_subscription(multisink, DEFAULT_SINK)?;
-        self.poll_ready_subscription_work_now_with_waker(None)?;
+        self.poll_ready_subscription_work_now_with_waker(progress_waker)?;
         Ok(subscription)
     }
 

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -2980,7 +2980,7 @@ impl IvmRuntime {
         self.bind_shape_one_sink_with_waker(shape_id, binding_values, storage, None)
     }
 
-    fn bind_shape_one_sink_with_waker<S>(
+    pub(crate) fn bind_shape_one_sink_with_waker<S>(
         &mut self,
         shape_id: PreparedShapeId,
         binding_values: &[Value],
@@ -3001,12 +3001,13 @@ impl IvmRuntime {
         Ok(subscription)
     }
 
-    pub(crate) fn bind_shape_one_sink_with_output<S>(
+    pub(crate) fn bind_shape_one_sink_with_output_and_waker<S>(
         &mut self,
         shape_id: PreparedShapeId,
         binding_values: &[Value],
         public_output: RecordDescriptor,
         storage: &Rc<S>,
+        progress_waker: Option<&Waker>,
     ) -> Result<Subscription, IvmRuntimeError>
     where
         S: OrderedKvStorage + 'static,
@@ -3026,7 +3027,7 @@ impl IvmRuntime {
             storage,
         )?;
         let subscription = self.single_sink_subscription(multisink, DEFAULT_SINK)?;
-        self.poll_ready_subscription_work_now_with_waker(None)?;
+        self.poll_ready_subscription_work_now_with_waker(progress_waker)?;
         Ok(subscription)
     }
 

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -2550,7 +2550,21 @@ impl IvmRuntime {
         let mut cx = Context::from_waker(progress_waker.unwrap_or(Waker::noop()));
         match self.poll_pending_incremental(&mut cx) {
             Poll::Ready(result) => result,
-            Poll::Pending => Ok(()),
+            Poll::Pending if progress_waker.is_some() => Ok(()),
+            Poll::Pending => {
+                // A direct opening owns every explicitly retained CPU slice,
+                // including one queued behind an older cold hydration. Do not
+                // infer that ownership from a wake: scan the runtime's
+                // per-evaluation continuation state and leave all storage
+                // requests untouched for a later owner.
+                while self.has_resident_continuation() {
+                    match self.poll_resident_incremental(&mut cx) {
+                        Poll::Ready(result) => return result,
+                        Poll::Pending => {}
+                    }
+                }
+                Ok(())
+            }
         }
     }
 

--- a/crates/groove/src/storage/memory.rs
+++ b/crates/groove/src/storage/memory.rs
@@ -350,6 +350,10 @@ impl MemoryStorage {
 }
 
 impl OrderedKvStorage for MemoryStorage {
+    fn permits_eager_read_retry(&self) -> bool {
+        true
+    }
+
     fn get(&self, cf: String, key: Vec<u8>) -> StorageFuture<'_, Result<Option<Value>, Error>> {
         Box::pin(async move { self.with_cf(&cf, |values| values.get(&key).cloned()) })
     }

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -321,6 +321,15 @@ pub type ScanVisitor<'visitor> =
 /// reflected by those resident reads. A backend may evict retained data; after
 /// eviction, a later read may become pending again.
 pub trait OrderedKvStorage {
+    /// Whether a read that yields once may be immediately re-polled by the
+    /// caller without turning an external storage wait into a synchronous
+    /// drain. Backends return `true` only for executor-local storage whose
+    /// reads cannot require an external readiness event; the conservative
+    /// default keeps self-woken cold backends pending for their runtime owner.
+    fn permits_eager_read_retry(&self) -> bool {
+        false
+    }
+
     /// Begin an encoded storage transaction over this backend.
     ///
     /// The transaction buffers already-encoded key/value writes and presents
@@ -484,6 +493,10 @@ impl<S> OrderedKvStorage for Rc<S>
 where
     S: OrderedKvStorage,
 {
+    fn permits_eager_read_retry(&self) -> bool {
+        self.as_ref().permits_eager_read_retry()
+    }
+
     fn scan(&self, request: ScanRequest) -> StorageFuture<'_, Result<StorageScan<'_>, Error>> {
         self.as_ref().scan(request)
     }
@@ -574,6 +587,10 @@ impl<S> OrderedKvStorage for &S
 where
     S: OrderedKvStorage,
 {
+    fn permits_eager_read_retry(&self) -> bool {
+        S::permits_eager_read_retry(*self)
+    }
+
     fn scan(&self, request: ScanRequest) -> StorageFuture<'_, Result<StorageScan<'_>, Error>> {
         S::scan(*self, request)
     }
@@ -1815,6 +1832,10 @@ impl<S> OrderedKvStorage for StagedWriteOverlay<'_, S>
 where
     S: OrderedKvStorage,
 {
+    fn permits_eager_read_retry(&self) -> bool {
+        self.base.permits_eager_read_retry()
+    }
+
     fn put_if_absent(
         &self,
         _cf: String,

--- a/crates/groove/tests/async_hydration_session.rs
+++ b/crates/groove/tests/async_hydration_session.rs
@@ -814,8 +814,16 @@ fn hydration_failure_ends_only_affected_terminal_and_releases_later_work() {
 
 #[test]
 fn resident_publication_returns_before_independent_recursive_hydration() {
+    struct WakeCount(AtomicUsize);
+
+    impl ArcWake for WakeCount {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
     let (storage, control) = TestStorage::controlled(&["albums", "edges"]);
-    let mut database = block_on(Database::new(albums_and_edges_schema(), storage)).unwrap();
+    let mut database = block_on(Database::new(albums_and_edges_schema(), storage.clone())).unwrap();
     let mut seed = database.open_batch();
     seed.insert("edges", vec![Value::U64(1), Value::U64(1), Value::U64(2)]);
     seed.insert("edges", vec![Value::U64(2), Value::U64(2), Value::U64(3)]);
@@ -835,6 +843,10 @@ fn resident_publication_returns_before_independent_recursive_hydration() {
             .len(),
         3
     );
+    // Force the recursive branch to make a real storage request. Otherwise
+    // the receipt exercises only bounded resident CPU slices, not independent
+    // cold hydration.
+    storage.evict_scans("edges");
     control.take_observed();
     control.pause_on(TestStorageOperation::ScanOpen);
 
@@ -845,30 +857,54 @@ fn resident_publication_returns_before_independent_recursive_hydration() {
     );
     batch.delete("edges", PrimaryKeyValue::U64(2));
     let mut publication = Box::pin(database.apply_batch(batch));
-    let waker = noop_waker();
-    let mut context = Context::from_waker(&waker);
+    let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+    let owner_waker = waker(Arc::clone(&wakes));
+    let mut context = Context::from_waker(&owner_waker);
     let Poll::Ready(result) = publication.as_mut().poll(&mut context) else {
         panic!("resident publication must not wait for independent hydration");
     };
-    let _published = result.unwrap();
+    let published = result.unwrap();
+    let publication_id = published.publication();
+    assert!(
+        control.observed().contains(&TestStorageOperation::ScanOpen),
+        "the recursive branch must have retained a real cold scan while the resident publication returned"
+    );
     drop(publication);
 
-    control.resume_operation(TestStorageOperation::ScanOpen);
+    assert_eq!(albums.try_recv().unwrap().deltas.len(), 1);
+    assert!(reach.try_recv().is_err());
+
+    // The initial cold poll has only installed its waker. A separate bounded
+    // owner turn reaches the paused storage operation; it must remain pending
+    // rather than falsely treating the recursive branch as resident work.
+    let mut recursive_progress = Box::pin(database.drive_progress());
+    assert!(matches!(
+        recursive_progress.as_mut().poll(&mut context),
+        Poll::Pending
+    ));
+    drop(recursive_progress);
+
+    // A resident one-shot query must still complete while the independent
+    // recursive branch is paused on storage.
     let mut query = Box::pin(database.query_graph(GraphBuilder::table("albums")));
     let Poll::Ready(rows) = query.as_mut().poll(&mut context) else {
-        panic!("resident one-shot query must complete in its first poll");
+        panic!("resident one-shot query must complete while recursive hydration is cold");
     };
-    let rows = rows.unwrap();
-    assert_eq!(rows.deltas.len(), 1);
+    assert_eq!(rows.unwrap().deltas.len(), 1);
     drop(query);
 
+    let wakes_before_resume = wakes.0.load(Ordering::Acquire);
+    control.resume_operation(TestStorageOperation::ScanOpen);
     assert_eq!(
-        block_on(database.next_subscription(&reach))
-            .unwrap()
-            .deltas
-            .len(),
-        2
+        wakes.0.load(Ordering::Acquire),
+        wakes_before_resume + 1,
+        "the paused recursive scan must retain the bounded owner's waker"
     );
+    let resumed = block_on(database.next_subscription_with_publication(&reach)).unwrap();
+    assert_eq!(resumed.publication, Some(publication_id));
+    assert_eq!(resumed.deltas.deltas.len(), 2);
+    let persistence = block_on(published.persist());
+    database.finish_persistence(persistence).unwrap();
 }
 
 #[test]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -279,6 +279,7 @@ impl CoreTickScheduler for NapiTickScheduler {
         let urgency = match urgency {
             CoreTickUrgency::Immediate => "immediate",
             CoreTickUrgency::Deferred => "deferred",
+            CoreTickUrgency::AfterCurrentTurn => "after-current-turn",
         };
         let _ = self.callback.call(
             Ok(urgency.to_string()),

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -652,6 +652,7 @@ impl TickScheduler for WasmTickScheduler {
         let urgency = match urgency {
             TickUrgency::Immediate => "immediate",
             TickUrgency::Deferred => "deferred",
+            TickUrgency::AfterCurrentTurn => "after-current-turn",
         };
         let _ = self
             .callback

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1254,6 +1254,14 @@ pub enum TickUrgency {
     /// Coalesce bursty local work before ticking. Used for uploads created by
     /// local writes.
     Deferred,
+    /// Service work in a later host turn, rather than recursively entering a
+    /// second database tick from the current transport/query owner turn.
+    ///
+    /// This is for work that may start cold I/O (notably subscriber view
+    /// hydration). It preserves prompt eventual progress without allowing a
+    /// just-admitted subscription to monopolize the owner before later inbound
+    /// frames and durability receipts are observed.
+    AfterCurrentTurn,
 }
 
 /// Runtime-neutral wake hook for thread-affine [`Node`] sync work.

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1807,7 +1807,7 @@ where
             let (maintained, mut snapshot) = node
                 .lock()
                 .await
-                .open_maintained_view_subscription_in_authorization_mode(
+                .open_maintained_view_subscription_in_authorization_mode_with_waker(
                     &shape,
                     &binding,
                     author,
@@ -1815,6 +1815,7 @@ where
                     &read_view,
                     Some(prepared_plan),
                     authorization_mode,
+                    progress_waker,
                 )
                 .await?;
             if state.borrow().closed.get() {
@@ -1938,10 +1939,11 @@ where
                     let drained = node
                         .lock()
                         .await
-                        .drain_local_maintained_view_subscription_preserving_rows(
+                        .drain_local_maintained_view_subscription_preserving_rows_with_waker(
                             &mut maintained,
                             Some(binding_view),
                             &local_overlay_row_keys,
+                            progress_waker,
                         )
                         .await;
                     {
@@ -2238,7 +2240,7 @@ where
                 let (replacement, snapshot) = node
                     .lock()
                     .await
-                    .open_maintained_view_subscription_in_authorization_mode(
+                    .open_maintained_view_subscription_in_authorization_mode_with_waker(
                         &shape,
                         &binding,
                         author,
@@ -2246,6 +2248,7 @@ where
                         &read_view,
                         None,
                         authorization_mode,
+                        progress_waker,
                     )
                     .await?;
                 let replacement_subscription_id = replacement.subscription_id();
@@ -2299,7 +2302,11 @@ where
                     let mut node_ref = node.lock().await;
                     if authoritative_snapshot_available {
                         match node_ref
-                            .drain_local_maintained_view_subscription_state(maintained, None)
+                            .drain_local_maintained_view_subscription_state_with_waker(
+                                maintained,
+                                None,
+                                progress_waker,
+                            )
                             .await
                         {
                             Ok(_) => {
@@ -2315,7 +2322,11 @@ where
                         }
                     } else {
                         match node_ref
-                            .drain_local_maintained_view_subscription(maintained, None)
+                            .drain_local_maintained_view_subscription_with_waker(
+                                maintained,
+                                None,
+                                progress_waker,
+                            )
                             .await
                         {
                             Ok(update) => update,
@@ -2406,7 +2417,11 @@ where
                         // publishing its redundant reconstruction.
                         node.lock()
                             .await
-                            .drain_local_maintained_view_subscription_state(maintained, None)
+                            .drain_local_maintained_view_subscription_state_with_waker(
+                                maintained,
+                                None,
+                                progress_waker,
+                            )
                             .await?;
                     }
                     let settled = subscription_is_settled(
@@ -2462,10 +2477,11 @@ where
                             && shape.query().aggregate.is_none())
                         .then_some(settled_binding_view);
                         match node_ref
-                            .drain_local_maintained_view_subscription_preserving_rows(
+                            .drain_local_maintained_view_subscription_preserving_rows_with_waker(
                                 maintained,
                                 authoritative_binding_view,
                                 &local_overlay_row_keys,
+                                progress_waker,
                             )
                             .await
                         {

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1543,11 +1543,12 @@ where
         }
         let mut remote_sync_applied = false;
         let mut released_outbox_tx_ids = HashSet::new();
-        // A later subscriber can mutate Core state after an earlier peer link
-        // has already had its turn in this pass.  Remember that generation so
-        // the post-receive serve pass below reaches that earlier link too;
-        // websocket hosts are event-driven and need not provide unrelated
-        // follow-up traffic just to flush a freshly accepted row.
+        // A later connection can mutate Core state after an earlier subscriber
+        // has already had its turn in this pass. Remember that generation so
+        // every subscriber is served on a fresh owner turn below. In
+        // particular, do not recursively re-enter a just-admitted subscriber:
+        // its initial view can suspend on cold storage, while later inbound
+        // commit frames and their local fates must still get a turn.
         let subscriber_dirty_epoch_before = self.subscriber_dirty_epoch.get();
         let connections = self.connections.borrow().clone();
         for connection in &connections {
@@ -1562,18 +1563,9 @@ where
             self.subscriber_dirty_epoch.get() != subscriber_dirty_epoch_before;
         if remote_sync_applied || subscriber_state_changed {
             for connection in &connections {
-                let should_tick = {
-                    let mut connection = connection.lock().await;
-                    connection.mark_subscriber_dirty() || subscriber_state_changed
-                };
-                if should_tick {
-                    let mut connection = connection.lock().await;
-                    let next = connection.tick().await?;
-                    released_outbox_tx_ids.extend(connection.take_released_outbox_tx_ids());
-                    stats.subscription_events += next.subscription_events;
-                    stats.remote_sync_applied += next.remote_sync_applied;
-                }
+                connection.lock().await.mark_subscriber_dirty();
             }
+            self.schedule_tick(TickUrgency::AfterCurrentTurn);
         }
         if let Some(budget) = self.edge_cache_budget.get() {
             let mut pins = crate::peer::PeerEvictionPins::default();

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1562,10 +1562,32 @@ where
         let subscriber_state_changed =
             self.subscriber_dirty_epoch.get() != subscriber_dirty_epoch_before;
         if remote_sync_applied || subscriber_state_changed {
-            for connection in &connections {
-                connection.lock().await.mark_subscriber_dirty();
+            // A binding with a host scheduler can service this newly dirty
+            // subscriber on the next owner turn.  A bare `Db` intentionally
+            // permits manual driving without installing such a scheduler,
+            // though: dropping the wake in that mode would leave the
+            // subscriber dirty until unrelated inbound traffic happened to
+            // arrive. Preserve the former bounded second serve pass there.
+            if self.scheduler.borrow().is_some() {
+                for connection in &connections {
+                    connection.lock().await.mark_subscriber_dirty();
+                }
+                self.schedule_tick(TickUrgency::AfterCurrentTurn);
+            } else {
+                for connection in &connections {
+                    let should_tick = {
+                        let mut connection = connection.lock().await;
+                        connection.mark_subscriber_dirty() || subscriber_state_changed
+                    };
+                    if should_tick {
+                        let mut connection = connection.lock().await;
+                        let next = connection.tick().await?;
+                        released_outbox_tx_ids.extend(connection.take_released_outbox_tx_ids());
+                        stats.subscription_events += next.subscription_events;
+                        stats.remote_sync_applied += next.remote_sync_applied;
+                    }
+                }
             }
-            self.schedule_tick(TickUrgency::AfterCurrentTurn);
         }
         if let Some(budget) = self.edge_cache_budget.get() {
             let mut pins = crate::peer::PeerEvictionPins::default();

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -770,7 +770,10 @@ where
     /// Rebuild this subscriber's maintained views if its process-local claims
     /// changed. Policy claim values are bound when a maintained view opens, so
     /// retaining the old view after a claim change would retain its authority.
-    async fn rebind_subscriber_views_after_claim_change(&mut self) -> Result<bool, Error> {
+    async fn rebind_subscriber_views_after_claim_change(
+        &mut self,
+        progress_waker: Option<&std::task::Waker>,
+    ) -> Result<bool, Error> {
         let connection_epoch = self.connection_epoch;
         let identity = match &self.link {
             ConnectionLink::Subscriber(SubscriberConnectionState { ingest_context, .. }) => {
@@ -815,12 +818,13 @@ where
             };
             let update = {
                 let mut node = self.node.lock().await;
-                peer.rehydrate_query_for_subscription_with_opts(
+                peer.rehydrate_query_for_subscription_with_opts_and_waker(
                     &mut node,
                     maintained_subscription,
                     &shape,
                     &binding,
                     coverage.opts,
+                    progress_waker,
                 )
                 .await?
             };
@@ -996,6 +1000,11 @@ where
     /// tighter one: the client keeps the same subscription, but its visible
     /// membership must be recalculated immediately.
     pub(super) async fn rehydrate_subscriber_views(&mut self) -> Result<(), Error> {
+        let progress_waker = self
+            .scheduler
+            .borrow()
+            .as_ref()
+            .and_then(|scheduler| scheduler.query_runtime_waker());
         self.bind_subscriber_session_claims();
         let connection_epoch = self.connection_epoch;
         let ConnectionLink::Subscriber(SubscriberConnectionState {
@@ -1030,12 +1039,13 @@ where
             };
             let update = {
                 let mut node = self.node.lock().await;
-                peer.rehydrate_query_for_subscription_with_opts(
+                peer.rehydrate_query_for_subscription_with_opts_and_waker(
                     &mut node,
                     group_subscription,
                     &shape,
                     &binding,
                     coverage.opts.clone(),
+                    progress_waker.as_ref(),
                 )
                 .await?
             };
@@ -1144,7 +1154,8 @@ where
         let connection_epoch = self.connection_epoch;
         self.observe_shared_subscriber_dirty_epoch();
         self.bind_subscriber_session_claims();
-        self.rebind_subscriber_views_after_claim_change().await?;
+        self.rebind_subscriber_views_after_claim_change(progress_waker.as_ref())
+            .await?;
         match &mut self.link {
             ConnectionLink::Upstream(UpstreamConnectionState {
                 local_receiver,
@@ -2691,6 +2702,7 @@ where
                                 ingest_context.trust,
                                 authority_scope_hydrations,
                                 authority_scope_hydration_count,
+                                progress_waker.as_ref(),
                             )
                             .await?;
                             if !self.pending_control_responses.is_empty() {
@@ -3678,20 +3690,22 @@ where
                                 if group.initialized
                                     || peer.has_maintained_subscription(group_subscription)
                                 {
-                                    peer.rehydrate_query_for_subscription_from_maintained_subscription(
+                                    peer.rehydrate_query_for_subscription_from_maintained_subscription_and_waker(
                                         &mut node,
                                         group_subscription,
                                         subscription,
                                         &group.shape,
+                                        progress_waker.as_ref(),
                                     )
                                     .await
                                 } else {
-                                    peer.rehydrate_query_for_subscription_with_opts(
+                                    peer.rehydrate_query_for_subscription_with_opts_and_waker(
                                         &mut node,
                                         group_subscription,
                                         &group.shape,
                                         &group.binding,
                                         coverage.opts.clone(),
+                                        progress_waker.as_ref(),
                                     )
                                     .await
                                     .map(|update| {
@@ -3774,21 +3788,23 @@ where
                         let update_result = {
                             let mut node = self.node.lock().await;
                             if settled_handoff {
-                                peer.rehydrate_query_for_subscription_with_opts(
+                                peer.rehydrate_query_for_subscription_with_opts_and_waker(
                                     &mut node,
                                     group_subscription,
                                     &group.shape,
                                     &group.binding,
                                     coverage.opts.clone(),
+                                    progress_waker.as_ref(),
                                 )
                                 .await
                             } else {
-                                peer.query_update_for_subscription_with_opts(
+                                peer.query_update_for_subscription_with_opts_and_waker(
                                     &mut node,
                                     group_subscription,
                                     &group.shape,
                                     &group.binding,
                                     coverage.opts.clone(),
+                                    progress_waker.as_ref(),
                                 )
                                 .await
                             }
@@ -4242,6 +4258,7 @@ async fn serve_authorization_scope_intent<S>(
         ServedAuthorizationScopeHydration,
     >,
     hydration_count: &mut u64,
+    progress_waker: Option<&std::task::Waker>,
 ) -> Result<(), Error>
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
@@ -4365,12 +4382,13 @@ where
         peer.declare_known_state(subscription, None);
         let update = {
             let mut node = node.lock().await;
-            peer.rehydrate_query_for_subscription_with_opts(
+            peer.rehydrate_query_for_subscription_with_opts_and_waker(
                 &mut node,
                 subscription,
                 shape,
                 binding,
                 scope.options.clone(),
+                progress_waker,
             )
             .await?
         };

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -2512,7 +2512,7 @@ where
                     send_catalogue_snapshot_if_needed(&self.node, peer, self.transport.as_mut())?;
                 }
                 let mut applied_inbound = false;
-                let mut scheduled_immediate = false;
+                let mut scheduled_follow_up = false;
                 let mut sent_view_update = false;
                 let mut needs_subscription_refresh = false;
                 let relay_rejections = self
@@ -3344,8 +3344,13 @@ where
                                     ),
                                 );
                             }
-                            schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
-                            scheduled_immediate = true;
+                            // Opening a subscription creates work that may
+                            // require cold storage. Let the current transport
+                            // owner return first, so other frames (notably
+                            // local write receipts) can be ingressed before
+                            // initial hydration is attempted.
+                            schedule_tick_in(&self.scheduler, TickUrgency::AfterCurrentTurn);
+                            scheduled_follow_up = true;
                             Ok::<bool, Error>(false)
                             })
                             .await?;
@@ -3642,8 +3647,8 @@ where
                     )
                     .await?;
                 }
-                if applied_inbound && !scheduled_immediate {
-                    schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                if applied_inbound && !scheduled_follow_up {
+                    schedule_tick_in(&self.scheduler, TickUrgency::AfterCurrentTurn);
                 }
                 if applied_inbound {
                     let next = self.subscriber_dirty_epoch.get().wrapping_add(1);
@@ -3655,7 +3660,7 @@ where
                     // is a separately scheduled turn so it cannot withhold the
                     // writer's durability receipt or later cancellation/flush
                     // traffic on this connection.
-                    schedule_tick_in(&self.scheduler, TickUrgency::Immediate);
+                    schedule_tick_in(&self.scheduler, TickUrgency::AfterCurrentTurn);
                     return Ok(true);
                 }
                 if *serve_dirty

--- a/crates/jazz/src/db/subscriptions.rs
+++ b/crates/jazz/src/db/subscriptions.rs
@@ -488,12 +488,16 @@ where
                 authorization_mode,
             )
             .await?;
+        // The subscription opener performs one bounded IVM poll. Keep the
+        // current host scheduler as the cold-storage continuation owner,
+        // rather than the short-lived foreground future opening this stream.
+        let progress_waker = self.node.query_runtime_waker();
         let (subscription, snapshot) = self
             .node
             .node
             .lock()
             .await
-            .open_maintained_view_subscription_in_authorization_mode(
+            .open_maintained_view_subscription_in_authorization_mode_with_waker(
                 &local_shape,
                 &local_binding,
                 author,
@@ -501,6 +505,7 @@ where
                 &opts.read_view,
                 Some(_local_plan),
                 authorization_mode,
+                progress_waker.as_ref(),
             )
             .await?;
         let root_occurrence_ids = subscription.root_occurrence_ids().to_vec();

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -237,6 +237,13 @@ fn rate_limited_push_waits_then_retries_the_exact_batch_without_rejecting_the_wr
     // Core rate-limits. Capture it before the Core transport drains it.
     writer.tick().unwrap();
     core.tick().unwrap();
+    scheduler.take();
+    writer.tick().unwrap();
+    assert_eq!(
+        scheduler.take(),
+        vec![TickUrgency::Immediate, TickUrgency::AfterCurrentTurn],
+        "the requested upload frontier preserves its exact coalesced scheduler-owned writer wake"
+    );
     writer.tick().unwrap();
     let first_batch = writer_outbound
         .borrow()
@@ -372,6 +379,13 @@ fn unauthenticated_reconnect_restarts_after_deadline_and_does_not_prevent_ttl_cl
 
     writer.tick().unwrap();
     core.tick().unwrap();
+    scheduler.take();
+    writer.tick().unwrap();
+    assert_eq!(
+        scheduler.take(),
+        vec![TickUrgency::Immediate, TickUrgency::AfterCurrentTurn],
+        "the requested upload frontier preserves its exact coalesced scheduler-owned writer wake"
+    );
     writer.tick().unwrap();
     assert!(
         writer_outbound

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -552,9 +552,9 @@ fn reconnect_with_different_authenticated_link_never_replays_upload_frontier() {
     );
 }
 
-/// A Core immediately refreshes a peer-edge subscriber that was visited before
-/// a later client upload in the same service pass, so Bob receives Alice's
-/// later canonical row without needing an unrelated next websocket frame.
+/// A Core schedules a fresh owner turn for a peer-edge subscriber that was
+/// visited before a later client upload, so Bob receives Alice's later
+/// canonical row without an unrelated next websocket frame.
 ///
 /// ```text
 /// bob --empty Global subscribe--> peer edge --> Core
@@ -566,15 +566,18 @@ fn reconnect_with_different_authenticated_link_never_replays_upload_frontier() {
 ///
 /// The peer connection is deliberately accepted before Alice's connection.
 /// That makes Core service the already-covered peer first, then accept Alice's
-/// write. The one Core tick following Alice's upload must revisit the earlier
-/// peer before it returns; otherwise an event-driven websocket host has no
-/// reason to call Core again and Bob stays indefinitely at the old empty cut.
+/// write. The Core tick following Alice's upload must request a fresh owner
+/// turn for the earlier peer. It deliberately must not recurse into that peer
+/// synchronously: opening the view can suspend on cold storage and would
+/// otherwise withhold inbound write receipts.
 #[test]
-fn core_later_client_upload_refreshes_earlier_peer_subscription_in_same_tick() {
+fn core_later_client_upload_refreshes_earlier_peer_subscription_on_next_owner_turn() {
     let schema = schema();
     let alice = AuthorSubject::for_test_bytes([0xa1; 16]);
     let bob_author = AuthorSubject::for_test_bytes([0xb1; 16]);
     let core = open_core(0xd1, AuthorSubject::SYSTEM, &schema);
+    let core_scheduler = Rc::new(RecordingScheduler::default());
+    core.server.set_scheduler(Some(core_scheduler.clone()));
     let peer_edge = open_db(0xd2, AuthorSubject::SYSTEM, &schema);
     let bob = open_db(0xd3, bob_author, &schema);
 
@@ -609,6 +612,7 @@ fn core_later_client_upload_refreshes_earlier_peer_subscription_in_same_tick() {
         core_to_peer.borrow().is_empty(),
         "the empty opening has been fully consumed before Alice writes"
     );
+    core_scheduler.take();
 
     let alice_edge = open_db(0xd4, alice, &schema);
     let (alice_transport, core_alice_transport) = duplex();
@@ -626,8 +630,18 @@ fn core_later_client_upload_refreshes_earlier_peer_subscription_in_same_tick() {
         .unwrap();
 
     // One edge tick uploads Alice's local commit; one Core tick finalizes it
-    // and must also serve the earlier peer connection.
+    // and asks the host for a fresh turn to serve the earlier peer connection.
     alice_edge.tick().unwrap();
+    core.tick().unwrap();
+    let wakes = core_scheduler.take();
+    assert!(
+        wakes.contains(&TickUrgency::AfterCurrentTurn),
+        "the post-receive subscriber refresh yields to a fresh owner turn instead of recursively ticking a potentially cold view"
+    );
+    assert!(
+        core_to_peer.borrow().is_empty(),
+        "the first pass does not synchronously re-enter the earlier subscriber"
+    );
     core.tick().unwrap();
     let later_view_updates = core_to_peer
         .borrow()
@@ -652,7 +666,7 @@ fn core_later_client_upload_refreshes_earlier_peer_subscription_in_same_tick() {
         .count();
     assert_eq!(
         later_view_updates, 1,
-        "the first Core service pass after Alice's upload sends the later canonical membership to the already-covered peer"
+        "the scheduled Core owner turn sends the later canonical membership to the already-covered peer"
     );
 
     // Applying that upstream ViewUpdate must dirty and refresh the existing
@@ -667,7 +681,7 @@ fn core_later_client_upload_refreshes_earlier_peer_subscription_in_same_tick() {
     assert!(updated.is_empty());
     assert!(removed.is_empty());
 
-    // The bounded second pass clears its dirty work. A quiet later tick must
+    // The scheduled follow-up clears its dirty work. A quiet later tick must
     // neither replay the unchanged view nor self-arm another serving loop.
     core.tick().unwrap();
     assert!(

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -754,7 +754,6 @@ impl MaintainedSubscriptionView {
             version.table() == table.as_str()
                 && version.row_uuid() == row_uuid
                 && version.deletion().is_none()
-                && !version.is_register_record()
         }) || self
             .replacement_for(table.as_str(), row_uuid)
             .0

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -58,6 +58,10 @@ pub(crate) struct MaintainedSubscriptionView {
     /// witness terminal, so raw membership alone is not publishable.
     published_result_members: BTreeSet<ResultMemberEntry>,
     result_payloads: BTreeMap<ResultMemberEntry, ResultMemberPayloadEntry>,
+    /// Payloads paired with memberships already exposed to a consumer. Keep
+    /// this separate from `result_payloads`: the latter records the raw
+    /// result-terminal state while a membership waits for its content witness.
+    published_result_payloads: BTreeMap<ResultMemberEntry, ResultMemberPayloadEntry>,
     /// Incrementally maintained collector output. The key is the root row and
     /// the encoded tree so a -/+ replacement for one root never requires
     /// touching the rendered trees for other roots.
@@ -77,6 +81,7 @@ impl Default for MaintainedSubscriptionView {
             result_weights: BTreeMap::new(),
             published_result_members: BTreeSet::new(),
             result_payloads: BTreeMap::new(),
+            published_result_payloads: BTreeMap::new(),
             structured_app_rows: BTreeMap::new(),
             structured_app_row_descriptor: None,
             retains_structured_app_rows: true,
@@ -330,6 +335,15 @@ impl MaintainedSubscriptionView {
             transitions.requires_authoritative_membership_reconcile |=
                 delta_transitions.requires_authoritative_membership_reconcile;
         }
+        self.finalize_multisink_transitions(&mut transitions, node_aliases);
+        Ok(transitions)
+    }
+
+    fn finalize_multisink_transitions(
+        &mut self,
+        transitions: &mut ResultTransitions,
+        node_aliases: &BTreeMap<NodeUuid, NodeAlias>,
+    ) {
         // A multisink delta need not contain every terminal that participates
         // in one maintained result. In particular, a current-membership row
         // can arrive before its content witness while a cold source finishes
@@ -338,10 +352,21 @@ impl MaintainedSubscriptionView {
         // present. A later content-only delta revisits all pending members and
         // promotes the now-complete one without requiring another membership
         // edge.
-        let (adds, removes) = self.reconcile_publishable_result_members(node_aliases);
+        // Synthetic/path payloads are self-contained. Row-digest payloads,
+        // however, are the Stream-A half of a real-row membership and must
+        // cross the same witness boundary as that membership.
+        transitions
+            .result_payload_adds
+            .retain(|(member, _)| member.as_row().is_none());
+        transitions
+            .result_payload_removes
+            .retain(|member| member.as_row().is_none());
+        let (adds, removes, payload_adds, payload_removes) =
+            self.reconcile_publishable_result_members(node_aliases);
         transitions.adds = adds;
         transitions.removes = removes;
-        Ok(transitions)
+        transitions.result_payload_adds.extend(payload_adds);
+        transitions.result_payload_removes.extend(payload_removes);
     }
 
     pub(crate) fn apply_decoded_deltas(
@@ -493,6 +518,14 @@ impl MaintainedSubscriptionView {
         let result_payloads_bytes = btree_map_bytes(self.result_payloads.len())
             + self
                 .result_payloads
+                .iter()
+                .map(|(member, payload)| {
+                    result_member_entry_bytes(member) + result_member_payload_entry_bytes(payload)
+                })
+                .sum::<usize>()
+            + btree_map_bytes(self.published_result_payloads.len())
+            + self
+                .published_result_payloads
                 .iter()
                 .map(|(member, payload)| {
                     result_member_entry_bytes(member) + result_member_payload_entry_bytes(payload)
@@ -659,7 +692,12 @@ impl MaintainedSubscriptionView {
     fn reconcile_publishable_result_members(
         &mut self,
         node_aliases: &BTreeMap<NodeUuid, NodeAlias>,
-    ) -> (Vec<ResultMemberEntry>, Vec<ResultMemberEntry>) {
+    ) -> (
+        Vec<ResultMemberEntry>,
+        Vec<ResultMemberEntry>,
+        Vec<(ResultMemberEntry, ResultMemberPayloadEntry)>,
+        Vec<ResultMemberEntry>,
+    ) {
         let publishable = self
             .result_weights
             .iter()
@@ -671,14 +709,35 @@ impl MaintainedSubscriptionView {
         let adds = publishable
             .difference(&self.published_result_members)
             .cloned()
-            .collect();
+            .collect::<Vec<_>>();
         let removes = self
             .published_result_members
             .difference(&publishable)
             .cloned()
-            .collect();
+            .collect::<Vec<_>>();
+        let payload_removes = removes
+            .iter()
+            .filter(|member| self.published_result_payloads.contains_key(*member))
+            .cloned()
+            .collect::<Vec<_>>();
+        let payload_adds = adds
+            .iter()
+            .filter_map(|member| {
+                self.result_payloads
+                    .get(member)
+                    .cloned()
+                    .map(|payload| (member.clone(), payload))
+            })
+            .collect::<Vec<_>>();
         self.published_result_members = publishable;
-        (adds, removes)
+        for member in &payload_removes {
+            self.published_result_payloads.remove(member);
+        }
+        for (member, payload) in &payload_adds {
+            self.published_result_payloads
+                .insert(member.clone(), payload.clone());
+        }
+        (adds, removes, payload_adds, payload_removes)
     }
 
     fn result_member_has_bundle_witness(
@@ -2850,17 +2909,19 @@ mod tests {
         let member = ResultMemberEntry::from(result(row(1), 10));
         let mut maintained = MaintainedSubscriptionView::default();
 
-        maintained
+        let mut first = maintained
             .apply_decoded_deltas([(result_current(member.clone()), 1)], &aliases)
             .unwrap();
-        let (adds, removes) = maintained.reconcile_publishable_result_members(&aliases);
+        maintained.finalize_multisink_transitions(&mut first, &aliases);
         assert!(
-            adds.is_empty(),
+            first.adds.is_empty(),
             "Stream A must remain pending without Stream B"
         );
-        assert!(removes.is_empty());
+        assert!(first.removes.is_empty());
+        assert!(first.result_payload_adds.is_empty());
+        assert!(first.result_payload_removes.is_empty());
 
-        maintained
+        let mut second = maintained
             .apply_decoded_deltas(
                 [(
                     DecodedMaintainedEvent::VersionContent(version(row(1), 10, "ready")),
@@ -2869,16 +2930,159 @@ mod tests {
                 &aliases,
             )
             .unwrap();
-        let (adds, removes) = maintained.reconcile_publishable_result_members(&aliases);
-        assert_eq!(adds, vec![member.clone()]);
-        assert!(removes.is_empty());
+        maintained.finalize_multisink_transitions(&mut second, &aliases);
+        assert_eq!(second.adds, vec![member.clone()]);
+        assert!(second.removes.is_empty());
+        assert!(second.result_payload_adds.is_empty());
+        assert!(second.result_payload_removes.is_empty());
 
-        maintained
+        let mut third = maintained
             .apply_decoded_deltas([(result_current(member.clone()), -1)], &aliases)
             .unwrap();
-        let (adds, removes) = maintained.reconcile_publishable_result_members(&aliases);
-        assert!(adds.is_empty());
-        assert_eq!(removes, vec![member]);
+        maintained.finalize_multisink_transitions(&mut third, &aliases);
+        assert!(third.adds.is_empty());
+        assert_eq!(third.removes, vec![member]);
+        assert!(third.result_payload_adds.is_empty());
+        assert!(third.result_payload_removes.is_empty());
+    }
+
+    #[test]
+    fn row_digest_payload_waits_for_its_membership_witness_boundary() {
+        let aliases = aliases();
+        let member = ResultMemberEntry::from(
+            RealRowMemberEntry::current_content(result(row(1), 10))
+                .with_row_digest(vec![0xd1, 0x6e]),
+        );
+        let payload = ResultMemberPayloadEntry {
+            member: member.clone(),
+            descriptor: vec![0x01],
+            record: vec![0x02],
+        };
+        let mut maintained = MaintainedSubscriptionView::default();
+
+        // The raw result terminal carries both Stream-A fields, but neither
+        // may be published before Stream B proves the content row.
+        let mut raw = maintained
+            .apply_decoded_deltas(
+                [(
+                    DecodedMaintainedEvent::ResultCurrent {
+                        member: member.clone(),
+                        payload: payload.clone(),
+                    },
+                    1,
+                )],
+                &aliases,
+            )
+            .unwrap();
+        assert_eq!(
+            raw.result_payload_adds,
+            vec![(member.clone(), payload.clone())]
+        );
+        maintained.finalize_multisink_transitions(&mut raw, &aliases);
+        assert!(raw.adds.is_empty());
+        assert!(raw.removes.is_empty());
+        assert!(raw.result_payload_adds.is_empty());
+        assert!(raw.result_payload_removes.is_empty());
+
+        // A pending membership may disappear and re-enter with a replacement
+        // payload before its witness arrives. Neither half becomes visible,
+        // and the later promotion must use the replacement payload only.
+        let mut pending_remove = maintained
+            .apply_decoded_deltas([(result_current(member.clone()), -1)], &aliases)
+            .unwrap();
+        maintained.finalize_multisink_transitions(&mut pending_remove, &aliases);
+        assert!(pending_remove.adds.is_empty());
+        assert!(pending_remove.removes.is_empty());
+        assert!(pending_remove.result_payload_adds.is_empty());
+        assert!(pending_remove.result_payload_removes.is_empty());
+
+        let replacement_payload = ResultMemberPayloadEntry {
+            member: member.clone(),
+            descriptor: vec![0x03],
+            record: vec![0x04],
+        };
+        let mut pending_readd = maintained
+            .apply_decoded_deltas(
+                [(
+                    DecodedMaintainedEvent::ResultCurrent {
+                        member: member.clone(),
+                        payload: replacement_payload.clone(),
+                    },
+                    1,
+                )],
+                &aliases,
+            )
+            .unwrap();
+        maintained.finalize_multisink_transitions(&mut pending_readd, &aliases);
+        assert!(pending_readd.adds.is_empty());
+        assert!(pending_readd.removes.is_empty());
+        assert!(pending_readd.result_payload_adds.is_empty());
+        assert!(pending_readd.result_payload_removes.is_empty());
+
+        let mut content = maintained
+            .apply_decoded_deltas(
+                [(
+                    DecodedMaintainedEvent::VersionContent(version(row(1), 10, "ready")),
+                    1,
+                )],
+                &aliases,
+            )
+            .unwrap();
+        maintained.finalize_multisink_transitions(&mut content, &aliases);
+        assert_eq!(content.adds, vec![member.clone()]);
+        assert!(content.removes.is_empty());
+        assert_eq!(
+            content.result_payload_adds,
+            vec![(member.clone(), replacement_payload.clone())]
+        );
+        assert!(content.result_payload_removes.is_empty());
+
+        // Losing an already-published content witness must withdraw both
+        // stream halves; restoring that witness emits the current pair again.
+        let mut content_retraction = maintained
+            .apply_decoded_deltas(
+                [(
+                    DecodedMaintainedEvent::VersionContent(version(row(1), 10, "ready")),
+                    -1,
+                )],
+                &aliases,
+            )
+            .unwrap();
+        maintained.finalize_multisink_transitions(&mut content_retraction, &aliases);
+        assert!(content_retraction.adds.is_empty());
+        assert_eq!(content_retraction.removes, vec![member.clone()]);
+        assert!(content_retraction.result_payload_adds.is_empty());
+        assert_eq!(
+            content_retraction.result_payload_removes,
+            vec![member.clone()]
+        );
+
+        let mut content_restore = maintained
+            .apply_decoded_deltas(
+                [(
+                    DecodedMaintainedEvent::VersionContent(version(row(1), 10, "ready")),
+                    1,
+                )],
+                &aliases,
+            )
+            .unwrap();
+        maintained.finalize_multisink_transitions(&mut content_restore, &aliases);
+        assert_eq!(content_restore.adds, vec![member.clone()]);
+        assert!(content_restore.removes.is_empty());
+        assert_eq!(
+            content_restore.result_payload_adds,
+            vec![(member.clone(), replacement_payload)]
+        );
+        assert!(content_restore.result_payload_removes.is_empty());
+
+        let mut removal = maintained
+            .apply_decoded_deltas([(result_current(member.clone()), -1)], &aliases)
+            .unwrap();
+        maintained.finalize_multisink_transitions(&mut removal, &aliases);
+        assert!(removal.adds.is_empty());
+        assert_eq!(removal.removes, vec![member.clone()]);
+        assert!(removal.result_payload_adds.is_empty());
+        assert_eq!(removal.result_payload_removes, vec![member]);
     }
 
     #[test]

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -53,6 +53,10 @@ struct VersionDecodePlan {
 #[derive(Clone, Debug)]
 pub(crate) struct MaintainedSubscriptionView {
     result_weights: BTreeMap<ResultMemberEntry, i64>,
+    /// Result memberships already exposed to the subscription consumer. A
+    /// result-current terminal can advance before the companion content
+    /// witness terminal, so raw membership alone is not publishable.
+    published_result_members: BTreeSet<ResultMemberEntry>,
     result_payloads: BTreeMap<ResultMemberEntry, ResultMemberPayloadEntry>,
     /// Incrementally maintained collector output. The key is the root row and
     /// the encoded tree so a -/+ replacement for one root never requires
@@ -71,6 +75,7 @@ impl Default for MaintainedSubscriptionView {
     fn default() -> Self {
         Self {
             result_weights: BTreeMap::new(),
+            published_result_members: BTreeSet::new(),
             result_payloads: BTreeMap::new(),
             structured_app_rows: BTreeMap::new(),
             structured_app_row_descriptor: None,
@@ -325,6 +330,17 @@ impl MaintainedSubscriptionView {
             transitions.requires_authoritative_membership_reconcile |=
                 delta_transitions.requires_authoritative_membership_reconcile;
         }
+        // A multisink delta need not contain every terminal that participates
+        // in one maintained result. In particular, a current-membership row
+        // can arrive before its content witness while a cold source finishes
+        // on a later runtime turn. Keep that raw membership internally, but
+        // do not publish Stream A until its Stream B bundle witness is
+        // present. A later content-only delta revisits all pending members and
+        // promotes the now-complete one without requiring another membership
+        // edge.
+        let (adds, removes) = self.reconcile_publishable_result_members(node_aliases);
+        transitions.adds = adds;
+        transitions.removes = removes;
         Ok(transitions)
     }
 
@@ -467,6 +483,12 @@ impl MaintainedSubscriptionView {
                 .result_weights
                 .keys()
                 .map(|member| result_member_entry_bytes(member) + mem::size_of::<i64>())
+                .sum::<usize>()
+            + btree_map_bytes(self.published_result_members.len())
+            + self
+                .published_result_members
+                .iter()
+                .map(result_member_entry_bytes)
                 .sum::<usize>();
         let result_payloads_bytes = btree_map_bytes(self.result_payloads.len())
             + self
@@ -619,6 +641,67 @@ impl MaintainedSubscriptionView {
                     .insert(payload.member.clone(), payload.clone());
             }
         }
+        // An authoritative reset has already published these aggregate
+        // members through its replacement snapshot. Do not re-emit them when
+        // the next unrelated multisink delta is drained.
+        self.published_result_members
+            .retain(|member| !matches!(member, ResultMemberEntry::Synthetic { .. }));
+        self.published_result_members.extend(
+            self.result_weights
+                .iter()
+                .filter(|(member, weight)| {
+                    matches!(member, ResultMemberEntry::Synthetic { .. }) && **weight > 0
+                })
+                .map(|(member, _)| member.clone()),
+        );
+    }
+
+    fn reconcile_publishable_result_members(
+        &mut self,
+        node_aliases: &BTreeMap<NodeUuid, NodeAlias>,
+    ) -> (Vec<ResultMemberEntry>, Vec<ResultMemberEntry>) {
+        let publishable = self
+            .result_weights
+            .iter()
+            .filter(|(member, weight)| {
+                **weight > 0 && self.result_member_has_bundle_witness(member, node_aliases)
+            })
+            .map(|(member, _)| member.clone())
+            .collect::<BTreeSet<_>>();
+        let adds = publishable
+            .difference(&self.published_result_members)
+            .cloned()
+            .collect();
+        let removes = self
+            .published_result_members
+            .difference(&publishable)
+            .cloned()
+            .collect();
+        self.published_result_members = publishable;
+        (adds, removes)
+    }
+
+    fn result_member_has_bundle_witness(
+        &self,
+        member: &ResultMemberEntry,
+        node_aliases: &BTreeMap<NodeUuid, NodeAlias>,
+    ) -> bool {
+        let Some((table, row_uuid, tx_id)) = member.as_row() else {
+            // Synthetic aggregate output is self-contained in its payload
+            // fact, so it has no Stream B history-row witness.
+            return true;
+        };
+        self.versions_by_tx(tx_id).iter().any(|version| {
+            version.table() == table.as_str()
+                && version.row_uuid() == row_uuid
+                && version.deletion().is_none()
+                && !version.is_register_record()
+        }) || self
+            .replacement_for(table.as_str(), row_uuid)
+            .0
+            .is_some_and(|version| {
+                version_tx_id_from_aliases(&version, node_aliases) == Some(tx_id)
+            })
     }
 
     fn apply_result_delta(
@@ -2755,6 +2838,47 @@ mod tests {
         assert!(second.adds.is_empty());
         assert_eq!(second.removes, vec![member]);
         assert!(maintained.result_weights.is_empty());
+    }
+
+    #[test]
+    fn membership_waits_for_later_content_witness_before_publication() {
+        // Model two separately delivered multisink deltas: Stream A reports
+        // membership first, while a cold Stream B finishes the exact history
+        // witness only on the later runtime turn. Publishing the first delta
+        // would make the wire builder fail closed for the missing bundle.
+        let aliases = aliases();
+        let member = ResultMemberEntry::from(result(row(1), 10));
+        let mut maintained = MaintainedSubscriptionView::default();
+
+        maintained
+            .apply_decoded_deltas([(result_current(member.clone()), 1)], &aliases)
+            .unwrap();
+        let (adds, removes) = maintained.reconcile_publishable_result_members(&aliases);
+        assert!(
+            adds.is_empty(),
+            "Stream A must remain pending without Stream B"
+        );
+        assert!(removes.is_empty());
+
+        maintained
+            .apply_decoded_deltas(
+                [(
+                    DecodedMaintainedEvent::VersionContent(version(row(1), 10, "ready")),
+                    1,
+                )],
+                &aliases,
+            )
+            .unwrap();
+        let (adds, removes) = maintained.reconcile_publishable_result_members(&aliases);
+        assert_eq!(adds, vec![member.clone()]);
+        assert!(removes.is_empty());
+
+        maintained
+            .apply_decoded_deltas([(result_current(member.clone()), -1)], &aliases)
+            .unwrap();
+        let (adds, removes) = maintained.reconcile_publishable_result_members(&aliases);
+        assert!(adds.is_empty());
+        assert_eq!(removes, vec![member]);
     }
 
     #[test]

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -3244,70 +3244,67 @@ where
                 progress_waker,
             )
             .await?;
+        // Opening a maintained view is an async ownership boundary: one
+        // stream cannot be published while another is still hydrating its
+        // content witnesses. The bounded opening poll may leave cold storage
+        // pending, but this future remains the real owner until it receives
+        // the complete initial multisink snapshot.
+        let initial_snapshot = self
+            .database
+            .next_multisink_subscription(&subscription)
+            .await
+            .map_err(Error::Groove)?;
         let mut maintained = MaintainedSubscriptionView::default();
         let mut transitions = super::maintained_subscription_view::ResultTransitions::default();
-        let initial_received = match subscription.try_recv() {
-            Ok(snapshot) => {
-                let snapshot_transitions = maintained.apply_multisink_deltas(
-                    snapshot,
-                    &terminal_schemas,
-                    &tables,
-                    &self.node_aliases,
-                )?;
-                transitions.adds.extend(snapshot_transitions.adds);
-                transitions.removes.extend(snapshot_transitions.removes);
-                transitions
-                    .result_payload_adds
-                    .extend(snapshot_transitions.result_payload_adds);
-                transitions
-                    .result_payload_removes
-                    .extend(snapshot_transitions.result_payload_removes);
-                transitions
-                    .program_fact_adds
-                    .extend(snapshot_transitions.program_fact_adds);
-                transitions
-                    .program_fact_removes
-                    .extend(snapshot_transitions.program_fact_removes);
-                true
-            }
-            Err(std::sync::mpsc::TryRecvError::Empty) => false,
-            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                return Err(Error::InvalidStoredValue(
-                    "seeded maintained subscription disconnected",
-                ));
-            }
-        };
-        if initial_received {
-            loop {
-                match subscription.try_recv() {
-                    Ok(deltas) => {
-                        let delta_transitions = maintained.apply_multisink_deltas(
-                            deltas,
-                            &terminal_schemas,
-                            &tables,
-                            &self.node_aliases,
-                        )?;
-                        transitions.adds.extend(delta_transitions.adds);
-                        transitions.removes.extend(delta_transitions.removes);
-                        transitions
-                            .result_payload_adds
-                            .extend(delta_transitions.result_payload_adds);
-                        transitions
-                            .result_payload_removes
-                            .extend(delta_transitions.result_payload_removes);
-                        transitions
-                            .program_fact_adds
-                            .extend(delta_transitions.program_fact_adds);
-                        transitions
-                            .program_fact_removes
-                            .extend(delta_transitions.program_fact_removes);
-                    }
-                    Err(std::sync::mpsc::TryRecvError::Empty) => break,
-                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                        return Err(Error::InvalidStoredValue(
-                            "seeded maintained subscription disconnected",
-                        ));
-                    }
+        let snapshot_transitions = maintained.apply_multisink_deltas(
+            initial_snapshot,
+            &terminal_schemas,
+            &tables,
+            &self.node_aliases,
+        )?;
+        transitions.adds.extend(snapshot_transitions.adds);
+        transitions.removes.extend(snapshot_transitions.removes);
+        transitions
+            .result_payload_adds
+            .extend(snapshot_transitions.result_payload_adds);
+        transitions
+            .result_payload_removes
+            .extend(snapshot_transitions.result_payload_removes);
+        transitions
+            .program_fact_adds
+            .extend(snapshot_transitions.program_fact_adds);
+        transitions
+            .program_fact_removes
+            .extend(snapshot_transitions.program_fact_removes);
+        loop {
+            match subscription.try_recv() {
+                Ok(deltas) => {
+                    let delta_transitions = maintained.apply_multisink_deltas(
+                        deltas,
+                        &terminal_schemas,
+                        &tables,
+                        &self.node_aliases,
+                    )?;
+                    transitions.adds.extend(delta_transitions.adds);
+                    transitions.removes.extend(delta_transitions.removes);
+                    transitions
+                        .result_payload_adds
+                        .extend(delta_transitions.result_payload_adds);
+                    transitions
+                        .result_payload_removes
+                        .extend(delta_transitions.result_payload_removes);
+                    transitions
+                        .program_fact_adds
+                        .extend(delta_transitions.program_fact_adds);
+                    transitions
+                        .program_fact_removes
+                        .extend(delta_transitions.program_fact_removes);
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    return Err(Error::InvalidStoredValue(
+                        "seeded maintained subscription disconnected",
+                    ));
                 }
             }
         }
@@ -3317,7 +3314,7 @@ where
             terminal_schemas,
             transitions,
             tables,
-            initial_received,
+            true,
         ))
     }
 

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -2948,6 +2948,7 @@ where
             .clone()
     }
 
+    #[allow(dead_code)] // Test-only and feature-gated direct view callers keep the no-owner form.
     pub(crate) async fn open_seeded_maintained_subscription_view(
         &mut self,
         shape: &ValidatedQuery,
@@ -2955,6 +2956,33 @@ where
         identity: AuthorSubject,
         tier: DurabilityTier,
         read_view: &ReadViewSpec,
+    ) -> Result<
+        (
+            MultisinkSubscription,
+            MaintainedSubscriptionView,
+            MaintainedTerminalSchemas,
+            super::maintained_subscription_view::ResultTransitions,
+            BTreeMap<String, TableSchema>,
+            bool,
+        ),
+        Error,
+    > {
+        self.open_seeded_maintained_subscription_view_with_waker(
+            shape, binding, identity, tier, read_view, None,
+        )
+        .await
+    }
+
+    /// Owner-loop variant retaining a durable wake route during cold initial
+    /// hydration.
+    pub(crate) async fn open_seeded_maintained_subscription_view_with_waker(
+        &mut self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        identity: AuthorSubject,
+        tier: DurabilityTier,
+        read_view: &ReadViewSpec,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<
         (
             MultisinkSubscription,
@@ -2975,6 +3003,7 @@ where
             QueryAuthorizationMode::TrustedServing,
             None,
             PreparedClaimBindingMode::Strict,
+            progress_waker,
         )
         .await
     }
@@ -2983,12 +3012,37 @@ where
     /// browser peer. The relay's Global receipt already names the
     /// authority-selected members, so this must consume that membership as
     /// its source instead of applying the query window a second time.
+    #[allow(dead_code)] // Test-only and feature-gated direct view callers keep the no-owner form.
     pub(crate) async fn open_seeded_relay_edge_subscription_view(
         &mut self,
         shape: &ValidatedQuery,
         binding: &Binding,
         identity: AuthorSubject,
         read_view: &ReadViewSpec,
+    ) -> Result<
+        (
+            MultisinkSubscription,
+            MaintainedSubscriptionView,
+            MaintainedTerminalSchemas,
+            super::maintained_subscription_view::ResultTransitions,
+            BTreeMap<String, TableSchema>,
+            bool,
+        ),
+        Error,
+    > {
+        self.open_seeded_relay_edge_subscription_view_with_waker(
+            shape, binding, identity, read_view, None,
+        )
+        .await
+    }
+
+    pub(crate) async fn open_seeded_relay_edge_subscription_view_with_waker(
+        &mut self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        identity: AuthorSubject,
+        read_view: &ReadViewSpec,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<
         (
             MultisinkSubscription,
@@ -3011,6 +3065,7 @@ where
             QueryAuthorizationMode::ClientLocal,
             settled_binding_view,
             PreparedClaimBindingMode::Strict,
+            progress_waker,
         )
         .await
     }
@@ -3062,6 +3117,7 @@ where
     /// Hydrate a terminal CommitUnit authorization-support clause. Unlike an
     /// ordinary prepared query, a missing policy claim is a denied proof and
     /// is surfaced to the peer as an empty, settled authorization view.
+    #[allow(dead_code)] // Test-only and feature-gated direct view callers keep the no-owner form.
     pub(crate) async fn open_seeded_authorization_support_subscription_view(
         &mut self,
         shape: &ValidatedQuery,
@@ -3069,6 +3125,31 @@ where
         identity: AuthorSubject,
         tier: DurabilityTier,
         read_view: &ReadViewSpec,
+    ) -> Result<
+        (
+            MultisinkSubscription,
+            MaintainedSubscriptionView,
+            MaintainedTerminalSchemas,
+            super::maintained_subscription_view::ResultTransitions,
+            BTreeMap<String, TableSchema>,
+            bool,
+        ),
+        Error,
+    > {
+        self.open_seeded_authorization_support_subscription_view_with_waker(
+            shape, binding, identity, tier, read_view, None,
+        )
+        .await
+    }
+
+    pub(crate) async fn open_seeded_authorization_support_subscription_view_with_waker(
+        &mut self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        identity: AuthorSubject,
+        tier: DurabilityTier,
+        read_view: &ReadViewSpec,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<
         (
             MultisinkSubscription,
@@ -3089,6 +3170,7 @@ where
             QueryAuthorizationMode::TrustedServing,
             None,
             PreparedClaimBindingMode::FailClosedAuthorizationSupport,
+            progress_waker,
         )
         .await
     }
@@ -3103,6 +3185,7 @@ where
         authorization_mode: QueryAuthorizationMode,
         settled_binding_view: Option<BindingViewKey>,
         prepared_claim_binding_mode: PreparedClaimBindingMode,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<
         (
             MultisinkSubscription,
@@ -3158,6 +3241,7 @@ where
                 &binding,
                 binding_source_shape,
                 prepared_claim_binding_mode,
+                progress_waker,
             )
             .await?;
         let mut maintained = MaintainedSubscriptionView::default();

--- a/crates/jazz/src/node/query_eval/lowering.rs
+++ b/crates/jazz/src/node/query_eval/lowering.rs
@@ -709,7 +709,11 @@ where
         binding: &Binding,
         binding_source_shape: String,
         prepared_claim_binding_mode: PreparedClaimBindingMode,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<MultisinkSubscription, Error> {
+        // Subscription opening performs one bounded IVM poll.  When that poll
+        // finds cold storage, retain the node owner's wake route so the
+        // runtime can resume it without unrelated transport traffic.
         let params = prepared_params_from_domain(&program.lowered.parameters);
         let route_params = prepared_route_param_names(&program.lowered.parameters);
         if params.is_empty() {
@@ -719,7 +723,10 @@ where
                 .into_iter()
                 .map(|terminal| (terminal.sink, terminal.graph))
                 .collect();
-            return self.database.subscribe(sinks).map_err(Error::Groove);
+            return self
+                .database
+                .subscribe_with_waker(sinks, progress_waker)
+                .map_err(Error::Groove);
         }
         let param_names = params
             .iter()
@@ -762,7 +769,7 @@ where
             .prepare(terminals, binding_source_shape, binding_descriptor)
             .await?;
         self.database
-            .bind_shape(prepared.id(), &values)
+            .bind_shape_with_waker(prepared.id(), &values, progress_waker)
             .await
             .map_err(Error::Groove)
     }

--- a/crates/jazz/src/node/query_eval/maintained_views.rs
+++ b/crates/jazz/src/node/query_eval/maintained_views.rs
@@ -180,6 +180,7 @@ impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
 {
+    #[allow(dead_code)] // Test-only and feature-gated direct view callers keep the no-owner form.
     pub(crate) async fn open_maintained_view_subscription_in_authorization_mode(
         &mut self,
         shape: &ValidatedQuery,
@@ -189,6 +190,32 @@ where
         read_view: &ReadViewSpec,
         retained_prepared_plan: Option<SubscriptionPreparedPlan>,
         authorization_mode: QueryAuthorizationMode,
+    ) -> Result<(LocalMaintainedViewSubscription, RelationSnapshot), Error> {
+        self.open_maintained_view_subscription_in_authorization_mode_with_waker(
+            shape,
+            binding,
+            identity,
+            tier,
+            read_view,
+            retained_prepared_plan,
+            authorization_mode,
+            None,
+        )
+        .await
+    }
+
+    /// Owner-loop variant that preserves a durable wake route while opening
+    /// cold maintained subscription hydration.
+    pub(crate) async fn open_maintained_view_subscription_in_authorization_mode_with_waker(
+        &mut self,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        identity: AuthorSubject,
+        tier: DurabilityTier,
+        read_view: &ReadViewSpec,
+        retained_prepared_plan: Option<SubscriptionPreparedPlan>,
+        authorization_mode: QueryAuthorizationMode,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<(LocalMaintainedViewSubscription, RelationSnapshot), Error> {
         if let Some(retained) = retained_prepared_plan.as_ref() {
             if retained.authorization_mode != authorization_mode {
@@ -213,6 +240,7 @@ where
                 authorization_mode,
                 settled_binding_view,
                 PreparedClaimBindingMode::Strict,
+                progress_waker,
             )
             .await?;
         let mut local = LocalMaintainedViewSubscription {
@@ -256,31 +284,65 @@ where
         Ok((local, initial.snapshot))
     }
 
+    #[allow(dead_code)] // Test-only direct callers use the no-owner form.
     pub(crate) async fn drain_local_maintained_view_subscription(
         &mut self,
         local: &mut LocalMaintainedViewSubscription,
         authoritative_binding_view: Option<BindingViewKey>,
     ) -> Result<Option<LocalMaintainedViewSubscriptionUpdate>, Error> {
-        self.drain_local_maintained_view_subscription_preserving_rows(
+        self.drain_local_maintained_view_subscription_with_waker(
+            local,
+            authoritative_binding_view,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn drain_local_maintained_view_subscription_with_waker(
+        &mut self,
+        local: &mut LocalMaintainedViewSubscription,
+        authoritative_binding_view: Option<BindingViewKey>,
+        progress_waker: Option<&std::task::Waker>,
+    ) -> Result<Option<LocalMaintainedViewSubscriptionUpdate>, Error> {
+        self.drain_local_maintained_view_subscription_preserving_rows_with_waker(
             local,
             authoritative_binding_view,
             &BTreeSet::new(),
+            progress_waker,
         )
         .await
         .map(|(update, _)| update)
     }
 
+    #[allow(dead_code)] // Test-only direct callers use the no-owner form.
     pub(crate) async fn drain_local_maintained_view_subscription_preserving_rows(
         &mut self,
         local: &mut LocalMaintainedViewSubscription,
         authoritative_binding_view: Option<BindingViewKey>,
         preserved_row_keys: &BTreeSet<(String, RowUuid)>,
     ) -> Result<(Option<LocalMaintainedViewSubscriptionUpdate>, bool), Error> {
+        self.drain_local_maintained_view_subscription_preserving_rows_with_waker(
+            local,
+            authoritative_binding_view,
+            preserved_row_keys,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn drain_local_maintained_view_subscription_preserving_rows_with_waker(
+        &mut self,
+        local: &mut LocalMaintainedViewSubscription,
+        authoritative_binding_view: Option<BindingViewKey>,
+        preserved_row_keys: &BTreeSet<(String, RowUuid)>,
+        progress_waker: Option<&std::task::Waker>,
+    ) -> Result<(Option<LocalMaintainedViewSubscriptionUpdate>, bool), Error> {
         let (transitions, suppressed_authoritative_change) = self
             .drain_local_maintained_view_subscription_transitions(
                 local,
                 authoritative_binding_view,
                 preserved_row_keys,
+                progress_waker,
             )
             .await?;
         let Some(transitions) = transitions else {
@@ -292,16 +354,32 @@ where
         Ok((Some(update), suppressed_authoritative_change))
     }
 
+    #[allow(dead_code)] // Test-only direct callers use the no-owner form.
     pub(crate) async fn drain_local_maintained_view_subscription_state(
         &mut self,
         local: &mut LocalMaintainedViewSubscription,
         authoritative_binding_view: Option<BindingViewKey>,
+    ) -> Result<bool, Error> {
+        self.drain_local_maintained_view_subscription_state_with_waker(
+            local,
+            authoritative_binding_view,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn drain_local_maintained_view_subscription_state_with_waker(
+        &mut self,
+        local: &mut LocalMaintainedViewSubscription,
+        authoritative_binding_view: Option<BindingViewKey>,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<bool, Error> {
         let (Some(transitions), _) = self
             .drain_local_maintained_view_subscription_transitions(
                 local,
                 authoritative_binding_view,
                 &BTreeSet::new(),
+                progress_waker,
             )
             .await?
         else {
@@ -431,6 +509,7 @@ where
         local: &mut LocalMaintainedViewSubscription,
         authoritative_binding_view: Option<BindingViewKey>,
         preserved_row_keys: &BTreeSet<(String, RowUuid)>,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<
         (
             Option<super::maintained_subscription_view::ResultTransitions>,
@@ -438,7 +517,8 @@ where
         ),
         Error,
     > {
-        self.drive_ready_query_runtime().await?;
+        self.drive_ready_query_runtime_with_waker(progress_waker)
+            .await?;
         if local.result_query.aggregate.is_some()
             && let Some(remote_members) =
                 self.query.settled_result_sets.get(&local.binding_view_key)

--- a/crates/jazz/src/node/query_eval/tests/bindings.rs
+++ b/crates/jazz/src/node/query_eval/tests/bindings.rs
@@ -278,6 +278,7 @@ fn nested_read_policies_reuse_an_outer_equivalent_claim_slot() {
             &binding,
             source_shape.clone(),
             PreparedClaimBindingMode::Strict,
+            None,
         )
         .unwrap_or_else(|error| {
             panic!(

--- a/crates/jazz/src/node/query_eval/tests/maintained_views.rs
+++ b/crates/jazz/src/node/query_eval/tests/maintained_views.rs
@@ -2,6 +2,72 @@
 
 use super::*;
 
+/// A direct maintained-view opening must retain its async owner through a
+/// cold, yielding local scan. Returning an empty Stream A snapshot here lets
+/// a serving peer emit membership before Stream B has its content witness.
+#[test]
+fn maintained_open_awaits_cold_multisink_witnesses() {
+    let test_schema = schema();
+    let column_families = test_schema.column_families();
+    let families = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let storage = groove::storage::YieldingStorage::wrap(
+        groove::storage::MemoryStorage::new(&families).expect("open memory storage"),
+    );
+    let mut node = NodeState::new(NodeUuid::from_bytes([23; 16]), test_schema, storage.clone())
+        .expect("open yielding node");
+    let issue = row(23);
+    let shape = Query::from("issues")
+        .select(["title", "state", "assignee", "priority"])
+        .validate(&schema())
+        .expect("validate issues query");
+    let binding = shape.bind(BTreeMap::new()).expect("bind issues query");
+    let tx_id = node
+        .commit_mergeable_settled(
+            MergeableCommit::new("issues", issue, 23_000)
+                .made_by(AuthorSubject::SYSTEM)
+                .cells(BTreeMap::from([
+                    ("title".to_owned(), Value::String("cold issue".to_owned())),
+                    ("state".to_owned(), Value::String("open".to_owned())),
+                    ("assignee".to_owned(), Value::Uuid(author(23).test_uuid())),
+                    ("priority".to_owned(), Value::U64(23)),
+                ])),
+        )
+        .expect("commit cold issue");
+    node.apply_fate_update(
+        tx_id,
+        Fate::Accepted,
+        Some(GlobalTime(23)),
+        Some(DurabilityTier::Global),
+    )
+    .expect("accept cold issue");
+    storage.evict_all();
+    let (shape, binding, plan) = node
+        .prepare_query_binding_for_link_in_authorization_mode(
+            &shape,
+            &binding,
+            DurabilityTier::Local,
+            AuthorSubject::SYSTEM,
+            QueryAuthorizationMode::ClientLocal,
+        )
+        .expect("prepare cold maintained query");
+    let (local, initial) = node
+        .open_maintained_view_subscription_in_authorization_mode(
+            &shape,
+            &binding,
+            AuthorSubject::SYSTEM,
+            DurabilityTier::Local,
+            &ReadViewSpec::default(),
+            Some(plan),
+            QueryAuthorizationMode::ClientLocal,
+        )
+        .expect("await complete cold maintained snapshot");
+    assert!(local.initial_received);
+    assert_eq!(initial.root_count, 1);
+}
+
 #[test]
 fn settled_edge_authority_preserves_an_ordinary_local_content_update() {
     let (_server_dir, mut server) = open_node();

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -979,6 +979,7 @@ self.database.finish_persistence(persisted)?;
 
     /// Resume all query work that can make progress now, without holding the
     /// caller open for storage-blocked nodes.
+    #[allow(dead_code)] // Test-only and feature-gated direct callers use the no-owner form.
     pub(crate) async fn drive_ready_query_runtime(&mut self) -> Result<(), Error> {
         self.drive_ready_query_runtime_with_waker(None).await
     }

--- a/crates/jazz/src/peer/publication.rs
+++ b/crates/jazz/src/peer/publication.rs
@@ -254,6 +254,7 @@ impl PeerState {
                     read_view: &read_view,
                     purpose: RehydratePurpose::Query,
                 },
+                None,
             )
             .await?
             {
@@ -273,6 +274,7 @@ impl PeerState {
                 &binding,
                 subscription,
                 Some(table),
+                None,
             )
             .await?
             {
@@ -286,6 +288,7 @@ impl PeerState {
                     &binding,
                     subscription,
                     Some(table),
+                    None,
                 )
                 .await?
                 .ok_or(Error::InvalidStoredValue(
@@ -344,8 +347,38 @@ impl PeerState {
     where
         S: OrderedKvStorage,
     {
-        self.query_update_inner_for_subscription(node, subscription, shape, binding, opts)
-            .await
+        self.query_update_for_subscription_with_opts_and_waker(
+            node,
+            subscription,
+            shape,
+            binding,
+            opts,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn query_update_for_subscription_with_opts_and_waker<S>(
+        &mut self,
+        node: &mut NodeState<S>,
+        subscription: SubscriptionKey,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        opts: RegisterShapeOptions,
+        progress_waker: Option<&std::task::Waker>,
+    ) -> Result<Option<SyncMessage>, Error>
+    where
+        S: OrderedKvStorage,
+    {
+        self.query_update_inner_for_subscription(
+            node,
+            subscription,
+            shape,
+            binding,
+            opts,
+            progress_waker,
+        )
+        .await
     }
 
     async fn query_update_inner<S>(
@@ -390,13 +423,14 @@ impl PeerState {
                 shape,
                 binding,
                 opts.clone(),
+                None,
             )
             .await?
         {
             return Ok(update);
         }
         node.drive_query_runtime().await?;
-        self.query_update_inner_for_subscription(node, subscription, shape, binding, opts)
+        self.query_update_inner_for_subscription(node, subscription, shape, binding, opts, None)
             .await?
             .ok_or(Error::InvalidStoredValue(
                 "maintained hydration ended without a query publication",
@@ -410,6 +444,7 @@ impl PeerState {
         shape: &ValidatedQuery,
         binding: &Binding,
         opts: RegisterShapeOptions,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<Option<SyncMessage>, Error>
     where
         S: OrderedKvStorage,
@@ -437,6 +472,7 @@ impl PeerState {
                 binding,
                 subscription,
                 None,
+                progress_waker,
             )
             .await;
         }
@@ -482,6 +518,7 @@ impl PeerState {
                 read_view: &read_view,
                 purpose: RehydratePurpose::Query,
             },
+            progress_waker,
         )
         .await
     }
@@ -493,6 +530,7 @@ impl PeerState {
         binding: &Binding,
         subscription: SubscriptionKey,
         result_table_filter: Option<&str>,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<Option<SyncMessage>, Error>
     where
         S: OrderedKvStorage,
@@ -507,6 +545,7 @@ impl PeerState {
             shape,
             subscription,
             result_table_filter,
+            progress_waker,
         )
         .await?;
         if !self
@@ -571,6 +610,7 @@ impl PeerState {
                     read_view: &read_view,
                     purpose: RehydratePurpose::Query,
                 },
+                progress_waker,
             )
             .await;
         }
@@ -704,11 +744,13 @@ impl PeerState {
         shape: &ValidatedQuery,
         subscription: SubscriptionKey,
         result_table_filter: Option<&str>,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<ResultTransitions, Error>
     where
         S: OrderedKvStorage,
     {
-        node.drive_ready_query_runtime().await?;
+        node.drive_ready_query_runtime_with_waker(progress_waker)
+            .await?;
         let previous_member_result_set = self
             .publication_states
             .get(&subscription)
@@ -869,6 +911,7 @@ impl PeerState {
         &mut self,
         node: &mut NodeState<S>,
         request: MaintainedRehydrateRequest<'_>,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<Option<SyncMessage>, Error>
     where
         S: OrderedKvStorage,
@@ -899,26 +942,34 @@ impl PeerState {
             // only a window or policy-scoped exact-ID read would change
             // semantics if evaluated from the relay's local cache.
             RehydratePurpose::Query if relay_edge_requires_authority_source => {
-                node.open_seeded_relay_edge_subscription_view(shape, binding, self.identity(), read_view)
+                node.open_seeded_relay_edge_subscription_view_with_waker(
+                    shape,
+                    binding,
+                    self.identity(),
+                    read_view,
+                    progress_waker,
+                )
                     .await
             }
             RehydratePurpose::Query => {
-                node.open_seeded_maintained_subscription_view(
+                node.open_seeded_maintained_subscription_view_with_waker(
                     shape,
                     binding,
                     self.identity(),
                     tier,
                     read_view,
+                    progress_waker,
                 )
                 .await
             }
             RehydratePurpose::AuthorizationSupport => node
-                .open_seeded_authorization_support_subscription_view(
+                .open_seeded_authorization_support_subscription_view_with_waker(
                     shape,
                     binding,
                     self.identity(),
                     tier,
                     read_view,
+                    progress_waker,
                 )
                 .await,
         };
@@ -1264,6 +1315,30 @@ impl PeerState {
     where
         S: OrderedKvStorage,
     {
+        self.rehydrate_query_for_subscription_with_opts_and_waker(
+            node,
+            subscription,
+            shape,
+            binding,
+            opts,
+            None,
+        )
+        .await
+    }
+
+    /// Owner-loop variant retaining the tick owner's cold-query wake route.
+    pub(crate) async fn rehydrate_query_for_subscription_with_opts_and_waker<S>(
+        &mut self,
+        node: &mut NodeState<S>,
+        subscription: SubscriptionKey,
+        shape: &ValidatedQuery,
+        binding: &Binding,
+        opts: RegisterShapeOptions,
+        progress_waker: Option<&std::task::Waker>,
+    ) -> Result<Option<SyncMessage>, Error>
+    where
+        S: OrderedKvStorage,
+    {
         self.rehydrate_query_for_subscription_with_purpose(
             node,
             subscription,
@@ -1271,6 +1346,7 @@ impl PeerState {
             binding,
             opts,
             RehydratePurpose::Query,
+            progress_waker,
         )
         .await
     }
@@ -1283,6 +1359,7 @@ impl PeerState {
         binding: &Binding,
         opts: RegisterShapeOptions,
         purpose: RehydratePurpose,
+        progress_waker: Option<&std::task::Waker>,
     ) -> Result<Option<SyncMessage>, Error>
     where
         S: OrderedKvStorage,
@@ -1341,6 +1418,7 @@ impl PeerState {
                 read_view: &read_view,
                 purpose,
             },
+            progress_waker,
         )
         .await
     }
@@ -1373,6 +1451,7 @@ impl PeerState {
                 binding,
                 opts,
                 RehydratePurpose::AuthorizationSupport,
+                None,
             )
             .await
             .and_then(|update| {
@@ -1396,12 +1475,34 @@ impl PeerState {
     where
         S: OrderedKvStorage,
     {
+        self.rehydrate_query_for_subscription_from_maintained_subscription_and_waker(
+            node,
+            maintained_subscription,
+            target_subscription,
+            shape,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn rehydrate_query_for_subscription_from_maintained_subscription_and_waker<S>(
+        &mut self,
+        node: &mut NodeState<S>,
+        maintained_subscription: SubscriptionKey,
+        target_subscription: SubscriptionKey,
+        shape: &ValidatedQuery,
+        progress_waker: Option<&std::task::Waker>,
+    ) -> Result<Option<SyncMessage>, Error>
+    where
+        S: OrderedKvStorage,
+    {
         self.clear_stale_groove_runtime_handles(node, maintained_subscription);
         let source_transitions = self.drain_maintained_subscription_view_changes(
             node,
             shape,
             maintained_subscription,
             None,
+            progress_waker,
         )
         .await?;
         if !self

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -708,6 +708,7 @@ struct TickSchedulerImpl {
 struct TickState {
     immediate: AtomicBool,
     deferred: AtomicBool,
+    after_current_turn: AtomicBool,
     delayed: AtomicBool,
     notify: tokio::sync::Notify,
 }
@@ -731,7 +732,12 @@ impl TickSchedulerImpl {
     fn take(&self) -> Option<TickUrgency> {
         if self.state.immediate.swap(false, Ordering::AcqRel) {
             self.state.deferred.store(false, Ordering::Release);
+            self.state
+                .after_current_turn
+                .store(false, Ordering::Release);
             Some(TickUrgency::Immediate)
+        } else if self.state.after_current_turn.swap(false, Ordering::AcqRel) {
+            Some(TickUrgency::AfterCurrentTurn)
         } else if self.state.deferred.swap(false, Ordering::AcqRel) {
             Some(TickUrgency::Deferred)
         } else {
@@ -743,6 +749,9 @@ impl TickSchedulerImpl {
         match urgency {
             TickUrgency::Immediate => self.state.immediate.store(true, Ordering::Release),
             TickUrgency::Deferred => self.state.deferred.store(true, Ordering::Release),
+            TickUrgency::AfterCurrentTurn => {
+                self.state.after_current_turn.store(true, Ordering::Release)
+            }
         }
         self.state.notify.notify_one();
     }
@@ -1285,6 +1294,8 @@ impl ClientDb {
                     };
                     if urgency == TickUrgency::Deferred {
                         tokio::time::sleep(Duration::from_millis(1)).await;
+                    } else if urgency == TickUrgency::AfterCurrentTurn {
+                        tokio::task::yield_now().await;
                     }
                     let tick_result = match inner.borrow().backend() {
                         Ok(db) => db.tick(),

--- a/examples/band-chat/apps/nextjs-betterauth/tests/browser/band-chat.test.tsx
+++ b/examples/band-chat/apps/nextjs-betterauth/tests/browser/band-chat.test.tsx
@@ -50,6 +50,11 @@ afterEach(async () => {
 });
 
 it("renders the serving-authority owner, guest-message, and removal flow", async () => {
+  // Regression: each mounted preview registers several local subscriptions
+  // (rooms, profiles, messages, and members) while its persistent worker is
+  // still opening.  Admission may hold *delivery* until storage opens, but it
+  // must not serially defer native registrations: that ordering used to leave
+  // the policy-maintained member view without a Stream B witness.
   const server = await getJazzServerInfo(
     `019d4a17-4591-7c0a-a320-${crypto.randomUUID().slice(0, 12)}`,
   );

--- a/examples/docs/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
+++ b/examples/docs/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
@@ -173,7 +173,13 @@ describe("React Todo App E2E", () => {
     await act(async () => checkbox.click());
 
     await waitFor(
-      () => el.querySelector("#todo-list li")!.classList.contains("done"),
+      () => {
+        // A subscription update may replace the list item between polling
+        // iterations. Keep waiting for the asserted state rather than turning
+        // that ordinary transient into a test-process TypeError.
+        const updatedTodo = el.querySelector("#todo-list li");
+        return updatedTodo?.classList.contains("done") ?? false;
+      },
       3000,
       "Todo should be marked done",
     );

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -209,8 +209,18 @@ export interface DbSubscriptionSource {
     callback: (delta: SubscriptionDelta<T>) => void,
     options?: QueryOptions,
     session?: Session,
-  ): () => void;
+  ): SubscriptionHandle;
 }
+
+/**
+ * Cancels a subscription. Browser-worker followers also expose the initial
+ * admission boundary so framework bindings can surface an asynchronous open
+ * failure through their ordinary subscription error state rather than as an
+ * ambient exception.
+ *
+ * @internal
+ */
+export type SubscriptionHandle = (() => void) & { readonly ready?: Promise<void> };
 
 const dbSubscriptionSources = new WeakMap<Db, DbSubscriptionSource>();
 
@@ -2356,22 +2366,22 @@ export class Db {
     options?: QueryOptions,
     session?: Session,
     statusReady = false,
-  ): () => void {
+  ): SubscriptionHandle {
     // Constructing a browser follower starts its init handshake. Do that before
     // asking whether this is a newly attaching peer.
     const client = this.getClient(query._schema);
-    // See all(): only a newly attached browser peer delays this tier's
-    // subscription setup until it knows the shared worker's state. All other
-    // runtimes, including established browser peers, start synchronously.
-    const initialOfflineState =
-      !statusReady && options?.tier === ReadTier.RemoteIfPossible
-        ? this.connection.initialExplicitOfflineState()
-        : null;
-    if (initialOfflineState) {
+    // A newly attached browser peer has no durable runtime until its worker
+    // handshake completes. In particular, do not publish the ordinary local
+    // empty seed before that handshake: a storage-open failure belongs to the
+    // initiating subscription, not to an ambient deferred exception after a
+    // misleading successful result. Direct runtimes and already-ready browser
+    // peers return null and retain their synchronous local subscription path.
+    const initialReadiness = !statusReady ? this.connection.initialExplicitOfflineState() : null;
+    if (initialReadiness) {
       let unsubscribed = false;
       let unsubscribe = () => {};
       const readyAbort = new AbortController();
-      void initialOfflineState
+      const ready = initialReadiness
         .then(() => {
           if (unsubscribed || readyAbort.signal.aborted) return;
           const installed = this.subscribeDelta(query, callback, options, session, true);
@@ -2384,15 +2394,20 @@ export class Db {
         })
         .catch((error: unknown) => {
           if (unsubscribed || readyAbort.signal.aborted || this.isShuttingDown) return;
-          setTimeout(() => {
-            throw error;
-          }, 0);
+          throw error;
         });
-      return () => {
+      // Direct `Db.subscribe` has historically returned only cancellation, so
+      // retain an internal rejection handler for callers that do not consume
+      // the readiness property. Framework bindings consume `ready` below via
+      // DbSubscriptionSource and surface it as their normal error state.
+      void ready.catch(() => undefined);
+      const handle = (() => {
         unsubscribed = true;
         readyAbort.abort();
         unsubscribe();
-      };
+      }) as SubscriptionHandle;
+      Object.defineProperty(handle, "ready", { value: ready });
+      return handle;
     }
     const manager = new SubscriptionManager<T>();
     const builderJson = query._build();

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -2365,50 +2365,17 @@ export class Db {
     callback: (delta: SubscriptionDelta<T>) => void,
     options?: QueryOptions,
     session?: Session,
-    statusReady = false,
   ): SubscriptionHandle {
     // Constructing a browser follower starts its init handshake. Do that before
     // asking whether this is a newly attaching peer.
     const client = this.getClient(query._schema);
-    // A newly attached browser peer has no durable runtime until its worker
-    // handshake completes. In particular, do not publish the ordinary local
-    // empty seed before that handshake: a storage-open failure belongs to the
-    // initiating subscription, not to an ambient deferred exception after a
-    // misleading successful result. Direct runtimes and already-ready browser
-    // peers return null and retain their synchronous local subscription path.
-    const initialReadiness = !statusReady ? this.connection.initialExplicitOfflineState() : null;
-    if (initialReadiness) {
-      let unsubscribed = false;
-      let unsubscribe = () => {};
-      const readyAbort = new AbortController();
-      const ready = initialReadiness
-        .then(() => {
-          if (unsubscribed || readyAbort.signal.aborted) return;
-          const installed = this.subscribeDelta(query, callback, options, session, true);
-          // Native subscription installation can synchronously deliver an
-          // opening delta. If that callback unsubscribes the outer handle,
-          // dispose the just-created inner subscription rather than retaining
-          // it after this continuation returns.
-          if (unsubscribed || readyAbort.signal.aborted) installed();
-          else unsubscribe = installed;
-        })
-        .catch((error: unknown) => {
-          if (unsubscribed || readyAbort.signal.aborted || this.isShuttingDown) return;
-          throw error;
-        });
-      // Direct `Db.subscribe` has historically returned only cancellation, so
-      // retain an internal rejection handler for callers that do not consume
-      // the readiness property. Framework bindings consume `ready` below via
-      // DbSubscriptionSource and surface it as their normal error state.
-      void ready.catch(() => undefined);
-      const handle = (() => {
-        unsubscribed = true;
-        readyAbort.abort();
-        unsubscribe();
-      }) as SubscriptionHandle;
-      Object.defineProperty(handle, "ready", { value: ready });
-      return handle;
-    }
+    // A newly attached browser peer does not yet know whether its worker can
+    // open durable storage.  Keep the native subscription installation in the
+    // old immediate order (several hooks may register together), but hold its
+    // public deltas until that one admission succeeds.  This makes a corrupt
+    // store fail the subscription that triggered it without publishing a
+    // misleading empty opening or perturbing maintained-view registration.
+    const initialReadiness = this.connection.initialExplicitOfflineState();
     const manager = new SubscriptionManager<T>();
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson));
@@ -2426,9 +2393,19 @@ export class Db {
           builtQuery.partialSelect,
         ),
       );
+    let deliveryReady = initialReadiness === null;
+    const bufferedDeltas: SubscriptionDelta<T>[] = [];
+    let startLocalSeed: (() => void) | null = null;
+    const deliver = (delta: SubscriptionDelta<T>) => {
+      if (!deliveryReady) {
+        bufferedDeltas.push(delta);
+        return;
+      }
+      callback(delta);
+    };
     const handleDelta = (delta: Parameters<SubscriptionManager<T>["handleDelta"]>[0]) => {
       const typedDelta = manager.handleDelta(delta, transform);
-      callback(typedDelta);
+      deliver(typedDelta);
     };
 
     const queryOptions = nativeDbQueryOptions(query._schema, builtQuery.table, options);
@@ -2494,8 +2471,41 @@ export class Db {
       builtQuery.table,
       queryOptions,
     );
+    const unsubscribe = () => {
+      unsubscribed = true;
+      readyAbort.abort();
+      this.unregisterActiveQuerySubscriptionTrace(traceId);
+      if (activeSubscription !== null && activeSubscription.id >= 0) {
+        client.unsubscribe(activeSubscription.id);
+      }
+      activeSubscription = null;
+      bufferedDeltas.length = 0;
+      manager.clear();
+    };
+    const ready = initialReadiness
+      ?.then(() => {
+        if (unsubscribed || this.isShuttingDown) return;
+        deliveryReady = true;
+        for (const delta of bufferedDeltas.splice(0)) {
+          callback(delta);
+        }
+        startLocalSeed?.();
+      })
+      .catch((error: unknown) => {
+        if (unsubscribed || this.isShuttingDown) return;
+        // The worker admitted no durable runtime.  Dispose the locally
+        // registered native subscription before surfacing that initiating
+        // operation's error through the handle/orchestrator.
+        unsubscribe();
+        throw error;
+      });
+    // Direct `Db.subscribe` has historically returned only cancellation, so
+    // retain an internal rejection handler for callers that do not consume
+    // the readiness property. Framework bindings consume `ready` below via
+    // DbSubscriptionSource and surface it as their normal error state.
+    if (ready) void ready.catch(() => undefined);
     if (queryOptions.tier == null || queryOptions.tier === "local") {
-      callback(manager.seed([]));
+      deliver(manager.seed([]));
     }
     if (
       this.connection.shouldDeferSubscriptionStart(resolveReadTier(queryOptions.tier ?? "local"))
@@ -2563,33 +2573,29 @@ export class Db {
           tier: "local",
           propagation: "local-only",
         });
-      const seedRows =
-        session == null
-          ? seedQuery()
-          : this.withRuntimeOperationContext({ session }, () => seedQuery());
-      void seedRows
-        .then((rows) => {
-          if (unsubscribed) return;
-          callback(manager.seed(rows));
-        })
-        .catch((error: unknown) => {
-          setTimeout(() => {
-            throw error;
-          }, 0);
-        });
+      const seedLocal = () => {
+        const seedRows =
+          session == null
+            ? seedQuery()
+            : this.withRuntimeOperationContext({ session }, () => seedQuery());
+        void seedRows
+          .then((rows) => {
+            if (unsubscribed) return;
+            deliver(manager.seed(rows));
+          })
+          .catch((error: unknown) => {
+            setTimeout(() => {
+              throw error;
+            }, 0);
+          });
+      };
+      if (initialReadiness) startLocalSeed = seedLocal;
+      else seedLocal();
     }
 
-    // Return unsubscribe function
-    return () => {
-      unsubscribed = true;
-      readyAbort.abort();
-      this.unregisterActiveQuerySubscriptionTrace(traceId);
-      if (activeSubscription !== null && activeSubscription.id >= 0) {
-        client.unsubscribe(activeSubscription.id);
-      }
-      activeSubscription = null;
-      manager.clear();
-    };
+    const handle = unsubscribe as SubscriptionHandle;
+    if (ready) Object.defineProperty(handle, "ready", { value: ready });
+    return handle;
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -94,7 +94,7 @@ const SERVER_PUMP_DEBOUNCE_MS = 16;
 const MAX_CORE_TICKS_PER_TURN = 4;
 
 type ReadAuthorizationHost = "client-local" | "trusted-serving";
-type CoreTickWake = "immediate" | "deferred" | `after:${number}`;
+type CoreTickWake = "immediate" | "deferred" | "after-current-turn" | `after:${number}`;
 
 type NativeDbConstructor = {
   openMemory(schema: Uint8Array, config: Uint8Array): NativeDb;
@@ -806,6 +806,7 @@ export class NativeRuntimeAdapter implements Runtime {
       if (
         urgency === "immediate" ||
         urgency === "deferred" ||
+        urgency === "after-current-turn" ||
         (typeof urgency === "string" && urgency.startsWith("after:"))
       ) {
         this.scheduleCoreWake(urgency as CoreTickWake);
@@ -2774,6 +2775,14 @@ export class NativeRuntimeAdapter implements Runtime {
 
   private scheduleCoreWake(urgency: CoreTickWake): void {
     if (this.closed) return;
+    if (urgency === "after-current-turn") {
+      // A microtask would set `coreTickAgain` while a core tick is still
+      // running, recursively entering the next tick before the browser can
+      // deliver newly-produced frames. Cold subscriber hydration must yield
+      // to the host task queue so inbound commits/fates get a fair turn.
+      setTimeout(() => this.scheduleCoreWake("immediate"), 0);
+      return;
+    }
     if (urgency.startsWith("after:")) {
       const delayMs = Number(urgency.slice("after:".length));
       if (!Number.isSafeInteger(delayMs) || delayMs < 0) return;

--- a/packages/jazz-tools/src/subscriptions-orchestrator.test.ts
+++ b/packages/jazz-tools/src/subscriptions-orchestrator.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Session } from "./runtime/context.js";
-import type { QueryBuilder, QueryOptions } from "./runtime/db.js";
+import type { QueryBuilder, QueryOptions, SubscriptionHandle } from "./runtime/db.js";
 import type { SubscriptionDelta } from "./runtime/subscription-manager.js";
 import {
   SubscriptionsOrchestrator,
@@ -31,6 +31,7 @@ type UnitHarness = {
   calls: SubscribeCall[];
   emit: (index: number, delta: SubscriptionDelta<Todo>) => void;
   setThrowOnSubscribe: (error: Error | null) => void;
+  setNextReadiness: (readiness: Promise<void> | null) => void;
 };
 
 function makeTodo(id: string, title = `todo-${id}`): Todo {
@@ -68,6 +69,7 @@ function createUnitHarness(
 ): UnitHarness {
   const calls: SubscribeCall[] = [];
   let throwOnSubscribe: Error | null = null;
+  let nextReadiness: Promise<void> | null = null;
 
   const db: {
     subscribeDelta<T extends { id: string }>(
@@ -75,18 +77,22 @@ function createUnitHarness(
       callback: (delta: SubscriptionDelta<T>) => void,
       options?: QueryOptions,
       session?: Session,
-    ): () => void;
+    ): SubscriptionHandle;
   } = {
     subscribeDelta<T extends { id: string }>(
       query: QueryBuilder<T>,
       callback: (delta: SubscriptionDelta<T>) => void,
       options?: QueryOptions,
       session?: Session,
-    ): () => void {
+    ): SubscriptionHandle {
       if (throwOnSubscribe) {
         throw throwOnSubscribe;
       }
-      const unsubscribe = vi.fn();
+      const unsubscribe = vi.fn() as SubscriptionHandle;
+      if (nextReadiness) {
+        Object.defineProperty(unsubscribe, "ready", { value: nextReadiness });
+        nextReadiness = null;
+      }
       calls.push({
         callback: callback as (delta: SubscriptionDelta<any>) => void,
         query: query as QueryBuilder<any>,
@@ -117,6 +123,9 @@ function createUnitHarness(
     },
     setThrowOnSubscribe(error) {
       throwOnSubscribe = error;
+    },
+    setNextReadiness(readiness) {
+      nextReadiness = readiness;
     },
   };
 }
@@ -389,6 +398,28 @@ describe("SubscriptionsOrchestrator unit coverage", () => {
         data: undefined,
         error: setupError,
       });
+    } finally {
+      await harness.manager.shutdown();
+    }
+  });
+
+  it("SO-U14a asynchronous subscription admission failure marks entry rejected", async () => {
+    const harness = createUnitHarness();
+    const admissionError = new Error("browser storage open failed");
+    harness.setNextReadiness(Promise.reject(admissionError));
+
+    try {
+      const { entry } = harness.makeEntry();
+      const onError = vi.fn();
+      entry.subscribe({ onError });
+
+      await expect(entry.promise).rejects.toBe(admissionError);
+      expect(entry.state).toEqual({
+        status: "rejected",
+        data: undefined,
+        error: admissionError,
+      });
+      expect(onError).toHaveBeenCalledWith(admissionError);
     } finally {
       await harness.manager.shutdown();
     }

--- a/packages/jazz-tools/src/subscriptions-orchestrator.test.ts
+++ b/packages/jazz-tools/src/subscriptions-orchestrator.test.ts
@@ -19,7 +19,7 @@ type SubscribeCall = {
   query: QueryBuilder<any>;
   options?: QueryOptions;
   session?: Session;
-  unsubscribe: ReturnType<typeof vi.fn>;
+  unsubscribe: SubscriptionHandle;
 };
 
 type UnitHarness = {

--- a/packages/jazz-tools/src/subscriptions-orchestrator.ts
+++ b/packages/jazz-tools/src/subscriptions-orchestrator.ts
@@ -387,7 +387,7 @@ export class SubscriptionsOrchestrator {
   private subscribeEntry<T extends { id: string }>(entry: InternalCacheEntry<T>): void {
     const generation = entry.generation;
     try {
-      entry.unsubscribe = this.db.subscribeDelta<T>(
+      const subscription = this.db.subscribeDelta<T>(
         entry.query,
         (delta) => {
           if (entry.generation !== generation) return;
@@ -426,6 +426,21 @@ export class SubscriptionsOrchestrator {
         entry.options,
         this.session ?? undefined,
       );
+      entry.unsubscribe = subscription;
+      if (subscription.ready) {
+        void subscription.ready.catch((error: unknown) => {
+          // A newer subscription or a caller teardown owns its own result.
+          // Never let a stale browser-worker open failure reject a recreated
+          // query entry.
+          if (entry.generation !== generation || entry.unsubscribe !== subscription) return;
+          entry.state = { status: "rejected", data: undefined, error };
+          entry.rejectfulfilled(error);
+          for (const listener of Array.from(entry.listeners)) {
+            listener.onError?.(error);
+          }
+          this.scheduleCleanup(entry);
+        });
+      }
     } catch (error) {
       // Only a synchronous setup (protocol-level) failure from the delta source
       // lands here and drives the entry to `rejected`. Data-level errors inside

--- a/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
@@ -669,21 +669,36 @@ describe("useAllSuspense browser integration", () => {
       "expected suspense rows mount for gather query",
     );
 
-    const {
-      value: { id: rootId },
-    } = await client.db.insert(teams, {
+    const root = await client.db.insert(teams, {
       name: "root",
       org_id: undefined,
       parent_id: undefined,
     });
-    const {
-      value: { id: midId },
-    } = await client.db.insert(teams, {
+    const rootId = root.value.id;
+    const mid = await client.db.insert(teams, {
       name: "mid",
       org_id: undefined,
       parent_id: rootId,
     });
-    await client.db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
+    const midId = mid.value.id;
+    const leaf = await client.db.insert(teams, {
+      name: "leaf",
+      org_id: undefined,
+      parent_id: midId,
+    });
+
+    // A cold recursive gather may hydrate over several owner turns. Its work
+    // must never starve unrelated local writes or their receipts.
+    const waitForLocal = (label: string, wait: Promise<void>) =>
+      Promise.race([
+        wait,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error(`${label} local acknowledgement timed out`)), 5_000),
+        ),
+      ]);
+    await waitForLocal("root", root.wait({ tier: "local" }));
+    await waitForLocal("mid", mid.wait({ tier: "local" }));
+    await waitForLocal("leaf", leaf.wait({ tier: "local" }));
 
     await waitForCondition(
       () => {

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -301,6 +301,48 @@ describe("SharedWorker bridge with IndexedDB", () => {
     expect(db).toBeInstanceOf(Db);
   });
 
+  it("registers concurrent local subscriptions before worker admission while withholding openings", async () => {
+    const db = track(
+      await createDb({
+        appId: "concurrent-local-subscription-admission",
+        secret: generateAuthSecret(),
+        driver: { type: "persistent", dbName: uniqueDbName("concurrent-local-subscription") },
+      }),
+    );
+    // Selecting the schema begins the worker handshake but cannot complete it
+    // in this same call stack. The registration spy distinguishes the required
+    // native ordering from the old workaround that waited before subscribing.
+    const client = (
+      db as unknown as {
+        getClient(schema: typeof todos._schema): { subscribe: (...args: never[]) => number };
+      }
+    ).getClient(todos._schema);
+    const nativeSubscribe = vi.spyOn(client, "subscribe");
+    const source = getDbSubscriptionSource(db);
+    const firstDeltas: unknown[] = [];
+    const secondDeltas: unknown[] = [];
+    const first = source.subscribeDelta(todos, (delta) => firstDeltas.push(delta), {
+      tier: "local",
+    });
+    const second = source.subscribeDelta(todos, (delta) => secondDeltas.push(delta), {
+      tier: "local",
+    });
+    try {
+      expect(first.ready).toBeDefined();
+      expect(second.ready).toBeDefined();
+      expect(nativeSubscribe).toHaveBeenCalledTimes(2);
+      expect(firstDeltas).toEqual([]);
+      expect(secondDeltas).toEqual([]);
+      await expect(Promise.all([first.ready, second.ready])).resolves.toEqual([
+        undefined,
+        undefined,
+      ]);
+    } finally {
+      first();
+      second();
+    }
+  });
+
   it("keeps createDb schema-lazy and rejects the first local subscription when durable storage cannot open", async () => {
     const ambientErrors: string[] = [];
     const unhandledRejections: string[] = [];

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -303,55 +303,83 @@ describe("SharedWorker bridge with IndexedDB", () => {
 
   it("keeps createDb schema-lazy but rejects the first local read when durable storage cannot open", async () => {
     const ambientErrors: string[] = [];
+    const unhandledRejections: string[] = [];
     const recordAmbientError = (event: ErrorEvent) => {
       ambientErrors.push(event.error instanceof Error ? event.error.message : event.message);
     };
+    const recordUnhandledRejection = (event: PromiseRejectionEvent) => {
+      event.preventDefault();
+      unhandledRejections.push(
+        event.reason instanceof Error ? event.reason.message : String(event.reason),
+      );
+    };
     globalThis.addEventListener("error", recordAmbientError);
+    globalThis.addEventListener("unhandledrejection", recordUnhandledRejection);
     errorListeners.add(recordAmbientError);
     const dbName = uniqueDbName("corrupt-storage-open");
     const secret = generateAuthSecret();
-    const initial = track(
-      await createDb({
-        appId: "test-app",
-        secret,
-        driver: { type: "persistent", dbName },
-      }),
-    );
-    await initial.insert(todos, { title: "durable sentinel", done: false }).wait({ tier: "local" });
-    await initial.shutdown();
-    untrack(initial);
-    // The last follower releases its worker context after the short idle
-    // window. Without this, a cached worker runtime never reopens the raw
-    // IndexedDB namespace and cannot observe the corruption below.
-    await sleep(100);
+    let reopened: Db | null = null;
+    try {
+      const initial = track(
+        await createDb({
+          appId: "test-app",
+          secret,
+          driver: { type: "persistent", dbName },
+        }),
+      );
+      await initial
+        .insert(todos, { title: "durable sentinel", done: false })
+        .wait({ tier: "local" });
+      await initial.shutdown();
+      untrack(initial);
+      // The last follower releases its worker context after the short idle
+      // window. Without this, a cached worker runtime never reopens the raw
+      // IndexedDB namespace and cannot observe the corruption below.
+      await sleep(100);
 
-    await replaceStorageManifest(dbName, {
-      ...INDEXEDDB_STORAGE_MANIFEST,
-      storageEpoch: 2,
-    });
-    const recordsBeforeRead = await rawStorageRecords(dbName);
+      await replaceStorageManifest(dbName, {
+        ...INDEXEDDB_STORAGE_MANIFEST,
+        storageEpoch: 2,
+      });
+      const recordsBeforeRead = await rawStorageRecords(dbName);
 
-    const reopened = track(
-      await createDb({
-        appId: "test-app",
-        secret,
-        driver: { type: "persistent", dbName },
-      }),
-    );
-    // `createDb` intentionally does not select a schema or open durable
-    // storage. The first schema-backed public operation owns the failure.
-    await expect(
-      withTimeout(
-        reopened.all(todos, { tier: "local" }),
-        5_000,
-        "corrupt storage read did not settle",
-      ),
-    ).rejects.toThrow("Missing or invalid IndexedDB storage epoch manifest");
-    await sleep(0);
-    expect(ambientErrors).toEqual([]);
-    expect(await rawStorageRecords(dbName)).toEqual(recordsBeforeRead);
-    globalThis.removeEventListener("error", recordAmbientError);
-    errorListeners.delete(recordAmbientError);
+      reopened = track(
+        await createDb({
+          appId: "test-app",
+          secret,
+          driver: { type: "persistent", dbName },
+        }),
+      );
+      // `createDb` intentionally does not select a schema or open durable
+      // storage. The first schema-backed public operation owns the failure.
+      await expect(
+        withTimeout(
+          reopened.all(todos, { tier: "local" }),
+          5_000,
+          "corrupt storage read did not settle",
+        ),
+      ).rejects.toThrow("Missing or invalid IndexedDB storage epoch manifest");
+      // The rejected operation leaves no durable peer to flush. Shutdown is
+      // still an explicit observation point for the same readiness failure, not
+      // an ambient error deferred to best-effort test cleanup.
+      await expect(reopened.shutdown()).rejects.toThrow(
+        "Missing or invalid IndexedDB storage epoch manifest",
+      );
+      untrack(reopened);
+      reopened = null;
+      await sleep(0);
+      expect(ambientErrors).toEqual([]);
+      expect(unhandledRejections).toEqual([]);
+      expect(await rawStorageRecords(dbName)).toEqual(recordsBeforeRead);
+    } finally {
+      if (reopened) {
+        await reopened.shutdown().catch(() => undefined);
+        untrack(reopened);
+      }
+      globalThis.removeEventListener("error", recordAmbientError);
+      globalThis.removeEventListener("unhandledrejection", recordUnhandledRejection);
+      errorListeners.delete(recordAmbientError);
+    }
   });
 
   // -------------------------------------------------------------------------

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -12,6 +12,11 @@ import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
 import type { Schema } from "../../src/drivers/types.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import {
+  INDEXEDDB_STORAGE_MANIFEST,
+  INDEXEDDB_STORAGE_MANIFEST_KEY,
+  INDEXEDDB_STORAGE_MANIFEST_STORE,
+} from "../../src/runtime/indexeddb-page-store.js";
+import {
   TestCleanup,
   createSyncedDb,
   sleep,
@@ -292,6 +297,44 @@ describe("SharedWorker bridge with IndexedDB", () => {
     );
     expect(db).toBeDefined();
     expect(db).toBeInstanceOf(Db);
+  });
+
+  it("keeps createDb schema-lazy but rejects the first local read when durable storage cannot open", async () => {
+    const dbName = uniqueDbName("corrupt-storage-open");
+    const initial = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    await initial.insert(todos, { title: "durable sentinel", done: false }).wait({ tier: "local" });
+    await initial.shutdown();
+    untrack(initial);
+    // The last follower releases its worker context after the short idle
+    // window. Without this, a cached worker runtime never reopens the raw
+    // IndexedDB namespace and cannot observe the corruption below.
+    await sleep(100);
+
+    await replaceStorageManifest(dbName, {
+      ...INDEXEDDB_STORAGE_MANIFEST,
+      storageEpoch: 2,
+    });
+
+    const reopened = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    // `createDb` intentionally does not select a schema or open durable
+    // storage. The first schema-backed public operation owns the failure.
+    await expect(
+      withTimeout(
+        reopened.all(todos, { tier: "local" }),
+        5_000,
+        "corrupt storage read did not settle",
+      ),
+    ).rejects.toThrow("Missing or invalid IndexedDB storage epoch manifest");
   });
 
   // -------------------------------------------------------------------------
@@ -2764,5 +2807,32 @@ async function publishPermissionsForServer(
     adminSecret,
     schema: schema ?? app.wasmSchema,
     permissions,
+  });
+}
+
+async function replaceStorageManifest(name: string, manifest: unknown): Promise<void> {
+  const database = await requestResult(indexedDB.open(name));
+  const transaction = database.transaction(INDEXEDDB_STORAGE_MANIFEST_STORE, "readwrite");
+  transaction
+    .objectStore(INDEXEDDB_STORAGE_MANIFEST_STORE)
+    .put(manifest, INDEXEDDB_STORAGE_MANIFEST_KEY);
+  await transactionDone(transaction);
+  database.close();
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () =>
+      reject(transaction.error ?? new Error("IndexedDB transaction failed"));
+    transaction.onabort = () =>
+      reject(transaction.error ?? new Error("IndexedDB transaction aborted"));
   });
 }

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -12,6 +12,8 @@ import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
 import type { Schema } from "../../src/drivers/types.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import {
+  INDEXEDDB_BTREE_METADATA_STORE,
+  INDEXEDDB_BTREE_PAGES_STORE,
   INDEXEDDB_STORAGE_MANIFEST,
   INDEXEDDB_STORAGE_MANIFEST_KEY,
   INDEXEDDB_STORAGE_MANIFEST_STORE,
@@ -300,10 +302,18 @@ describe("SharedWorker bridge with IndexedDB", () => {
   });
 
   it("keeps createDb schema-lazy but rejects the first local read when durable storage cannot open", async () => {
+    const ambientErrors: string[] = [];
+    const recordAmbientError = (event: ErrorEvent) => {
+      ambientErrors.push(event.error instanceof Error ? event.error.message : event.message);
+    };
+    globalThis.addEventListener("error", recordAmbientError);
+    errorListeners.add(recordAmbientError);
     const dbName = uniqueDbName("corrupt-storage-open");
+    const secret = generateAuthSecret();
     const initial = track(
       await createDb({
         appId: "test-app",
+        secret,
         driver: { type: "persistent", dbName },
       }),
     );
@@ -319,10 +329,12 @@ describe("SharedWorker bridge with IndexedDB", () => {
       ...INDEXEDDB_STORAGE_MANIFEST,
       storageEpoch: 2,
     });
+    const recordsBeforeRead = await rawStorageRecords(dbName);
 
     const reopened = track(
       await createDb({
         appId: "test-app",
+        secret,
         driver: { type: "persistent", dbName },
       }),
     );
@@ -335,6 +347,11 @@ describe("SharedWorker bridge with IndexedDB", () => {
         "corrupt storage read did not settle",
       ),
     ).rejects.toThrow("Missing or invalid IndexedDB storage epoch manifest");
+    await sleep(0);
+    expect(ambientErrors).toEqual([]);
+    expect(await rawStorageRecords(dbName)).toEqual(recordsBeforeRead);
+    globalThis.removeEventListener("error", recordAmbientError);
+    errorListeners.delete(recordAmbientError);
   });
 
   // -------------------------------------------------------------------------
@@ -2818,6 +2835,27 @@ async function replaceStorageManifest(name: string, manifest: unknown): Promise<
     .put(manifest, INDEXEDDB_STORAGE_MANIFEST_KEY);
   await transactionDone(transaction);
   database.close();
+}
+
+async function rawStorageRecords(name: string): Promise<Record<string, unknown>> {
+  const database = await requestResult(indexedDB.open(name));
+  const storeNames = [
+    INDEXEDDB_BTREE_PAGES_STORE,
+    INDEXEDDB_BTREE_METADATA_STORE,
+    INDEXEDDB_STORAGE_MANIFEST_STORE,
+  ];
+  const transaction = database.transaction(storeNames, "readonly");
+  const records = Object.fromEntries(
+    await Promise.all(
+      storeNames.map(async (storeName) => {
+        const store = transaction.objectStore(storeName);
+        return [storeName, await requestResult(store.getAll())] as const;
+      }),
+    ),
+  );
+  await transactionDone(transaction);
+  database.close();
+  return records;
 }
 
 function requestResult<T>(request: IDBRequest<T>): Promise<T> {

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
+import { createDb, Db, getDbSubscriptionSource, type QueryBuilder } from "../../src/runtime/db.js";
 import type { Schema } from "../../src/drivers/types.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import {
@@ -301,7 +301,7 @@ describe("SharedWorker bridge with IndexedDB", () => {
     expect(db).toBeInstanceOf(Db);
   });
 
-  it("keeps createDb schema-lazy but rejects the first local read when durable storage cannot open", async () => {
+  it("keeps createDb schema-lazy and rejects the first local subscription when durable storage cannot open", async () => {
     const ambientErrors: string[] = [];
     const unhandledRejections: string[] = [];
     const recordAmbientError = (event: ErrorEvent) => {
@@ -351,14 +351,34 @@ describe("SharedWorker bridge with IndexedDB", () => {
         }),
       );
       // `createDb` intentionally does not select a schema or open durable
-      // storage. The first schema-backed public operation owns the failure.
+      // storage. The first schema-backed subscription owns the failure. This
+      // assertion is intentionally synchronous: the old path published an
+      // empty local seed here before the worker attempted to open IndexedDB.
+      const cancelledDeltas: unknown[] = [];
+      const cancelled = getDbSubscriptionSource(reopened).subscribeDelta(
+        todos,
+        (delta) => cancelledDeltas.push(delta),
+        { tier: "local" },
+      );
+      cancelled();
+      const subscriptionDeltas: unknown[] = [];
+      const subscription = getDbSubscriptionSource(reopened).subscribeDelta(
+        todos,
+        (delta) => subscriptionDeltas.push(delta),
+        { tier: "local" },
+      );
+      expect(cancelledDeltas).toEqual([]);
+      expect(subscriptionDeltas).toEqual([]);
+      await expect(cancelled.ready ?? Promise.resolve()).resolves.toBeUndefined();
       await expect(
         withTimeout(
-          reopened.all(todos, { tier: "local" }),
+          subscription.ready ?? Promise.resolve(),
           5_000,
-          "corrupt storage read did not settle",
+          "corrupt storage subscription did not settle",
         ),
       ).rejects.toThrow("Missing or invalid IndexedDB storage epoch manifest");
+      expect(subscriptionDeltas).toEqual([]);
+      subscription();
       // The rejected operation leaves no durable peer to flush. Shutdown is
       // still an explicit observation point for the same readiness failure, not
       // an ambient error deferred to best-effort test cleanup.


### PR DESCRIPTION
🤖 Fixes #2339 and supplies complementary coverage for #2335.

## Before

createDb intentionally resolves before schema-backed IndexedDB opens. Point reads awaited worker readiness, but a newly attached local subscription could publish an empty seed first. Corrupt browser storage could therefore briefly look like a valid empty result before its structured open failure arrived.

The first readiness fix also exposed a deeper scheduler bug: bounding resident IVM work could leave direct/no-owner subscriptions incomplete, while an older storage-pending evaluation at the queue head could hide an unrelated later resident continuation. In real browser topologies this surfaced as “authorization hydration suspended outside an owner-loop subscription.”

## After

- Browser followers defer local seed publication and native subscription setup until worker readiness succeeds.
- Resident-only direct progress scans every queued evaluation for explicitly runnable CPU continuation work, so an older cold hydration cannot starve an independent resident subscription or write.
- Cold storage futures are never repolled merely because another direct operation starts.
- Only storage implementations that explicitly attest an executor-local eager retry may be retried without an owner; MemoryStorage does, while opaque/cold backends remain suspended for their durable runtime owner.
- Owner-attached polling remains bounded and preserves wake ownership and fairness.

## Examples

- A closed IndexedDB store with an unsupported epoch produces no subscription callback before the structured manifest error; cancellation before readiness performs no setup.
- A cold docs hydration may remain parked while a later recursive edges write drains and publishes its resident result.
- A no-owner maintained point subscription still materializes its seed before its caller immediately receives it.
- A self-woken cold storage request remains parked until the owner that installed its durable waker resumes it.

## Verification

- Real Chromium + SharedWorker + IndexedDB corrupt-manifest lifecycle, raw-record preservation, cancellation, and no ambient error.
- Full Groove library suite: 615/615.
- Mixed multiple-cold-head/resident-tail, recursive/cycle, direct no-owner, and owner-wake receipts.
- Exact Jazz maintained physical-point materialization and authorization regressions.
- Independent adversarial review with planted head-only/resident-scheduler regressions.