### PR TITLE
Bound settled-state storage keys

### DIFF
--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -1198,7 +1198,7 @@ where
         .await
     }
 
-    async fn query_version_by_alias_with_storage_in_schema(
+    pub(super) async fn query_version_by_alias_with_storage_in_schema(
         &mut self,
         schema_version: SchemaVersionId,
         table: &str,

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -2042,9 +2042,38 @@ fn settled_result_member_key(
     binding_view_key: BindingViewKey,
     member: &ResultMemberEntry,
 ) -> Result<Vec<Value>, Error> {
+    let member_bytes = codec::result_member_storage_bytes(member)?;
     let mut key = binding_view_store_prefix(binding_view_key);
-    key.push(Value::Bytes(codec::result_member_storage_bytes(member)?));
+    key.push(Value::Bytes(
+        settled_result_member_digest(&member_bytes).to_vec(),
+    ));
     Ok(key)
+}
+
+/// Domain-separated identity for one settled result member.  A member may
+/// contain an application-controlled synthetic payload, so its canonical bytes
+/// belong in the direct-store value rather than an ordered storage key.  The
+/// fixed-size digest retains idempotent add/remove semantics without allowing
+/// a large member to make an IDB/B-tree key exceed its page bound.
+const SETTLED_RESULT_MEMBER_DIGEST_DOMAIN: &str = "jazz.settled-result-member-key.v1";
+
+fn settled_result_member_digest(member_bytes: &[u8]) -> [u8; 32] {
+    blake3::derive_key(SETTLED_RESULT_MEMBER_DIGEST_DOMAIN, member_bytes)
+}
+
+fn settled_result_member_storage_write(
+    binding_view_key: BindingViewKey,
+    member: &ResultMemberEntry,
+) -> Result<groove::db::DirectRecordStoreWrite, Error> {
+    let member_bytes = codec::result_member_storage_bytes(member)?;
+    let mut key = binding_view_store_prefix(binding_view_key);
+    key.push(Value::Bytes(
+        settled_result_member_digest(&member_bytes).to_vec(),
+    ));
+    Ok(groove::db::DirectRecordStoreWrite::Set {
+        key,
+        value: vec![Value::Bytes(member_bytes)],
+    })
 }
 
 fn settled_program_fact_key(

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -2052,8 +2052,35 @@ fn settled_program_fact_key(
     fact: &ViewFactEntry,
 ) -> Result<Vec<Value>, Error> {
     let mut key = binding_view_store_prefix(binding_view_key);
-    key.push(Value::Bytes(codec::program_fact_storage_bytes(fact)?));
+    key.push(Value::Bytes(
+        settled_program_fact_digest(&codec::program_fact_storage_bytes(fact)?).to_vec(),
+    ));
     Ok(key)
+}
+
+/// Domain-separated identity for a settled program fact. Facts can include a
+/// hydrated application payload, so the full canonical encoding belongs in a
+/// value cell. The key keeps only this fixed-size identity, preserving ordered
+/// B-tree page bounds while retaining exact payload validation on recovery.
+const SETTLED_PROGRAM_FACT_DIGEST_DOMAIN: &str = "jazz.settled-program-fact-key.v1";
+
+fn settled_program_fact_digest(fact_bytes: &[u8]) -> [u8; 32] {
+    blake3::derive_key(SETTLED_PROGRAM_FACT_DIGEST_DOMAIN, fact_bytes)
+}
+
+fn settled_program_fact_storage_write(
+    binding_view_key: BindingViewKey,
+    fact: &ViewFactEntry,
+) -> Result<groove::db::DirectRecordStoreWrite, Error> {
+    let fact_bytes = codec::program_fact_storage_bytes(fact)?;
+    let mut key = binding_view_store_prefix(binding_view_key);
+    key.push(Value::Bytes(
+        settled_program_fact_digest(&fact_bytes).to_vec(),
+    ));
+    Ok(groove::db::DirectRecordStoreWrite::Set {
+        key,
+        value: vec![Value::Bytes(fact_bytes)],
+    })
 }
 
 fn binding_view_key_from_store_key(

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -564,17 +564,11 @@ where
                 .collect::<Vec<_>>();
             if let Some(members) = rewrite {
                 for member in members {
-                    operations.push(DirectRecordStoreWrite::Set {
-                        key: settled_result_member_key(binding_view_key, member)?,
-                        value: vec![Value::U64(1)],
-                    });
+                    operations.push(settled_result_member_storage_write(binding_view_key, member)?);
                 }
             } else {
                 for member in adds {
-                    operations.push(DirectRecordStoreWrite::Set {
-                        key: settled_result_member_key(binding_view_key, member)?,
-                        value: vec![Value::U64(1)],
-                    });
+                    operations.push(settled_result_member_storage_write(binding_view_key, member)?);
                 }
             }
             store.write_many(&operations).await?;
@@ -588,10 +582,7 @@ where
             });
         }
         for member in adds {
-            operations.push(DirectRecordStoreWrite::Set {
-                key: settled_result_member_key(binding_view_key, member)?,
-                value: vec![Value::U64(1)],
-            });
+            operations.push(settled_result_member_storage_write(binding_view_key, member)?);
         }
         if !operations.is_empty() {
             store.write_many(&operations).await?;
@@ -756,7 +747,20 @@ where
                 &entry.key,
                 "settled result member binding key must be valid",
             )?;
-            let member_bytes = match &entry.key[3] {
+            let member_digest = match &entry.key[3] {
+                Value::Bytes(bytes) => bytes,
+                _ => {
+                    return Err(Error::InvalidStoredValue(
+                        "settled result member digest must be bytes",
+                    ));
+                }
+            };
+            if member_digest.len() != 32 {
+                return Err(Error::InvalidStoredValue(
+                    "settled result member digest must be 32 bytes",
+                ));
+            }
+            let member_bytes = match entry.value.get_idx(0)? {
                 Value::Bytes(bytes) => bytes,
                 _ => {
                     return Err(Error::InvalidStoredValue(
@@ -764,7 +768,12 @@ where
                     ));
                 }
             };
-            let member = result_member_from_storage_bytes(member_bytes)?;
+            if settled_result_member_digest(&member_bytes).as_slice() != member_digest {
+                return Err(Error::InvalidStoredValue(
+                    "settled result member payload does not match its digest",
+                ));
+            }
+            let member = result_member_from_storage_bytes(&member_bytes)?;
             recovered_members.push((binding_view_key, member));
         }
         let mut settled_result_sets =

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -624,17 +624,11 @@ where
                 .collect::<Vec<_>>();
             if let Some(facts) = rewrite {
                 for fact in facts {
-                    operations.push(DirectRecordStoreWrite::Set {
-                        key: settled_program_fact_key(binding_view_key, fact)?,
-                        value: vec![Value::U64(1)],
-                    });
+                    operations.push(settled_program_fact_storage_write(binding_view_key, fact)?);
                 }
             } else {
                 for fact in adds {
-                    operations.push(DirectRecordStoreWrite::Set {
-                        key: settled_program_fact_key(binding_view_key, fact)?,
-                        value: vec![Value::U64(1)],
-                    });
+                    operations.push(settled_program_fact_storage_write(binding_view_key, fact)?);
                 }
             }
             store.write_many(&operations).await?;
@@ -648,10 +642,7 @@ where
             });
         }
         for fact in adds {
-            operations.push(DirectRecordStoreWrite::Set {
-                key: settled_program_fact_key(binding_view_key, fact)?,
-                value: vec![Value::U64(1)],
-            });
+            operations.push(settled_program_fact_storage_write(binding_view_key, fact)?);
         }
         if !operations.is_empty() {
             store.write_many(&operations).await?;
@@ -807,7 +798,20 @@ where
                 &entry.key,
                 "settled program fact binding key must be valid",
             )?;
