### PR TITLE
Safely reuse foreground node identities

### DIFF
--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -2485,6 +2485,33 @@ impl WasmDb {
         Ok(())
     }
 
+    /// Internal foreground-lease handoff boundary. Values cross the JS ABI as
+    /// BigInt, never lossy IEEE-754 numbers.
+    #[wasm_bindgen(js_name = foregroundTxTimeHighWater)]
+    pub fn foreground_tx_time_high_water(&self) -> Result<u64, JsValue> {
+        match &self.inner {
+            WasmDbInner::Memory(db) => Ok(block_on(db.foreground_tx_time_high_water()).0),
+            #[cfg(target_arch = "wasm32")]
+            WasmDbInner::Browser(db) => Ok(block_on(db.foreground_tx_time_high_water()).0),
+            WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
+        }
+    }
+
+    /// Internal foreground-lease bootstrap boundary. The worker-owned lease
+    /// metadata has already validated this HLC value; this simply merges it
+    /// into the native runtime before the first local transaction is minted.
+    #[wasm_bindgen(js_name = seedForegroundTxTimeHighWater)]
+    pub fn seed_foreground_tx_time_high_water(&self, high_water: u64) -> Result<(), JsValue> {
+        let high_water = jazz::time::TxTime(high_water);
+        match &self.inner {
+            WasmDbInner::Memory(db) => block_on(db.seed_foreground_tx_time_high_water(high_water)),
+            #[cfg(target_arch = "wasm32")]
+            WasmDbInner::Browser(db) => block_on(db.seed_foreground_tx_time_high_water(high_water)),
+            WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
+        }
+        Ok(())
+    }
+
     #[wasm_bindgen(js_name = setRelayAuthoritySessionOwner)]
     pub fn set_relay_authority_session_owner(&self) -> Result<(), JsValue> {
         match &self.inner {

--- a/crates/jazz/SPEC/19_native_relays.md
+++ b/crates/jazz/SPEC/19_native_relays.md
@@ -45,7 +45,13 @@ identities are derived inside the host from the admitted author and a fresh
 process-local node handle. Reusing a scope with a different path, schema, or
 identity fails. Trusted logout revokes the capability and atomically closes all
 relay/client aliases opened through it; guessed and revoked capabilities cannot
-open a scope. Tokens belong to upstream session negotiation. Logout also
+open a scope. Each attached UI client owns one exclusive foreground-node lease
+before it can mint a transaction. A clean detach reads the client runtime's
+complete minted-HLC high-water through the native core, atomically persists it
+while the lease remains active, and only then returns that node to the relay's
+reusable pool. A crash, failed readout/persistence, forced close, or other
+uncertain detach retires the node permanently; no expiry or handle-derived node
+may make it reusable. Tokens belong to upstream session negotiation. Logout also
 chooses either
 retention or deletion through a separate, user-visible storage-lifecycle API.
 No current host may reuse a relay after an auth-scope change.

--- a/crates/jazz/SPEC/2_data_model_identity.md
+++ b/crates/jazz/SPEC/2_data_model_identity.md
@@ -86,9 +86,21 @@ reusable. A failed readout, failed persistence, crash, forced shutdown, or
 lost peer is an uncertain termination: the node is retired permanently. There
 is no lease expiry, central transaction minting, fencing generation, or range
 allocation in this model. The
-An `AuthorSubject` is instead the exact canonical JSON string `[iss,sub]`; its
+`AuthorSubject` is instead the exact canonical JSON string `[iss,sub]`; its
 in-memory intern is never durable or portable. The well-known
 `AuthorSubject::SYSTEM` string passes all policies (ch. 7, `INV-DATA-3`).
+
+Hosts mediate this contract rather than making a relay mint transaction ids.
+The browser's durable SharedWorker owns the foreground-lease pool for its
+physical IndexedDB replica and gives each attached tab a separate lease over a
+dedicated port. A persistent Node foreground owner keeps its pool under the
+current working directory, namespaced by app, environment, and auth scope;
+exclusive state and per-node lock files serialize multiple processes in that
+same working directory. A dead or ambiguous lock owner retires its dirty node,
+never lends it to a later process. Explicit memory-mode runtimes deliberately
+create no filesystem lease state and receive a fresh in-memory node instead.
+Those are host adapters for the same lease contract, not alternate TxId
+formats or durability semantics.
 
 Storage may use compact local aliases without changing the wire identity model.
 Each node interns `NodeUuid` and `SchemaVersionId` to local `u64` aliases

--- a/crates/jazz/SPEC/2_data_model_identity.md
+++ b/crates/jazz/SPEC/2_data_model_identity.md
@@ -80,12 +80,16 @@ zero high-water or a node returned by a prior _clean_ handoff together with the
 exact HLC high-water reported by that runtime's native core. The runtime must
 seed its HLC at or above that high-water, and the high-water includes every
 minted transaction, including one later rolled back or never submitted. On
-clean shutdown the host reads that value from the native/Wasm runtime and
-atomically persists it while the lease is still active before making the node
-reusable. A failed readout, failed persistence, crash, forced shutdown, or
-lost peer is an uncertain termination: the node is retired permanently. There
-is no lease expiry, central transaction minting, fencing generation, or range
-allocation in this model. The
+clean shutdown the host first closes mutation admission and drains any
+already-started synchronous, asynchronous, and streaming write work; only then
+may it capture the native/Wasm high-water. It atomically persists
+`max(previous durable floor, captured high-water)` while the lease is still
+active before making the node reusable. A failed readout, failed persistence,
+crash, forced shutdown, or lost peer is an uncertain termination: the node is
+retired permanently. High-waters are canonical packed-HLC `u64`s; hosts reject
+out-of-range receipts rather than allowing a persisted value to poison a later
+native open. There is no lease expiry, central transaction minting, fencing
+generation, or range allocation in this model. The
 `AuthorSubject` is instead the exact canonical JSON string `[iss,sub]`; its
 in-memory intern is never durable or portable. The well-known
 `AuthorSubject::SYSTEM` string passes all policies (ch. 7, `INV-DATA-3`).
@@ -95,9 +99,14 @@ The browser's durable SharedWorker owns the foreground-lease pool for its
 physical IndexedDB replica and gives each attached tab a separate lease over a
 dedicated port. A persistent Node foreground owner keeps its pool under the
 current working directory, namespaced by app, environment, and auth scope;
-exclusive state and per-node lock files serialize multiple processes in that
-same working directory. A dead or ambiguous lock owner retires its dirty node,
-never lends it to a later process. Explicit memory-mode runtimes deliberately
+exclusive state as a per-node O_EXCL active claim plus a separate durable
+per-node reusable high-water receipt. A claimant creates its active claim
+before reading a reusable receipt; it never deletes or reclaims an unknown
+active claim. A clean handoff fsyncs the replacement receipt, fsyncs its
+directory, removes only its own active claim, and fsyncs that directory again.
+Thus a crash before claim removal permanently quarantines that node; even a
+random allocation collision with a reusable receipt must inherit that receipt's
+floor. Explicit memory-mode runtimes deliberately
 create no filesystem lease state and receive a fresh in-memory node instead.
 Those are host adapters for the same lease contract, not alternate TxId
 formats or durability semantics.

--- a/crates/jazz/SPEC/2_data_model_identity.md
+++ b/crates/jazz/SPEC/2_data_model_identity.md
@@ -17,7 +17,7 @@ Invariant digest:
 - `INV-DATA-2`: `NodeAlias` and `SchemaVersionAlias` MUST be node-local storage aliases allocated in `jazz_nodes` and `jazz_schema_versions`; all egress from stored rows MUST resolve aliases back to `NodeUuid` and `SchemaVersionId`.
 - `INV-DATA-3`: `AuthorSubject::SYSTEM` MUST have the exact portable value `["urn:jazz:system","system"]`, and no authenticated user may claim the reserved system issuer.
 - `INV-DATA-4`: `TxTime` MUST encode physical milliseconds in the high 46 bits and a logical counter in the low 18 bits. Its unsigned packed order is its canonical ordering. Its internal allocator MUST advance the physical component on logical exhaustion and return a typed overflow only after exhausting the final packed value.
-- `INV-DATA-5`: A `TxId` MUST identify a transaction as `(time: TxTime, node: NodeUuid)`; each concurrently transaction-issuing physical replica MUST have a distinct `NodeUuid`, established before it mints any transaction and retained across that replica's reopen; stored transaction rows MUST use primary key `(time, node_id)` where `node_id` is the local alias for the wire `NodeUuid`.
+- `INV-DATA-5`: A `TxId` MUST identify a transaction as `(time: TxTime, node: NodeUuid)`; each concurrently transaction-issuing runtime MUST hold one exclusive `NodeUuid` before it mints, and a node may be reused only after an explicit clean handoff durably records that runtime's complete minted-HLC high-water; a failed, dropped, or otherwise uncertain lease is permanently retired. Stored transaction rows MUST use primary key `(time, node_id)` where `node_id` is the local alias for the wire `NodeUuid`.
 - `INV-DATA-6`: `SchemaVersionId` MUST be UUIDv5 over `JazzSchema::canonical_bytes()` in namespace `SCHEMA_VERSION_NAMESPACE`.
 - `INV-DATA-7`: Canonical schema identity MUST change when a column's `MergeStrategy` changes.
 - `INV-DATA-9`: A declared `MergeStrategy::Counter` MUST be accepted only on non-nullable integer columns. Public `Integer` and `BigInt` columns lower to `I32` and `I64`; internal schemas may use `U8`, `U16`, `U32`, `U64`, `I32`, or `I64`.
@@ -66,12 +66,26 @@ distinct packed HLC newtype `GlobalTime` (ch. 3–4). A transaction id combines 
 packed hybrid logical clock (`TxTime`,
 physical milliseconds plus a logical counter) with the writing node; the
 transaction is identified and tie-broken by both values (`INV-DATA-5`). Node
-identity is a physical-replica identity, not an app, account, author, database
-name, or worker-name derivation: two independent durable replicas may share all
-of those logical values but must still use distinct nodes, because equal HLC
-times would otherwise name the same transaction. A durable replica loads its
-node before minting and retains it across reopen so recovery and at-least-once
-delivery can recognize its own transactions. The
+identity is neither an app, account, author, database-name, nor worker-name
+derivation. Two independent durable replicas may share all of those logical
+values but must still use distinct durable-owner nodes, because equal HLC times
+would otherwise name the same transaction. A durable replica loads its node
+before minting and retains it across reopen so recovery and at-least-once
+delivery can recognize its own transactions.
+
+A foreground runtime is a separate live transaction issuer, even when it is
+paired with a durable relay. Its host gives it an exclusive foreground-node
+lease before its first write. The lease starts with either a new CSPRNG node and
+zero high-water or a node returned by a prior _clean_ handoff together with the
+exact HLC high-water reported by that runtime's native core. The runtime must
+seed its HLC at or above that high-water, and the high-water includes every
+minted transaction, including one later rolled back or never submitted. On
+clean shutdown the host reads that value from the native/Wasm runtime and
+atomically persists it while the lease is still active before making the node
+reusable. A failed readout, failed persistence, crash, forced shutdown, or
+lost peer is an uncertain termination: the node is retired permanently. There
+is no lease expiry, central transaction minting, fencing generation, or range
+allocation in this model. The
 An `AuthorSubject` is instead the exact canonical JSON string `[iss,sub]`; its
 in-memory intern is never durable or portable. The well-known
 `AuthorSubject::SYSTEM` string passes all policies (ch. 7, `INV-DATA-3`).

--- a/crates/jazz/SPEC/9_topology_edge.md
+++ b/crates/jazz/SPEC/9_topology_edge.md
@@ -122,7 +122,10 @@ is distinct from a foreground replica/node ID, which remains per live client,
 and from credentials, which are never persisted as the ownership marker.
 
 The main-thread client is deliberately non-durable: its authored transactions
-start at `Pending`/`None`. The worker relay persists the unchanged commit unit and
+start at `Pending`/`None`. Each live foreground owns an exclusive leased
+`NodeUuid` and mints its own transaction identities locally; its clean handoff
+may reuse that identity only after the worker durably records the runtime-owned
+HLC high-water, while an unclean termination retires it. The worker relay persists the unchanged commit unit and
 returns `Pending`/`Local`; that durability acknowledgement does not assign fate.
 The relay forwards later Edge/Global durability and authority fates back over the
 same client-worker link. A worker without an upstream can therefore satisfy

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -1,6 +1,7 @@
 //! Database construction, schema views, write-state waiting, and connection controls.
 
 use super::*;
+use crate::time::TxTime;
 
 impl<S> Db<S>
 where
@@ -422,6 +423,27 @@ where
     /// writes begin.
     pub fn set_non_durable_client(&self) {
         self.node.set_non_durable_client();
+    }
+
+    /// Return the highest transaction HLC observed by this live runtime.
+    ///
+    /// This narrow internal lifecycle boundary is used by foreground lease
+    /// adapters during clean handoff. It is deliberately not a public query or
+    /// application clock API.
+    #[doc(hidden)]
+    pub async fn foreground_tx_time_high_water(&self) -> TxTime {
+        self.node.node.lock().await.tx_time_high_water()
+    }
+
+    /// Seed a foreground runtime from the durable lease owner's last confirmed
+    /// high-water mark before it mints any transaction identities.
+    #[doc(hidden)]
+    pub async fn seed_foreground_tx_time_high_water(&self, high_water: TxTime) {
+        self.node
+            .node
+            .lock()
+            .await
+            .seed_tx_time_high_water(high_water);
     }
 
     /// Configure this durable process as the internal browser relay that owns

--- a/crates/jazz/src/db/tests/lifecycle.rs
+++ b/crates/jazz/src/db/tests/lifecycle.rs
@@ -75,3 +75,41 @@ fn db_close_is_idempotent() {
     doctest_support::block_on(db.close()).unwrap();
     doctest_support::block_on(db.close()).unwrap();
 }
+
+#[test]
+fn foreground_handoff_high_water_includes_an_unsubmitted_public_write() {
+    // This lifecycle-only receipt deliberately reaches the hidden handoff
+    // boundary: applications cannot query or seed a runtime HLC. The write is
+    // otherwise public and has no upstream, so it proves a clean lease return
+    // covers a TxId that was minted locally but never submitted.
+    let first = doctest_support::block_on(doctest_support::open_todos_db()).unwrap();
+    let floor = TxTime::new(1_000_000, 17);
+    doctest_support::block_on(first.seed_foreground_tx_time_high_water(floor));
+
+    let first_write = first
+        .insert(
+            "todos",
+            doctest_support::todo_cells("unsubmitted foreground write", false),
+            Default::default(),
+        )
+        .unwrap();
+    let first_tx = first_write.mergeable_tx_id();
+    assert!(first_tx.time > floor);
+    assert_eq!(
+        doctest_support::block_on(first.foreground_tx_time_high_water()),
+        first_tx.time
+    );
+
+    // A later owner of the same node begins strictly above every identity the
+    // prior runtime allocated, even when its wall clock has not advanced.
+    let second = doctest_support::block_on(doctest_support::open_todos_db()).unwrap();
+    doctest_support::block_on(second.seed_foreground_tx_time_high_water(first_tx.time));
+    let second_write = second
+        .insert(
+            "todos",
+            doctest_support::todo_cells("continued foreground write", false),
+            Default::default(),
+        )
+        .unwrap();
+    assert!(second_write.mergeable_tx_id().time > first_tx.time);
+}

--- a/crates/jazz/src/foreground_node_lease.rs
+++ b/crates/jazz/src/foreground_node_lease.rs
@@ -1,0 +1,163 @@
+//! Exclusive foreground transaction-node leases.
+//!
+//! Hosts own persistence and random allocation. This small core state machine
+//! only makes the safety boundary explicit: an active node cannot be issued
+//! twice; only a clean runtime-owned HLC handoff makes it reusable; every
+//! uncertain lease is permanently retired for this host lifetime.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::ids::NodeUuid;
+use crate::time::TxTime;
+
+/// A node identity exclusively issued to one live foreground runtime.
+///
+/// `confirmed_tx_time` is the high-water mark reported by the runtime that
+/// minted with this identity. It covers every minted transaction, including a
+/// transaction that was rolled back or never submitted upstream.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ForegroundNodeLease {
+    /// The wire-stable transaction-node identity.
+    pub node: NodeUuid,
+    /// The runtime-confirmed HLC high-water mark for `node`.
+    pub confirmed_tx_time: TxTime,
+}
+
+/// Failed foreground-node lease state transitions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ForegroundNodeLeaseError {
+    /// An allocator attempted to issue an identity that is still live, ready
+    /// for reuse, or permanently retired.
+    #[error("foreground node identity is already known to this lease pool")]
+    DuplicateNode,
+    /// A clean handoff or retirement did not name the currently active lease.
+    #[error("foreground node lease is not active")]
+    InactiveLease,
+}
+
+/// Host-owned lifecycle state for foreground transaction-node identities.
+///
+/// This type deliberately has no clock, storage, process, or random source.
+/// An adapter persists its state atomically around [`Self::clean_handoff`] and
+/// supplies fresh CSPRNG node identities to [`Self::acquire_fresh`]. A host may
+/// reuse only a lease returned after it has durably recorded the exact HLC
+/// high-water reported by the native runtime; otherwise it calls
+/// [`Self::retire`] and that identity is never issued again by this pool.
+#[derive(Debug, Default)]
+pub struct ForegroundNodeLeasePool {
+    reusable: BTreeMap<NodeUuid, TxTime>,
+    active: BTreeSet<NodeUuid>,
+    retired: BTreeSet<NodeUuid>,
+}
+
+impl ForegroundNodeLeasePool {
+    /// Acquire one previously cleanly returned lease, if any.
+    pub fn acquire_reusable(&mut self) -> Option<ForegroundNodeLease> {
+        let (node, confirmed_tx_time) = self
+            .reusable
+            .iter()
+            .next()
+            .map(|(node, high_water)| (*node, *high_water))?;
+        let removed = self.reusable.remove(&node);
+        debug_assert_eq!(removed, Some(confirmed_tx_time));
+        let inserted = self.active.insert(node);
+        debug_assert!(inserted);
+        Some(ForegroundNodeLease {
+            node,
+            confirmed_tx_time,
+        })
+    }
+
+    /// Issue a never-before-seen identity to one live foreground runtime.
+    pub fn acquire_fresh(
+        &mut self,
+        node: NodeUuid,
+    ) -> Result<ForegroundNodeLease, ForegroundNodeLeaseError> {
+        if self.active.contains(&node)
+            || self.reusable.contains_key(&node)
+            || self.retired.contains(&node)
+        {
+            return Err(ForegroundNodeLeaseError::DuplicateNode);
+        }
+        let inserted = self.active.insert(node);
+        debug_assert!(inserted);
+        Ok(ForegroundNodeLease {
+            node,
+            confirmed_tx_time: TxTime::default(),
+        })
+    }
+
+    /// Mark an active lease reusable after the adapter has durably persisted
+    /// this runtime-owned high-water mark.
+    ///
+    /// Callers must never construct this from JavaScript input. A failed native
+    /// readout or failed persistence is an uncertain termination and must use
+    /// [`Self::retire`] instead.
+    pub fn clean_handoff(
+        &mut self,
+        lease: ForegroundNodeLease,
+    ) -> Result<(), ForegroundNodeLeaseError> {
+        if !self.active.remove(&lease.node) {
+            return Err(ForegroundNodeLeaseError::InactiveLease);
+        }
+        let replaced = self.reusable.insert(lease.node, lease.confirmed_tx_time);
+        debug_assert!(replaced.is_none());
+        Ok(())
+    }
+
+    /// Permanently retire an active identity after unclean or uncertain end of
+    /// life. Retired identities are never reused by this pool.
+    pub fn retire(&mut self, lease: ForegroundNodeLease) -> Result<(), ForegroundNodeLeaseError> {
+        if !self.active.remove(&lease.node) {
+            return Err(ForegroundNodeLeaseError::InactiveLease);
+        }
+        let inserted = self.retired.insert(lease.node);
+        debug_assert!(inserted);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(value: u8) -> NodeUuid {
+        NodeUuid::from_bytes([value; 16])
+    }
+
+    #[test]
+    fn reuses_only_a_cleanly_returned_runtime_high_water() {
+        let mut pool = ForegroundNodeLeasePool::default();
+        let lease = pool.acquire_fresh(node(1)).unwrap();
+        pool.clean_handoff(ForegroundNodeLease {
+            confirmed_tx_time: TxTime(99),
+            ..lease
+        })
+        .unwrap();
+
+        assert_eq!(
+            pool.acquire_reusable(),
+            Some(ForegroundNodeLease {
+                node: node(1),
+                confirmed_tx_time: TxTime(99),
+            })
+        );
+    }
+
+    #[test]
+    fn unclean_lease_is_retired_and_cannot_be_reissued() {
+        let mut pool = ForegroundNodeLeasePool::default();
+        let lease = pool.acquire_fresh(node(2)).unwrap();
+        pool.retire(lease).unwrap();
+
+        assert_eq!(pool.acquire_reusable(), None);
+        assert_eq!(
+            pool.acquire_fresh(node(2)),
+            Err(ForegroundNodeLeaseError::DuplicateNode)
+        );
+        assert_eq!(
+            pool.clean_handoff(lease),
+            Err(ForegroundNodeLeaseError::InactiveLease)
+        );
+    }
+}

--- a/crates/jazz/src/lib.rs
+++ b/crates/jazz/src/lib.rs
@@ -448,6 +448,8 @@ pub mod binding_codec;
 pub mod cold_settle_attribution;
 /// High-level thread-affine database facade.
 pub mod db;
+/// Host-facing exclusive lifecycle for foreground transaction-node identities.
+pub mod foreground_node_lease;
 /// Poll ready-immediate database futures without an async runtime.
 pub use db::block_on;
 /// Wire-stable identifiers.

--- a/crates/jazz/src/node/state/lifecycle.rs
+++ b/crates/jazz/src/node/state/lifecycle.rs
@@ -701,6 +701,21 @@ where
         self.node_uuid
     }
 
