### PR TITLE
Fix packaged zstd feature negotiation

### DIFF
--- a/crates/jazz-napi/Cargo.toml
+++ b/crates/jazz-napi/Cargo.toml
@@ -4,8 +4,13 @@ version = "0.1.0"
 edition = "2024"
 
 [features]
-default = ["rocksdb"]
+# The published Node binding is a WebSocket peer. Its TypeScript carrier
+# advertises the binding's actual wire capabilities, so the default package
+# includes the same native zstd codec used by the shipped jazz-tools server.
+# RocksDB's unrelated zstd dependency does not enable Jazz transport zstd.
+default = ["rocksdb", "transport-compression-zstd"]
 rocksdb = ["dep:jazz-storage-rocksdb"]
+transport-compression-zstd = ["jazz/transport-compression-zstd"]
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -12,6 +12,14 @@ export declare class JazzServer {
 }
 
 export declare class NapiDb {
+  /**
+   * Exact wire capabilities compiled into this native binding.
+   *
+   * The TypeScript WebSocket carrier uses this for its Hello instead of an
+   * independent feature list, so a package cannot advertise a codec this
+   * native artifact cannot decode.
+   */
+  wireFeatures(): number
   insertEncoded(table: string, cells: Uint8Array, options?: InsertOptions | undefined | null): Write
   updateEncoded(table: string, rowId: Uint8Array, patch: Uint8Array, options?: UpdateOptions | undefined | null): Write
   /**

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1504,6 +1504,16 @@ impl StreamingMutation {
 
 #[napi]
 impl NapiDb {
+    /// Exact wire capabilities compiled into this native binding.
+    ///
+    /// The TypeScript WebSocket carrier uses this for its Hello instead of an
+    /// independent feature list, so a package cannot advertise a codec this
+    /// native artifact cannot decode.
+    #[napi(js_name = "wireFeatures")]
+    pub fn wire_features(&self) -> u32 {
+        jazz::wire::current_wire_features() as u32
+    }
+
     fn require_trusted_backend(&self) -> napi::Result<()> {
         self.trusted_backend.then_some(()).ok_or_else(|| {
             napi::Error::from_reason("backend attribution requires an explicit backend runtime")
@@ -3449,6 +3459,25 @@ impl NapiDb {
         local_node: Buffer,
         local_epoch: BigInt,
     ) -> napi::Result<Transport> {
+        let local_features = jazz::wire::current_wire_features();
+        if protocol_version != jazz::wire::WIRE_PROTOCOL_VERSION {
+            return Err(napi::Error::from_reason(format!(
+                "server negotiated wire protocol {protocol_version}, but this native binding supports only {}",
+                jazz::wire::WIRE_PROTOCOL_VERSION
+            )));
+        }
+        let features = features as u64;
+        let unsupported = features & !local_features;
+        if unsupported != 0 {
+            return Err(napi::Error::from_reason(format!(
+                "server negotiated wire features {features:#x}, but this native binding was not compiled with {unsupported:#x}"
+            )));
+        }
+        if features & jazz::wire::FEATURE_SYNC_MESSAGE_PAYLOAD == 0 {
+            return Err(napi::Error::from_reason(
+                "server did not negotiate required sync message payload frames",
+            ));
+        }
         let remote_node: [u8; 16] = remote_node.as_ref().try_into().map_err(|_| {
             napi::Error::from_reason("server hello authority node must be 16 bytes")
         })?;
@@ -3474,14 +3503,14 @@ impl NapiDb {
                 epoch: remote_epoch,
             },
             link_identity: CoreAuthorSubject::for_test_bytes(local_node),
-            negotiated_features: features as u64,
+            negotiated_features: features,
         };
         let transport = Box::new(CoreWireTransportAdapter::new_with_session_context(
             NapiWireTransport {
                 queues: queues.clone(),
             },
             protocol_version,
-            features as u64,
+            features,
             None,
             Some(session_context),
         ));
@@ -3501,7 +3530,7 @@ impl NapiDb {
             queues,
             auxiliary_pump,
             protocol_version,
-            features: features as u64,
+            features,
         })
     }
 

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1077,6 +1077,16 @@ enum WasmTxKind {
 
 #[wasm_bindgen]
 impl WasmDb {
+    /// Exact wire capabilities compiled into this WASM artifact.
+    ///
+    /// The TypeScript WebSocket carrier uses this for its Hello instead of an
+    /// independent feature list, so a package cannot advertise a codec this
+    /// WASM artifact cannot decode.
+    #[wasm_bindgen(js_name = wireFeatures)]
+    pub fn wire_features(&self) -> u32 {
+        jazz::wire::current_wire_features() as u32
+    }
+
     fn require_trusted_backend(&self) -> Result<(), JsValue> {
         self.trusted_backend.then_some(()).ok_or_else(|| {
             JsValue::from_str("backend attribution requires an explicit backend runtime")

--- a/examples/band-chat/apps/nextjs-betterauth/tests/browser/band-chat.test.tsx
+++ b/examples/band-chat/apps/nextjs-betterauth/tests/browser/band-chat.test.tsx
@@ -49,8 +49,13 @@ afterEach(async () => {
   }
 });
 
-it("renders the serving-authority owner, guest-message, and removal flow", async () => {
-  // Regression: each mounted preview registers several local subscriptions
+it("negotiates persistent browser workers and renders the owner, guest-message, and removal flow", async () => {
+  // Regression: a persistent browser worker creates its NativeRuntimeAdapter
+  // around WasmDb, then uses that artifact's feature mask for the server Hello.
+  // Removing WasmDb.wireFeatures makes this first remote worker connection fail
+  // before either mounted user can complete the shared room flow.
+  //
+  // Each mounted preview also registers several local subscriptions
   // (rooms, profiles, messages, and members) while its persistent worker is
   // still opening.  Admission may hold *delivery* until storage opens, but it
   // must not serially defer native registrations: that ordering used to leave

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -125,9 +125,9 @@ it("ships a zstd-capable NAPI receiver and rejects an uncompiled negotiated feat
       db.connectUpstreamWithSession(
         1,
         features | (1 << 30),
-        deterministicBytes("napi-wire-capability:remote"),
+        Buffer.from(deterministicBytes("napi-wire-capability:remote")),
         1n,
-        deterministicBytes("napi-wire-capability:local"),
+        Buffer.from(deterministicBytes("napi-wire-capability:local")),
         1n,
       ),
     ).toThrow(/native binding was not compiled with 0x40000000/);

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -10,7 +10,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { SubscriptionEvent as NapiSubscriptionEvent } from "jazz-napi";
 import type { ColumnType, Value, WasmSchema } from "../drivers/types.js";
 import { startLocalJazzServer, type LocalJazzServerHandle } from "../testing/index.js";
-import { webSocketUrl } from "./native-runtime/websocket.js";
+import { FEATURE_PAYLOAD_ZSTD, webSocketUrl } from "./native-runtime/websocket.js";
 import { openConfig } from "./native-runtime/native-codec.js";
 import { NativeRuntimeAdapter } from "./native-runtime/native-runtime-adapter.js";
 import { encodeSchema } from "./native-runtime/native-runtime-adapter.js";
@@ -105,6 +105,35 @@ it("accepts only canonical authors through the NAPI open-config codec", async ()
       ),
     ),
   ).toThrow(/canonical UTF-8 JSON/i);
+});
+
+it("ships a zstd-capable NAPI receiver and rejects an uncompiled negotiated feature before admission", async () => {
+  const { NapiDb } = await loadNapiModule();
+  const db = NapiDb.openMemory(
+    encodeSchema(TEST_SCHEMA),
+    openConfig(
+      deterministicBytes("napi-wire-capability:node"),
+      testAuthorBytes("napi-wire-capability:author"),
+      1,
+      true,
+    ),
+  );
+  try {
+    const features = db.wireFeatures();
+    expect(features & FEATURE_PAYLOAD_ZSTD).toBe(FEATURE_PAYLOAD_ZSTD);
+    expect(() =>
+      db.connectUpstreamWithSession(
+        1,
+        features | (1 << 30),
+        deterministicBytes("napi-wire-capability:remote"),
+        1n,
+        deterministicBytes("napi-wire-capability:local"),
+        1n,
+      ),
+    ).toThrow(/native binding was not compiled with 0x40000000/);
+  } finally {
+    await db.close();
+  }
 });
 
 const SIGNED_DEFAULT_CASES: Array<{

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -297,6 +297,8 @@ type NativeDb = {
   ): void;
   onMutationError(callback: (event: MutationErrorEvent) => void): void;
   setNonDurableClient?(): void;
+  /** Exact wire features compiled into the native artifact backing this DB. */
+  wireFeatures?(): number;
   setLargeValueStagingPolicy?(
     incomingBytesPerWindow: number,
     windowMs: number,
@@ -2085,6 +2087,7 @@ export class NativeRuntimeAdapter implements Runtime {
     const carrier = new WebSocketCarrier({
       endpointUrl: url,
       peerIdentity: transportIdentity,
+      features: this.nativeWireFeatures(),
       authJson,
       onFrame: (frame) => {
         if (generation !== this.serverConnectionGeneration) return;
@@ -2194,6 +2197,19 @@ export class NativeRuntimeAdapter implements Runtime {
       this.node,
       localEpoch,
     );
+  }
+
+  private nativeWireFeatures(): number {
+    if (!this.db.wireFeatures) {
+      throw new Error(
+        "native binding does not expose its wire feature mask; install the matching jazz-napi package",
+      );
+    }
+    const features = this.db.wireFeatures();
+    if (!Number.isSafeInteger(features) || features < 0 || features > 0xffff_ffff) {
+      throw new Error(`native binding returned invalid wire feature mask ${features}`);
+    }
+    return features;
   }
 
   async disconnect(options: { rejectWaiters?: boolean } = {}): Promise<void> {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -2202,7 +2202,7 @@ export class NativeRuntimeAdapter implements Runtime {
   private nativeWireFeatures(): number {
     if (!this.db.wireFeatures) {
       throw new Error(
-        "native binding does not expose its wire feature mask; install the matching jazz-napi package",
+        "native runtime binding does not expose its wire feature mask; install the matching Jazz native runtime package",
       );
     }
     const features = this.db.wireFeatures();

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -542,6 +542,7 @@ describe("NativeRuntimeAdapter server transport", () => {
       {
         openMemory: () => ({
           connectUpstream: () => transport,
+          wireFeatures: () => CLIENT_WIRE_FEATURES,
           setTickScheduler: (callback: (urgency: "immediate" | "deferred") => void) => {
             schedulerCallback = callback;
           },
@@ -1036,6 +1037,9 @@ function fakeDb<T extends object>(
   const result: Record<string, unknown> = {
     setTickScheduler: () => undefined,
     onMutationError: () => undefined,
+    // The production binding advertises its compiled capability mask. Keep
+    // this transport fixture honest about the same handshake boundary.
+    wireFeatures: () => CLIENT_WIRE_FEATURES,
     beginTransaction: (
       openTransactionId: string,
       kind: FakeOpenBatch["kind"],

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -106,6 +106,31 @@ describe("NativeRuntimeAdapter server transport", () => {
     expect(sockets[1]!.closed).toBe(true);
   });
 
+  it("identifies a missing wire mask as a generic native-runtime artifact mismatch", () => {
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            connectUpstream: () => new FakeTransport([]),
+            tick: () => undefined,
+            wireFeatures: undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    expect(() => runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}")).toThrow(
+      "native runtime binding does not expose its wire feature mask; install the matching Jazz native runtime package",
+    );
+  });
+
   it("uses the canonical credential author for websocket identity, not the raw runtime host", async () => {
     const sockets: FakeWebSocket[] = [];
     globalThis.WebSocket = class extends FakeWebSocket {

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -4,6 +4,7 @@ import type { BrowserWebSocket } from "./websocket.js";
 import { PostcardReader, PostcardWriter } from "./native-codec.js";
 import {
   CLIENT_WIRE_FEATURES,
+  FEATURE_PAYLOAD_ZSTD,
   FEATURE_SYNC_MESSAGE_PAYLOAD,
   MAX_WIRE_PROTOCOL_VERSION,
   MIN_WIRE_PROTOCOL_VERSION,
@@ -281,6 +282,18 @@ describe("websocket frame carrier", () => {
     const suffixed = Uint8Array.from([...hello, 0]);
     expect(new PostcardReader(suffixed).u64()).toBe(0);
     expect(() => isWireHello(suffixed)).toThrow("WireFrame::Hello has trailing postcard bytes");
+  });
+
+  it("rejects a server codec that this native artifact did not advertise", async () => {
+    const localFeatures = CLIENT_WIRE_FEATURES & ~FEATURE_PAYLOAD_ZSTD;
+    const { carrier, socket } = carrierForTest({ features: localFeatures });
+    socket.emitMessage(
+      encodeWebSocketFrameBatch([
+        encodeServerHello(1n, WIRE_PROTOCOL_VERSION, { features: CLIENT_WIRE_FEATURES }),
+      ]),
+    );
+    await expect(carrier.ready()).rejects.toThrow("server accepted unsupported wire features 0x10");
+    expect(socket.closed).toBe(true);
   });
 
   it("decodes exact Rust-produced Hello frames and rejects only true suffixes", async () => {
@@ -750,11 +763,15 @@ function encodeServerHello(
   return writer.finish();
 }
 
-function carrierForTest(): { carrier: WebSocketCarrier; socket: MessageWebSocket } {
+function carrierForTest(options: { features?: number } = {}): {
+  carrier: WebSocketCarrier;
+  socket: MessageWebSocket;
+} {
   let socket: MessageWebSocket | undefined;
   const carrier = new WebSocketCarrier({
     endpointUrl: "ws://127.0.0.1:4200/apps/app-a/ws",
     peerIdentity: new Uint8Array(16),
+    features: options.features,
     onFrame: () => {},
     WebSocket: class extends MessageWebSocket {
       constructor(url: string) {

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
@@ -24,6 +24,8 @@ export type WebSocketNegotiation = {
 export type WebSocketCarrierOptions = {
   endpointUrl: string;
   peerIdentity: Uint8Array;
+  /** Features supported by the native runtime that will receive this link. */
+  features?: number;
   authJson?: string;
   onFrame: WebSocketFrameHandler;
   onError?: WebSocketErrorHandler;
@@ -94,12 +96,13 @@ export function decodeWebSocketFrameBatch(batch: Uint8Array): Uint8Array[] {
   return frames;
 }
 
-export function encodeWireClientHello(): Uint8Array {
+export function encodeWireClientHello(features = CLIENT_WIRE_FEATURES): Uint8Array {
+  assertWireFeatures(features, "client wire features");
   const writer = new PostcardWriter();
   writer.u64(0); // WireFrame::Hello
   writer.u64(MIN_WIRE_PROTOCOL_VERSION); // min_protocol_version
   writer.u64(MAX_WIRE_PROTOCOL_VERSION); // max_protocol_version
-  writer.u64(CLIENT_WIRE_FEATURES);
+  writer.u64(features);
   writer.u64(0); // WirePeerRole::Client
   // Browser carriers do not receive the authenticated session context needed
   // to validate scoped receipts. Do not self-assert an authority endpoint:
@@ -161,6 +164,7 @@ export class WebSocketCarrier {
   private readonly onFrame: WebSocketFrameHandler;
   private readonly onError?: WebSocketErrorHandler;
   private readonly onTerminal?: WebSocketTerminalHandler;
+  private readonly localFeatures: number;
   private readonly opened: Promise<WebSocketNegotiation>;
   private resolveNegotiation!: (value: WebSocketNegotiation) => void;
   private rejectNegotiation!: (reason: unknown) => void;
@@ -174,6 +178,8 @@ export class WebSocketCarrier {
     this.onFrame = options.onFrame;
     this.onError = options.onError;
     this.onTerminal = options.onTerminal;
+    this.localFeatures = options.features ?? CLIENT_WIRE_FEATURES;
+    assertWireFeatures(this.localFeatures, "client wire features");
     this.socket = new WebSocketCtor(this.url);
     this.socket.binaryType = "arraybuffer";
     this.opened = new Promise<WebSocketNegotiation>((resolve, reject) => {
@@ -183,7 +189,7 @@ export class WebSocketCarrier {
     void waitForOpen(this.socket).then(
       () => {
         this.socket.send(encodeWebSocketPrelude(options.authJson ?? "{}", options.peerIdentity));
-        this.socket.send(encodeWebSocketFrameBatch([encodeWireClientHello()]));
+        this.socket.send(encodeWebSocketFrameBatch([encodeWireClientHello(this.localFeatures)]));
       },
       (error) => {
         this.reportTerminal({
@@ -281,7 +287,7 @@ export class WebSocketCarrier {
       if (isWireHello(frame)) {
         if (this.negotiated) continue;
         this.negotiated = true;
-        this.resolveNegotiation(decodeServerHello(frame));
+        this.resolveNegotiation(decodeServerHello(frame, this.localFeatures));
         continue;
       }
       if (!this.negotiated) {
@@ -317,7 +323,10 @@ export class WebSocketCarrier {
   }
 }
 
-function decodeServerHello(frame: Uint8Array): WebSocketNegotiation {
+function decodeServerHello(
+  frame: Uint8Array,
+  localFeatures = CLIENT_WIRE_FEATURES,
+): WebSocketNegotiation {
   const reader = new PostcardReader(frame);
   if (reader.u64() !== 0) throw new Error("expected WireFrame::Hello");
   const hello = readWireHelloBodyExact(reader);
@@ -327,12 +336,20 @@ function decodeServerHello(frame: Uint8Array): WebSocketNegotiation {
       `server must advertise exactly wire protocol ${WIRE_PROTOCOL_VERSION}, got ${min}..=${max}`,
     );
   }
-  const unsupportedFeatures = features & ~BigInt(CLIENT_WIRE_FEATURES);
+  const unsupportedFeatures = features & ~BigInt(localFeatures);
   if (unsupportedFeatures !== 0n) {
-    throw new Error(`server accepted unsupported wire features 0x${features.toString(16)}`);
+    throw new Error(
+      `server accepted unsupported wire features 0x${unsupportedFeatures.toString(16)}`,
+    );
   }
   if (role !== 1) throw new Error("expected WirePeerRole::Core server hello");
   return { protocolVersion: WIRE_PROTOCOL_VERSION, features: Number(features), authority };
+}
+
+function assertWireFeatures(features: number, label: string): void {
+  if (!Number.isSafeInteger(features) || features < 0 || features > 0xffff_ffff) {
+    throw new Error(`${label} must be an unsigned 32-bit integer, got ${features}`);
+  }
 }
 
 function readWireHelloBodyExact(reader: PostcardReader): {

--- a/packages/jazz-tools/src/runtime/native-runtime/wire-frame-artifact-corpus.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/wire-frame-artifact-corpus.test.ts
@@ -18,6 +18,10 @@ type ArtifactFrameValidator = {
   __testWireFrameCorpusFeatures(): string;
 };
 
+type WasmArtifactFrameValidator = ArtifactFrameValidator & {
+  WasmDb: { prototype: { wireFeatures?: () => number } };
+};
+
 // The source fixtures freeze the exact Rust-produced v1 bytes. This test then
 // sends every complete Hello/message frame through both freshly generated artifacts,
 // not a JavaScript mirror of the Rust frame/payload/compression decoder.
@@ -36,7 +40,7 @@ describe("wire frame artifact corpus", () => {
         // This is a deliberately test-only export (`skip_typescript` in
         // napi-rs), so production declarations must not advertise it.
         loadNapiModule() as Promise<unknown> as Promise<ArtifactFrameValidator>,
-        loadWasmModuleForTest() as Promise<ArtifactFrameValidator>,
+        loadWasmModuleForTest() as Promise<WasmArtifactFrameValidator>,
       ]);
 
       // This executes the actual sealed artifact which package assembly
@@ -46,6 +50,12 @@ describe("wire frame artifact corpus", () => {
       expect(BigInt(napi.__testWireFrameCorpusFeatures()) & BigInt(FEATURE_PAYLOAD_ZSTD)).not.toBe(
         0n,
       );
+
+      // A persistent browser worker creates a NativeRuntimeAdapter around this
+      // exact WasmDb export. It must use the artifact's own feature mask when
+      // sending its WebSocket Hello; otherwise a freshly sealed browser artifact
+      // fails before it can connect, even if the NAPI artifact is current.
+      expect(typeof wasm.WasmDb.prototype.wireFeatures).toBe("function");
 
       for (const artifact of [napi, wasm]) {
         const negotiatedFeatures = artifact.__testWireFrameCorpusFeatures();

--- a/packages/jazz-tools/src/runtime/native-runtime/wire-frame-artifact-corpus.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/wire-frame-artifact-corpus.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { hasJazzNapiBuild, loadNapiModule } from "../testing/napi-runtime-test-utils.js";
 import { hasJazzWasmBuild, loadWasmModuleForTest } from "../testing/wasm-runtime-test-utils.js";
+import { FEATURE_PAYLOAD_ZSTD } from "./websocket.js";
 
 type FrameFixture = { name: string; frame_hex: string };
 type ArtifactCorpus = {
@@ -37,6 +38,14 @@ describe("wire frame artifact corpus", () => {
         loadNapiModule() as Promise<unknown> as Promise<ArtifactFrameValidator>,
         loadWasmModuleForTest() as Promise<ArtifactFrameValidator>,
       ]);
+
+      // This executes the actual sealed artifact which package assembly
+      // publishes, rather than inferring transport support from Cargo.toml.
+      // A package receiver must advertise and decode the same zstd capability
+      // as the packaged jazz-tools server binary.
+      expect(BigInt(napi.__testWireFrameCorpusFeatures()) & BigInt(FEATURE_PAYLOAD_ZSTD)).not.toBe(
+        0n,
+      );
 
       for (const artifact of [napi, wasm]) {
         const negotiatedFeatures = artifact.__testWireFrameCorpusFeatures();

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -293,6 +293,8 @@ declare module "jazz-wasm" {
     /** @internal Foreground node-lease bootstrap only. */
     seedForegroundTxTimeHighWater(highWater: bigint): void;
     setRelayAuthoritySessionOwner(): void;
+    /** Exact wire features compiled into this WASM artifact. */
+    wireFeatures(): number;
     close(): Promise<boolean>;
     connectUpstream(): WasmTransport;
     connectUpstreamWithSession(


### PR DESCRIPTION
🤖 Fixes #2362 by making the shipped NAPI package and WebSocket handshake agree about the transport codecs that are actually compiled into the native artifact.

Before:
- `jazz-tools` always advertised zstd in its client Hello.
- The published NAPI binding was built without Jazz’s `transport-zstd` feature.
- A zstd-capable server selected the advertised feature, then the client failed only when decoding the first compressed payload and left durability waits hanging.

After:
- The published NAPI binding compiles zstd by default.
- The binding exposes its active wire-feature mask; the JS carrier advertises exactly that mask.
- Both JS and native admission reject an unsupported server-selected feature before attaching the transport.

Example: a deliberately built no-zstd binding now advertises no zstd bit and rejects a server Hello that selects zstd, instead of accepting negotiation and failing on the first payload.

Verification:
- 79 focused NAPI, transport, WebSocket, and artifact-corpus receipts passed.
- TypeScript check passed.
- A planted no-zstd binding reported the reduced mask and rejected zstd before admission.

This is stacked on #2347 and is independently adversarially reviewed.