-            let fact_bytes = match &entry.key[3] {
+            let fact_digest = match &entry.key[3] {
+                Value::Bytes(bytes) => bytes,
+                _ => {
+                    return Err(Error::InvalidStoredValue(
+                        "settled program fact digest must be bytes",
+                    ));
+                }
+            };
+            if fact_digest.len() != 32 {
+                return Err(Error::InvalidStoredValue(
+                    "settled program fact digest must be 32 bytes",
+                ));
+            }
+            let fact_bytes = match entry.value.get_idx(0)? {
                 Value::Bytes(bytes) => bytes,
                 _ => {
                     return Err(Error::InvalidStoredValue(
@@ -815,7 +819,12 @@ where
                     ));
                 }
             };
-            let fact = codec::program_fact_from_storage_bytes(fact_bytes)?;
+            if settled_program_fact_digest(&fact_bytes).as_slice() != fact_digest {
+                return Err(Error::InvalidStoredValue(
+                    "settled program fact payload does not match its digest",
+                ));
+            }
+            let fact = codec::program_fact_from_storage_bytes(&fact_bytes)?;
             settled_program_facts
                 .entry(binding_view_key)
                 .or_default()

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -794,6 +794,73 @@ fn malformed_branch_key_rejects_multi_key_commit_without_residue() {
     assert!(node.query_table_versions("todos").unwrap().is_empty());
 }
 
+/// Internal maintained-view witness receipt: a branched writer's large
+/// immutable history record must reload from that exact branch, never from an
+/// implicit default coordinate. This targets the pre-serialization storage
+/// identity boundary that public queries cannot directly expose.
+#[test]
+fn maintained_witness_reloads_the_exact_large_nondefault_branch_version() {
+    // `canonical_history_version_for_maintained_witness` is used before a
+    // maintained result is serialized. A physical row can have both default
+    // and non-default branch versions in one transaction, so table/row/tx
+    // coordinates alone are insufficient: falling back to the default branch
+    // silently ships a different immutable VersionRecord.
+    let schema = branch_view_schema();
+    let (_dir, mut node) =
+        open_history_complete_node_with_schema(NodeUuid::from_bytes([0x70; 16]), schema.clone());
+    let row_uuid = row(0x71);
+    let branch = branch_selector(0x72);
+    let owner = AuthorSubject::for_test_bytes([0x73; 16]);
+    let cells = |title: String| {
+        BTreeMap::from([
+            ("title".to_owned(), Value::String(title)),
+            ("owner".to_owned(), Value::Uuid(owner.test_uuid())),
+        ])
+    };
+    // Keep this below the large-value promotion threshold: the regression is
+    // about reloading a large *VersionRecord* from history, not about a query
+    // evaluator materializing an application large value first.
+    let branch_title = "non-default branch canonical body".repeat(1_500);
+    let tx_id = node
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row_uuid, 10)
+                .branch(branch.clone())
+                .cells(cells(branch_title.clone())),
+        )
+        .unwrap();
+    let versions = futures::executor::block_on(node.query_versions_for_tx(tx_id)).unwrap();
+    let branched = versions
+        .iter()
+        .find(|version| version.branch_key().is_canonical() && *version.branch_key() != BranchKey::default())
+        .expect("non-default branch row is persisted")
+        .clone();
+    let storage_table = node
+        .version_storage_sources_for_layer(branched.table(), branched.layer())
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("content versions have history storage");
+    assert!(futures::executor::block_on(node.query_version_by_alias_with_storage_in_schema(
+        schema.version_id(),
+        branched.table(),
+        &storage_table,
+        &BranchKey::default(),
+        branched.row_uuid(),
+        branched.tx_time(),
+        branched.tx_node_alias(),
+    ))
+    .unwrap()
+    .is_none(), "a missing branch coordinate must never silently use a default branch");
+    let canonical = futures::executor::block_on(
+        node.canonical_history_version_for_maintained_witness(&branched),
+    )
+    .unwrap();
+    let canonical_wire = node.version_record_from_row(&canonical).unwrap();
+    assert_eq!(canonical.branch_key(), branched.branch_key());
+    assert_eq!(canonical_wire.branch_key(), branched.branch_key());
+    assert_eq!(canonical_wire.cell_at(1), Some(Value::String(branch_title)));
+}
+
 #[test]
 fn branch_coordinates_use_one_canonical_prefix_in_memory_and_after_rocks_reopen() {
     let schema = branch_view_schema();

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -851,8 +851,33 @@ fn maintained_witness_reloads_the_exact_large_nondefault_branch_version() {
     ))
     .unwrap()
     .is_none(), "a missing branch coordinate must never silently use a default branch");