+    /// Highest HLC value this runtime has observed or minted.
+    ///
+    /// A foreground lease owner persists this value before returning a node
+    /// identity to its pool.  It intentionally includes identities allocated
+    /// for transactions that were later rolled back or never submitted.
+    pub(crate) fn tx_time_high_water(&self) -> TxTime {
+        self.clock.tx_time
+    }
+
+    /// Establish a durable-owner supplied lower bound before this runtime can
+    /// mint its first transaction identity.
+    pub(crate) fn seed_tx_time_high_water(&mut self, high_water: TxTime) {
+        self.merge_tx_time(high_water);
+    }
+
     pub(crate) fn authored_commit_durability(&self) -> DurabilityTier {
         self.authored_commit_durability
     }

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -5,6 +5,7 @@ import { getTrustedReservedSession, setTrustedReservedSession } from "../db-inte
 import type { BrowserWorkerConnection } from "../runtime-source.js";
 import { reloadAfterStorageInvalidation } from "../browser-storage-invalidation.js";
 import { runCleanupSteps } from "../run-cleanup-steps.js";
+import { NativeRuntimeAdapter } from "../native-runtime/native-runtime-adapter.js";
 import {
   ConnectionManager,
   type ConnectionManagerClientInput,
@@ -32,7 +33,14 @@ export class BrowserConnectionManager extends ConnectionManager {
     super(host);
   }
 
-  async start(): Promise<void> {}
+  async start(): Promise<void> {
+    // This resolves before public Db construction returns, preserving the
+    // synchronous application mutation API while leasing the TxId node before
+    // the foreground runtime can exist or mint a transaction.
+    this.foregroundNodeLease = await this.host.runtimeSource.acquireBrowserForegroundNodeLease(
+      this.host.config,
+    );
+  }
 
   protected override onClientCreated({ schema, client }: ConnectionManagerClientInput): void {
     const workerConfig = { ...this.host.config };
@@ -213,12 +221,31 @@ export class BrowserConnectionManager extends ConnectionManager {
     const unregisterInspectorControl = this.unregisterInspectorControl;
     this.unregisterInspectorControl = null;
 
+    const lease = this.foregroundNodeLease;
+    this.foregroundNodeLease = undefined;
+    const client = this.getCurrentClient();
     await runCleanupSteps([
       () => unregisterInspectorControl?.(),
       // A rejected physical-root admission created no follower and therefore
       // has nothing to flush. Shutdown remains idempotent after a caller has
       // already received that operation-level error.
       () => (admissionFailed ? undefined : connection?.flushLocal()),
+      async () => {
+        if (!lease) return;
+        // The native value includes identities minted for rolled-back and
+        // unsubmitted writes. Any failure in this readout or its atomic worker
+        // persistence retires the node rather than risking reuse.
+        try {
+          const runtime = client?.getRuntime();
+          if (!runtime || !(runtime instanceof NativeRuntimeAdapter)) {
+            await lease.retire();
+            return;
+          }
+          await lease.returnWithHighWater(runtime.foregroundTxTimeHighWater());
+        } catch {
+          await lease.retire().catch(() => undefined);
+        }
+      },
       () => {
         // The tab runtime is explicitly non-durable; once its worker peer has
         // flushed, graceful evaluator teardown cannot add durability and may wait

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -237,7 +237,12 @@ export class BrowserConnectionManager extends ConnectionManager {
         // persistence retires the node rather than risking reuse.
         try {
           const runtime = client?.getRuntime();
-          if (!runtime || !(runtime instanceof NativeRuntimeAdapter)) {
+          if (!runtime) {
+            // No foreground client existed, hence no transaction identity was
+            // minted after the lease was acquired.
+            await lease.returnWithHighWater(lease.confirmedTxTime);
+            return;
+          } else if (!(runtime instanceof NativeRuntimeAdapter)) {
             await lease.retire();
             return;
           }

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -246,7 +246,7 @@ export class BrowserConnectionManager extends ConnectionManager {
             await lease.retire();
             return;
           }
-          await lease.returnWithHighWater(runtime.foregroundTxTimeHighWater());
+          await lease.returnWithHighWater(await runtime.quiesceForegroundTxTimeHighWater());
         } catch {
           await lease.retire().catch(() => undefined);
         }

--- a/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
@@ -1,4 +1,5 @@
 import type { DurabilityTier } from "../client.js";
+import { NativeRuntimeAdapter } from "../native-runtime/native-runtime-adapter.js";
 import {
   ConnectionManager,
   type ConnectionManagerClientInput,
@@ -15,7 +16,39 @@ export class DirectConnectionManager extends ConnectionManager {
     super(host);
   }
 
-  async start(): Promise<void> {}
+  async start(): Promise<void> {
+    // Node foreground clients use the same pre-runtime lease contract as
+    // browser tabs. This preserves the synchronous mutation API after Db
+    // creation while no live process can mint under an unleased node.
+    this.foregroundNodeLease = await this.host.runtimeSource.acquireForegroundNodeLease(
+      this.host.config,
+    );
+  }
+
+  override async shutdown(): Promise<void> {
+    const lease = this.foregroundNodeLease;
+    this.foregroundNodeLease = undefined;
+    const client = this.getCurrentClient();
+    try {
+      if (lease) {
+        const runtime = client?.getRuntime();
+        if (!runtime) {
+          // No schema client was ever materialized, so no local TxId could
+          // have been minted. Returning the confirmed prior high-water is a
+          // complete clean handoff, not an uncertain retirement.
+          await lease.returnWithHighWater(lease.confirmedTxTime);
+        } else if (!(runtime instanceof NativeRuntimeAdapter)) {
+          await lease.retire();
+        } else {
+          await lease.returnWithHighWater(runtime.foregroundTxTimeHighWater());
+        }
+      }
+    } catch {
+      await lease?.retire().catch(() => undefined);
+    } finally {
+      await super.shutdown();
+    }
+  }
 
   protected override onClientCreated({ client }: ConnectionManagerClientInput): void {
     if (this.isDisconnected) {

--- a/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/direct-connection-manager.ts
@@ -40,7 +40,7 @@ export class DirectConnectionManager extends ConnectionManager {
         } else if (!(runtime instanceof NativeRuntimeAdapter)) {
           await lease.retire();
         } else {
-          await lease.returnWithHighWater(runtime.foregroundTxTimeHighWater());
+          await lease.returnWithHighWater(await runtime.quiesceForegroundTxTimeHighWater());
         }
       }
     } catch {

--- a/packages/jazz-tools/src/runtime/connection-manager/types.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/types.ts
@@ -3,7 +3,7 @@ import type { WasmSchema } from "../../drivers/types.js";
 import type { DurabilityTier, JazzClient, MutationErrorEvent } from "../client.js";
 import type { Session } from "../context.js";
 import type { DbConfig } from "../db.js";
-import type { RuntimeSource } from "../runtime-source.js";
+import type { BrowserForegroundNodeLease, RuntimeSource } from "../runtime-source.js";
 import { resolveTelemetryCollectorUrlFromEnv } from "../sync-telemetry.js";
 import type { AuthFailureReason } from "../auth-state.js";
 import { getTrustedReservedSession, setTrustedReservedSession } from "../db-internal-session.js";
@@ -62,6 +62,9 @@ export abstract class ConnectionManager {
   private clientSchema: WasmSchema | null = null;
   private disposeRuntimeTelemetry: (() => void) | null = null;
 
+  /** Browser managers set this during their asynchronous bootstrap. */
+  protected foregroundNodeLease: BrowserForegroundNodeLease | undefined;
+
   protected constructor(protected readonly host: DbForConnection) {}
 
   abstract start(): Promise<void>;
@@ -94,6 +97,7 @@ export abstract class ConnectionManager {
       config: runtimeConfig,
       schema: runtimeSchema,
       onAuthFailure: (reason) => this.host.markUnauthenticated(reason),
+      foregroundNodeLease: this.foregroundNodeLease,
     });
     client.onMutationError((event) => this.host.onMutationError(event));
 

--- a/packages/jazz-tools/src/runtime/connection-manager/types.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/types.ts
@@ -3,7 +3,7 @@ import type { WasmSchema } from "../../drivers/types.js";
 import type { DurabilityTier, JazzClient, MutationErrorEvent } from "../client.js";
 import type { Session } from "../context.js";
 import type { DbConfig } from "../db.js";
-import type { BrowserForegroundNodeLease, RuntimeSource } from "../runtime-source.js";
+import type { ForegroundNodeLease, RuntimeSource } from "../runtime-source.js";
 import { resolveTelemetryCollectorUrlFromEnv } from "../sync-telemetry.js";
 import type { AuthFailureReason } from "../auth-state.js";
 import { getTrustedReservedSession, setTrustedReservedSession } from "../db-internal-session.js";
@@ -63,7 +63,7 @@ export abstract class ConnectionManager {
   private disposeRuntimeTelemetry: (() => void) | null = null;
 
   /** Browser managers set this during their asynchronous bootstrap. */
-  protected foregroundNodeLease: BrowserForegroundNodeLease | undefined;
+  protected foregroundNodeLease: ForegroundNodeLease | undefined;
 
   protected constructor(protected readonly host: DbForConnection) {}
 

--- a/packages/jazz-tools/src/runtime/db.browser-mode.test.ts
+++ b/packages/jazz-tools/src/runtime/db.browser-mode.test.ts
@@ -40,7 +40,10 @@ describe("createDb browser mode", () => {
     (globalThis as Record<string, unknown>).Worker = class {};
 
     const createdDb = {} as Db;
-    const createSpy = vi.spyOn(Db, "create").mockReturnValue(createdDb);
+    // Direct creation is now asynchronous so a Node foreground lease can be
+    // acquired before any runtime is materialized. Memory-mode browser Dbs
+    // still use that direct (non-worker) path, but do not acquire a lease.
+    const createSpy = vi.spyOn(Db, "createWithDirectConnection").mockResolvedValue(createdDb);
 
     const result = await createDb({
       appId: "driver-mode-memory",

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1603,6 +1603,16 @@ export class Db {
     return new Db(config, runtimeSource);
   }
 
+  /** @internal Create a direct Db after its pre-runtime identity bootstrap. */
+  static async createWithDirectConnection(
+    config: DbConfig,
+    runtimeSource: AnyRuntimeSource,
+  ): Promise<Db> {
+    const db = new Db(config, runtimeSource);
+    await db.connection.start();
+    return db;
+  }
+
   /** @internal Create a Db whose durable peer lives in a dedicated browser worker. */
   static async createWithBrowserWorker(
     config: DbConfig,
@@ -2818,7 +2828,7 @@ export async function createDbWithRuntimeSource<RuntimeConfig extends DbConfig>(
   const db =
     runtimeSource.supportsBrowserWorker && isBrowserRuntime() && driver.type === "persistent"
       ? await Db.createWithBrowserWorker(resolvedConfig, runtimeSource as AnyRuntimeSource)
-      : Db.create(resolvedConfig, runtimeSource as AnyRuntimeSource);
+      : await Db.createWithDirectConnection(resolvedConfig, runtimeSource as AnyRuntimeSource);
 
   if (localFirstSecret) {
     db.initLocalFirstAuth(localFirstSecret, 3600, !config.jwtToken);

--- a/packages/jazz-tools/src/runtime/default-runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/default-runtime-source.ts
@@ -220,12 +220,14 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
       selfSignedClientProof,
       backendMode,
     );
+    if (foregroundNodeLease) {
+      mainThreadPeerRuntime.seedForegroundTxTimeHighWater(foregroundNodeLease.confirmedTxTime);
+    }
     if (browserMode) {
       mainThreadPeerRuntime.setNonDurableClient();
       if (!foregroundNodeLease) {
         throw new Error("Persistent browser runtime requires a foreground node lease");
       }
-      mainThreadPeerRuntime.seedForegroundTxTimeHighWater(foregroundNodeLease.confirmedTxTime);
     }
 
     const context: AppContext = {
@@ -252,6 +254,22 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
       runtimeSources: browserWorkerRuntimeSources(config),
       dbName,
       authSessionKey: createBrowserAuthSessionKey(config),
+    });
+  }
+
+  override async acquireForegroundNodeLease(config: DbConfig) {
+    if (!isNodeRuntime() || (config.driver?.type ?? "persistent") !== "persistent") {
+      return undefined;
+    }
+    // This guarded dynamic import keeps Node filesystem code out of the path
+    // executed by browser/RN bundles while remaining visible to Node test and
+    // package tooling.
+    const { acquireNodeForegroundNodeLease } =
+      await import("./native-runtime/node-foreground-node-lease.js");
+    return await acquireNodeForegroundNodeLease({
+      appId: config.appId,
+      env: config.env ?? "dev",
+      authScope: createBrowserAuthSessionKey(config),
     });
   }
 
@@ -416,6 +434,10 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
 
 function isBrowserRuntime(): boolean {
   return typeof window !== "undefined" && typeof Worker !== "undefined";
+}
+
+function isNodeRuntime(): boolean {
+  return typeof process !== "undefined" && Boolean(process.versions?.node);
 }
 
 function isPersistentBrowserConfig(config: DbConfig): boolean {

--- a/packages/jazz-tools/src/runtime/default-runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/default-runtime-source.ts
@@ -19,7 +19,10 @@ import {
 } from "./runtime-source.js";
 import { NativeRuntimeAdapter } from "./native-runtime/native-runtime-adapter.js";
 import type { NativeSelfSignedClientProof } from "./native-runtime/native-codec.js";
-import { SharedBrowserWorkerConnection } from "./native-runtime/browser-shared-worker-connection.js";
+import {
+  SharedBrowserForegroundNodeLease,
+  SharedBrowserWorkerConnection,
+} from "./native-runtime/browser-shared-worker-connection.js";
 import { AttachedBrowserWorkerConnection } from "./native-runtime/attached-browser-worker-connection.js";
 import { MessagePortBrowserFollowerConnection } from "./native-runtime/browser-follower-connection.js";
 import { installWasmTelemetry } from "./sync-telemetry.js";
@@ -188,6 +191,7 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
     config,
     schema,
     onAuthFailure,
+    foregroundNodeLease,
   }: RuntimeClientContext<DbConfig>): JazzClient {
     setGlobalWasmLogLevel(config.logLevel);
 
@@ -203,7 +207,7 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
     // identity. Reusing a deterministic node across independently opened tabs
     // would let their fresh HLC registers mint the same TxId before either has
     // observed the other's first commit.
-    const node = randomBytes();
+    const node = foregroundNodeLease?.node.slice() ?? randomBytes();
     const author = authorBytesForSession(runtimeAuthorFromConfig(config));
     const flushEvery = initialSyncFlushEvery(config);
     const browserMode = isPersistentBrowserConfig(config);
@@ -218,6 +222,10 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
     );
     if (browserMode) {
       mainThreadPeerRuntime.setNonDurableClient();
+      if (!foregroundNodeLease) {
+        throw new Error("Persistent browser runtime requires a foreground node lease");
+      }
+      mainThreadPeerRuntime.seedForegroundTxTimeHighWater(foregroundNodeLease.confirmedTxTime);
     }
 
     const context: AppContext = {
@@ -233,6 +241,18 @@ export class DefaultRuntimeSource extends RuntimeSource<DbConfig> {
     };
     setTrustedReservedSession(context, getTrustedReservedSession(config));
     return JazzClient.connectWithRuntime(mainThreadPeerRuntime, context, runtimeOptions);
+  }
+
+  override async acquireBrowserForegroundNodeLease(config: DbConfig) {
+    if (!isPersistentBrowserConfig(config)) {
+      throw new Error("Browser foreground node leases require persistent browser storage");
+    }
+    const dbName = resolveDefaultPersistentDbName(config);
+    return await SharedBrowserForegroundNodeLease.acquire({
+      runtimeSources: browserWorkerRuntimeSources(config),
+      dbName,
+      authSessionKey: createBrowserAuthSessionKey(config),
+    });
   }
 
   override createBrowserWorkerConnection({

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
@@ -323,6 +323,37 @@ describe("IndexedDbPageStore", () => {
     }
   });
 
+  it("leases distinct foreground nodes concurrently and reuses only a clean handoff", async () => {
+    const name = databaseName();
+    const store = await IndexedDbPageStore.open(name);
+    const [first, second] = await Promise.all([
+      store.acquireForegroundNodeLease(),
+      store.acquireForegroundNodeLease(),
+    ]);
+    expect(first.node).not.toEqual(second.node);
+
+    await store.returnForegroundNodeLease(first.leaseId, 123456789n);
+    const reused = await store.acquireForegroundNodeLease();
+    expect(reused.node).toEqual(first.node);
+    expect(reused.confirmedTxTime).toBe(123456789n);
+    await store.retireForegroundNodeLease(second.leaseId);
+    await store.retireForegroundNodeLease(reused.leaseId);
+    store.close();
+  });
+
+  it("retires an abandoned foreground lease on worker restart", async () => {
+    const name = databaseName();
+    let store = await IndexedDbPageStore.open(name);
+    const abandoned = await store.acquireForegroundNodeLease();
+    store.close();
+
+    store = await IndexedDbPageStore.open(name);
+    const replacement = await store.acquireForegroundNodeLease(true);
+    expect(replacement.node).not.toEqual(abandoned.node);
+    await store.retireForegroundNodeLease(replacement.leaseId);
+    store.close();
+  });
+
   it("rejects a missing or malformed physical replica node before touching pages", async () => {
     for (const replicaNode of [null, new Uint8Array(INDEXEDDB_REPLICA_NODE_BYTES - 1)]) {
       const name = databaseName();

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
@@ -341,6 +341,22 @@ describe("IndexedDbPageStore", () => {
     store.close();
   });
 
+  it("never lowers a returned foreground floor and rejects values native u64 cannot seed", async () => {
+    const name = databaseName();
+    const store = await IndexedDbPageStore.open(name);
+    const first = await store.acquireForegroundNodeLease();
+    await store.returnForegroundNodeLease(first.leaseId, 99n);
+    const second = await store.acquireForegroundNodeLease();
+    await store.returnForegroundNodeLease(second.leaseId, 1n);
+    const continued = await store.acquireForegroundNodeLease();
+    expect(continued.confirmedTxTime).toBe(99n);
+    await expect(store.returnForegroundNodeLease(continued.leaseId, 1n << 64n)).rejects.toThrow(
+      "Invalid IndexedDB foreground node lease handoff",
+    );
+    await store.retireForegroundNodeLease(continued.leaseId);
+    store.close();
+  });
+
   it("retires an abandoned foreground lease on worker restart", async () => {
     const name = databaseName();
     let store = await IndexedDbPageStore.open(name);

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
@@ -33,6 +33,7 @@ export const INDEXEDDB_REPLICA_NODE_BYTES = 16;
 /** Durable worker-owned pool for browser foreground TxId node leases. */
 export const INDEXEDDB_FOREGROUND_NODE_LEASES_KEY = "foreground-node-leases-v1";
 export const INDEXEDDB_FOREGROUND_NODE_LEASES_FORMAT = "jazz-foreground-node-leases-v1";
+const MAX_TX_TIME = (1n << 64n) - 1n;
 const CURRENT_METADATA_KEY = "current";
 const MIN_PAGE_SIZE = 1024;
 const MAX_PAGE_SIZE = 0x8000_0000;
@@ -254,7 +255,7 @@ export class IndexedDbPageStore {
    * foreground node reusable. An unknown lease is rejected fail-closed.
    */
   async returnForegroundNodeLease(leaseId: string, confirmedTxTime: bigint): Promise<void> {
-    if (!isLeaseId(leaseId) || confirmedTxTime < 0n) {
+    if (!isLeaseId(leaseId) || !isTxTime(confirmedTxTime)) {
       throw new Error("Invalid IndexedDB foreground node lease handoff");
     }
     await this.updateForegroundNodeLeasePool((pool) => {
@@ -262,9 +263,11 @@ export class IndexedDbPageStore {
       if (index < 0) throw new Error("Unknown IndexedDB foreground node lease");
       const [lease] = pool.active.splice(index, 1);
       if (!lease) throw new Error("Unknown IndexedDB foreground node lease");
+      const previous = BigInt(lease.confirmedTxTime);
       pool.reusable.push({
         ...lease,
-        confirmedTxTime: confirmedTxTime.toString(),
+        // An old caller or a wall-clock rollback cannot lower a durable floor.
+        confirmedTxTime: (confirmedTxTime > previous ? confirmedTxTime : previous).toString(),
       });
     });
   }
@@ -646,7 +649,8 @@ function assertStoredForegroundNodeLease(
   if (
     !isLeaseId(lease.leaseId) ||
     !isNodeBuffer(lease.node) ||
-    !isCanonicalNonNegativeBigintString(lease.confirmedTxTime)
+    !isCanonicalNonNegativeBigintString(lease.confirmedTxTime) ||
+    !isTxTime(BigInt(lease.confirmedTxTime))
   ) {
     throw new Error("Invalid IndexedDB foreground node lease");
   }
@@ -665,6 +669,10 @@ function isLeaseId(value: unknown): value is string {
 
 function isCanonicalNonNegativeBigintString(value: unknown): value is string {
   return typeof value === "string" && /^(0|[1-9][0-9]*)$/.test(value);
+}
+
+function isTxTime(value: bigint): boolean {
+  return value >= 0n && value <= MAX_TX_TIME;
 }
 
 function bytesKey(bytes: ArrayBuffer): string {

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
@@ -30,6 +30,9 @@ export const INDEXEDDB_BROWSER_RUNTIME_OWNER_KEY = "browser-runtime-owner";
  */
 export const INDEXEDDB_REPLICA_NODE_KEY = "replica-node-v1";
 export const INDEXEDDB_REPLICA_NODE_BYTES = 16;
+/** Durable worker-owned pool for browser foreground TxId node leases. */
+export const INDEXEDDB_FOREGROUND_NODE_LEASES_KEY = "foreground-node-leases-v1";
+export const INDEXEDDB_FOREGROUND_NODE_LEASES_FORMAT = "jazz-foreground-node-leases-v1";
 const CURRENT_METADATA_KEY = "current";
 const MIN_PAGE_SIZE = 1024;
 const MAX_PAGE_SIZE = 0x8000_0000;
@@ -103,6 +106,28 @@ export interface IndexedDbPageCommit {
   pages: ReadonlyMap<number, Uint8Array>;
   deletedPageIds?: readonly number[];
 }
+
+export interface ForegroundNodeLease {
+  /** Opaque CSPRNG lease token, valid only while its port remains attached. */
+  leaseId: string;
+  /** NodeUuid leased exclusively to this foreground runtime. */
+  node: Uint8Array;
+  /** HLC high-water persisted by the preceding clean lease holder. */
+  confirmedTxTime: bigint;
+}
+
+type StoredForegroundNodeLease = {
+  leaseId: string;
+  node: ArrayBuffer;
+  confirmedTxTime: string;
+};
+
+type StoredForegroundNodeLeasePool = {
+  format: typeof INDEXEDDB_FOREGROUND_NODE_LEASES_FORMAT;
+  active: StoredForegroundNodeLease[];
+  reusable: StoredForegroundNodeLease[];
+  retired: ArrayBuffer[];
+};
 
 export class IndexedDbStorageInvalidatedError extends Error {
   constructor(readonly databaseName: string) {
@@ -198,6 +223,63 @@ export class IndexedDbPageStore {
     return this.replicaNodeBytes.slice();
   }
 
+  /**
+   * Atomically acquire a foreground TxId node lease.
+   *
+   * An `active` record left behind by an earlier worker process is never
+   * reused: its holder may have minted identities after its last persistence
+   * point. A fresh worker retires it before allocating a new or cleanly
+   * returned identity. The current SharedWorker keeps live leases in memory,
+   * so this recovery rule only applies during worker bootstrap.
+   */
+  async acquireForegroundNodeLease(recoverAbandoned = false): Promise<ForegroundNodeLease> {
+    return await this.updateForegroundNodeLeasePool((pool) => {
+      if (recoverAbandoned) {
+        for (const active of pool.active) pool.retired.push(active.node);
+        pool.active = [];
+      }
+      const reusable = pool.reusable.pop();
+      const lease: StoredForegroundNodeLease = {
+        leaseId: crypto.randomUUID(),
+        node: reusable?.node ?? nodeBytesToBuffer(randomReplicaNodeBytes()),
+        confirmedTxTime: reusable?.confirmedTxTime ?? "0",
+      };
+      pool.active.push(lease);
+      return storedForegroundNodeLeaseToPublic(lease);
+    });
+  }
+
+  /**
+   * Atomically persist the runtime-observed HLC high-water before making a
+   * foreground node reusable. An unknown lease is rejected fail-closed.
+   */
+  async returnForegroundNodeLease(leaseId: string, confirmedTxTime: bigint): Promise<void> {
+    if (!isLeaseId(leaseId) || confirmedTxTime < 0n) {
+      throw new Error("Invalid IndexedDB foreground node lease handoff");
+    }
+    await this.updateForegroundNodeLeasePool((pool) => {
+      const index = pool.active.findIndex((lease) => lease.leaseId === leaseId);
+      if (index < 0) throw new Error("Unknown IndexedDB foreground node lease");
+      const [lease] = pool.active.splice(index, 1);
+      if (!lease) throw new Error("Unknown IndexedDB foreground node lease");
+      pool.reusable.push({
+        ...lease,
+        confirmedTxTime: confirmedTxTime.toString(),
+      });
+    });
+  }
+
+  /** Permanently retire a lease whose owner did not complete clean handoff. */
+  async retireForegroundNodeLease(leaseId: string): Promise<void> {
+    if (!isLeaseId(leaseId)) throw new Error("Invalid IndexedDB foreground node lease");
+    await this.updateForegroundNodeLeasePool((pool) => {
+      const index = pool.active.findIndex((lease) => lease.leaseId === leaseId);
+      if (index < 0) return;
+      const [lease] = pool.active.splice(index, 1);
+      if (lease) pool.retired.push(lease.node);
+    });
+  }
+
   async metadata(): Promise<IndexedDbBtreeMetadata | null> {
     this.assertValid();
     const tx = this.db.transaction(INDEXEDDB_BTREE_METADATA_STORE, "readonly");
@@ -275,6 +357,33 @@ export class IndexedDbPageStore {
       throw new Error("Missing or invalid IndexedDB replica node identity");
     }
     return bytes.slice();
+  }
+
+  private async updateForegroundNodeLeasePool<T>(
+    update: (pool: StoredForegroundNodeLeasePool) => T,
+  ): Promise<T> {
+    this.assertValid();
+    const tx = relaxedReadWriteTransaction(this.db, [INDEXEDDB_STORAGE_MANIFEST_STORE]);
+    const done = transactionDone(tx);
+    const store = tx.objectStore(INDEXEDDB_STORAGE_MANIFEST_STORE);
+    try {
+      const value = await requestResult(store.get(INDEXEDDB_FOREGROUND_NODE_LEASES_KEY));
+      const pool =
+        value === undefined ? emptyForegroundNodeLeasePool() : decodeForegroundNodeLeasePool(value);
+      const result = update(pool);
+      assertForegroundNodeLeasePool(pool);
+      store.put(pool, INDEXEDDB_FOREGROUND_NODE_LEASES_KEY);
+      await done;
+      return result;
+    } catch (error) {
+      try {
+        tx.abort();
+      } catch {
+        // The transaction may already have completed/aborted after a request failure.
+      }
+      await done.catch(() => undefined);
+      throw error;
+    }
   }
 
   async readPage(pageId: number): Promise<Uint8Array | null> {
@@ -449,6 +558,117 @@ function randomReplicaNodeBytes(): Uint8Array {
   }
   globalThis.crypto.getRandomValues(bytes);
   return bytes;
+}
+
+function nodeBytesToBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.slice().buffer as ArrayBuffer;
+}
+
+function emptyForegroundNodeLeasePool(): StoredForegroundNodeLeasePool {
+  return {
+    format: INDEXEDDB_FOREGROUND_NODE_LEASES_FORMAT,
+    active: [],
+    reusable: [],
+    retired: [],
+  };
+}
+
+function storedForegroundNodeLeaseToPublic(lease: StoredForegroundNodeLease): ForegroundNodeLease {
+  return {
+    leaseId: lease.leaseId,
+    node: new Uint8Array(lease.node).slice(),
+    confirmedTxTime: BigInt(lease.confirmedTxTime),
+  };
+}
+
+function decodeForegroundNodeLeasePool(value: unknown): StoredForegroundNodeLeasePool {
+  assertForegroundNodeLeasePool(value);
+  return {
+    format: value.format,
+    active: value.active.map(copyStoredForegroundNodeLease),
+    reusable: value.reusable.map(copyStoredForegroundNodeLease),
+    retired: value.retired.map((node) => node.slice(0)),
+  };
+}
+
+function copyStoredForegroundNodeLease(
+  lease: StoredForegroundNodeLease,
+): StoredForegroundNodeLease {
+  return {
+    leaseId: lease.leaseId,
+    node: lease.node.slice(0),
+    confirmedTxTime: lease.confirmedTxTime,
+  };
+}
+
+function assertForegroundNodeLeasePool(
+  value: unknown,
+): asserts value is StoredForegroundNodeLeasePool {
+  if (!value || typeof value !== "object") {
+    throw new Error("Invalid IndexedDB foreground node lease pool");
+  }
+  const pool = value as Partial<StoredForegroundNodeLeasePool>;
+  if (
+    pool.format !== INDEXEDDB_FOREGROUND_NODE_LEASES_FORMAT ||
+    !Array.isArray(pool.active) ||
+    !Array.isArray(pool.reusable) ||
+    !Array.isArray(pool.retired)
+  ) {
+    throw new Error("Invalid IndexedDB foreground node lease pool");
+  }
+  const nodes = new Set<string>();
+  const leaseIds = new Set<string>();
+  for (const lease of [...pool.active, ...pool.reusable]) {
+    assertStoredForegroundNodeLease(lease);
+    const nodeKey = bytesKey(lease.node);
+    if (leaseIds.has(lease.leaseId) || nodes.has(nodeKey)) {
+      throw new Error("Invalid IndexedDB foreground node lease pool");
+    }
+    leaseIds.add(lease.leaseId);
+    nodes.add(nodeKey);
+  }
+  for (const node of pool.retired) {
+    const nodeKey = isNodeBuffer(node) ? bytesKey(node) : null;
+    if (!nodeKey || nodes.has(nodeKey)) {
+      throw new Error("Invalid IndexedDB foreground node lease pool");
+    }
+    nodes.add(nodeKey);
+  }
+}
+
+function assertStoredForegroundNodeLease(
+  value: unknown,
+): asserts value is StoredForegroundNodeLease {
+  if (!value || typeof value !== "object") {
+    throw new Error("Invalid IndexedDB foreground node lease");
+  }
+  const lease = value as Partial<StoredForegroundNodeLease>;
+  if (
+    !isLeaseId(lease.leaseId) ||
+    !isNodeBuffer(lease.node) ||
+    !isCanonicalNonNegativeBigintString(lease.confirmedTxTime)
+  ) {
+    throw new Error("Invalid IndexedDB foreground node lease");
+  }
+}
+
+function isNodeBuffer(value: unknown): value is ArrayBuffer {
+  return value instanceof ArrayBuffer && value.byteLength === INDEXEDDB_REPLICA_NODE_BYTES;
+}
+
+function isLeaseId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+  );
+}
+
+function isCanonicalNonNegativeBigintString(value: unknown): value is string {
+  return typeof value === "string" && /^(0|[1-9][0-9]*)$/.test(value);
+}
+
+function bytesKey(bytes: ArrayBuffer): string {
+  return Array.from(new Uint8Array(bytes), (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function requestResult<T>(request: IDBRequest<T>): Promise<T> {

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -3,15 +3,161 @@ import {
   resolveBrowserWorkerRuntimeSources,
   resolveBrowserWorkerUrl,
 } from "../browser-worker-config.js";
-import type { BrowserWorkerConnection, BrowserWorkerConnectionContext } from "../runtime-source.js";
+import type {
+  BrowserForegroundNodeLease,
+  BrowserWorkerConnection,
+  BrowserWorkerConnectionContext,
+} from "../runtime-source.js";
 import { MessagePortBrowserFollowerConnection } from "./browser-follower-connection.js";
 import type {
   BrowserSharedWorkerConnectRequest,
   BrowserSharedWorkerConnectResponse,
+  BrowserForegroundNodeLeaseAcquireResponse,
+  BrowserForegroundNodeLeasePortEvent,
+  BrowserForegroundNodeLeasePortRequest,
   BrowserFollowerPortRequest,
   BrowserWorkerInitOptions,
 } from "./browser-worker-protocol.js";
 import type { NativeRuntimeAdapter } from "./native-runtime-adapter.js";
+
+export type BrowserForegroundNodeLeaseOptions = Pick<
+  BrowserWorkerInitOptions,
+  "runtimeSources" | "dbName" | "authSessionKey"
+>;
+
+/**
+ * Lease-only worker connection established before a foreground schema/runtime
+ * exists. Its port stays open as the durable owner's liveness witness until
+ * explicit clean return or retirement.
+ */
+export class SharedBrowserForegroundNodeLease implements BrowserForegroundNodeLease {
+  private worker: SharedWorker | null = null;
+  private port: MessagePort | null = null;
+  private closed = false;
+
+  private constructor(
+    readonly node: Uint8Array,
+    readonly confirmedTxTime: bigint,
+    private readonly leaseId: string,
+  ) {}
+
+  static async acquire(
+    options: BrowserForegroundNodeLeaseOptions,
+  ): Promise<SharedBrowserForegroundNodeLease> {
+    const runtimeSources = resolveBrowserWorkerRuntimeSources(options.runtimeSources);
+    const workerName = [
+      "jazz-runtime",
+      options.authSessionKey,
+      options.dbName,
+      createBrowserWorkerAssetScope(runtimeSources),
+    ].join(":");
+    const createWorker =
+      runtimeSources?.brokerWorkerUrl || runtimeSources?.baseUrl || runtimeSources?.wasmVersion
+        ? (name: string) =>
+            new SharedWorker(resolveBrowserWorkerUrl(runtimeSources), { type: "module", name })
+        : (name: string) =>
+            new SharedWorker(new URL("../../worker/jazz-broker-worker.js", import.meta.url), {
+              type: "module",
+              name,
+            });
+    const worker = createWorker(workerName);
+    const port = worker.port;
+    port.start();
+    const lease = await new Promise<SharedBrowserForegroundNodeLease>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        cleanup();
+        port.close();
+        reject(new Error("Shared browser runtime did not issue a foreground node lease"));
+      }, 1000);
+      const cleanup = () => {
+        clearTimeout(timeout);
+        port.removeEventListener("message", onMessage);
+        port.removeEventListener("messageerror", onMessageError);
+      };
+      const onMessage = (event: MessageEvent<BrowserForegroundNodeLeaseAcquireResponse>) => {
+        const message = event.data;
+        if (message?.type === "foreground-node-lease-error") {
+          cleanup();
+          reject(new Error(message.message));
+          return;
+        }
+        if (message?.type !== "foreground-node-lease-ready") return;
+        if (!/^(0|[1-9][0-9]*)$/.test(message.confirmedTxTime)) {
+          cleanup();
+          reject(
+            new Error("Shared browser runtime returned an invalid foreground lease high-water"),
+          );
+          return;
+        }
+        cleanup();
+        const result = new SharedBrowserForegroundNodeLease(
+          message.node.slice(),
+          BigInt(message.confirmedTxTime),
+          message.leaseId,
+        );
+        result.worker = worker;
+        result.port = port;
+        resolve(result);
+      };
+      const onMessageError = () => {
+        cleanup();
+        reject(new Error("Shared browser foreground lease port message error"));
+      };
+      port.addEventListener("message", onMessage);
+      port.addEventListener("messageerror", onMessageError);
+      port.postMessage({
+        type: "acquire-foreground-node-lease",
+        dbName: options.dbName,
+      });
+    });
+    return lease;
+  }
+
+  async returnWithHighWater(highWater: bigint): Promise<void> {
+    if (highWater < 0n) throw new Error("Invalid foreground transaction high-water");
+    await this.finish({
+      type: "return-foreground-node-lease",
+      confirmedTxTime: highWater.toString(),
+    });
+  }
+
+  async retire(): Promise<void> {
+    if (this.closed) return;
+    await this.finish({ type: "retire-foreground-node-lease" });
+  }
+
+  private async finish(message: BrowserForegroundNodeLeasePortRequest): Promise<void> {
+    if (this.closed) throw new Error("Shared browser foreground lease is already closed");
+    const port = this.port;
+    if (!port) throw new Error("Shared browser foreground lease port is unavailable");
+    await new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        port.removeEventListener("message", onMessage);
+        port.removeEventListener("messageerror", onMessageError);
+      };
+      const onMessage = (event: MessageEvent<BrowserForegroundNodeLeasePortEvent>) => {
+        const result = event.data;
+        if (result?.type !== "foreground-node-lease-result") return;
+        cleanup();
+        if (result.error) reject(new Error(result.error));
+        else resolve();
+      };
+      const onMessageError = () => {
+        cleanup();
+        reject(new Error("Shared browser foreground lease port message error"));
+      };
+      port.addEventListener("message", onMessage);
+      port.addEventListener("messageerror", onMessageError);
+      port.postMessage(message);
+    }).finally(() => {
+      this.closed = true;
+      this.port?.close();
+      this.port = null;
+      this.worker?.port.close();
+      this.worker = null;
+    });
+  }
+}
 
 export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
   private worker: SharedWorker | null = null;

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -60,7 +60,11 @@ export class SharedBrowserForegroundNodeLease implements ForegroundNodeLease {
               type: "module",
               name,
             });
-    const worker = createWorker(workerName);
+    // Lease acquisition and the schema/runtime connection must enter the same
+    // physical SharedWorker realm. Runtime connections generation-qualify the
+    // base name so a realm that has begun closing can be retired; omitting the
+    // suffix here would create a second durable owner for the same IndexedDB.
+    const worker = createWorker(`${workerName}:generation-${readWorkerGeneration(workerName)}`);
     const port = worker.port;
     port.start();
     const lease = await new Promise<SharedBrowserForegroundNodeLease>((resolve, reject) => {

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -4,7 +4,7 @@ import {
   resolveBrowserWorkerUrl,
 } from "../browser-worker-config.js";
 import type {
-  BrowserForegroundNodeLease,
+  ForegroundNodeLease,
   BrowserWorkerConnection,
   BrowserWorkerConnectionContext,
 } from "../runtime-source.js";
@@ -30,7 +30,7 @@ export type BrowserForegroundNodeLeaseOptions = Pick<
  * exists. Its port stays open as the durable owner's liveness witness until
  * explicit clean return or retirement.
  */
-export class SharedBrowserForegroundNodeLease implements BrowserForegroundNodeLease {
+export class SharedBrowserForegroundNodeLease implements ForegroundNodeLease {
   private worker: SharedWorker | null = null;
   private port: MessagePort | null = null;
   private closed = false;

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-protocol.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-protocol.ts
@@ -28,6 +28,31 @@ export interface BrowserSharedWorkerConnectRequest {
   options: BrowserWorkerInitOptions;
 }
 
+/** Lease-only bootstrap that runs before the foreground schema is known. */
+export interface BrowserForegroundNodeLeaseAcquireRequest {
+  type: "acquire-foreground-node-lease";
+  dbName: string;
+}
+
+export type BrowserForegroundNodeLeaseAcquireResponse =
+  | {
+      type: "foreground-node-lease-ready";
+      leaseId: string;
+      node: Uint8Array;
+      /** Canonical decimal u64: never a lossy JS number. */
+      confirmedTxTime: string;
+    }
+  | { type: "foreground-node-lease-error"; message: string };
+
+export type BrowserForegroundNodeLeasePortRequest =
+  | { type: "return-foreground-node-lease"; confirmedTxTime: string }
+  | { type: "retire-foreground-node-lease" };
+
+export type BrowserForegroundNodeLeasePortEvent = {
+  type: "foreground-node-lease-result";
+  error?: string;
+};
+
 export type BrowserSharedWorkerConnectResponse =
   | { type: "worker-alive" }
   | { type: "runtime-ready" }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -651,6 +651,11 @@ export class NativeRuntimeAdapter implements Runtime {
   private readonly completedTxs: Map<string, CompletedTx>;
   private readonly writes: Map<string, Write>;
   private readonly pendingLocalSettlements = new Set<Promise<void>>();
+  // A streaming mutation can wait on its source while owning a native upload
+  // handle. A foreground lease cannot return until every admitted handle has
+  // published its write (and advanced the HLC) or has been aborted. Local
+  // settlement starts only after a write has already been minted.
+  private readonly pendingStreamingMutations = new Set<Promise<void>>();
   // Streaming sources can be consumed concurrently, but native `finish()`
   // mutates the owner runtime. WASM evaluates that runtime behind one async
   // borrow, so overlapping finalization can deadlock. Keep only this atomic
@@ -708,6 +713,9 @@ export class NativeRuntimeAdapter implements Runtime {
   // the native HLC, but physical native disposal still happens through the
   // ordinary client shutdown path.
   private foregroundLeaseQuiesced = false;
+  // A concurrent ordinary close must not dispose native state between a lease
+  // handoff's mutation drain and its HLC readout.
+  private foregroundLeaseCapture: Promise<bigint> | null = null;
   private physicalCloseStarted = false;
   private nextSubscriptionId = 1;
 
@@ -900,13 +908,21 @@ export class NativeRuntimeAdapter implements Runtime {
    * native disposal after the lease owner has durably recorded this value.
    * @internal
    */
-  async quiesceForegroundTxTimeHighWater(): Promise<bigint> {
+  quiesceForegroundTxTimeHighWater(): Promise<bigint> {
     if (this !== this.ownerRuntime) {
-      return await this.ownerRuntime.quiesceForegroundTxTimeHighWater();
+      return this.ownerRuntime.quiesceForegroundTxTimeHighWater();
     }
+    if (this.foregroundLeaseCapture) return this.foregroundLeaseCapture;
     if (this.closed) throw new Error("Native runtime is already closed");
     this.closed = true;
     this.foregroundLeaseQuiesced = true;
+    const capture = this.captureForegroundTxTimeHighWater();
+    this.foregroundLeaseCapture = capture;
+    return capture;
+  }
+
+  private async captureForegroundTxTimeHighWater(): Promise<bigint> {
+    await Promise.all(this.pendingStreamingMutations);
     await Promise.all(this.pendingLocalSettlements);
     await this.coreTickCompletion?.catch(() => undefined);
     return this.foregroundTxTimeHighWater();
@@ -1117,6 +1133,10 @@ export class NativeRuntimeAdapter implements Runtime {
     // Stop admitting/scheduling work first, but keep every WASM receiver alive
     // until the evaluator future that may currently borrow it has unwound.
     this.closed = true;
+    await this.foregroundLeaseCapture?.catch(() => undefined);
+    if (this.pendingStreamingMutations.size > 0) {
+      await Promise.all(this.pendingStreamingMutations);
+    }
     if (this.pendingLocalSettlements.size > 0) {
       await Promise.all(this.pendingLocalSettlements);
     }
@@ -1207,6 +1227,7 @@ export class NativeRuntimeAdapter implements Runtime {
     _writeContext?: string | null,
     objectId?: string | null,
   ): InsertResult {
+    this.assertMutationAdmission("Insert");
     const suppliedRowId = objectId ? parseUuid(objectId) : undefined;
     const writeSession = sessionFromWriteContext(_writeContext);
     this.applySessionClaims(writeSession);
@@ -1270,6 +1291,7 @@ export class NativeRuntimeAdapter implements Runtime {
     const begin = this.db.beginStreamingMutationEncoded;
     const operation =
       mutation === "insert" ? "Insert" : mutation === "update" ? "Update" : "Upsert";
+    this.assertMutationAdmission(operation);
     if (this.currentTx(writeContext, operation)) {
       throw new Error("Streaming mutations are not supported inside a transaction");
     }
@@ -1327,6 +1349,12 @@ export class NativeRuntimeAdapter implements Runtime {
           branchView?.head,
           branchView?.base,
         );
+    const owner = this.ownerRuntime;
+    let releaseAdmission!: () => void;
+    const admission = new Promise<void>((resolve) => {
+      releaseAdmission = resolve;
+    });
+    owner.pendingStreamingMutations.add(admission);
     const encoder = new TextEncoder();
     const pushBounded = async (bytes: Uint8Array): Promise<void> => {
       const hostWindowBytes = 64 * 1024;
@@ -1358,7 +1386,6 @@ export class NativeRuntimeAdapter implements Runtime {
         }
       }
       if (pendingHighSurrogate) await pushBounded(encoder.encode(pendingHighSurrogate));
-      const owner = this.ownerRuntime;
       const previousFinalization = owner.streamingFinalization;
       let releaseFinalization!: () => void;
       const finalization = new Promise<void>((resolve) => {
@@ -1376,6 +1403,9 @@ export class NativeRuntimeAdapter implements Runtime {
     } catch (error) {
       await upload.abort();
       throw error;
+    } finally {
+      releaseAdmission();
+      owner.pendingStreamingMutations.delete(admission);
     }
   }
 
@@ -1385,6 +1415,7 @@ export class NativeRuntimeAdapter implements Runtime {
     values: InsertValues,
     writeContext?: string | null,
   ): InsertResult {
+    this.assertMutationAdmission("Restore");
     const rowId = parseUuid(objectId);
     const writeSession = sessionFromWriteContext(writeContext);
     this.applySessionClaims(writeSession);
@@ -1434,6 +1465,7 @@ export class NativeRuntimeAdapter implements Runtime {
     values: Record<string, Value>,
     writeContext?: string | null,
   ): MutationResult {
+    this.assertMutationAdmission("Update");
     const rowId = parseUuid(objectId);
     const writeSession = sessionFromWriteContext(writeContext);
     this.applySessionClaims(writeSession);
@@ -1484,6 +1516,7 @@ export class NativeRuntimeAdapter implements Runtime {
     descriptors: readonly unknown[],
     writeContext?: string | null,
   ): MutationResult {
+    this.assertMutationAdmission("Update");
     const rowId = parseUuid(objectId);
     const updatedAtMs = effectiveUpdatedAtMs(writeContext);
     const branchView = branchViewFromWriteContext(writeContext);
@@ -1518,6 +1551,7 @@ export class NativeRuntimeAdapter implements Runtime {
     values: InsertValues,
     writeContext?: string | null,
   ): MutationResult {
+    this.assertMutationAdmission("Upsert");
     const rowId = parseUuid(objectId);
     const definition = this.table(table);
     const writeSession = sessionFromWriteContext(writeContext);
@@ -1577,6 +1611,7 @@ export class NativeRuntimeAdapter implements Runtime {
   }
 
   delete(table: string, objectId: string, writeContext?: string | null): MutationResult {
+    this.assertMutationAdmission("Delete");
     this.table(table);
     const rowId = parseUuid(objectId);
     const writeSession = sessionFromWriteContext(writeContext);
@@ -2280,6 +2315,13 @@ export class NativeRuntimeAdapter implements Runtime {
     this.scheduleServerPump();
     this.notifyPeerTransportWork();
     return { kind: "committed", txId };
+  }
+
+  /** Refuse every mutation once a foreground lease begins clean handoff. */
+  private assertMutationAdmission(operation: string): void {
+    if (this.ownerRuntime.closed) {
+      throw new Error(`${operation} failed: native runtime is closed`);
+    }
   }
 
   private resultForRow(

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -704,6 +704,11 @@ export class NativeRuntimeAdapter implements Runtime {
   private serverPumpAgain = false;
   private serverConnectionGeneration = 0;
   private closed = false;
+  // A foreground lease handoff closes mutation admission before it snapshots
+  // the native HLC, but physical native disposal still happens through the
+  // ordinary client shutdown path.
+  private foregroundLeaseQuiesced = false;
+  private physicalCloseStarted = false;
   private nextSubscriptionId = 1;
 
   static fromDb(
@@ -886,6 +891,25 @@ export class NativeRuntimeAdapter implements Runtime {
       throw new Error("Native runtime does not expose foreground transaction high-water");
     }
     return this.db.foregroundTxTimeHighWater();
+  }
+
+  /**
+   * Close mutation admission, drain already-started native work, then return
+   * the final HLC high-water. No synchronous or async write can mint after
+   * this resolves. The ordinary `close()` call remains responsible for final
+   * native disposal after the lease owner has durably recorded this value.
+   * @internal
+   */
+  async quiesceForegroundTxTimeHighWater(): Promise<bigint> {
+    if (this !== this.ownerRuntime) {
+      return await this.ownerRuntime.quiesceForegroundTxTimeHighWater();
+    }
+    if (this.closed) throw new Error("Native runtime is already closed");
+    this.closed = true;
+    this.foregroundLeaseQuiesced = true;
+    await Promise.all(this.pendingLocalSettlements);
+    await this.coreTickCompletion?.catch(() => undefined);
+    return this.foregroundTxTimeHighWater();
   }
 
   /** @internal Seed a foreground lease high-water before the first local write. */
@@ -1087,14 +1111,15 @@ export class NativeRuntimeAdapter implements Runtime {
       this.closeRuntimeState();
       return;
     }
-    if (this.closed) return;
-    if (this.pendingLocalSettlements.size > 0) {
-      await Promise.all(this.pendingLocalSettlements);
-    }
-    if (this.closed) return;
+    if (this.physicalCloseStarted) return;
+    if (this.closed && !this.foregroundLeaseQuiesced) return;
+    this.physicalCloseStarted = true;
     // Stop admitting/scheduling work first, but keep every WASM receiver alive
     // until the evaluator future that may currently borrow it has unwound.
     this.closed = true;
+    if (this.pendingLocalSettlements.size > 0) {
+      await Promise.all(this.pendingLocalSettlements);
+    }
     await this.coreTickCompletion?.catch(() => undefined);
     this.closeRuntimeState(true);
     await this.db.close?.();
@@ -1682,6 +1707,9 @@ export class NativeRuntimeAdapter implements Runtime {
     if (this !== this.ownerRuntime) {
       return this.ownerRuntime.beginTransaction(kind, id, sessionJson);
     }
+    if (this.closed) {
+      throw new Error("Begin transaction failed: native runtime is closed");
+    }
     if (this.pendingTxs.has(id) || this.completedTxs.has(id)) {
       throw new Error(`Begin transaction failed: transaction ${id} has already been opened`);
     }
@@ -1717,6 +1745,9 @@ export class NativeRuntimeAdapter implements Runtime {
 
   commitTransaction(openTransactionId: OpenTransactionId): TxId {
     if (this !== this.ownerRuntime) return this.ownerRuntime.commitTransaction(openTransactionId);
+    if (this.closed) {
+      throw new Error("Commit transaction failed: native runtime is closed");
+    }
     const pending = this.pendingTxs.get(openTransactionId);
     if (!pending) {
       throw new Error(commitTransactionMessage(openTransactionId, this.completedTxs));

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -189,6 +189,8 @@ type NativeDb = {
     opts: unknown,
   ): NativeReadResult | Promise<NativeReadResult>;
   setIdentityClaims?(author: Uint8Array, claims: Record<string, unknown> | undefined | null): void;
+  foregroundTxTimeHighWater?(): bigint;
+  seedForegroundTxTimeHighWater?(highWater: bigint): void;
   setRelayAuthoritySessionOwner?(): void;
   attachQuery?(query: PreparedQuery, opts: unknown): unknown;
   attachQueryForIdentity?(query: PreparedQuery, author: Uint8Array, opts: unknown): unknown;
@@ -875,6 +877,26 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     this.db.setNonDurableClient();
     this.nonDurableClient = true;
+  }
+
+  /** @internal Return the native HLC high-water for a foreground lease handoff. */
+  foregroundTxTimeHighWater(): bigint {
+    if (this !== this.ownerRuntime) return this.ownerRuntime.foregroundTxTimeHighWater();
+    if (!this.db.foregroundTxTimeHighWater) {
+      throw new Error("Native runtime does not expose foreground transaction high-water");
+    }
+    return this.db.foregroundTxTimeHighWater();
+  }
+
+  /** @internal Seed a foreground lease high-water before the first local write. */
+  seedForegroundTxTimeHighWater(highWater: bigint): void {
+    if (this !== this.ownerRuntime) {
+      return this.ownerRuntime.seedForegroundTxTimeHighWater(highWater);
+    }
+    if (!this.db.seedForegroundTxTimeHighWater) {
+      throw new Error("Native runtime does not expose foreground transaction high-water seeding");
+    }
+    this.db.seedForegroundTxTimeHighWater(highWater);
   }
 
   /** Configure Jazz-owned upload rate and unpublished-tree expiry policy. */

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
@@ -170,11 +170,13 @@ type TxForTest = {
 };
 
 it("quiesces foreground mutation admission before capturing its final HLC", async () => {
+  const insertEncoded = vi.fn(() => ({ ...fakeWrite(), rowId: new Uint8Array(16) }));
   const runtime = new NativeRuntimeAdapter(
     {
       openMemory: () =>
         fakeDb({
           foregroundTxTimeHighWater: () => 41n,
+          insertEncoded,
           prepareQuery: () => ({}),
           tick: () => undefined,
         }),
@@ -194,6 +196,263 @@ it("quiesces foreground mutation admission before capturing its final HLC", asyn
   // after the high-water was captured, nor can a new synchronous batch start.
   expect(() => runtime.commitTransaction(preexisting)).toThrow("native runtime is closed");
   expect(() => beginTestBatch(runtime)).toThrow("native runtime is closed");
+  expect(() => runtime.insert("todos", { title: { type: "Text", value: "late" } })).toThrow(
+    "native runtime is closed",
+  );
+  expect(insertEncoded).not.toHaveBeenCalled();
+  await runtime.close();
+});
+
+it("drains an already admitted streaming mutation before returning its foreground HLC", async () => {
+  let highWater = 7n;
+  let releaseSource!: () => void;
+  const sourceGate = new Promise<void>((resolve) => {
+    releaseSource = resolve;
+  });
+  const beginStreamingMutationEncoded = vi.fn(() => ({
+    push: () => undefined,
+    finish: () => {
+      highWater = 42n;
+      return fakeWrite();
+    },
+    abort: () => true,
+  }));
+  const runtime = new NativeRuntimeAdapter(
+    {
+      openMemory: () =>
+        fakeDb({
+          foregroundTxTimeHighWater: () => highWater,
+          beginStreamingMutationEncoded,
+          prepareQuery: () => ({}),
+          tick: () => undefined,
+        }),
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    testSchema,
+    new Uint8Array(16),
+    TEST_RUNTIME_AUTHOR,
+    1,
+    true,
+  );
+
+  const stream = runtime.streamingMutation(
+    "insert",
+    "todos",
+    {},
+    "title",
+    (async function* () {
+      await sourceGate;
+      yield "late write";
+    })(),
+  );
+  await Promise.resolve();
+  expect(beginStreamingMutationEncoded).toHaveBeenCalledOnce();
+
+  let handoffResolved = false;
+  const handoff = runtime.quiesceForegroundTxTimeHighWater().then((value) => {
+    handoffResolved = true;
+    return value;
+  });
+  await Promise.resolve();
+  expect(handoffResolved).toBe(false);
+
+  releaseSource();
+  await stream;
+  expect(await handoff).toBe(42n);
+  await runtime.close();
+});
+
+it("waits for a failed stream's native abort before foreground handoff", async () => {
+  let releaseSource!: () => void;
+  const sourceGate = new Promise<void>((resolve) => {
+    releaseSource = resolve;
+  });
+  let releaseAbort!: () => void;
+  const abortGate = new Promise<boolean>((resolve) => {
+    releaseAbort = () => resolve(true);
+  });
+  const abort = vi.fn(() => abortGate);
+  const runtime = new NativeRuntimeAdapter(
+    {
+      openMemory: () =>
+        fakeDb({
+          foregroundTxTimeHighWater: () => 7n,
+          beginStreamingMutationEncoded: () => ({
+            push: () => undefined,
+            finish: () => fakeWrite(),
+            abort,
+          }),
+          prepareQuery: () => ({}),
+          tick: () => undefined,
+        }),
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    testSchema,
+    new Uint8Array(16),
+    TEST_RUNTIME_AUTHOR,
+    1,
+    true,
+  );
+
+  const stream = runtime.streamingMutation(
+    "insert",
+    "todos",
+    {},
+    "title",
+    (async function* () {
+      await sourceGate;
+      yield "partial upload";
+      throw new Error("source cancelled");
+    })(),
+  );
+  await Promise.resolve();
+  const handoff = runtime.quiesceForegroundTxTimeHighWater();
+  releaseSource();
+  await vi.waitFor(() => expect(abort).toHaveBeenCalledOnce());
+
+  let handoffResolved = false;
+  void handoff.then(() => {
+    handoffResolved = true;
+  });
+  await Promise.resolve();
+  expect(handoffResolved).toBe(false);
+
+  releaseAbort();
+  await expect(stream).rejects.toThrow("source cancelled");
+  await expect(handoff).resolves.toBe(7n);
+  await runtime.close();
+});
+
+it("does not let a concurrent close preempt foreground HLC capture", async () => {
+  const order: string[] = [];
+  let releaseSource!: () => void;
+  const sourceGate = new Promise<void>((resolve) => {
+    releaseSource = resolve;
+  });
+  const runtime = new NativeRuntimeAdapter(
+    {
+      openMemory: () =>
+        fakeDb({
+          foregroundTxTimeHighWater: () => {
+            order.push("high-water");
+            return 42n;
+          },
+          beginStreamingMutationEncoded: () => ({
+            push: () => undefined,
+            finish: () => fakeWrite(),
+            abort: () => true,
+          }),
+          prepareQuery: () => ({}),
+          tick: () => undefined,
+          close: () => {
+            order.push("close");
+          },
+        }),
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    testSchema,
+    new Uint8Array(16),
+    TEST_RUNTIME_AUTHOR,
+    1,
+    true,
+  );
+
+  const stream = runtime.streamingMutation(
+    "insert",
+    "todos",
+    {},
+    "title",
+    (async function* () {
+      await sourceGate;
+      yield "finish before close";
+    })(),
+  );
+  await Promise.resolve();
+  const handoff = runtime.quiesceForegroundTxTimeHighWater();
+  const close = runtime.close();
+  releaseSource();
+  await stream;
+  await expect(handoff).resolves.toBe(42n);
+  await close;
+  expect(order).toEqual(["high-water", "close"]);
+});
+
+it("waits for every concurrently admitted stream before foreground handoff", async () => {
+  let highWater = 7n;
+  let releaseFirst!: () => void;
+  let releaseSecond!: () => void;
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const secondGate = new Promise<void>((resolve) => {
+    releaseSecond = resolve;
+  });
+  const runtime = new NativeRuntimeAdapter(
+    {
+      openMemory: () =>
+        fakeDb({
+          foregroundTxTimeHighWater: () => highWater,
+          beginStreamingMutationEncoded: () => ({
+            push: () => undefined,
+            finish: () => {
+              highWater += 1n;
+              return fakeWrite();
+            },
+            abort: () => true,
+          }),
+          prepareQuery: () => ({}),
+          tick: () => undefined,
+        }),
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    testSchema,
+    new Uint8Array(16),
+    TEST_RUNTIME_AUTHOR,
+    1,
+    true,
+  );
+  const makeSource = (gate: Promise<void>, value: string) =>
+    (async function* () {
+      await gate;
+      yield value;
+    })();
+  const first = runtime.streamingMutation(
+    "insert",
+    "todos",
+    {},
+    "title",
+    makeSource(firstGate, "one"),
+  );
+  const second = runtime.streamingMutation(
+    "insert",
+    "todos",
+    {},
+    "title",
+    makeSource(secondGate, "two"),
+  );
+  await Promise.resolve();
+  const handoff = runtime.quiesceForegroundTxTimeHighWater();
+  let handoffResolved = false;
+  void handoff.then(() => {
+    handoffResolved = true;
+  });
+
+  releaseFirst();
+  await first;
+  await Promise.resolve();
+  expect(handoffResolved).toBe(false);
+
+  releaseSecond();
+  await second;
+  await expect(handoff).resolves.toBe(9n);
   await runtime.close();
 });
 

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
@@ -169,6 +169,34 @@ type TxForTest = {
   ): void;
 };
 
+it("quiesces foreground mutation admission before capturing its final HLC", async () => {
+  const runtime = new NativeRuntimeAdapter(
+    {
+      openMemory: () =>
+        fakeDb({
+          foregroundTxTimeHighWater: () => 41n,
+          prepareQuery: () => ({}),
+          tick: () => undefined,
+        }),
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    testSchema,
+    new Uint8Array(16),
+    TEST_RUNTIME_AUTHOR,
+    1,
+    true,
+  );
+  const preexisting = beginTestBatch(runtime);
+  expect(await runtime.quiesceForegroundTxTimeHighWater()).toBe(41n);
+  // This is the P0 handoff ordering: an already-open batch cannot mint H+1
+  // after the high-water was captured, nor can a new synchronous batch start.
+  expect(() => runtime.commitTransaction(preexisting)).toThrow("native runtime is closed");
+  expect(() => beginTestBatch(runtime)).toThrow("native runtime is closed");
+  await runtime.close();
+});
+
 function uuidBytes(value: string): Uint8Array {
   const hex = value.replaceAll("-", "");
   const bytes = new Uint8Array(16);

--- a/packages/jazz-tools/src/runtime/native-runtime/node-foreground-node-lease.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/node-foreground-node-lease.test.ts
@@ -1,0 +1,300 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  acquireNodeForegroundNodeLease,
+  nodeForegroundNodeLeaseDirectoryForTest,
+  type NodeForegroundNodeLeaseOptions,
+} from "./node-foreground-node-lease.js";
+import { createBrowserAuthSessionKey } from "../browser-worker-config.js";
+
+const roots: string[] = [];
+let restoreCwd: (() => void) | undefined;
+const publicRuntimeEntry = new URL("../../../dist/runtime/index.js", import.meta.url).href;
+
+afterEach(async () => {
+  restoreCwd?.();
+  restoreCwd = undefined;
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function isolatedOptions(): Promise<NodeForegroundNodeLeaseOptions> {
+  const root = await mkdtemp(join(tmpdir(), "jazz-node-foreground-lease-"));
+  roots.push(root);
+  const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(root);
+  restoreCwd = () => cwdSpy.mockRestore();
+  return { appId: "node-lease-test", env: "test", authScope: "test-user" };
+}
+
+type PublicNodeChild = {
+  child: ChildProcess;
+  ready: Promise<void>;
+};
+
+/**
+ * Uses the built public `createDb` entrypoint in a separate Node process. The
+ * lease pool must protect this surface, rather than merely an internal helper.
+ */
+function spawnPublicPersistentDb(
+  root: string,
+  appId: string,
+  mode: "hold" | "close",
+): PublicNodeChild {
+  const child = spawn(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      [
+        `import { createDb } from ${JSON.stringify(publicRuntimeEntry)};`,
+        `const db = await createDb({ appId: ${JSON.stringify(appId)} });`,
+        'process.stdout.write("ready\\n");',
+        mode === "close"
+          ? 'await db.shutdown(); process.stdout.write("closed\\n");'
+          : "setInterval(() => {}, 1_000);",
+      ].join("\n"),
+    ],
+    { cwd: root, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const ready = new Promise<void>((resolve, reject) => {
+    let output = "";
+    let errors = "";
+    const timeout = setTimeout(() => {
+      reject(new Error(`public Node Db child did not become ready: ${errors}`));
+    }, 10_000);
+    child.once("error", fail);
+    child.once("exit", (code, signal) => {
+      if (!output.includes("ready\n"))
+        fail(new Error(`public Node Db child exited ${code}/${signal}: ${errors}`));
+    });
+    child.stdout?.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+      if (output.includes("ready\n")) succeed();
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      errors += chunk.toString();
+    });
+    function succeed() {
+      clearTimeout(timeout);
+      child.off("error", fail);
+      resolve();
+    }
+    function fail(error: Error) {
+      clearTimeout(timeout);
+      child.off("error", fail);
+      reject(error);
+    }
+  });
+  return { child, ready };
+}
+
+async function waitForExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((resolve, reject) => {
+    child.once("exit", () => resolve());
+    child.once("error", reject);
+  });
+}
+
+async function killChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGKILL");
+  await waitForExit(child);
+}
+
+describe("Node foreground node leases", () => {
+  it("reuses only a clean node and never lowers its HLC floor", async () => {
+    const options = await isolatedOptions();
+    const first = await acquireNodeForegroundNodeLease(options);
+    const node = first.node;
+    await first.returnWithHighWater(123456n);
+
+    const reopened = await acquireNodeForegroundNodeLease(options);
+    expect(reopened.node).toEqual(node);
+    expect(reopened.confirmedTxTime).toBe(123456n);
+    // A wall-clock rollback cannot lower the continuation floor.
+    await reopened.returnWithHighWater(1n);
+
+    const continued = await acquireNodeForegroundNodeLease(options);
+    expect(continued.node).toEqual(node);
+    expect(continued.confirmedTxTime).toBe(123456n);
+    await continued.retire();
+  });
+
+  it("allocates distinct nodes to concurrent foreground processes", async () => {
+    const options = await isolatedOptions();
+    const [first, second] = await Promise.all([
+      acquireNodeForegroundNodeLease(options),
+      acquireNodeForegroundNodeLease(options),
+    ]);
+    expect(first.node).not.toEqual(second.node);
+    await Promise.all([first.retire(), second.retire()]);
+  });
+
+  it("fails closed on a torn state receipt", async () => {
+    const options = await isolatedOptions();
+    const directory = nodeForegroundNodeLeaseDirectoryForTest(options);
+    await mkdir(directory, { recursive: true });
+    await writeFile(join(directory, "state.json"), "{torn", { flag: "w" });
+    await expect(acquireNodeForegroundNodeLease(options)).rejects.toThrow(
+      "Invalid Node foreground lease state",
+    );
+  });
+
+  it("retires a dirty node after its definitely-dead owner leaves a stale lock", async () => {
+    const options = await isolatedOptions();
+    const directory = nodeForegroundNodeLeaseDirectoryForTest(options);
+    const deadNode = "11".repeat(16);
+    await mkdir(directory, { recursive: true });
+    await writeFile(
+      join(directory, "state.json"),
+      JSON.stringify({
+        format: "jazz-node-foreground-node-leases-v1",
+        clean: [],
+        dirty: [{ node: deadNode, confirmedTxTime: "900" }],
+        retired: [],
+      }),
+    );
+    await writeFile(
+      join(directory, `slot-${deadNode}.lock`),
+      JSON.stringify({
+        pid: 999_999_999,
+        host: hostname(),
+        processStartIdentity: null,
+        nonce: "00000000-0000-4000-8000-000000000000",
+      }),
+    );
+
+    const lease = await acquireNodeForegroundNodeLease(options);
+    expect(lease.node).not.toEqual(Buffer.from(deadNode, "hex"));
+    await lease.retire();
+  });
+
+  it("fails closed rather than stealing a foreign or malformed state lock", async () => {
+    const options = await isolatedOptions();
+    const directory = nodeForegroundNodeLeaseDirectoryForTest(options);
+    await mkdir(directory, { recursive: true });
+    await writeFile(join(directory, "state.lock"), "not a receipt", { flag: "w" });
+    await expect(acquireNodeForegroundNodeLease(options)).rejects.toThrow(
+      "invalid foreground lease lock receipt",
+    );
+
+    await writeFile(
+      join(directory, "state.lock"),
+      JSON.stringify({
+        pid: process.pid,
+        host: "another-host",
+        processStartIdentity: null,
+        nonce: "00000000-0000-4000-8000-000000000000",
+      }),
+      { flag: "w" },
+    );
+    await expect(acquireNodeForegroundNodeLease(options)).rejects.toThrow(
+      "foreground lease lock belongs to a different host",
+    );
+  });
+
+  it("treats a recycled-PID receipt as abandoned and permanently retires its node", async () => {
+    if (process.platform !== "linux") return;
+    const options = await isolatedOptions();
+    const directory = nodeForegroundNodeLeaseDirectoryForTest(options);
+    const deadNode = "22".repeat(16);
+    await mkdir(directory, { recursive: true });
+    await writeFile(
+      join(directory, "state.json"),
+      JSON.stringify({
+        format: "jazz-node-foreground-node-leases-v1",
+        clean: [],
+        dirty: [{ node: deadNode, confirmedTxTime: "900" }],
+        retired: [],
+      }),
+    );
+    await writeFile(
+      join(directory, `slot-${deadNode}.lock`),
+      JSON.stringify({
+        pid: process.pid,
+        host: hostname(),
+        // Deliberately differs from this live process's /proc start tick.
+        processStartIdentity: "recycled-pid",
+        nonce: "00000000-0000-4000-8000-000000000000",
+      }),
+    );
+
+    const lease = await acquireNodeForegroundNodeLease(options);
+    expect(lease.node).not.toEqual(Buffer.from(deadNode, "hex"));
+    await lease.retire();
+    const state = JSON.parse(await readFile(join(directory, "state.json"), "utf8"));
+    expect(state.retired).toContain(deadNode);
+  });
+
+  it("keeps app and auth namespaces isolated inside one cwd", async () => {
+    const first = await isolatedOptions();
+    const second = { ...first, appId: "another-app" };
+    expect(nodeForegroundNodeLeaseDirectoryForTest(second)).not.toBe(
+      nodeForegroundNodeLeaseDirectoryForTest(first),
+    );
+    const [firstLease, secondLease] = await Promise.all([
+      acquireNodeForegroundNodeLease(first),
+      acquireNodeForegroundNodeLease(second),
+    ]);
+    try {
+      expect(firstLease.node).not.toEqual(secondLease.node);
+    } finally {
+      await Promise.all([firstLease.retire(), secondLease.retire()]);
+    }
+  });
+
+  it("protects public default persistent Db creation across processes and retires crash owners", async () => {
+    if (process.platform === "win32") return;
+    const root = await mkdtemp(join(tmpdir(), "jazz-node-public-foreground-lease-"));
+    roots.push(root);
+    const appId = "node-public-lease-test";
+    const options: NodeForegroundNodeLeaseOptions = {
+      appId,
+      env: "dev",
+      authScope: createBrowserAuthSessionKey({ appId }),
+    };
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(root);
+    const directory = nodeForegroundNodeLeaseDirectoryForTest(options);
+    cwdSpy.mockRestore();
+
+    const first = spawnPublicPersistentDb(root, appId, "hold");
+    const second = spawnPublicPersistentDb(root, appId, "hold");
+    try {
+      await Promise.all([first.ready, second.ready]);
+      const whileLive = JSON.parse(await readFile(join(directory, "state.json"), "utf8"));
+      expect(whileLive.dirty).toHaveLength(2);
+      expect(new Set(whileLive.dirty.map((slot: { node: string }) => slot.node)).size).toBe(2);
+
+      await Promise.all([killChild(first.child), killChild(second.child)]);
+
+      // A fresh public Db creation detects both definitely-dead processes,
+      // retires their nodes, and exposes only a new identity. It then closes
+      // cleanly, making that new node the sole reusable one.
+      const recovered = spawnPublicPersistentDb(root, appId, "close");
+      await recovered.ready;
+      await waitForExit(recovered.child);
+
+      const afterRecovery = JSON.parse(await readFile(join(directory, "state.json"), "utf8"));
+      expect(afterRecovery.dirty).toEqual([]);
+      expect(afterRecovery.clean).toHaveLength(1);
+      expect(afterRecovery.retired).toHaveLength(2);
+      const cleanReplacementNode = afterRecovery.clean[0].node;
+
+      const reopened = spawnPublicPersistentDb(root, appId, "hold");
+      await reopened.ready;
+      try {
+        const afterReopen = JSON.parse(await readFile(join(directory, "state.json"), "utf8"));
+        expect(afterReopen.dirty).toHaveLength(1);
+        expect(afterReopen.dirty[0].node).toBe(cleanReplacementNode);
+        expect(afterReopen.retired).toHaveLength(2);
+      } finally {
+        await killChild(reopened.child);
+      }
+    } finally {
+      await Promise.all([killChild(first.child), killChild(second.child)]);
+    }
+  }, 30_000);
+});

--- a/packages/jazz-tools/src/runtime/native-runtime/node-foreground-node-lease.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/node-foreground-node-lease.test.ts
@@ -1,8 +1,10 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { hostname, tmpdir } from "node:os";
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { schema as s } from "../../index.js";
+import { createDb } from "../db.js";
 import {
   acquireNodeForegroundNodeLease,
   nodeForegroundNodeLeaseDirectoryForTest,
@@ -13,6 +15,7 @@ import { createBrowserAuthSessionKey } from "../browser-worker-config.js";
 const roots: string[] = [];
 let restoreCwd: (() => void) | undefined;
 const publicRuntimeEntry = new URL("../../../dist/runtime/index.js", import.meta.url).href;
+const memoryApp = s.defineApp({ notes: s.table({ title: s.string() }) });
 
 afterEach(async () => {
   restoreCwd?.();
@@ -123,6 +126,15 @@ describe("Node foreground node leases", () => {
     await continued.retire();
   });
 
+  it("rejects a handoff high-water outside the native u64 HLC domain", async () => {
+    const lease = await acquireNodeForegroundNodeLease(await isolatedOptions());
+    await expect(lease.returnWithHighWater(1n << 64n)).rejects.toThrow(
+      "Invalid Node foreground lease handoff",
+    );
+    // The failed handoff leaves its active claim quarantined; do not retire it
+    // in this receipt because the tested invariant is exactly no reuse.
+  });
+
   it("allocates distinct nodes to concurrent foreground processes", async () => {
     const options = await isolatedOptions();
     const [first, second] = await Promise.all([
@@ -133,116 +145,70 @@ describe("Node foreground node leases", () => {
     await Promise.all([first.retire(), second.retire()]);
   });
 
-  it("fails closed on a torn state receipt", async () => {
-    const options = await isolatedOptions();
-    const directory = nodeForegroundNodeLeaseDirectoryForTest(options);
-    await mkdir(directory, { recursive: true });
-    await writeFile(join(directory, "state.json"), "{torn", { flag: "w" });
-    await expect(acquireNodeForegroundNodeLease(options)).rejects.toThrow(
-      "Invalid Node foreground lease state",
-    );
+  it("keeps explicit memory mode filesystem-free after a real public write", async () => {
+    const root = await mkdtemp(join(tmpdir(), "jazz-node-memory-foreground-lease-"));
+    roots.push(root);
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(root);
+    try {
+      const db = await createDb({ appId: "memory-lease-test", driver: { type: "memory" } });
+      db.insert(memoryApp.notes, { title: "first write" });
+      await db.shutdown();
+      await expect(readdir(join(root, ".jazz"))).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      cwdSpy.mockRestore();
+    }
   });
 
-  it("retires a dirty node after its definitely-dead owner leaves a stale lock", async () => {
+  it("quarantines an unknown active claim rather than reclaiming it", async () => {
     const options = await isolatedOptions();
     const directory = nodeForegroundNodeLeaseDirectoryForTest(options);
     const deadNode = "11".repeat(16);
-    await mkdir(directory, { recursive: true });
+    await mkdir(join(directory, "active"), { recursive: true });
     await writeFile(
-      join(directory, "state.json"),
+      join(directory, "active", deadNode),
       JSON.stringify({
-        format: "jazz-node-foreground-node-leases-v1",
-        clean: [],
-        dirty: [{ node: deadNode, confirmedTxTime: "900" }],
-        retired: [],
+        format: "jazz-node-foreground-node-leases-v2",
+        node: deadNode,
+        token: "00000000-0000-4000-8000-000000000000",
       }),
     );
-    await writeFile(
-      join(directory, `slot-${deadNode}.lock`),
-      JSON.stringify({
-        pid: 999_999_999,
-        host: hostname(),
-        processStartIdentity: null,
-        nonce: "00000000-0000-4000-8000-000000000000",
-      }),
-    );
-
     const lease = await acquireNodeForegroundNodeLease(options);
     expect(lease.node).not.toEqual(Buffer.from(deadNode, "hex"));
     await lease.retire();
   });
 
-  it("fails closed rather than stealing a foreign or malformed state lock", async () => {
+  it("fails closed on a malformed reusable receipt and retains its active claim", async () => {
     const options = await isolatedOptions();
     const directory = nodeForegroundNodeLeaseDirectoryForTest(options);
-    await mkdir(directory, { recursive: true });
-    await writeFile(join(directory, "state.lock"), "not a receipt", { flag: "w" });
+    const node = "22".repeat(16);
+    await mkdir(join(directory, "reusable"), { recursive: true });
+    await writeFile(join(directory, "reusable", node), "not-json");
     await expect(acquireNodeForegroundNodeLease(options)).rejects.toThrow(
-      "invalid foreground lease lock receipt",
+      "Invalid Node foreground lease receipt",
     );
-
-    await writeFile(
-      join(directory, "state.lock"),
-      JSON.stringify({
-        pid: process.pid,
-        host: "another-host",
-        processStartIdentity: null,
-        nonce: "00000000-0000-4000-8000-000000000000",
-      }),
-      { flag: "w" },
-    );
-    await expect(acquireNodeForegroundNodeLease(options)).rejects.toThrow(
-      "foreground lease lock belongs to a different host",
-    );
+    expect(await readdir(join(directory, "active"))).toContain(node);
   });
 
-  it("treats a recycled-PID receipt as abandoned and permanently retires its node", async () => {
-    if (process.platform !== "linux") return;
-    const options = await isolatedOptions();
-    const directory = nodeForegroundNodeLeaseDirectoryForTest(options);
-    const deadNode = "22".repeat(16);
-    await mkdir(directory, { recursive: true });
-    await writeFile(
-      join(directory, "state.json"),
-      JSON.stringify({
-        format: "jazz-node-foreground-node-leases-v1",
-        clean: [],
-        dirty: [{ node: deadNode, confirmedTxTime: "900" }],
-        retired: [],
-      }),
-    );
-    await writeFile(
-      join(directory, `slot-${deadNode}.lock`),
-      JSON.stringify({
-        pid: process.pid,
-        host: hostname(),
-        // Deliberately differs from this live process's /proc start tick.
-        processStartIdentity: "recycled-pid",
-        nonce: "00000000-0000-4000-8000-000000000000",
-      }),
-    );
-
-    const lease = await acquireNodeForegroundNodeLease(options);
-    expect(lease.node).not.toEqual(Buffer.from(deadNode, "hex"));
-    await lease.retire();
-    const state = JSON.parse(await readFile(join(directory, "state.json"), "utf8"));
-    expect(state.retired).toContain(deadNode);
-  });
-
-  it("keeps app and auth namespaces isolated inside one cwd", async () => {
+  it("keeps app, environment, and auth namespaces isolated inside one cwd", async () => {
     const first = await isolatedOptions();
-    const second = { ...first, appId: "another-app" };
-    expect(nodeForegroundNodeLeaseDirectoryForTest(second)).not.toBe(
-      nodeForegroundNodeLeaseDirectoryForTest(first),
-    );
-    const [firstLease, secondLease] = await Promise.all([
+    const variants = [
+      { ...first, appId: "another-app" },
+      { ...first, env: "production" },
+      { ...first, authScope: "another-user" },
+    ];
+    for (const variant of variants) {
+      expect(nodeForegroundNodeLeaseDirectoryForTest(variant)).not.toBe(
+        nodeForegroundNodeLeaseDirectoryForTest(first),
+      );
+    }
+    const [firstLease, ...otherLeases] = await Promise.all([
       acquireNodeForegroundNodeLease(first),
-      acquireNodeForegroundNodeLease(second),
+      ...variants.map(acquireNodeForegroundNodeLease),
     ]);
     try {
-      expect(firstLease.node).not.toEqual(secondLease.node);
+      for (const lease of otherLeases) expect(firstLease.node).not.toEqual(lease.node);
     } finally {
-      await Promise.all([firstLease.retire(), secondLease.retire()]);
+      await Promise.all([firstLease.retire(), ...otherLeases.map((lease) => lease.retire())]);
     }
   });
 
@@ -264,32 +230,27 @@ describe("Node foreground node leases", () => {
     const second = spawnPublicPersistentDb(root, appId, "hold");
     try {
       await Promise.all([first.ready, second.ready]);
-      const whileLive = JSON.parse(await readFile(join(directory, "state.json"), "utf8"));
-      expect(whileLive.dirty).toHaveLength(2);
-      expect(new Set(whileLive.dirty.map((slot: { node: string }) => slot.node)).size).toBe(2);
+      expect(await readdir(join(directory, "active"))).toHaveLength(2);
 
       await Promise.all([killChild(first.child), killChild(second.child)]);
 
-      // A fresh public Db creation detects both definitely-dead processes,
-      // retires their nodes, and exposes only a new identity. It then closes
-      // cleanly, making that new node the sole reusable one.
+      // A crash leaves both active claims quarantined. The recovered process
+      // receives a fresh UUID, then returns only that UUID cleanly.
       const recovered = spawnPublicPersistentDb(root, appId, "close");
       await recovered.ready;
       await waitForExit(recovered.child);
 
-      const afterRecovery = JSON.parse(await readFile(join(directory, "state.json"), "utf8"));
-      expect(afterRecovery.dirty).toEqual([]);
-      expect(afterRecovery.clean).toHaveLength(1);
-      expect(afterRecovery.retired).toHaveLength(2);
-      const cleanReplacementNode = afterRecovery.clean[0].node;
+      expect(await readdir(join(directory, "active"))).toHaveLength(2);
+      const clean = await readdir(join(directory, "reusable"));
+      expect(clean).toHaveLength(1);
+      const cleanReplacementNode = clean[0];
 
       const reopened = spawnPublicPersistentDb(root, appId, "hold");
       await reopened.ready;
       try {
-        const afterReopen = JSON.parse(await readFile(join(directory, "state.json"), "utf8"));
-        expect(afterReopen.dirty).toHaveLength(1);
-        expect(afterReopen.dirty[0].node).toBe(cleanReplacementNode);
-        expect(afterReopen.retired).toHaveLength(2);
+        const active = await readdir(join(directory, "active"));
+        expect(active).toHaveLength(3);
+        expect(active).toContain(cleanReplacementNode);
       } finally {
         await killChild(reopened.child);
       }

--- a/packages/jazz-tools/src/runtime/native-runtime/node-foreground-node-lease.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/node-foreground-node-lease.ts
@@ -1,0 +1,352 @@
+/**
+ * Node-only durable foreground TxId lease pool.
+ *
+ * This module is dynamically imported only from a Node runtime source. Keep
+ * every `node:` import here so browser and React Native bundles never resolve
+ * filesystem code.
+ */
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { link, mkdir, open, readFile, rename, unlink, type FileHandle } from "node:fs/promises";
+import { hostname } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import type { ForegroundNodeLease } from "../runtime-source.js";
+
+const FORMAT = "jazz-node-foreground-node-leases-v1";
+const STATE_FILE = "state.json";
+const STATE_LOCK_FILE = "state.lock";
+
+type StoredSlot = { node: string; confirmedTxTime: string };
+type StoredState = {
+  format: typeof FORMAT;
+  clean: StoredSlot[];
+  dirty: StoredSlot[];
+  retired: string[];
+};
+
+export type NodeForegroundNodeLeaseOptions = {
+  appId: string;
+  env: string;
+  /** Stable non-secret auth namespace; never stores claims or credentials. */
+  authScope: string;
+};
+
+/**
+ * Acquire a node identity for exactly one live Node process.
+ *
+ * Slot locks stay held for the process lifetime. A later process first turns
+ * every dirty slot whose previous PID has exited into a permanently retired
+ * UUID, then allocates only a clean or fresh node. There is intentionally no
+ * expiry or PID-time heuristic that could reuse an uncertain identity.
+ */
+export async function acquireNodeForegroundNodeLease(
+  options: NodeForegroundNodeLeaseOptions,
+): Promise<ForegroundNodeLease> {
+  const directory = leaseDirectory(options);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  return await withStateLock(directory, async () => {
+    const state = await readState(directory);
+    await retireAbandonedDirtySlots(directory, state);
+
+    const slot = state.clean.pop() ?? {
+      node: randomBytes(16).toString("hex"),
+      confirmedTxTime: "0",
+    };
+    const slotLock = await acquireSlotLock(directory, slot.node);
+    try {
+      state.dirty.push(slot);
+      // The dirty record is the admission point: never expose an identity
+      // until its active ownership survives a process crash.
+      await writeStateAtomically(directory, state);
+      return new NodeForegroundNodeLease(directory, slot, slotLock);
+    } catch (error) {
+      // No caller received this identity. Best-effort release avoids leaving a
+      // live-process lock that could otherwise block the still-clean slot
+      // forever; a cleanup failure remains fail-closed and is reported.
+      await slotLock.close().catch(() => undefined);
+      await unlink(slotLockPath(directory, slot.node)).catch(() => undefined);
+      throw error;
+    }
+  });
+}
+
+/** @internal Test-only locator for white-box durability receipts. */
+export function nodeForegroundNodeLeaseDirectoryForTest(
+  options: NodeForegroundNodeLeaseOptions,
+): string {
+  return leaseDirectory(options);
+}
+
+class NodeForegroundNodeLease implements ForegroundNodeLease {
+  readonly node: Uint8Array;
+  readonly confirmedTxTime: bigint;
+  private finished = false;
+
+  constructor(
+    private readonly directory: string,
+    private readonly slot: StoredSlot,
+    private readonly slotLock: FileHandle,
+  ) {
+    this.node = Buffer.from(slot.node, "hex");
+    this.confirmedTxTime = BigInt(slot.confirmedTxTime);
+  }
+
+  async returnWithHighWater(highWater: bigint): Promise<void> {
+    if (this.finished || highWater < 0n) throw new Error("Invalid Node foreground lease handoff");
+    await this.finish(async (state) => {
+      const slot = takeDirtySlot(state, this.slot.node);
+      // A corrupted/old caller must not move the durable floor backwards.
+      const confirmedTxTime =
+        highWater > BigInt(slot.confirmedTxTime) ? highWater : BigInt(slot.confirmedTxTime);
+      state.clean.push({ ...slot, confirmedTxTime: confirmedTxTime.toString() });
+    });
+  }
+
+  async retire(): Promise<void> {
+    if (this.finished) return;
+    await this.finish(async (state) => {
+      const slot = takeDirtySlot(state, this.slot.node);
+      state.retired.push(slot.node);
+    });
+  }
+
+  private async finish(update: (state: StoredState) => Promise<void>): Promise<void> {
+    try {
+      await withStateLock(this.directory, async () => {
+        const state = await readState(this.directory);
+        await update(state);
+        await writeStateAtomically(this.directory, state);
+      });
+      // Release only after the durable state has been atomically renamed and
+      // fsynced. A failure leaves both lock and dirty record in place.
+      await this.slotLock.close();
+      await unlink(slotLockPath(this.directory, this.slot.node));
+      this.finished = true;
+    } catch (error) {
+      throw new Error(`Node foreground lease handoff failed: ${asError(error).message}`);
+    }
+  }
+}
+
+function leaseDirectory(options: NodeForegroundNodeLeaseOptions): string {
+  const namespace = createHash("sha256")
+    .update(JSON.stringify([options.appId, options.env, options.authScope]))
+    .digest("hex");
+  return resolve(process.cwd(), ".jazz", "foreground-node-leases", "v1", namespace);
+}
+
+async function withStateLock<T>(directory: string, run: () => Promise<T>): Promise<T> {
+  const lockPath = join(directory, STATE_LOCK_FILE);
+  const handle = await acquireExclusiveLock(lockPath);
+  try {
+    return await run();
+  } finally {
+    await handle.close();
+    await unlink(lockPath).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    });
+  }
+}
+
+async function acquireSlotLock(directory: string, node: string) {
+  return await acquireExclusiveLock(slotLockPath(directory, node));
+}
+
+async function acquireExclusiveLock(path: string) {
+  for (;;) {
+    const receipt = `${JSON.stringify({
+      pid: process.pid,
+      host: hostname(),
+      processStartIdentity: await processStartIdentity(process.pid),
+      nonce: randomUUID(),
+    })}\n`;
+    const staging = `${path}.${process.pid}.${randomUUID()}.acquiring`;
+    try {
+      const staged = await open(staging, "wx", 0o600);
+      try {
+        await staged.writeFile(receipt);
+        await staged.sync();
+      } finally {
+        await staged.close();
+      }
+      await link(staging, path);
+      await unlink(staging);
+      return await open(path, "r");
+    } catch (error) {
+      await unlink(staging).catch((unlinkError: unknown) => {
+        if ((unlinkError as NodeJS.ErrnoException).code !== "ENOENT") throw unlinkError;
+      });
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      if (await lockOwnerIsAlive(path)) {
+        await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+        continue;
+      }
+      // A dead owner cannot complete a critical section. Removing its stale
+      // lock lets the new process retire its dirty slot under the state lock.
+      await unlink(path).catch((unlinkError: unknown) => {
+        if ((unlinkError as NodeJS.ErrnoException).code !== "ENOENT") throw unlinkError;
+      });
+    }
+  }
+}
+
+async function lockOwnerIsAlive(path: string): Promise<boolean> {
+  try {
+    const owner = parseLockOwner(await readFile(path, "utf8"));
+    if (owner.host !== hostname()) {
+      throw new Error("foreground lease lock belongs to a different host");
+    }
+    process.kill(owner.pid, 0);
+    if (owner.processStartIdentity !== null) {
+      const current = await processStartIdentity(owner.pid);
+      if (current && current !== owner.processStartIdentity) return false;
+    }
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ESRCH" || code === "ENOENT") return false;
+    // EPERM and malformed/partial/foreign receipts fail closed: never steal.
+    if (code === "EPERM") return true;
+    throw error;
+  }
+}
+
+type LockOwner = {
+  pid: number;
+  host: string;
+  processStartIdentity: string | null;
+  nonce: string;
+};
+
+function parseLockOwner(value: string): LockOwner {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("invalid foreground lease lock receipt");
+  }
+  if (!parsed || typeof parsed !== "object")
+    throw new Error("invalid foreground lease lock receipt");
+  const owner = parsed as Partial<LockOwner>;
+  if (
+    !Number.isSafeInteger(owner.pid) ||
+    Number(owner.pid) <= 0 ||
+    typeof owner.host !== "string" ||
+    owner.host.length === 0 ||
+    (owner.processStartIdentity !== null && typeof owner.processStartIdentity !== "string") ||
+    typeof owner.nonce !== "string" ||
+    !/^[0-9a-f-]{36}$/i.test(owner.nonce)
+  ) {
+    throw new Error("invalid foreground lease lock receipt");
+  }
+  return owner as LockOwner;
+}
+
+async function processStartIdentity(pid: number): Promise<string | null> {
+  if (process.platform !== "linux") return null;
+  try {
+    // Linux field 22 is the monotonic process-start tick. It distinguishes
+    // recycled PIDs without assuming that procfs exists on another platform.
+    return (await readFile(`/proc/${pid}/stat`, "utf8")).trim().split(" ")[21] ?? null;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function readState(directory: string): Promise<StoredState> {
+  try {
+    const state = JSON.parse(await readFile(join(directory, STATE_FILE), "utf8"));
+    assertState(state);
+    return state;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyState();
+    throw new Error(`Invalid Node foreground lease state: ${asError(error).message}`);
+  }
+}
+
+async function retireAbandonedDirtySlots(directory: string, state: StoredState): Promise<void> {
+  const remaining: StoredSlot[] = [];
+  for (const slot of state.dirty) {
+    if (await lockOwnerIsAlive(slotLockPath(directory, slot.node))) {
+      remaining.push(slot);
+    } else {
+      state.retired.push(slot.node);
+      await unlink(slotLockPath(directory, slot.node)).catch((error: unknown) => {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      });
+    }
+  }
+  state.dirty = remaining;
+}
+
+async function writeStateAtomically(directory: string, state: StoredState): Promise<void> {
+  assertState(state);
+  const destination = join(directory, STATE_FILE);
+  const temporary = join(directory, `.${STATE_FILE}.${process.pid}.${randomUUID()}.tmp`);
+  const encoded = `${JSON.stringify(state)}\n`;
+  const file = await open(temporary, "wx", 0o600);
+  try {
+    await file.writeFile(encoded);
+    await file.sync();
+  } finally {
+    await file.close();
+  }
+  await rename(temporary, destination);
+  // Durably publish the rename before a node is exposed/reused. Directory
+  // fsync is POSIX-specific; failure is fail-closed rather than guessed away.
+  const parent = await open(dirname(destination), "r");
+  try {
+    await parent.sync();
+  } finally {
+    await parent.close();
+  }
+}
+
+function emptyState(): StoredState {
+  return { format: FORMAT, clean: [], dirty: [], retired: [] };
+}
+
+function takeDirtySlot(state: StoredState, node: string): StoredSlot {
+  const index = state.dirty.findIndex((slot) => slot.node === node);
+  if (index < 0) throw new Error("Node foreground lease is no longer active");
+  const [slot] = state.dirty.splice(index, 1);
+  if (!slot) throw new Error("Node foreground lease is no longer active");
+  return slot;
+}
+
+function assertState(value: unknown): asserts value is StoredState {
+  if (!value || typeof value !== "object") throw new Error("state is not an object");
+  const state = value as Partial<StoredState>;
+  if (
+    state.format !== FORMAT ||
+    !Array.isArray(state.clean) ||
+    !Array.isArray(state.dirty) ||
+    !Array.isArray(state.retired)
+  ) {
+    throw new Error("state has an incompatible format");
+  }
+  const nodes = new Set<string>();
+  for (const slot of [...state.clean, ...state.dirty]) {
+    if (!slot || typeof slot !== "object") throw new Error("invalid slot");
+    if (
+      !/^[0-9a-f]{32}$/.test(slot.node) ||
+      !/^(0|[1-9][0-9]*)$/.test(slot.confirmedTxTime) ||
+      nodes.has(slot.node)
+    ) {
+      throw new Error("invalid slot");
+    }
+    nodes.add(slot.node);
+  }
+  for (const node of state.retired) {
+    if (!/^[0-9a-f]{32}$/.test(node) || nodes.has(node)) throw new Error("invalid retired slot");
+    nodes.add(node);
+  }
+}
+
+function slotLockPath(directory: string, node: string): string {
+  return join(directory, `slot-${node}.lock`);
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/jazz-tools/src/runtime/native-runtime/node-foreground-node-lease.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/node-foreground-node-lease.ts
@@ -1,27 +1,33 @@
 /**
  * Node-only durable foreground TxId lease pool.
  *
+ * There deliberately is no process-wide lock. A node's `active/<uuid>` file
+ * is its exclusive O_EXCL claim, while `reusable/<uuid>` is a separately
+ * durable high-water receipt. An abandoned active claim is never removed or
+ * inferred safe: it permanently quarantines that UUID.
+ *
  * This module is dynamically imported only from a Node runtime source. Keep
  * every `node:` import here so browser and React Native bundles never resolve
  * filesystem code.
  */
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import { link, mkdir, open, readFile, rename, unlink, type FileHandle } from "node:fs/promises";
-import { hostname } from "node:os";
+import { mkdir, open, readFile, readdir, rename, unlink } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import type { ForegroundNodeLease } from "../runtime-source.js";
 
-const FORMAT = "jazz-node-foreground-node-leases-v1";
-const STATE_FILE = "state.json";
-const STATE_LOCK_FILE = "state.lock";
+const FORMAT = "jazz-node-foreground-node-leases-v2";
+const ACTIVE_DIRECTORY = "active";
+const REUSABLE_DIRECTORY = "reusable";
+const RETIRED_DIRECTORY = "retired";
+const NODE_RE = /^[0-9a-f]{32}$/;
+const MAX_TX_TIME = (1n << 64n) - 1n;
 
-type StoredSlot = { node: string; confirmedTxTime: string };
-type StoredState = {
+type ReusableReceipt = {
   format: typeof FORMAT;
-  clean: StoredSlot[];
-  dirty: StoredSlot[];
-  retired: string[];
+  node: string;
+  confirmedTxTime: string;
 };
+type ActiveClaim = { format: typeof FORMAT; node: string; token: string };
 
 export type NodeForegroundNodeLeaseOptions = {
   appId: string;
@@ -31,42 +37,44 @@ export type NodeForegroundNodeLeaseOptions = {
 };
 
 /**
- * Acquire a node identity for exactly one live Node process.
+ * Acquire an exclusive NodeUuid for one live foreground runtime.
  *
- * Slot locks stay held for the process lifetime. A later process first turns
- * every dirty slot whose previous PID has exited into a permanently retired
- * UUID, then allocates only a clean or fresh node. There is intentionally no
- * expiry or PID-time heuristic that could reuse an uncertain identity.
+ * A claim is created before its receipt is read. Thus two processes cannot
+ * both consume a returned UUID, and a crash at any point leaves an active
+ * claim which future processes skip forever. This intentionally trades a rare
+ * UUID leak for no possibility of TxId reuse.
  */
 export async function acquireNodeForegroundNodeLease(
   options: NodeForegroundNodeLeaseOptions,
 ): Promise<ForegroundNodeLease> {
   const directory = leaseDirectory(options);
-  await mkdir(directory, { recursive: true, mode: 0o700 });
-  return await withStateLock(directory, async () => {
-    const state = await readState(directory);
-    await retireAbandonedDirtySlots(directory, state);
+  await ensureDirectories(directory);
 
-    const slot = state.clean.pop() ?? {
-      node: randomBytes(16).toString("hex"),
-      confirmedTxTime: "0",
-    };
-    const slotLock = await acquireSlotLock(directory, slot.node);
+  for (;;) {
+    // Directory iteration is only a reuse optimisation. The O_EXCL claim is
+    // the arbitration primitive.
+    const candidates = await reusableNodes(directory);
+    const node = candidates.shift() ?? randomBytes(16).toString("hex");
+    const claim = await tryAcquireActiveClaim(directory, node);
+    if (!claim) continue;
     try {
-      state.dirty.push(slot);
-      // The dirty record is the admission point: never expose an identity
-      // until its active ownership survives a process crash.
-      await writeStateAtomically(directory, state);
-      return new NodeForegroundNodeLease(directory, slot, slotLock);
+      if (await exists(retiredPath(directory, node))) {
+        await leaveClaimQuarantined(claim);
+        continue;
+      }
+      const receipt = await readReusableReceipt(directory, node);
+      return new NodeForegroundNodeLease(
+        directory,
+        node,
+        claim,
+        receipt ? BigInt(receipt.confirmedTxTime) : 0n,
+      );
     } catch (error) {
-      // No caller received this identity. Best-effort release avoids leaving a
-      // live-process lock that could otherwise block the still-clean slot
-      // forever; a cleanup failure remains fail-closed and is reported.
-      await slotLock.close().catch(() => undefined);
-      await unlink(slotLockPath(directory, slot.node)).catch(() => undefined);
+      // Do not remove a claim after any uncertain read/validation failure.
+      await leaveClaimQuarantined(claim);
       throw error;
     }
-  });
+  }
 }
 
 /** @internal Test-only locator for white-box durability receipts. */
@@ -78,51 +86,46 @@ export function nodeForegroundNodeLeaseDirectoryForTest(
 
 class NodeForegroundNodeLease implements ForegroundNodeLease {
   readonly node: Uint8Array;
-  readonly confirmedTxTime: bigint;
   private finished = false;
 
   constructor(
     private readonly directory: string,
-    private readonly slot: StoredSlot,
-    private readonly slotLock: FileHandle,
+    private readonly nodeHex: string,
+    private readonly claim: ActiveClaim,
+    readonly confirmedTxTime: bigint,
   ) {
-    this.node = Buffer.from(slot.node, "hex");
-    this.confirmedTxTime = BigInt(slot.confirmedTxTime);
+    this.node = Buffer.from(nodeHex, "hex");
   }
 
-  async returnWithHighWater(highWater: bigint): Promise<void> {
-    if (this.finished || highWater < 0n) throw new Error("Invalid Node foreground lease handoff");
-    await this.finish(async (state) => {
-      const slot = takeDirtySlot(state, this.slot.node);
-      // A corrupted/old caller must not move the durable floor backwards.
-      const confirmedTxTime =
-        highWater > BigInt(slot.confirmedTxTime) ? highWater : BigInt(slot.confirmedTxTime);
-      state.clean.push({ ...slot, confirmedTxTime: confirmedTxTime.toString() });
-    });
+  async returnWithHighWater(runtimeHighWater: bigint): Promise<void> {
+    if (this.finished || !isTxTime(runtimeHighWater)) {
+      throw new Error("Invalid Node foreground lease handoff");
+    }
+    try {
+      // The active claim remains present while we publish the receipt. A crash
+      // before unlink quarantines this UUID despite the new receipt.
+      const existing = await readReusableReceipt(this.directory, this.nodeHex);
+      const confirmedTxTime = maxBigInt(
+        this.confirmedTxTime,
+        existing ? BigInt(existing.confirmedTxTime) : 0n,
+        runtimeHighWater,
+      );
+      await writeReusableReceipt(this.directory, this.nodeHex, confirmedTxTime);
+      await removeOwnedActiveClaim(this.directory, this.claim);
+      this.finished = true;
+    } catch (error) {
+      throw new Error(`Node foreground lease handoff failed: ${asError(error).message}`);
+    }
   }
 
   async retire(): Promise<void> {
     if (this.finished) return;
-    await this.finish(async (state) => {
-      const slot = takeDirtySlot(state, this.slot.node);
-      state.retired.push(slot.node);
-    });
-  }
-
-  private async finish(update: (state: StoredState) => Promise<void>): Promise<void> {
     try {
-      await withStateLock(this.directory, async () => {
-        const state = await readState(this.directory);
-        await update(state);
-        await writeStateAtomically(this.directory, state);
-      });
-      // Release only after the durable state has been atomically renamed and
-      // fsynced. A failure leaves both lock and dirty record in place.
-      await this.slotLock.close();
-      await unlink(slotLockPath(this.directory, this.slot.node));
+      await writeRetiredReceipt(this.directory, this.nodeHex);
+      await removeOwnedActiveClaim(this.directory, this.claim);
       this.finished = true;
     } catch (error) {
-      throw new Error(`Node foreground lease handoff failed: ${asError(error).message}`);
+      throw new Error(`Node foreground lease retirement failed: ${asError(error).message}`);
     }
   }
 }
@@ -134,219 +137,203 @@ function leaseDirectory(options: NodeForegroundNodeLeaseOptions): string {
   return resolve(process.cwd(), ".jazz", "foreground-node-leases", "v1", namespace);
 }
 
-async function withStateLock<T>(directory: string, run: () => Promise<T>): Promise<T> {
-  const lockPath = join(directory, STATE_LOCK_FILE);
-  const handle = await acquireExclusiveLock(lockPath);
-  try {
-    return await run();
-  } finally {
-    await handle.close();
-    await unlink(lockPath).catch((error: unknown) => {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-    });
+async function ensureDirectories(directory: string): Promise<void> {
+  await Promise.all(
+    [
+      directory,
+      activeDirectory(directory),
+      reusableDirectory(directory),
+      retiredDirectory(directory),
+    ].map((path) => mkdir(path, { recursive: true, mode: 0o700 })),
+  );
+}
+
+async function reusableNodes(directory: string): Promise<string[]> {
+  const entries = await readdir(reusableDirectory(directory), { withFileTypes: true });
+  const candidates: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !NODE_RE.test(entry.name)) continue;
+    if (
+      !(await exists(activePath(directory, entry.name))) &&
+      !(await exists(retiredPath(directory, entry.name)))
+    ) {
+      candidates.push(entry.name);
+    }
   }
+  return candidates.sort();
 }
 
-async function acquireSlotLock(directory: string, node: string) {
-  return await acquireExclusiveLock(slotLockPath(directory, node));
-}
-
-async function acquireExclusiveLock(path: string) {
-  for (;;) {
-    const receipt = `${JSON.stringify({
-      pid: process.pid,
-      host: hostname(),
-      processStartIdentity: await processStartIdentity(process.pid),
-      nonce: randomUUID(),
-    })}\n`;
-    const staging = `${path}.${process.pid}.${randomUUID()}.acquiring`;
+async function tryAcquireActiveClaim(directory: string, node: string): Promise<ActiveClaim | null> {
+  if (!NODE_RE.test(node)) throw new Error("Invalid Node foreground lease node");
+  const claim: ActiveClaim = { format: FORMAT, node, token: randomUUID() };
+  try {
+    const file = await open(activePath(directory, node), "wx", 0o600);
     try {
-      const staged = await open(staging, "wx", 0o600);
-      try {
-        await staged.writeFile(receipt);
-        await staged.sync();
-      } finally {
-        await staged.close();
-      }
-      await link(staging, path);
-      await unlink(staging);
-      return await open(path, "r");
-    } catch (error) {
-      await unlink(staging).catch((unlinkError: unknown) => {
-        if ((unlinkError as NodeJS.ErrnoException).code !== "ENOENT") throw unlinkError;
-      });
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      if (await lockOwnerIsAlive(path)) {
-        await new Promise((resolveWait) => setTimeout(resolveWait, 10));
-        continue;
-      }
-      // A dead owner cannot complete a critical section. Removing its stale
-      // lock lets the new process retire its dirty slot under the state lock.
-      await unlink(path).catch((unlinkError: unknown) => {
-        if ((unlinkError as NodeJS.ErrnoException).code !== "ENOENT") throw unlinkError;
-      });
+      await file.writeFile(`${JSON.stringify(claim)}\n`);
+      await file.sync();
+    } finally {
+      await file.close();
     }
-  }
-}
-
-async function lockOwnerIsAlive(path: string): Promise<boolean> {
-  try {
-    const owner = parseLockOwner(await readFile(path, "utf8"));
-    if (owner.host !== hostname()) {
-      throw new Error("foreground lease lock belongs to a different host");
-    }
-    process.kill(owner.pid, 0);
-    if (owner.processStartIdentity !== null) {
-      const current = await processStartIdentity(owner.pid);
-      if (current && current !== owner.processStartIdentity) return false;
-    }
-    return true;
+    await syncDirectory(activeDirectory(directory));
+    return claim;
   } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === "ESRCH" || code === "ENOENT") return false;
-    // EPERM and malformed/partial/foreign receipts fail closed: never steal.
-    if (code === "EPERM") return true;
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") return null;
     throw error;
   }
 }
 
-type LockOwner = {
-  pid: number;
-  host: string;
-  processStartIdentity: string | null;
-  nonce: string;
-};
-
-function parseLockOwner(value: string): LockOwner {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(value);
-  } catch {
-    throw new Error("invalid foreground lease lock receipt");
+async function removeOwnedActiveClaim(directory: string, claim: ActiveClaim): Promise<void> {
+  const path = activePath(directory, claim.node);
+  const actual = parseActiveClaim(await readFile(path, "utf8"));
+  if (actual.token !== claim.token || actual.node !== claim.node) {
+    throw new Error("Node foreground lease active claim is no longer owned by this runtime");
   }
-  if (!parsed || typeof parsed !== "object")
-    throw new Error("invalid foreground lease lock receipt");
-  const owner = parsed as Partial<LockOwner>;
-  if (
-    !Number.isSafeInteger(owner.pid) ||
-    Number(owner.pid) <= 0 ||
-    typeof owner.host !== "string" ||
-    owner.host.length === 0 ||
-    (owner.processStartIdentity !== null && typeof owner.processStartIdentity !== "string") ||
-    typeof owner.nonce !== "string" ||
-    !/^[0-9a-f-]{36}$/i.test(owner.nonce)
-  ) {
-    throw new Error("invalid foreground lease lock receipt");
-  }
-  return owner as LockOwner;
+  await unlink(path);
+  await syncDirectory(activeDirectory(directory));
 }
 
-async function processStartIdentity(pid: number): Promise<string | null> {
-  if (process.platform !== "linux") return null;
+async function leaveClaimQuarantined(_claim: ActiveClaim): Promise<void> {
+  // Intentionally empty: an unremoved active claim is the durable quarantine.
+}
+
+async function readReusableReceipt(
+  directory: string,
+  node: string,
+): Promise<ReusableReceipt | null> {
   try {
-    // Linux field 22 is the monotonic process-start tick. It distinguishes
-    // recycled PIDs without assuming that procfs exists on another platform.
-    return (await readFile(`/proc/${pid}/stat`, "utf8")).trim().split(" ")[21] ?? null;
+    return parseReusableReceipt(await readFile(reusablePath(directory, node), "utf8"), node);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-    throw error;
+    throw new Error(`Invalid Node foreground lease receipt: ${asError(error).message}`);
   }
 }
 
-async function readState(directory: string): Promise<StoredState> {
+async function writeReusableReceipt(
+  directory: string,
+  node: string,
+  confirmedTxTime: bigint,
+): Promise<void> {
+  const receipt: ReusableReceipt = {
+    format: FORMAT,
+    node,
+    confirmedTxTime: confirmedTxTime.toString(),
+  };
+  await writeFileAtomically(reusablePath(directory, node), `${JSON.stringify(receipt)}\n`);
+}
+
+async function writeRetiredReceipt(directory: string, node: string): Promise<void> {
+  const path = retiredPath(directory, node);
   try {
-    const state = JSON.parse(await readFile(join(directory, STATE_FILE), "utf8"));
-    assertState(state);
-    return state;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyState();
-    throw new Error(`Invalid Node foreground lease state: ${asError(error).message}`);
-  }
-}
-
-async function retireAbandonedDirtySlots(directory: string, state: StoredState): Promise<void> {
-  const remaining: StoredSlot[] = [];
-  for (const slot of state.dirty) {
-    if (await lockOwnerIsAlive(slotLockPath(directory, slot.node))) {
-      remaining.push(slot);
-    } else {
-      state.retired.push(slot.node);
-      await unlink(slotLockPath(directory, slot.node)).catch((error: unknown) => {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-      });
+    const file = await open(path, "wx", 0o600);
+    try {
+      await file.writeFile(`${JSON.stringify({ format: FORMAT, node })}\n`);
+      await file.sync();
+    } finally {
+      await file.close();
     }
+    await syncDirectory(retiredDirectory(directory));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
   }
-  state.dirty = remaining;
 }
 
-async function writeStateAtomically(directory: string, state: StoredState): Promise<void> {
-  assertState(state);
-  const destination = join(directory, STATE_FILE);
-  const temporary = join(directory, `.${STATE_FILE}.${process.pid}.${randomUUID()}.tmp`);
-  const encoded = `${JSON.stringify(state)}\n`;
+async function writeFileAtomically(destination: string, value: string): Promise<void> {
+  const temporary = join(dirname(destination), `.${randomUUID()}.tmp`);
   const file = await open(temporary, "wx", 0o600);
   try {
-    await file.writeFile(encoded);
+    await file.writeFile(value);
     await file.sync();
   } finally {
     await file.close();
   }
   await rename(temporary, destination);
-  // Durably publish the rename before a node is exposed/reused. Directory
-  // fsync is POSIX-specific; failure is fail-closed rather than guessed away.
-  const parent = await open(dirname(destination), "r");
+  await syncDirectory(dirname(destination));
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const directory = await open(path, "r");
   try {
-    await parent.sync();
+    await directory.sync();
   } finally {
-    await parent.close();
+    await directory.close();
   }
 }
 
-function emptyState(): StoredState {
-  return { format: FORMAT, clean: [], dirty: [], retired: [] };
+async function exists(path: string): Promise<boolean> {
+  try {
+    await readFile(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
 }
 
-function takeDirtySlot(state: StoredState, node: string): StoredSlot {
-  const index = state.dirty.findIndex((slot) => slot.node === node);
-  if (index < 0) throw new Error("Node foreground lease is no longer active");
-  const [slot] = state.dirty.splice(index, 1);
-  if (!slot) throw new Error("Node foreground lease is no longer active");
-  return slot;
-}
-
-function assertState(value: unknown): asserts value is StoredState {
-  if (!value || typeof value !== "object") throw new Error("state is not an object");
-  const state = value as Partial<StoredState>;
+function parseReusableReceipt(value: string, expectedNode: string): ReusableReceipt {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("receipt is not JSON");
+  }
+  const receipt = parsed as Partial<ReusableReceipt>;
   if (
-    state.format !== FORMAT ||
-    !Array.isArray(state.clean) ||
-    !Array.isArray(state.dirty) ||
-    !Array.isArray(state.retired)
+    !receipt ||
+    receipt.format !== FORMAT ||
+    receipt.node !== expectedNode ||
+    typeof receipt.confirmedTxTime !== "string" ||
+    !/^(0|[1-9][0-9]*)$/.test(receipt.confirmedTxTime) ||
+    !isTxTime(BigInt(receipt.confirmedTxTime))
+  )
+    throw new Error("receipt has an invalid shape");
+  return receipt as ReusableReceipt;
+}
+
+function parseActiveClaim(value: string): ActiveClaim {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("active claim is not JSON");
+  }
+  const claim = parsed as Partial<ActiveClaim>;
+  if (
+    !claim ||
+    claim.format !== FORMAT ||
+    typeof claim.node !== "string" ||
+    !NODE_RE.test(claim.node) ||
+    typeof claim.token !== "string" ||
+    !/^[0-9a-f-]{36}$/i.test(claim.token)
   ) {
-    throw new Error("state has an incompatible format");
+    throw new Error("active claim has an invalid shape");
   }
-  const nodes = new Set<string>();
-  for (const slot of [...state.clean, ...state.dirty]) {
-    if (!slot || typeof slot !== "object") throw new Error("invalid slot");
-    if (
-      !/^[0-9a-f]{32}$/.test(slot.node) ||
-      !/^(0|[1-9][0-9]*)$/.test(slot.confirmedTxTime) ||
-      nodes.has(slot.node)
-    ) {
-      throw new Error("invalid slot");
-    }
-    nodes.add(slot.node);
-  }
-  for (const node of state.retired) {
-    if (!/^[0-9a-f]{32}$/.test(node) || nodes.has(node)) throw new Error("invalid retired slot");
-    nodes.add(node);
-  }
+  return claim as ActiveClaim;
 }
 
-function slotLockPath(directory: string, node: string): string {
-  return join(directory, `slot-${node}.lock`);
+function activeDirectory(directory: string): string {
+  return join(directory, ACTIVE_DIRECTORY);
 }
-
+function reusableDirectory(directory: string): string {
+  return join(directory, REUSABLE_DIRECTORY);
+}
+function retiredDirectory(directory: string): string {
+  return join(directory, RETIRED_DIRECTORY);
+}
+function activePath(directory: string, node: string): string {
+  return join(activeDirectory(directory), node);
+}
+function reusablePath(directory: string, node: string): string {
+  return join(reusableDirectory(directory), node);
+}
+function retiredPath(directory: string, node: string): string {
+  return join(retiredDirectory(directory), node);
+}
+function maxBigInt(...values: bigint[]): bigint {
+  return values.reduce((max, value) => (value > max ? value : max), 0n);
+}
+function isTxTime(value: bigint): boolean {
+  return value >= 0n && value <= MAX_TX_TIME;
+}
 function asError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/jazz-tools/src/runtime/runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/runtime-source.ts
@@ -18,11 +18,11 @@ export interface RuntimeClientContext<RuntimeConfig extends DbConfig = DbConfig>
    * Browser-only identity leased by the durable SharedWorker before the
    * synchronous foreground client is constructed.
    */
-  foregroundNodeLease?: BrowserForegroundNodeLease;
+  foregroundNodeLease?: ForegroundNodeLease;
 }
 
-/** Internal browser foreground TxId lease, never exposed as application API. */
-export interface BrowserForegroundNodeLease {
+/** Internal foreground TxId lease, never exposed as application API. */
+export interface ForegroundNodeLease {
   readonly node: Uint8Array;
   readonly confirmedTxTime: bigint;
   /** Atomically persists runtime high-water and makes this node reusable. */
@@ -108,7 +108,17 @@ export abstract class RuntimeSource<RuntimeConfig extends DbConfig = DbConfig> {
 
   abstract createClient(context: RuntimeClientContext<RuntimeConfig>): JazzClient;
 
-  acquireBrowserForegroundNodeLease(_config: RuntimeConfig): Promise<BrowserForegroundNodeLease> {
+  /**
+   * Optional pre-runtime foreground identity lease for non-browser hosts.
+   * Browser persistence uses the dedicated SharedWorker variant below.
+   */
+  async acquireForegroundNodeLease(
+    _config: RuntimeConfig,
+  ): Promise<ForegroundNodeLease | undefined> {
+    return undefined;
+  }
+
+  acquireBrowserForegroundNodeLease(_config: RuntimeConfig): Promise<ForegroundNodeLease> {
     return Promise.reject(
       new Error("Db runtime source does not support browser foreground leases"),
     );

--- a/packages/jazz-tools/src/runtime/runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/runtime-source.ts
@@ -14,6 +14,21 @@ export interface RuntimeClientContext<RuntimeConfig extends DbConfig = DbConfig>
   config: RuntimeConfig;
   schema: WasmSchema;
   onAuthFailure: (reason: AuthFailureReason) => void;
+  /**
+   * Browser-only identity leased by the durable SharedWorker before the
+   * synchronous foreground client is constructed.
+   */
+  foregroundNodeLease?: BrowserForegroundNodeLease;
+}
+
+/** Internal browser foreground TxId lease, never exposed as application API. */
+export interface BrowserForegroundNodeLease {
+  readonly node: Uint8Array;
+  readonly confirmedTxTime: bigint;
+  /** Atomically persists runtime high-water and makes this node reusable. */
+  returnWithHighWater(highWater: bigint): Promise<void>;
+  /** Permanently retires this node when clean handoff is not certain. */
+  retire(): Promise<void>;
 }
 
 export interface RuntimeTelemetryContext<RuntimeConfig extends DbConfig = DbConfig> {
@@ -92,6 +107,12 @@ export abstract class RuntimeSource<RuntimeConfig extends DbConfig = DbConfig> {
   }
 
   abstract createClient(context: RuntimeClientContext<RuntimeConfig>): JazzClient;
+
+  acquireBrowserForegroundNodeLease(_config: RuntimeConfig): Promise<BrowserForegroundNodeLease> {
+    return Promise.reject(
+      new Error("Db runtime source does not support browser foreground leases"),
+    );
+  }
 
   createBrowserWorkerConnection(
     _context: BrowserWorkerConnectionContext<RuntimeConfig>,

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -288,6 +288,10 @@ declare module "jazz-wasm" {
     onMutationError(callback: (event: any) => void): void;
     tick(): Promise<void>;
     setNonDurableClient(): void;
+    /** @internal Foreground node-lease handoff only. */
+    foregroundTxTimeHighWater(): bigint;
+    /** @internal Foreground node-lease bootstrap only. */
+    seedForegroundTxTimeHighWater(highWater: bigint): void;
     setRelayAuthoritySessionOwner(): void;
     close(): Promise<boolean>;
     connectUpstream(): WasmTransport;

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.ts
@@ -155,8 +155,14 @@ async function acquireForegroundNodeLease(
               throw new Error("Invalid foreground node lease high-water");
             }
             const highWater = BigInt(message.confirmedTxTime);
-            settled = true;
+            if (highWater > (1n << 64n) - 1n) {
+              throw new Error("Invalid foreground node lease high-water");
+            }
+            // Do not mark this finished until the durable returned receipt has
+            // committed. A failing return must still take the durable-retire
+            // path; otherwise an active lease could be silently forgotten.
             await owner!.pageStore.returnForegroundNodeLease(lease.leaseId, highWater);
+            settled = true;
             owner!.activeLeaseIds.delete(lease.leaseId);
             post(port, {
               type: "foreground-node-lease-result",

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.ts
@@ -7,6 +7,10 @@ import {
   transferableFrames,
 } from "../runtime/native-runtime/browser-worker-transport.js";
 import type {
+  BrowserForegroundNodeLeaseAcquireRequest,
+  BrowserForegroundNodeLeaseAcquireResponse,
+  BrowserForegroundNodeLeasePortEvent,
+  BrowserForegroundNodeLeasePortRequest,
   BrowserFollowerPortEvent,
   BrowserFollowerPortRequest,
   BrowserInspectorControlEvent,
@@ -72,9 +76,15 @@ type RuntimeContext = {
   transportStateWaiters: Set<() => void>;
 };
 
+type ForegroundLeaseOwner = {
+  pageStore: IndexedDbPageStore;
+  activeLeaseIds: Set<string>;
+};
+
 const workerGlobal = globalThis as SharedWorkerGlobal;
 const workerRealmId = crypto.randomUUID();
 const contexts = new Map<string, RuntimeContext>();
+const foregroundLeaseOwners = new Map<string, ForegroundLeaseOwner>();
 const inspectorControlPorts = new Set<MessagePort>();
 let wasmModulePromise: Promise<WasmModule> | null = null;
 let wasmModuleSource: string | null = null;
@@ -84,16 +94,118 @@ let nextResetId = 1;
 workerGlobal.onconnect = (event) => {
   const port = event.ports[0];
   if (!port) return;
-  const onBootstrapMessage = (messageEvent: MessageEvent<BrowserSharedWorkerConnectRequest>) => {
+  const onBootstrapMessage = (
+    messageEvent: MessageEvent<
+      BrowserSharedWorkerConnectRequest | BrowserForegroundNodeLeaseAcquireRequest
+    >,
+  ) => {
     const message = messageEvent.data;
-    if (message?.type !== "connect-runtime") return;
+    if (message?.type !== "connect-runtime" && message?.type !== "acquire-foreground-node-lease") {
+      return;
+    }
     port.removeEventListener("message", onBootstrapMessage);
-    post(port, { type: "worker-alive" });
-    void connectTab(port, message);
+    if (message.type === "connect-runtime") {
+      post(port, { type: "worker-alive" });
+      void connectTab(port, message);
+    } else {
+      void acquireForegroundNodeLease(port, message);
+    }
   };
   port.addEventListener("message", onBootstrapMessage);
   port.start();
 };
+
+async function acquireForegroundNodeLease(
+  port: MessagePort,
+  request: BrowserForegroundNodeLeaseAcquireRequest,
+): Promise<void> {
+  try {
+    let owner = foregroundLeaseOwners.get(request.dbName);
+    if (!owner) {
+      owner = {
+        pageStore: await IndexedDbPageStore.open(request.dbName),
+        activeLeaseIds: new Set(),
+      };
+      foregroundLeaseOwners.set(request.dbName, owner);
+    }
+    const lease = await owner.pageStore.acquireForegroundNodeLease(owner.activeLeaseIds.size === 0);
+    owner.activeLeaseIds.add(lease.leaseId);
+    post(port, {
+      type: "foreground-node-lease-ready",
+      leaseId: lease.leaseId,
+      node: lease.node,
+      confirmedTxTime: lease.confirmedTxTime.toString(),
+    } satisfies BrowserForegroundNodeLeaseAcquireResponse);
+
+    let settled = false;
+    const retire = async (): Promise<void> => {
+      if (settled) return;
+      settled = true;
+      owner!.activeLeaseIds.delete(lease.leaseId);
+      await owner!.pageStore.retireForegroundNodeLease(lease.leaseId);
+      maybeCloseWorker();
+    };
+    const onMessage = (event: MessageEvent<BrowserForegroundNodeLeasePortRequest>) => {
+      void (async () => {
+        const message = event.data;
+        try {
+          if (settled) return;
+          if (message?.type === "return-foreground-node-lease") {
+            if (!/^(0|[1-9][0-9]*)$/.test(message.confirmedTxTime)) {
+              throw new Error("Invalid foreground node lease high-water");
+            }
+            const highWater = BigInt(message.confirmedTxTime);
+            settled = true;
+            await owner!.pageStore.returnForegroundNodeLease(lease.leaseId, highWater);
+            owner!.activeLeaseIds.delete(lease.leaseId);
+            post(port, {
+              type: "foreground-node-lease-result",
+            } satisfies BrowserForegroundNodeLeasePortEvent);
+            cleanup();
+            port.close();
+            maybeCloseWorker();
+            return;
+          }
+          if (message?.type === "retire-foreground-node-lease") {
+            await retire();
+            post(port, {
+              type: "foreground-node-lease-result",
+            } satisfies BrowserForegroundNodeLeasePortEvent);
+            cleanup();
+            port.close();
+          }
+        } catch (error) {
+          // A failed clean handoff is indistinguishable from an interrupted
+          // one. Failed retirement leaves the active record for a later worker
+          // bootstrap to retire instead of making it reusable.
+          await retire().catch(() => undefined);
+          post(port, {
+            type: "foreground-node-lease-result",
+            error: asError(error).message,
+          } satisfies BrowserForegroundNodeLeasePortEvent);
+          cleanup();
+          port.close();
+        }
+      })();
+    };
+    const onMessageError = () => {
+      void retire().catch(() => undefined);
+      cleanup();
+    };
+    const cleanup = () => {
+      port.removeEventListener("message", onMessage);
+      port.removeEventListener("messageerror", onMessageError);
+    };
+    port.addEventListener("message", onMessage);
+    port.addEventListener("messageerror", onMessageError);
+  } catch (error) {
+    post(port, {
+      type: "foreground-node-lease-error",
+      message: asError(error).message,
+    } satisfies BrowserForegroundNodeLeaseAcquireResponse);
+    port.close();
+  }
+}
 
 async function connectTab(
   port: MessagePort,
@@ -789,7 +901,14 @@ function scheduleIdleContextRelease(context: RuntimeContext): void {
 }
 
 function maybeCloseWorker(): void {
-  if (contexts.size === 0 && inspectorControlPorts.size === 0) workerGlobal.close();
+  const hasActiveForegroundLease = [...foregroundLeaseOwners.values()].some(
+    (owner) => owner.activeLeaseIds.size > 0,
+  );
+  if (contexts.size === 0 && inspectorControlPorts.size === 0 && !hasActiveForegroundLease) {
+    for (const owner of foregroundLeaseOwners.values()) owner.pageStore.close();
+    foregroundLeaseOwners.clear();
+    workerGlobal.close();
+  }
 }
 
 function closeContextPeers(context: RuntimeContext): void {
@@ -884,7 +1003,11 @@ function runtimeKey(options: BrowserWorkerInitOptions): string {
 
 function post(
   port: MessagePort,
-  event: BrowserFollowerPortEvent | BrowserSharedWorkerConnectResponse,
+  event:
+    | BrowserFollowerPortEvent
+    | BrowserSharedWorkerConnectResponse
+    | BrowserForegroundNodeLeaseAcquireResponse
+    | BrowserForegroundNodeLeasePortEvent,
 ): void {
   port.postMessage(event);
 }

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.ts
@@ -867,6 +867,17 @@ async function finalizeContextStorageReset(context: RuntimeContext): Promise<voi
   context.disposeAuxiliaryTrace?.();
   context.disposeAuxiliaryTrace = null;
   contexts.delete(context.key);
+
+  // The reset deleted the physical lease pool along with the page tree. Drop
+  // the worker's handle to that erased epoch before a successor asks for a
+  // lease; otherwise it would try to mutate an invalidated IDB connection.
+  // Existing foregrounds are being reset/discarded and their captured owners
+  // may only fail closed while returning their now-retired leases.
+  const leaseOwner = foregroundLeaseOwners.get(context.options.dbName);
+  if (leaseOwner) {
+    foregroundLeaseOwners.delete(context.options.dbName);
+    leaseOwner.pageStore.close();
+  }
 }
 
 async function releaseIdleContext(context: RuntimeContext): Promise<void> {

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { createDb, Db, getDbSubscriptionSource, type QueryBuilder } from "../../src/runtime/db.js";
+import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
 import type { Schema } from "../../src/drivers/types.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import {

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -368,7 +368,7 @@ describe("SharedWorker bridge with IndexedDB", () => {
     }
   });
 
-  it("keeps createDb schema-lazy and rejects the first local subscription when durable storage cannot open", async () => {
+  it("rejects createDb operation-scoped when its foreground lease cannot open durable storage", async () => {
     const ambientErrors: string[] = [];
     const unhandledRejections: string[] = [];
     const recordAmbientError = (event: ErrorEvent) => {
@@ -385,7 +385,6 @@ describe("SharedWorker bridge with IndexedDB", () => {
     errorListeners.add(recordAmbientError);
     const dbName = uniqueDbName("corrupt-storage-open");
     const secret = generateAuthSecret();
-    let reopened: Db | null = null;
     try {
       const initial = track(
         await createDb({
@@ -410,59 +409,22 @@ describe("SharedWorker bridge with IndexedDB", () => {
       });
       const recordsBeforeRead = await rawStorageRecords(dbName);
 
-      reopened = track(
-        await createDb({
+      // Persistent create must acquire a durable foreground-node lease before
+      // any synchronous mutation can mint a transaction identity. Storage
+      // readiness therefore belongs to createDb, while schema selection stays
+      // lazy. The original cause must reject that operation directly.
+      await expect(
+        createDb({
           appId: "test-app",
           secret,
           driver: { type: "persistent", dbName },
         }),
-      );
-      // `createDb` intentionally does not select a schema or open durable
-      // storage. The first schema-backed subscription owns the failure. This
-      // assertion is intentionally synchronous: the old path published an
-      // empty local seed here before the worker attempted to open IndexedDB.
-      const cancelledDeltas: unknown[] = [];
-      const cancelled = getDbSubscriptionSource(reopened).subscribeDelta(
-        todos,
-        (delta) => cancelledDeltas.push(delta),
-        { tier: "local" },
-      );
-      cancelled();
-      const subscriptionDeltas: unknown[] = [];
-      const subscription = getDbSubscriptionSource(reopened).subscribeDelta(
-        todos,
-        (delta) => subscriptionDeltas.push(delta),
-        { tier: "local" },
-      );
-      expect(cancelledDeltas).toEqual([]);
-      expect(subscriptionDeltas).toEqual([]);
-      await expect(cancelled.ready ?? Promise.resolve()).resolves.toBeUndefined();
-      await expect(
-        withTimeout(
-          subscription.ready ?? Promise.resolve(),
-          5_000,
-          "corrupt storage subscription did not settle",
-        ),
       ).rejects.toThrow("Missing or invalid IndexedDB storage epoch manifest");
-      expect(subscriptionDeltas).toEqual([]);
-      subscription();
-      // The rejected operation leaves no durable peer to flush. Shutdown is
-      // still an explicit observation point for the same readiness failure, not
-      // an ambient error deferred to best-effort test cleanup.
-      await expect(reopened.shutdown()).rejects.toThrow(
-        "Missing or invalid IndexedDB storage epoch manifest",
-      );
-      untrack(reopened);
-      reopened = null;
       await sleep(0);
       expect(ambientErrors).toEqual([]);
       expect(unhandledRejections).toEqual([]);
       expect(await rawStorageRecords(dbName)).toEqual(recordsBeforeRead);
     } finally {
-      if (reopened) {
-        await reopened.shutdown().catch(() => undefined);
-        untrack(reopened);
-      }
       globalThis.removeEventListener("error", recordAmbientError);
       globalThis.removeEventListener("unhandledrejection", recordUnhandledRejection);
       errorListeners.delete(recordAmbientError);


### PR DESCRIPTION
🤖 Draft implementation of #2343: safely reuse foreground node identities without sharing one identity between concurrent runtimes.

## Governing model

Each live foreground receives its own exclusively leased node UUID and continues minting transaction IDs locally. The persistent environment owner records the lease and its confirmed HLC high-water.

- clean handoff: atomically persist the runtime-owned high-water, then return the node to the reusable pool;
- uncertain termination, failed readout, or failed persistence: permanently retire the node;
- no expiry reuse, centralized minting, fencing generation, or range allocation.

The high-water includes every locally minted transaction ID, even if its transaction was rolled back or never submitted.

## Current slice

The shared Jazz core now defines and tests `ForegroundNodeLeasePool`: exclusive issue, clean monotonic return, reusable high-water continuation, and permanent uncertain retirement. The specification freezes the ownership and safety contract.

## Adapter plan

- Browser SharedWorker persists the pool and mediates bootstrap/clean shutdown for foreground tabs.
- RN native relay owns the equivalent pool for attached foreground runtimes.
- Current Node backends are durable serving owners, not disposable foreground peers, and intentionally retain their stable durable identity. A future Node foreground-host topology can adopt the same contract.

### Example

Tab A receives node N, mints through time T, and cleanly closes. The worker durably records T before making N reusable. Tab B may then receive N and starts strictly above T. If A crashes or its high-water cannot be read or persisted, N is retired and B receives another node.

Stacked after #2345 because the physical browser replica must first own a unique durable identity.