+    // Model the maintained graph's real projection boundary: its history
+    // descriptor is unchanged, but a selected-out authored cell is represented
+    // by typed null. Falling through to this in-memory witness is forbidden;
+    // recovery must find the complete immutable row under the exact branch.
+    let mut partial_witness = branched.clone();
+    let descriptor = partial_witness.record.descriptor().clone();
+    let mut values = partial_witness.record.to_values().unwrap();
+    let title_position = node.catalogue.schema.tables[0]
+        .columns
+        .iter()
+        .position(|column| column.name == "title")
+        .unwrap();
+    values[crate::node::codec::HistoryRowRecord::USER_CELLS + title_position] =
+        Value::Nullable(None);
+    partial_witness.record = groove::records::OwnedRecord::new(
+        descriptor.create(&values).unwrap(),
+        descriptor,
+    );
+    assert_eq!(
+        partial_witness
+            .cell(&node.catalogue.schema.tables[0], "title")
+            .unwrap(),
+        None,
+        "the planted maintained witness must be observably partial"
+    );
     let canonical = futures::executor::block_on(
-        node.canonical_history_version_for_maintained_witness(&branched),
+        node.canonical_history_version_for_maintained_witness(&partial_witness),
     )
     .unwrap();
     let canonical_wire = node.version_record_from_row(&canonical).unwrap();

--- a/crates/jazz/src/node/tests/sync/known_state.rs
+++ b/crates/jazz/src/node/tests/sync/known_state.rs
@@ -1191,7 +1191,7 @@ fn settled_program_fact_add_remove_rewrite_and_reopen_use_one_durable_key_codec(
             },
             descriptor: groove::records::encode_record_descriptor(&payload_descriptor).unwrap(),
             record: payload_descriptor
-                .create(&[Value::String("payload".to_owned())])
+                .create(&[Value::String("large settled payload ".repeat(20_000))])
                 .unwrap(),
         },
     );
@@ -1202,6 +1202,25 @@ fn settled_program_fact_add_remove_rewrite_and_reopen_use_one_durable_key_codec(
             vec![],
         ))
         .unwrap();
+    let settled_facts_store = reader
+        .database
+        .direct_record_store(crate::schema::SETTLED_PROGRAM_FACTS_STORE)
+        .unwrap();
+    let durable_fact = futures::executor::block_on(settled_facts_store.prefix_entries(&[]))
+    .unwrap()
+    .into_iter()
+    .find(|entry| {
+        matches!(
+            entry.value.get_idx(0),
+            Ok(Value::Bytes(bytes)) if bytes.len() > 64 * 1024
+        )
+    })
+    .expect("settled program fact is durable");
+    assert!(matches!(&durable_fact.key[3], Value::Bytes(digest) if digest.len() == 32));
+    assert!(matches!(
+        durable_fact.value.get_idx(0).unwrap(),
+        Value::Bytes(bytes) if bytes.len() > 64 * 1024
+    ));
     drop(reader);
     let reopened = open_node_at(&reader_dir, schema());
     assert_eq!(
@@ -1240,7 +1259,7 @@ fn corrupt_settled_program_fact_recovery_does_not_publish_a_valid_prefix() {
             result_member_adds: Vec::new(),
             result_member_removes: Vec::new(),
             terminal_operations: Vec::new(),
-            program_fact_adds: vec![fact],
+            program_fact_adds: vec![fact.clone()],
             program_fact_removes: Vec::new(),
         }))
         .unwrap();
@@ -1253,9 +1272,13 @@ fn corrupt_settled_program_fact_recovery_does_not_publish_a_valid_prefix() {
                 Value::Uuid(uuid::Uuid::from_bytes([0xff; 16])),
                 Value::Uuid(uuid::Uuid::from_bytes([0xff; 16])),
                 Value::Uuid(uuid::Uuid::from_bytes([0xff; 16])),
-                Value::Bytes(vec![0]),
+                // A full-sized but wrong digest proves recovery verifies the
+                // key/value binding rather than only the digest's shape.
+                Value::Bytes(vec![0xff; 32]),
             ],
-            &[Value::U64(1)],
+            &[Value::Bytes(
+                crate::node::codec::program_fact_storage_bytes(&fact).unwrap(),
+            )],
         ))
     .unwrap();
     assert!(futures::executor::block_on(reader.recover_known_state_facts()).is_err());

--- a/crates/jazz/src/node/tests/sync/known_state.rs
+++ b/crates/jazz/src/node/tests/sync/known_state.rs
@@ -1229,6 +1229,148 @@ fn settled_program_fact_add_remove_rewrite_and_reopen_use_one_durable_key_codec(
     );
 }
 
+/// Internal direct-store recovery receipt for a local reader: large synthetic,
+/// path, and real result identities must reopen through bounded digest keys.
+/// This stays below the public client layer because applications cannot inspect
+/// the direct-store key/value boundary or inject a digest/payload mismatch.
+#[test]
+fn settled_result_members_use_digest_keys_and_recover_large_payloads() {
+    // The member itself is application-shaped data (synthetic rows and path
+    // tuples can be large).  It must therefore never become an ordered-store
+    // key: every durable key has a fixed 32-byte digest and the complete
+    // canonical member is retained in the value cell for exact recovery.
+    let (reader_dir, mut reader) = open_node_with_uuid(node(3));
+    let (shape, binding) = reader.whole_table_shape_binding("todos").unwrap();
+    register_shape_binding(&mut reader, &shape, &binding);
+    let subscription = reader.whole_table_subscription_key("todos").unwrap();
+    let key = BindingViewKey::from_canonical_subscription_key(subscription);
+    let update = |reset_result_set, adds, removes| {
+        SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+            subscription,
+            settled_through: GlobalTime(1),
+            reset_result_set,
+            version_carriers: Vec::new(),
+            peer_payload_inventory: crate::protocol::PeerPayloadInventory::default(),
+            result_member_adds: adds,
+            result_member_removes: removes,
+            terminal_operations: Vec::new(),
+            program_fact_adds: Vec::new(),
+            program_fact_removes: Vec::new(),
+        })
+    };
+
+    let mut real = crate::protocol::RealRowMemberEntry::current_content((
+        groove::Intern::from("todos".to_owned()),
+        row(61),
+        TxId::new(TxTime(61), node(61)),
+    ));
+    // Nearly the maximum member encoding: this used to make the ordered IDB
+    // key too large even though the direct-store value is intentionally able
+    // to carry it.
+    real.branch_or_prefix = Some(vec![0x61; 900 * 1024]);
+    // This is a pure output identity receipt, not a row payload delivery;
+    // avoid claiming that this synthetic view update carries a transaction
+    // whose version bundle was not included above.
+    real.content_tx = None;
+    let real = ResultMemberEntry::Row(real);
+    let synthetic_row = crate::node::codec::settled_result_value_storage_bytes(
+        &Value::String("synthetic ".repeat(10_000)),
+        &groove::records::ValueType::String,
+    )
+    .unwrap();
+    let synthetic_replacement = crate::node::codec::settled_result_value_storage_bytes(
+        &Value::U64(1),
+        &groove::records::ValueType::U64,
+    )
+    .unwrap();
+    let synthetic = ResultMemberEntry::Synthetic {
+        table: "totals".to_owned(),
+        row: synthetic_row,
+        replacement: crate::protocol::SyntheticReplacementToken::from_encoded_record(
+            synthetic_replacement,
+        ),
+    };
+    let path = ResultMemberEntry::PathTuple {
+        path: "album.tracks".to_owned(),
+        source_table: groove::Intern::from("albums".to_owned()),
+        source_row: row(62),
+        target_table: groove::Intern::from("tracks".to_owned()),
+        target_row: row(63),
+        edge_id: Some(vec![0x62; 64 * 1024]),
+        revision: vec![0x63; 96 * 1024],
+    };
+    reader
+        .apply_sync_message_settled(update(
+            false,
+            vec![real.clone(), synthetic.clone(), path.clone()],
+            vec![],
+        ))
+        .unwrap();
+    // Repeating an add is idempotent because the digest is a stable identity.
+    reader
+        .apply_sync_message_settled(update(false, vec![synthetic.clone()], vec![]))
+        .unwrap();
+    let store = reader
+        .database
+        .direct_record_store(crate::schema::SETTLED_RESULT_MEMBERS_STORE)
+        .unwrap();
+    let entries = futures::executor::block_on(store.prefix_entries(&[])).unwrap();
+    assert_eq!(entries.len(), 3);
+    assert!(entries.iter().all(|entry| {
+        entry.key.len() == 4
+            && matches!(&entry.key[3], Value::Bytes(digest) if digest.len() == 32)
+            && matches!(entry.value.get_idx(0), Ok(Value::Bytes(bytes)) if bytes.len() > 0)
+    }));
+    assert!(entries.iter().any(|entry| {
+        matches!(entry.value.get_idx(0), Ok(Value::Bytes(bytes)) if bytes.len() > 64 * 1024)
+    }));
+    assert!(entries.iter().any(|entry| {
+        matches!(entry.value.get_idx(0), Ok(Value::Bytes(bytes)) if bytes.len() > 800 * 1024)
+    }));
+    drop(reader);
+
+    let mut reopened = open_node_at(&reader_dir, schema());
+    assert_eq!(
+        reopened.query.settled_result_sets[&key],
+        BTreeSet::from([real.clone(), synthetic.clone(), path.clone()])
+    );
+    // Exercise delete and full rewrite using the same digest-key codec.
+    reopened
+        .apply_sync_message_settled(update(false, vec![], vec![path]))
+        .unwrap();
+    reopened
+        .apply_sync_message_settled(update(true, vec![synthetic.clone()], vec![]))
+        .unwrap();
+    drop(reopened);
+    let mut reopened = open_node_at(&reader_dir, schema());
+    assert_eq!(
+        reopened.query.settled_result_sets[&key],
+        BTreeSet::from([synthetic.clone()])
+    );
+
+    // A full-size but unrelated digest must fail closed rather than allowing a
+    // corrupt record to masquerade as a different member.
+    let store = reopened
+        .database
+        .direct_record_store(crate::schema::SETTLED_RESULT_MEMBERS_STORE)
+        .unwrap();
+    futures::executor::block_on(store.set(
+        &[
+            Value::Uuid(key.shape_id.0),
+            Value::Uuid(key.binding_id.0),
+            Value::Uuid(key.read_view.id),
+            Value::Bytes(vec![0xff; 32]),
+        ],
+        &[Value::Bytes(
+            crate::node::codec::result_member_storage_bytes(&synthetic).unwrap(),
+        )],
+    ))
+    .unwrap();
+    assert!(futures::executor::block_on(reopened.recover_known_state_facts()).is_err());
+    assert!(reopened.query.settled_result_sets.is_empty());
+    assert!(reopened.query.settled_through_by_binding_view.is_empty());
+}
+
 #[test]
 fn corrupt_settled_program_fact_recovery_does_not_publish_a_valid_prefix() {
     // Internal recovery-boundary coverage: force a valid persisted fact followed

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -1902,9 +1902,11 @@ where
             self.version_storage_sources_for_layer(version.table(), version.layer())?
         {
             let Some(canonical) = self
-                .query_version_by_alias_with_storage(
+                .query_version_by_alias_with_storage_in_schema(
+                    authored_schema,
                     version.table(),
                     &storage_table,
+                    version.branch_key(),
                     version.row_uuid(),
                     version.tx_time(),
                     version.tx_node_alias(),

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -603,9 +603,13 @@ impl RuntimeSchema {
                     ("shape_id", ValueType::Uuid),
                     ("binding_id", ValueType::Uuid),
                     ("read_view_id", ValueType::Uuid),
-                    ("member", ValueType::Bytes),
+                    ("member_digest", ValueType::Bytes),
                 ]),
-                RecordDescriptor::new([("present", ValueType::U64)]),
+                // Result members may contain synthetic application values or
+                // rich path identities. Their fixed digest is the ordered
+                // key; the complete canonical member belongs in this value
+                // cell where backends can use value-overflow storage.
+                RecordDescriptor::new([("member", ValueType::Bytes)]),
             ))
             .with_direct_record_store(DirectRecordStoreSchema::new(
                 SETTLED_PROGRAM_FACTS_STORE,

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -584,6 +584,11 @@ impl RuntimeSchema {
     }
 
     fn with_jazz_direct_record_stores(&self, schema: GrooveDatabaseSchema) -> GrooveDatabaseSchema {
+        // Ordered direct-store key audit (storage format V1): known-state keys
+        // are three UUIDs; settled member/fact identities are fixed 32-byte
+        // digests; clean-close and consistency markers are fixed internal
+        // strings. Application-shaped bytes therefore occur only in values,
+        // never in a direct-store key.
         schema
             .with_direct_record_store(DirectRecordStoreSchema::new(
                 KNOWN_STATE_FACTS_STORE,

--- a/crates/jazz/src/schema.rs
+++ b/crates/jazz/src/schema.rs
@@ -613,9 +613,13 @@ impl RuntimeSchema {
                     ("shape_id", ValueType::Uuid),
                     ("binding_id", ValueType::Uuid),
                     ("read_view_id", ValueType::Uuid),
-                    ("fact", ValueType::Bytes),
+                    // Program facts can contain an application result payload.
+                    // Keep their durable identity bounded so a promoted large
+                    // value is stored in the record body (where the backend
+                    // can use value overflow), not in an ordered B-tree key.
+                    ("fact_digest", ValueType::Bytes),
                 ]),
-                RecordDescriptor::new([("present", ValueType::U64)]),
+                RecordDescriptor::new([("fact", ValueType::Bytes)]),
             ))
             .with_direct_record_store(DirectRecordStoreSchema::new(
                 CLEAN_CLOSE_MARKERS_STORE,

--- a/packages/jazz-tools/tests/browser/large-value-worker-relay.test.ts
+++ b/packages/jazz-tools/tests/browser/large-value-worker-relay.test.ts
@@ -10,7 +10,7 @@ import { createDb, type Db } from "../../src/runtime/db.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import { schema as s } from "../../src/index.js";
 import { deploy } from "../../src/dev/catalogue.js";
-import { TestCleanup, uniqueDbName, waitForQuery, withTimeout } from "./support.js";
+import { TestCleanup, sleep, uniqueDbName, waitForQuery, withTimeout } from "./support.js";
 import { getJazzServerInfo } from "./testing-server.js";
 
 const app = s.defineApp({
@@ -27,6 +27,35 @@ const permissions = s.definePermissions(app, ({ policy }) => [
   policy.values.allowInsert.always(),
   policy.values.allowUpdate.always(),
   policy.values.allowDelete.always(),
+]);
+
+// This deliberately keeps the ordinary write API: `body` crosses Groove's
+// automatic 64 KiB promotion boundary during one user transaction which also
+// authors a referenced project. It is distinct from the streaming receipts
+// below, which each create one row in their own transaction.
+const transactionApp = s.defineApp({
+  projects: s.table({
+    name: s.string(),
+  }),
+  documents: s
+    .table({
+      branch: s.string(),
+      title: s.string(),
+      projectId: s.ref("projects"),
+      body: s.string(),
+    })
+    .branchBy("branch"),
+});
+
+const transactionPermissions = s.definePermissions(transactionApp, ({ policy }) => [
+  policy.projects.allowRead.always(),
+  policy.projects.allowInsert.always(),
+  policy.projects.allowUpdate.always(),
+  policy.projects.allowDelete.always(),
+  policy.documents.allowRead.always(),
+  policy.documents.allowInsert.always(),
+  policy.documents.allowUpdate.always(),
+  policy.documents.allowDelete.always(),
 ]);
 
 describe("browser persistent-worker large-value relay", () => {
@@ -132,11 +161,92 @@ describe("browser persistent-worker large-value relay", () => {
     expect(receivedBytes?.bytes).toEqual(bytes);
   }, 90_000);
 
+  /**
+   * A foreground tab sends this as exactly one CommitUnit after its worker has
+   * staged the promoted `body` tree. The relay must not reconstruct a second,
+   * incompatible payload for the same transaction while forwarding it to the
+   * server.
+   *
+   * tab transaction(project + large document) -> SharedWorker -> server
+   */
+  it("settles an ordinary multi-row transaction with an automatic large value", async () => {
+    const server = await withTimeout(
+      getJazzServerInfo(uniqueDbName("large-value-transaction-relay")),
+      10_000,
+      "test server did not become available",
+    );
+    await deploy({
+      appId: server.appId,
+      serverUrl: server.serverUrl,
+      adminSecret: server.adminSecret,
+      schema: transactionApp.wasmSchema,
+      permissions: transactionPermissions,
+    });
+
+    const secret = generateAuthSecret();
+    const writerDbName = uniqueDbName("large-value-transaction-writer");
+    const writer = await withTimeout(
+      openSyncedBrowserDb("large-value-transaction-writer", secret, server, true, writerDbName),
+      10_000,
+      "writer tab did not attach to its persistent worker",
+    );
+
+    // 240 KB crosses the inline boundary and needs multiple tree chunks.
+    // Keep this identical to the historical browser-corpus producer.
+    const body = "large value ".repeat(20_000);
+    const initial = await writer.transaction((tx) => {
+      const project = tx.insert(transactionApp.projects, { name: "relay project" });
+      const document = tx.insert(
+        transactionApp.documents,
+        {
+          branch: "main",
+          title: "relay document",
+          projectId: project.id,
+          body,
+        },
+        { branch: "main" },
+      );
+      return { project, document };
+    });
+
+    await withTimeout(
+      initial.wait({ tier: "global" }),
+      20_000,
+      "ordinary multi-row large-value transaction conflicted through the persistent worker",
+    );
+
+    const documents = await withTimeout(
+      writer.all(transactionApp.documents, { branch: "main", tier: "edge" }),
+      20_000,
+      "writer could not read its globally settled large document",
+    );
+    expect(documents).toEqual([expect.objectContaining({ title: "relay document", body })]);
+
+    // Reopen the persistent worker from IndexedDB, rather than merely reading
+    // the warm worker cache. This is the path that previously encountered the
+    // oversized settled-program-fact key after an apparently successful write.
+    await writer.shutdown();
+    cleanup.untrack(writer);
+    await sleep(100);
+    const reopened = await withTimeout(
+      openSyncedBrowserDb("large-value-transaction-reopen", secret, server, true, writerDbName),
+      10_000,
+      "reopened writer did not attach to persisted IndexedDB storage",
+    );
+    const reopenedDocuments = await withTimeout(
+      reopened.all(transactionApp.documents, { branch: "main", tier: "edge" }),
+      20_000,
+      "reopened writer could not hydrate the settled large document",
+    );
+    expect(reopenedDocuments).toEqual([expect.objectContaining({ title: "relay document", body })]);
+  }, 90_000);
+
   async function openSyncedBrowserDb(
     label: string,
     secret: string,
     server: Awaited<ReturnType<typeof getJazzServerInfo>>,
     persistent = true,
+    dbName = uniqueDbName(label),
   ): Promise<Db> {
     return cleanup.track(
       await createDb({
@@ -146,9 +256,7 @@ describe("browser persistent-worker large-value relay", () => {
         // The focused harness forwards the bounded redacted SharedWorker
         // flight recorder to Vitest, making a receipt failure inspectable.
         logLevel: "trace",
-        driver: persistent
-          ? { type: "persistent", dbName: uniqueDbName(label) }
-          : { type: "memory" },
+        driver: persistent ? { type: "persistent", dbName } : { type: "memory" },
       }),
     );
   }


### PR DESCRIPTION
🤖 Bounds authoritative settled-state storage keys and preserves exact canonical identities.

## Before

Three direct-store paths encoded authored data directly into ordered keys:

- branched row versions could lose their non-default branch coordinate when reconstructed;
- settled program facts lived in B-tree keys;
- settled result-member payloads, including large path values, lived in B-tree keys and could grow without a fixed bound.

This coupled storage correctness and backend key limits to arbitrary authored payload size.

## After

- commit units retain canonical branched versions, so reopening a maintained witness yields the exact non-default branch version;
- settled program facts are stored as fixed, domain-separated digest keys with canonical values;
- settled result members use fixed v1 BLAKE3 digest keys and canonical member values;
- recovery verifies key/value digest, type, length, and canonical decoding and fails closed on corruption;
- add, idempotence, remove, rewrite, and native RocksDB reopen preserve exact large members;
- a direct-store audit records why remaining known-state and marker keys are bounded UUIDs or constants.

For example, a roughly 900 KiB real result member no longer creates a roughly 900 KiB B-tree key. Its key is fixed-size; the canonical value carries the full member and is verified against the key on recovery.

## Compatibility

There is intentionally no legacy reader, migration, or v2 format. This establishes the permanent v1 representation on the pre-release storage line.

## Verification

- focused large settled-result add/remove/rewrite/reopen/corruption receipt
- 17/17 settled-state library tests
- exact large non-default-branch witness reload receipt
- direct-store key audit

Stacked on #2336. #2334 will regenerate its native compatibility corpus on top of this representation.
