### PR TITLE
Make maintained equality sources index-selective

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -142,11 +142,11 @@ jobs:
       - name: Install cargo-codspeed
         run: cargo install cargo-codspeed --version 5.0.1 --locked
 
-      - name: Build maintained selective-hydration receipt
-        run: cargo codspeed build --measurement-mode walltime --package jazz --features testing --bench selective_global_hydration
+      - name: Build maintained selective-hydration benchmark
+        run: cargo codspeed build -m walltime --package jazz --features testing --bench selective_global_hydration
 
-      - name: Run maintained selective-hydration receipt
+      - name: Run maintained selective-hydration benchmark
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: walltime
-          run: env JAZZ_SELECTIVE_HYDRATION_ROWS=10000,100000 JAZZ_SELECTIVE_HYDRATION_TARGET_ROWS=100 JAZZ_SELECTIVE_HYDRATION_RESULT_ROWS=50 cargo codspeed run --package jazz --bench selective_global_hydration
+          run: cargo codspeed run -m walltime --package jazz --bench selective_global_hydration

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -117,3 +117,36 @@ jobs:
         with:
           mode: walltime
           run: cargo codspeed run --package jazz-example-benchmark-w1 --bench reads_memory_walltime --bench reads_rocksdb_walltime
+
+  maintained-selective-hydration-walltime:
+    # This is the direct receipt for #2077: fixed owner/result cardinality
+    # while the persisted current table grows. Keep the deep 1M rung as an
+    # explicit local/nightly receipt; 10k and 100k fit the labelled PR job.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark')
+    name: Maintained selective hydration wall time
+    runs-on: codspeed-macro
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.93.1
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-bin: true
+          shared-key: codspeed-maintained-selective-hydration-${{ runner.arch }}-v1
+          workspaces: . -> target
+
+      - name: Install cargo-codspeed
+        run: cargo install cargo-codspeed --version 5.0.1 --locked
+
+      - name: Build maintained selective-hydration receipt
+        run: cargo codspeed build --measurement-mode walltime --package jazz --features testing --bench selective_global_hydration
+
+      - name: Run maintained selective-hydration receipt
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
+        with:
+          mode: walltime
+          run: env JAZZ_SELECTIVE_HYDRATION_ROWS=10000,100000 JAZZ_SELECTIVE_HYDRATION_TARGET_ROWS=100 JAZZ_SELECTIVE_HYDRATION_RESULT_ROWS=50 cargo codspeed run --package jazz --bench selective_global_hydration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,6 +2015,7 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "bytes",
+ "codspeed-divan-compat",
  "criterion",
  "ed25519-dalek",
  "flate2",

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -73,6 +73,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_crypto", "use_pem"] }
 jazz-storage-rocksdb.workspace = true
 jazz-storage-sqlite.workspace = true
+divan.workspace = true
 futures = "0.3"
 tokio = { version = "1", features = [
   "macros",

--- a/crates/jazz/benches/README.md
+++ b/crates/jazz/benches/README.md
@@ -57,12 +57,13 @@ than old helper behavior:
   tests cover recursive write-policy settlement with global/settled support
   rows; local-only support rows correctly do not authorize writes.
 
-`selective_global_hydration` is a custom JSONL receipt over the persisted
-Global query path. It holds one selected team and its result page fixed while
-total table rows increase, then records exact result digests and logical
-Global-current row/index reads. It is intentionally not a timing gate: the
-deterministic read counts establish whether hydration is selective before an
-engine optimization is attempted.
+`selective_global_hydration` is a Divan/CodSpeed wall-time benchmark over the
+persisted Global maintained-subscription hydration path. It measures fixed
+10k- and 100k-row tables while keeping the selected team and result page
+constant. Fixture seeding, reopening, preparation, and an exact result/read-
+bound validation pass are outside the timed closure. The full JSONL read-count
+receipt, including its 1M-row diagnostic rung, remains available by setting
+`JAZZ_SELECTIVE_HYDRATION_RECEIPT=1`.
 
 ## Intended next ports
 

--- a/crates/jazz/benches/selective_global_hydration.rs
+++ b/crates/jazz/benches/selective_global_hydration.rs
@@ -8,11 +8,13 @@
 //! cargo bench -p jazz --features testing --bench selective_global_hydration --quiet
 //! ```
 //!
-//! `JAZZ_SELECTIVE_HYDRATION_ROWS` controls the comma-separated table-size
-//! ladder. `JAZZ_SELECTIVE_HYDRATION_TARGET_ROWS`,
+//! The default run exposes fixed 10k and 100k wall-time benchmarks to Divan
+//! and CodSpeed. Set `JAZZ_SELECTIVE_HYDRATION_RECEIPT=1` to run the JSONL
+//! scale receipt instead; in that mode `JAZZ_SELECTIVE_HYDRATION_ROWS`
+//! controls the comma-separated table-size ladder and
+//! `JAZZ_SELECTIVE_HYDRATION_TARGET_ROWS`,
 //! `JAZZ_SELECTIVE_HYDRATION_RESULT_ROWS`, and
-//! `JAZZ_SELECTIVE_HYDRATION_BATCH_ROWS` control the fixed selection and seed
-//! batching.
+//! `JAZZ_SELECTIVE_HYDRATION_BATCH_ROWS` control selection and seed batching.
 
 mod schema_fixture;
 mod support;
@@ -22,7 +24,7 @@ use std::path::Path;
 use std::time::Instant;
 
 use jazz::db::{
-    Db, DbConfig, DbIdentity, LocalUpdates, MergeableTxOps, Propagation, ReadOpts,
+    Db, DbConfig, DbIdentity, LocalUpdates, MergeableTxOps, PreparedQuery, Propagation, ReadOpts,
     SeededRowIdSource, SubscriptionEvent, block_on,
 };
 use jazz::groove::db::StorageReadMetrics;
@@ -40,6 +42,23 @@ const TABLE: &str = "documents";
 
 fn main() {
     jazz_benchmark_guard::refuse_contaminated_measurement();
+
+    // CodSpeed recognizes Divan's benchmark protocol, not the JSONL receipt
+    // protocol below. Keep the latter for the 1M-row diagnostic rung, but make
+    // the normal bench target real wall-time benchmarks.
+    if std::env::var_os("JAZZ_SELECTIVE_HYDRATION_RECEIPT").is_some() {
+        run_receipt();
+        return;
+    }
+
+    divan::main();
+}
+
+/// Run the full read-count receipt, including the 1M diagnostic rung.
+///
+/// This is intentionally opt-in: it proves the selectivity invariant and is
+/// much too expensive to be a repeated CodSpeed sample.
+fn run_receipt() {
     let config = Config::from_env();
     config.validate();
 
@@ -94,6 +113,32 @@ fn main() {
         json!("A reusable settled fixture would avoid reseeding each scale rung while preserving the fixed-selection read boundary."),
     );
     support::emit_json_line("selective_global_hydration", fields);
+}
+
+/// CodSpeed wall-time receipt for the maintained initial hydration path at a
+/// fixed 10k-row table size. Seeding, reopening, query preparation, and one
+/// fully-asserted validation pass are deliberately outside the timed closure.
+#[divan::bench(sample_count = 10)]
+fn maintained_subscription_hydration_10k(bencher: divan::Bencher<'_, '_>) {
+    benchmark_maintained_subscription_hydration(bencher, 10_000);
+}
+
+/// The same fixed-selectivity workload at 100k rows. Fewer samples retain a
+/// useful hosted receipt without turning fixture setup into the dominant CI
+/// cost. The 1M rung remains available through `run_receipt` above.
+#[divan::bench(sample_count = 3)]
+fn maintained_subscription_hydration_100k(bencher: divan::Bencher<'_, '_>) {
+    benchmark_maintained_subscription_hydration(bencher, 100_000);
+}
+
+fn benchmark_maintained_subscription_hydration(bencher: divan::Bencher<'_, '_>, table_rows: usize) {
+    let fixture = HydrationFixture::new(table_rows);
+
+    // Keep the correctness/read-bound proof out of the measurement. The timed
+    // operation below is exactly the same initial maintained hydration.
+    fixture.assert_selective_hydration();
+
+    bencher.bench_local(|| divan::black_box(fixture.hydrate_maintained()));
 }
 
 #[derive(Clone, Copy)]
@@ -170,6 +215,130 @@ struct RungReceipt {
     prepare_metrics: StorageReadMetrics,
     query_metrics: StorageReadMetrics,
     maintained_metrics: StorageReadMetrics,
+}
+
+/// A settled RocksDB database plus its prepared fixed-selectivity query.
+///
+/// The tempdir is retained for the lifetime of the database so every timed
+/// sample reads the same reopened persisted fixture. Each benchmark invocation
+/// constructs this once, outside Divan's timed closure.
+struct HydrationFixture {
+    _temp: tempfile::TempDir,
+    db: Db<RocksDbStorage>,
+    prepared: PreparedQuery,
+    expected: Vec<RowUuid>,
+    target_rows: usize,
+}
+
+struct HydrationMeasurement {
+    row_count: usize,
+    result_digest: String,
+    metrics: StorageReadMetrics,
+}
+
+impl HydrationFixture {
+    fn new(table_rows: usize) -> Self {
+        let config = ConfigRef {
+            target_rows: 100,
+            result_rows: 50,
+            batch_rows: 1_000,
+        };
+        let temp = tempfile::tempdir().expect("create selective-hydration RocksDB directory");
+        let schema = schema();
+        let (seed_db, _, _) = open_db(temp.path(), schema.clone());
+        seed_rows(&seed_db, config, table_rows);
+        block_on(seed_db.close()).expect("close seeded selective-hydration database");
+        drop(seed_db);
+
+        let (db, _, _) = open_db(temp.path(), schema);
+        let query = selective_query(config.result_rows);
+        let prepared = db
+            .prepare_query_bound(
+                &query,
+                BTreeMap::from([("team".to_owned(), Value::Uuid(target_team().0))]),
+            )
+            .expect("prepare selective Global query");
+        let expected = (config.target_rows - config.result_rows..config.target_rows)
+            .rev()
+            .map(target_row)
+            .collect();
+
+        Self {
+            _temp: temp,
+            db,
+            prepared,
+            expected,
+            target_rows: config.target_rows,
+        }
+    }
+
+    fn assert_selective_hydration(&self) {
+        self.db.reset_storage_read_metrics_for_test();
+        let rows = block_on(self.db.all_for_identity(
+            &self.prepared,
+            global_read_opts(),
+            AuthorSubject::SYSTEM,
+        ))
+        .expect("run selective Global query");
+        let observed = rows.iter().map(|row| row.row_uuid()).collect::<Vec<_>>();
+        assert_eq!(observed, self.expected, "selective Global result changed");
+        let query_metrics = self.db.take_storage_read_metrics_for_test();
+        assert_selective_metrics(&query_metrics, self.target_rows, "query");
+
+        let measured = self.hydrate_maintained();
+        assert_eq!(measured.row_count, self.expected.len());
+        assert_eq!(measured.result_digest, digest_rows(&self.expected));
+        assert_selective_metrics(&measured.metrics, self.target_rows, "maintained");
+    }
+
+    /// The timed operation: create one maintained subscription and consume its
+    /// initial reset. It returns the same result digest and logical read
+    /// counters asserted by `assert_selective_hydration`, but performs no
+    /// assertion inside the wall-time sample.
+    fn hydrate_maintained(&self) -> HydrationMeasurement {
+        self.db.reset_storage_read_metrics_for_test();
+        let mut subscription = block_on(self.db.subscribe(&self.prepared, local_read_opts()))
+            .expect("open selective maintained subscription");
+        let SubscriptionEvent::Delta {
+            reset: true, added, ..
+        } = subscription
+            .try_next_event()
+            .expect("maintained subscription must emit its initial reset")
+        else {
+            panic!("maintained subscription must emit an initial reset");
+        };
+        let rows = added
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<Vec<_>>();
+        let metrics = self.db.take_storage_read_metrics_for_test();
+        HydrationMeasurement {
+            row_count: rows.len(),
+            result_digest: digest_rows(&rows),
+            metrics,
+        }
+    }
+}
+
+fn selective_query(result_rows: usize) -> Query {
+    Query::from(TABLE)
+        .filter(eq(col("team"), param("team")))
+        .filter(eq(col("active"), lit(true)))
+        .order_by("updated_at", OrderDirection::Desc)
+        .order_by("id", OrderDirection::Desc)
+        .limit(result_rows)
+}
+
+fn assert_selective_metrics(metrics: &StorageReadMetrics, target_rows: usize, phase: &str) {
+    assert!(
+        metrics.global_current_rows.reads <= target_rows,
+        "{phase} selective Global hydration read {} current rows for {target_rows} indexed candidates",
+        metrics.global_current_rows.reads,
+    );
+    assert!(
+        (1..=target_rows).contains(&metrics.global_current_indexes.reads),
+        "{phase} selective Global hydration must use the declared index without reading more than the fixed candidate set",
+    );
 }
 
 impl RungReceipt {

--- a/crates/jazz/benches/selective_global_hydration.rs
+++ b/crates/jazz/benches/selective_global_hydration.rs
@@ -23,7 +23,7 @@ use std::time::Instant;
 
 use jazz::db::{
     Db, DbConfig, DbIdentity, LocalUpdates, MergeableTxOps, Propagation, ReadOpts,
-    SeededRowIdSource, block_on,
+    SeededRowIdSource, SubscriptionEvent, block_on,
 };
 use jazz::groove::db::StorageReadMetrics;
 use jazz::groove::records::Value;
@@ -113,7 +113,10 @@ struct Config {
 impl Config {
     fn from_env() -> Self {
         Self {
-            table_rows: support::csv_usizes("JAZZ_SELECTIVE_HYDRATION_ROWS", "1000,10000,100000"),
+            table_rows: support::csv_usizes(
+                "JAZZ_SELECTIVE_HYDRATION_ROWS",
+                "10000,100000,1000000",
+            ),
             target_rows: support::env_usize("JAZZ_SELECTIVE_HYDRATION_TARGET_ROWS", 100),
             result_rows: support::env_usize("JAZZ_SELECTIVE_HYDRATION_RESULT_ROWS", 50),
             batch_rows: support::env_usize("JAZZ_SELECTIVE_HYDRATION_BATCH_ROWS", 1000),
@@ -160,10 +163,13 @@ struct RungReceipt {
     db_open_us: u128,
     prepare_us: u128,
     query_us: u128,
+    maintained_subscribe_us: u128,
     result_digest: String,
+    maintained_result_digest: String,
     open_metrics: StorageReadMetrics,
     prepare_metrics: StorageReadMetrics,
     query_metrics: StorageReadMetrics,
+    maintained_metrics: StorageReadMetrics,
 }
 
 impl RungReceipt {
@@ -186,9 +192,18 @@ impl RungReceipt {
         fields.insert("db_open_us".to_owned(), json!(self.db_open_us));
         fields.insert("prepare_us".to_owned(), json!(self.prepare_us));
         fields.insert("query_us".to_owned(), json!(self.query_us));
+        fields.insert(
+            "maintained_subscribe_us".to_owned(),
+            json!(self.maintained_subscribe_us),
+        );
+        fields.insert(
+            "maintained_result_digest".to_owned(),
+            json!(self.maintained_result_digest),
+        );
         insert_read_metrics(&mut fields, "open", &self.open_metrics);
         insert_read_metrics(&mut fields, "prepare", &self.prepare_metrics);
         insert_read_metrics(&mut fields, "query", &self.query_metrics);
+        insert_read_metrics(&mut fields, "maintained", &self.maintained_metrics);
         support::emit_json_line("selective_global_hydration", fields);
     }
 }
@@ -257,6 +272,49 @@ fn run_rung(config: ConfigRef, table_rows: usize) -> RungReceipt {
     let result_digest = digest_rows(&observed);
     assert_eq!(result_digest, digest_rows(&expected));
 
+    // A maintained subscription must hydrate through the same declared index
+    // and retain a live continuation, not fall back to a separate one-shot
+    // authority read. The fixture is history-complete: its ahead overlay is
+    // empty, so any table-size growth here is attributable to the settled
+    // source selection rather than unfinalized local writes.
+    db.reset_storage_read_metrics_for_test();
+    let subscribe_started = Instant::now();
+    let mut subscription = block_on(db.subscribe(&prepared, local_read_opts()))
+        .expect("open selective maintained subscription");
+    let maintained_subscribe_us = subscribe_started.elapsed().as_micros();
+    let maintained_metrics = db.take_storage_read_metrics_for_test();
+    let SubscriptionEvent::Delta {
+        reset: true,
+        added,
+        updated,
+        removed,
+        ..
+    } = subscription
+        .try_next_event()
+        .expect("maintained subscription must emit its initial reset")
+    else {
+        panic!("maintained subscription must emit an initial reset");
+    };
+    assert!(updated.is_empty());
+    assert!(removed.is_empty());
+    let maintained_rows = added
+        .into_iter()
+        .map(|row| row.row_uuid())
+        .collect::<Vec<_>>();
+    assert_eq!(maintained_rows, expected);
+    assert!(
+        maintained_metrics.global_current_rows.reads <= config.target_rows,
+        "maintained selective hydration read {} current rows for {} indexed candidates at table size {table_rows}",
+        maintained_metrics.global_current_rows.reads,
+        config.target_rows,
+    );
+    assert!(
+        (1..=config.target_rows).contains(&maintained_metrics.global_current_indexes.reads),
+        "maintained selective hydration must use the declared index without reading more than the fixed candidate set",
+    );
+    let maintained_result_digest = digest_rows(&maintained_rows);
+    assert_eq!(maintained_result_digest, result_digest);
+
     block_on(db.close()).expect("close measured selective-hydration database");
 
     RungReceipt {
@@ -268,10 +326,13 @@ fn run_rung(config: ConfigRef, table_rows: usize) -> RungReceipt {
         db_open_us: db_open_us_after_seed,
         prepare_us,
         query_us,
+        maintained_subscribe_us,
         result_digest,
+        maintained_result_digest,
         open_metrics,
         prepare_metrics,
         query_metrics,
+        maintained_metrics,
     }
 }
 
@@ -352,6 +413,16 @@ fn global_read_opts() -> ReadOpts {
     ReadOpts {
         tier: DurabilityTier::Global,
         local_updates: LocalUpdates::Deferred,
+        propagation: Propagation::LocalOnly,
+        include_deleted: false,
+        ..ReadOpts::default()
+    }
+}
+
+fn local_read_opts() -> ReadOpts {
+    ReadOpts {
+        tier: DurabilityTier::Local,
+        local_updates: LocalUpdates::Immediate,
         propagation: Propagation::LocalOnly,
         include_deleted: false,
         ..ReadOpts::default()

--- a/crates/jazz/benches/selective_global_hydration.rs
+++ b/crates/jazz/benches/selective_global_hydration.rs
@@ -133,12 +133,19 @@ fn maintained_subscription_hydration_100k(bencher: divan::Bencher<'_, '_>) {
 
 fn benchmark_maintained_subscription_hydration(bencher: divan::Bencher<'_, '_>, table_rows: usize) {
     let fixture = HydrationFixture::new(table_rows);
+    let baseline_subscriptions = fixture.active_groove_subscriptions();
 
     // Keep the correctness/read-bound proof out of the measurement. The timed
     // operation below is exactly the same initial maintained hydration.
     fixture.assert_selective_hydration();
+    fixture.assert_subscription_baseline(baseline_subscriptions, "validation hydration");
 
     bencher.bench_local(|| divan::black_box(fixture.hydrate_maintained()));
+    // `SubscriptionStream::drop` only queues its finalizer so it can never
+    // block a caller suspended on storage. Divan drops each timed result, but
+    // does not run Jazz's owner turn for us; drain that queued work outside
+    // the timing boundary before this fixture is released or reused.
+    fixture.assert_subscription_baseline(baseline_subscriptions, "Divan samples");
 }
 
 #[derive(Clone, Copy)]
@@ -291,6 +298,24 @@ impl HydrationFixture {
         assert_selective_metrics(&measured.metrics, self.target_rows, "maintained");
     }
 
+    fn active_groove_subscriptions(&self) -> usize {
+        self.db.active_groove_subscriptions_for_test()
+    }
+
+    /// Drain the non-blocking `SubscriptionStream::drop` finalizers and prove
+    /// a repeated benchmark cannot retain a Groove graph per sample.
+    ///
+    /// This must remain outside `hydrate_maintained`: the timed receipt is the
+    /// opening/reset path, while finalization is an ordinary later owner turn.
+    fn assert_subscription_baseline(&self, baseline: usize, phase: &str) {
+        block_on(self.db.tick()).expect("drain queued maintained-subscription finalizers");
+        assert_eq!(
+            self.active_groove_subscriptions(),
+            baseline,
+            "{phase} must retire every dropped maintained Groove subscription"
+        );
+    }
+
     /// The timed operation: create one maintained subscription and consume its
     /// initial reset. It returns the same result digest and logical read
     /// counters asserted by `assert_selective_hydration`, but performs no
@@ -312,6 +337,10 @@ impl HydrationFixture {
             .map(|row| row.row_uuid())
             .collect::<Vec<_>>();
         let metrics = self.db.take_storage_read_metrics_for_test();
+        // This only queues teardown. The caller deliberately runs `Db::tick`
+        // after the timed operation, where the owner can retire the retained
+        // Groove subscription without contaminating the sample.
+        drop(subscription);
         HydrationMeasurement {
             row_count: rows.len(),
             result_digest: digest_rows(&rows),

--- a/crates/jazz/src/db/tests/reads.rs
+++ b/crates/jazz/src/db/tests/reads.rs
@@ -18,6 +18,142 @@ fn indexed_documents_schema() -> JazzSchema {
     )
 }
 
+fn multi_index_documents_schema() -> JazzSchema {
+    build_public_db_test_schema(
+        PublicSchemaBuilder::new().table(
+            PublicTableSchemaBuilder::new("documents")
+                .column("team", PublicColumnType::Uuid)
+                .column("active", PublicColumnType::Boolean)
+                .column("title", PublicColumnType::Text)
+                .index_only(["team", "active"]),
+        ),
+    )
+}
+
+/// A maintained equality source is both an indexed hydration source and a
+/// live IVM source. In particular, a row changing either indexed equality must
+/// enter/leave exactly once rather than remaining filtered by the prefix that
+/// selected the initial snapshot.
+#[test]
+fn maintained_multi_index_query_tracks_either_index_transition() {
+    let schema = multi_index_documents_schema();
+    let author = AuthorSubject::for_test_bytes([0xd1; 16]);
+    let db = open_db(0xd1, author, &schema);
+    let team = row(0xa0);
+    let matching = row(1);
+    let inactive = row(2);
+    let other_team = row(3);
+    let cells = |team: RowUuid, active: bool, title: &str| {
+        BTreeMap::from([
+            ("team".to_owned(), Value::Uuid(team.0)),
+            ("active".to_owned(), Value::Bool(active)),
+            ("title".to_owned(), Value::String(title.to_owned())),
+        ])
+    };
+    for (id, values) in [
+        (matching, cells(team, true, "matching")),
+        (inactive, cells(team, false, "inactive")),
+        (other_team, cells(row(0xb0), true, "other team")),
+    ] {
+        db.insert(
+            "documents",
+            values,
+            crate::db::InsertOptions {
+                row_id: Some(id),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+
+    let query = Query::from("documents")
+        .filter(eq(col("team"), lit(Value::Uuid(team.0))))
+        .filter(eq(col("active"), lit(true)));
+    db.node.node.borrow_mut().reset_query_engine_read_metrics();
+    let mut subscription = prepared_subscribe(&db, &query, ReadOpts::default()).unwrap();
+    let initial = snapshot_from_event(block_on(subscription.next_raw()).unwrap());
+    assert_eq!(row_ids(&initial.rows), vec![matching]);
+    assert!(
+        db.node
+            .node
+            .borrow()
+            .query_engine_read_metrics()
+            .source_index_probes
+            >= 2,
+        "the maintained Local source must probe both equality indices"
+    );
+
+    db.update(
+        "documents",
+        inactive,
+        BTreeMap::from([("active".to_owned(), Value::Bool(true))]),
+        Default::default(),
+    )
+    .unwrap();
+    let (added, updated, removed) = delta_rows(block_on(subscription.next_raw()).unwrap());
+    assert_eq!(row_ids(&added), vec![inactive]);
+    assert!(updated.is_empty());
+    assert!(removed.is_empty());
+
+    db.update(
+        "documents",
+        inactive,
+        BTreeMap::from([("team".to_owned(), Value::Uuid(row(0xb0).0))]),
+        Default::default(),
+    )
+    .unwrap();
+    let (added, updated, removed) = delta_rows(block_on(subscription.next_raw()).unwrap());
+    assert!(added.is_empty());
+    assert!(updated.is_empty());
+    assert_eq!(
+        removed
+            .into_iter()
+            .map(|row| row.row_uuid)
+            .collect::<Vec<_>>(),
+        vec![inactive]
+    );
+}
+
+/// Empty durable index prefixes remain live sources. The first matching row
+/// must not be lost merely because indexed hydration had no row to materialize.
+#[test]
+fn maintained_empty_index_prefix_delivers_first_matching_insert_once() {
+    let schema = indexed_documents_schema();
+    let author = AuthorSubject::for_test_bytes([0xd2; 16]);
+    let db = open_db(0xd2, author, &schema);
+    let team = row(0xa2);
+    let query = Query::from("documents").filter(eq(col("team"), lit(Value::Uuid(team.0))));
+    let mut subscription = prepared_subscribe(&db, &query, ReadOpts::default()).unwrap();
+    let initial = snapshot_from_event(block_on(subscription.next_raw()).unwrap());
+    assert!(
+        initial.rows.is_empty(),
+        "empty prefix must still open a subscription"
+    );
+
+    let first = row(4);
+    db.insert(
+        "documents",
+        BTreeMap::from([
+            ("team".to_owned(), Value::Uuid(team.0)),
+            ("active".to_owned(), Value::Bool(true)),
+            ("title".to_owned(), Value::String("first".to_owned())),
+        ]),
+        crate::db::InsertOptions {
+            row_id: Some(first),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let (added, updated, removed) = delta_rows(block_on(subscription.next_raw()).unwrap());
+    assert_eq!(row_ids(&added), vec![first]);
+    assert!(updated.is_empty());
+    assert!(removed.is_empty());
+    assert!(
+        subscription.try_next_event().is_none(),
+        "first insert must deliver exactly once"
+    );
+}
+
 #[test]
 fn negated_membership_uses_two_valued_null_semantics() {
     let schema = build_public_db_test_schema(

--- a/crates/jazz/src/db/tests/reads.rs
+++ b/crates/jazz/src/db/tests/reads.rs
@@ -154,6 +154,39 @@ fn maintained_empty_index_prefix_delivers_first_matching_insert_once() {
     );
 }
 
+/// A Local subscription remains complete when its settled source is indexed;
+/// the empty ahead overlay does not replace that indexed snapshot.
+#[test]
+fn maintained_local_index_snapshot_is_complete() {
+    let schema = indexed_documents_schema();
+    let author = AuthorSubject::for_test_bytes([0xd3; 16]);
+    let db = open_db(0xd3, author, &schema);
+    let team = row(0xa3);
+    let matching = row(5);
+    for (id, row_team) in [(matching, team), (row(6), row(0xb3))] {
+        db.seed_settled_mergeable_for_bootstrap(
+            "documents",
+            id,
+            author,
+            BTreeMap::from([
+                ("team".to_owned(), Value::Uuid(row_team.0)),
+                ("active".to_owned(), Value::Bool(true)),
+                ("title".to_owned(), Value::String("settled".to_owned())),
+            ]),
+        )
+        .unwrap();
+    }
+
+    let query = Query::from("documents").filter(eq(col("team"), lit(Value::Uuid(team.0))));
+    db.node.node.borrow_mut().reset_query_engine_read_metrics();
+    let mut subscription = prepared_subscribe(&db, &query, ReadOpts::default()).unwrap();
+    let snapshot = snapshot_from_event(block_on(subscription.next_raw()).unwrap());
+    assert_eq!(row_ids(&snapshot.rows), vec![matching]);
+    let node = db.node.node.borrow();
+    let metrics = node.query_engine_read_metrics();
+    assert!(metrics.source_index_probes >= 1);
+}
+
 #[test]
 fn negated_membership_uses_two_valued_null_semantics() {
     let schema = build_public_db_test_schema(

--- a/crates/jazz/src/db/tests/reads.rs
+++ b/crates/jazz/src/db/tests/reads.rs
@@ -187,6 +187,65 @@ fn maintained_local_index_snapshot_is_complete() {
     assert!(metrics.source_index_probes >= 1);
 }
 
+/// A Global subscription starts empty until its authority has settled the
+/// indexed source, then installs the same complete indexed snapshot that its
+/// Local counterpart would observe. This exercises the asynchronous delivery
+/// boundary that previously made the direct maintained index experiment lose
+/// fresh snapshots on worker-backed storage.
+#[test]
+fn maintained_global_index_snapshot_waits_for_settled_source() {
+    let schema = indexed_documents_schema();
+    let client_author = AuthorSubject::for_test_bytes([0xd5; 16]);
+    let server = open_core(0xd4, AuthorSubject::SYSTEM, &schema);
+    let client = open_db(0xd5, client_author, &schema);
+    let team = row(0xa4);
+    let matching = seed(
+        &server,
+        "documents",
+        BTreeMap::from([
+            ("team".to_owned(), Value::Uuid(team.0)),
+            ("active".to_owned(), Value::Bool(true)),
+            ("title".to_owned(), Value::String("matching".to_owned())),
+        ]),
+    );
+    seed(
+        &server,
+        "documents",
+        BTreeMap::from([
+            ("team".to_owned(), Value::Uuid(row(0xb4).0)),
+            ("active".to_owned(), Value::Bool(true)),
+            ("title".to_owned(), Value::String("unrelated".to_owned())),
+        ]),
+    );
+
+    let (client_transport, server_transport) = duplex();
+    let _upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let _subscriber = server.accept_subscriber(server_transport, client_author);
+    let query = Query::from("documents").filter(eq(col("team"), lit(Value::Uuid(team.0))));
+    server.node().borrow_mut().reset_query_engine_read_metrics();
+    let mut subscription = prepared_subscribe(&client, &query, global_subscribe_opts()).unwrap();
+    assert!(
+        opened_rows(block_on(subscription.next_raw()).unwrap()).is_empty(),
+        "Global must not claim a snapshot before the authority settles it"
+    );
+
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+
+    let snapshot = snapshot_from_event(block_on(subscription.next_raw()).unwrap());
+    assert_eq!(row_ids(&snapshot.rows), vec![matching]);
+    assert!(
+        server
+            .node()
+            .borrow()
+            .query_engine_read_metrics()
+            .source_index_probes
+            >= 1,
+        "the authority must hydrate the settled Global source through its equality index"
+    );
+}
+
 #[test]
 fn negated_membership_uses_two_valued_null_semantics() {
     let schema = build_public_db_test_schema(

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -403,6 +403,7 @@ where
         authorization_mode: QueryAuthorizationMode,
         prepared_claim_binding_mode: PreparedClaimBindingMode,
     ) -> Result<QueryProgram, Error> {
+        let allow_secondary_indexes = matches!(&output, CurrentQueryProgramOutput::MaintainedView);
         let request = self.current_query_program_request_with_prepared_claim_mode(
             shape,
             binding,
@@ -421,7 +422,7 @@ where
         // subsequent table deltas pass through the very same predicate graph.
         // In particular, this is not a separate snapshot/RPC path, so its
         // initial frontier and live continuation share one membership proof.
-        let access_paths = self.query_program_access_paths(&request)?;
+        let access_paths = self.query_program_access_paths(&request, allow_secondary_indexes)?;
         self.compile_query_program_request_with_access_paths(request, access_paths)
             .await
     }

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -415,11 +415,13 @@ where
             prepared_claim_binding_mode,
             false,
         )?;
-        // Maintained index scans retain their established full source because
-        // an index can settle against a different persisted frontier. A
-        // physical primary-key source has no independent index frontier and
-        // remains incrementally complete for that one immutable row identity.
-        let access_paths = self.current_query_primary_key_access_paths(shape, binding)?;
+        // A maintained source may use the same conservative equality access
+        // path as a one-shot source.  The source remains an ordinary IVM
+        // source: its hydration is selected from the durable index while
+        // subsequent table deltas pass through the very same predicate graph.
+        // In particular, this is not a separate snapshot/RPC path, so its
+        // initial frontier and live continuation share one membership proof.
+        let access_paths = self.query_program_access_paths(&request)?;
         self.compile_query_program_request_with_access_paths(request, access_paths)
             .await
     }

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -416,13 +416,20 @@ where
             prepared_claim_binding_mode,
             false,
         )?;
-        // A maintained source may use the same conservative equality access
-        // path as a one-shot source.  The source remains an ordinary IVM
-        // source: its hydration is selected from the durable index while
-        // subsequent table deltas pass through the very same predicate graph.
-        // In particular, this is not a separate snapshot/RPC path, so its
-        // initial frontier and live continuation share one membership proof.
-        let access_paths = self.query_program_access_paths(&request, allow_secondary_indexes)?;
+        // Retain the established, guarded primary-key paths. In particular a
+        // policy-scoped or declared-`id` root must stay a complete current
+        // source: a point cap there can strand a deletion-driven membership
+        // transition. The new selector contributes only secondary equality
+        // indexes for concrete maintained roots; it must not widen that
+        // legacy guard by injecting another primary-key cap.
+        let mut access_paths = self.current_query_primary_key_access_paths(shape, binding)?;
+        if allow_secondary_indexes {
+            access_paths.extend(
+                self.query_program_access_paths(&request, true)?
+                    .into_iter()
+                    .filter(|(_, path)| matches!(path, CurrentAccessPath::Index { .. })),
+            );
+        }
         self.compile_query_program_request_with_access_paths(request, access_paths)
             .await
     }

--- a/crates/jazz/src/node/query_eval/authorization.rs
+++ b/crates/jazz/src/node/query_eval/authorization.rs
@@ -310,7 +310,10 @@ where
         let result = async {
             let access_paths = match forced_access_paths {
                 Some(access_paths) => access_paths,
-                None => self.query_program_access_paths(&request)?,
+                // Cached authorization dependencies deliberately do not carry
+                // secondary index prefixes resolved from this identity's
+                // claims. Their cache key describes claim shape, not values.
+                None => self.query_program_access_paths(&request, false)?,
             };
             let program =
                 if cache {

--- a/crates/jazz/src/node/query_eval/lowering.rs
+++ b/crates/jazz/src/node/query_eval/lowering.rs
@@ -543,6 +543,10 @@ where
                 } => outer_access_paths
                     .get(protected_source)
                     .cloned()
+                    // A cached policy graph may preserve a primary-key point
+                    // proof, but must never retain a secondary index prefix
+                    // resolved from the outer identity's claims.
+                    .filter(|path| matches!(path, CurrentAccessPath::PrimaryKey(_)))
                     .map(|path| BTreeMap::from([(protected_source.clone(), path)])),
                 _ => None,
             };

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -344,6 +344,7 @@ pub(super) fn select_current_access_path(
         column,
         prefix,
         intersections: probes.into_iter().skip(1).collect(),
+        maintained: false,
         source_limit: None,
     })
 }

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -37,6 +37,11 @@ pub(super) enum CurrentAccessPath {
         column: String,
         prefix: Vec<Value>,
         intersections: Vec<(String, Vec<Value>)>,
+        /// A maintained source keeps every equality probe as an ordinary IVM
+        /// source and intersects them in the graph. The fused storage request
+        /// is snapshot-only and cannot observe later transitions through a
+        /// secondary equality index.
+        maintained: bool,
         /// A proved physical source cap for an ordinary one-shot read. This is
         /// never selected by policy compilation or subscriptions.
         source_limit: Option<usize>,
@@ -1806,6 +1811,7 @@ where
                 prefix,
                 intersections,
                 source_limit,
+                ..
             } => {
                 if tier != DurabilityTier::Global {
                     return Ok(None);
@@ -1822,6 +1828,7 @@ where
                         &column,
                         &prefix,
                         &intersections,
+                        false,
                         source_limit,
                         &projection_target,
                     )
@@ -2115,6 +2122,7 @@ where
                     prefix,
                     intersections,
                     source_limit,
+                    maintained,
                 }) => {
                     let source_limit = (!exclude_deleted).then_some(source_limit).flatten();
                     self.node.query_engine_read_metrics.source_index_probes +=
@@ -2126,6 +2134,7 @@ where
                             &column,
                             &prefix,
                             &intersections,
+                            maintained,
                             source_limit,
                             &projection_target,
                         )
@@ -2208,6 +2217,7 @@ where
                 prefix,
                 intersections,
                 source_limit,
+                maintained,
             }) => {
                 // Select settled candidates before combining them with the
                 // corresponding Local ahead candidates below.
@@ -2221,6 +2231,7 @@ where
                         column,
                         prefix,
                         intersections,
+                        *maintained,
                         source_limit,
                         &projection_target,
                         raw_global_output.clone(),
@@ -3327,17 +3338,17 @@ where
             let Some(mut path) = select_current_access_path(&table, &equalities) else {
                 continue;
             };
-            // Multi-index intersection is an ephemeral one-shot source. Keep
-            // maintained programs and reusable policy graphs on their existing
-            // single-index path until the fused source has incremental-update
-            // semantics of its own.
-            if !allow_local && let CurrentAccessPath::Index { intersections, .. } = &mut path {
-                intersections.clear();
+            if !allow_local && let CurrentAccessPath::Index { maintained, .. } = &mut path {
+                *maintained = true;
             }
-            // Generic maintained programs remain Global-only. A one-shot Local
-            // caller opts in only after arranging equivalent index scans over
-            // both the settled and ahead physical sources.
-            if tier == DurabilityTier::Global || (allow_local && tier == DurabilityTier::Local) {
+            // Local/Edge sources still combine the selected settled candidates
+            // with the complete ahead overlay before choosing a winner, so a
+            // newer row which leaves an equality prefix cannot leave behind a
+            // stale settled match.
+            if matches!(
+                tier,
+                DurabilityTier::Global | DurabilityTier::Local | DurabilityTier::Edge
+            ) {
                 paths.insert(source, path);
             }
         }
@@ -3515,6 +3526,7 @@ where
         column: &str,
         prefix: &[Value],
         intersections: &[(String, Vec<Value>)],
+        maintained: bool,
         source_limit: Option<usize>,
         projection_target: &str,
     ) -> Result<GraphBuilder, Error> {
@@ -3524,6 +3536,7 @@ where
             column,
             prefix,
             intersections,
+            maintained,
             source_limit,
             projection_target,
             table.global_current_storage_tables()[0].record_schema(),
@@ -3537,6 +3550,7 @@ where
         column: &str,
         prefix: &[Value],
         intersections: &[(String, Vec<Value>)],
+        maintained: bool,
         source_limit: Option<usize>,
         projection_target: &str,
         _output: RecordDescriptor,
@@ -3605,13 +3619,37 @@ where
                 ))
             })
             .collect::<Result<Vec<_>, Error>>()?;
-        Ok(GraphBuilder::variant_index_intersection_scan(
-            storage_table,
-            physical_current_index_name(column_id),
-            scan,
-            intersections,
-            projection_target,
-        ))
+        let primary_index = physical_current_index_name(column_id);
+        if maintained {
+            // `IndexedRowsIntersection` is a hydration request, not a live
+            // source.  Model each equality as an index source and express the
+            // intersection in IVM so table deltas which enter or leave either
+            // prefix drive ordinary semi-join updates.
+            let mut graph = GraphBuilder::variant_index_scan(
+                storage_table.clone(),
+                primary_index,
+                projection_target,
+                scan,
+            );
+            for (index, scan) in intersections {
+                let right = GraphBuilder::variant_index_scan(
+                    storage_table.clone(),
+                    index,
+                    projection_target,
+                    scan,
+                );
+                graph = GraphBuilder::semi_join(graph, right, ["row_uuid"], ["row_uuid"]);
+            }
+            Ok(graph)
+        } else {
+            Ok(GraphBuilder::variant_index_intersection_scan(
+                storage_table,
+                primary_index,
+                scan,
+                intersections,
+                projection_target,
+            ))
+        }
     }
 }
 

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -3276,6 +3276,7 @@ where
     pub(super) fn query_program_access_paths(
         &self,
         request: &QueryProgramRequest,
+        allow_secondary_indexes: bool,
     ) -> Result<BTreeMap<SourceId, CurrentAccessPath>, Error> {
         // A policy proof may contain both an owner arm and a correlated
         // membership arm for the same protected source. Walking its nested
@@ -3299,6 +3300,7 @@ where
             &request.reads.primary,
             &request.policy,
             false,
+            allow_secondary_indexes,
         )
     }
 
@@ -3308,6 +3310,7 @@ where
         read_view: &ReadView<RequestedSourceStage>,
         policy: &PolicyContext,
         allow_local: bool,
+        allow_secondary_indexes: bool,
     ) -> Result<BTreeMap<SourceId, CurrentAccessPath>, Error> {
         let mut equalities_by_source = BTreeMap::new();
         // This deliberately small access-path selector only recognizes a
@@ -3338,6 +3341,15 @@ where
             let Some(mut path) = select_current_access_path(&table, &equalities) else {
                 continue;
             };
+            // Authorization dependencies are cached by policy shape and claim
+            // schema, not by a resolved claim value. A secondary-index prefix
+            // derived from this request could therefore make a later identity
+            // reuse another identity's candidate set. Keep those reusable
+            // graphs identity-neutral; maintained root views are compiled for
+            // this concrete request and may safely select their own index.
+            if !allow_secondary_indexes && matches!(path, CurrentAccessPath::Index { .. }) {
+                continue;
+            }
             if !allow_local && let CurrentAccessPath::Index { maintained, .. } = &mut path {
                 *maintained = true;
             }
@@ -3387,6 +3399,7 @@ where
             &input,
             &reads.primary,
             &PolicyContext::System,
+            true,
             true,
         )?;
 

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -327,27 +327,31 @@ fn indexed_conjunctive_read_policy_retains_the_final_policy_predicate() {
     }
 
     let query = Query::from("docs");
-    let (global, global_metrics) = query_rows_by_uuid_for_identity(
+    let (global, global_metrics) = maintained_rows_by_uuid_for_identity(
         &mut core,
         query.clone(),
         DurabilityTier::Global,
         owner,
     );
     let (local, _) =
-        query_rows_by_uuid_for_identity(&mut core, query, DurabilityTier::Local, owner);
+        maintained_rows_by_uuid_for_identity(&mut core, query, DurabilityTier::Local, owner);
 
     assert_eq!(global, local);
     assert_eq!(global, vec![owned_open]);
     assert!(!global.contains(&owned_closed));
     assert!(!global.contains(&foreign_open));
-    assert!(
-        global_metrics.source_index_probes >= 1,
-        "the conjunctive policy must narrow its Global source through owner"
-    );
+    // The cached authorization graph is deliberately identity-neutral.  The
+    // maintained root applies the owner's claim at its terminal instead of
+    // baking a concrete owner-index probe into a reusable policy dependency.
+    // The identity-neutral policy graph therefore deliberately scans its
+    // dependency, while the maintained root remains selective. Retaining the
+    // final literal predicate must not cause a secondary index probe.
+    assert_eq!(global_metrics.source_index_probes, 0);
+    assert!(global_metrics.source_full_scans >= 1);
 }
 
 #[test]
-fn policy_access_path_receipt_is_not_reused_across_claim_bindings() {
+fn policy_access_path_receipt_is_reused_across_claim_bindings_without_leaking_visibility() {
     let schema = policy_indexed_access_path_schema(public_claim_eq("owner", "tenant"));
     let (_writer_dir, mut writer) = open_node_with_schema(node(8), schema.clone());
     let (_core_dir, mut core) = open_node_with_schema(node(9), schema);
@@ -370,7 +374,7 @@ fn policy_access_path_receipt_is_not_reused_across_claim_bindings() {
         reader,
         BTreeMap::from([("tenant".to_owned(), Value::Uuid(first_owner.test_uuid()))]),
     );
-    let (first_rows, first_metrics) = query_rows_by_uuid_for_identity(
+    let (first_rows, first_metrics) = maintained_rows_by_uuid_for_identity(
         &mut core,
         query.clone(),
         DurabilityTier::Global,
@@ -381,12 +385,19 @@ fn policy_access_path_receipt_is_not_reused_across_claim_bindings() {
         BTreeMap::from([("tenant".to_owned(), Value::Uuid(second_owner.test_uuid()))]),
     );
     let (second_rows, second_metrics) =
-        query_rows_by_uuid_for_identity(&mut core, query, DurabilityTier::Global, reader);
+        maintained_rows_by_uuid_for_identity(&mut core, query, DurabilityTier::Global, reader);
 
     assert_eq!(first_rows, vec![first]);
     assert_eq!(second_rows, vec![second]);
-    assert!(first_metrics.source_index_probes >= 1);
-    assert!(second_metrics.source_index_probes >= 1);
+    // Changing the claim must change the visible rows, but not mutate the
+    // shared policy dependency into a claim-specialized source program.
+    // Both reads reuse the identity-neutral graph: it deliberately falls back
+    // to its complete policy source, but must never probe a claim-derived
+    // secondary index.
+    assert_eq!(first_metrics.source_index_probes, 0);
+    assert!(first_metrics.source_full_scans >= 1);
+    assert_eq!(second_metrics.source_index_probes, 0);
+    assert!(second_metrics.source_full_scans >= 1);
 }
 
 #[test]

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -106,6 +106,43 @@ fn query_rows_by_uuid_for_identity(
     (rows, node.query_engine_read_metrics().clone())
 }
 
+fn maintained_rows_by_uuid_for_identity(
+    node: &mut NodeState<RocksDbStorage>,
+    query: Query,
+    tier: DurabilityTier,
+    identity: AuthorSubject,
+) -> (Vec<RowUuid>, QueryEngineReadMetrics) {
+    // Keep the maintained subscription path on the same authenticated claim
+    // binding as the public one-shot helper above.
+    if identity != AuthorSubject::SYSTEM {
+        let mut claims = node.session_claims.get(&identity).cloned().unwrap_or_default();
+        claims
+            .entry("sub".to_owned())
+            .or_insert_with(|| Value::Uuid(identity.test_uuid()));
+        node.set_test_provider_claims(identity, claims);
+    }
+    let shape = query.validate(&node.catalogue.schema).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    node.reset_query_engine_read_metrics();
+    let (receiver, maintained, _schemas, _transitions, _tables, _incomplete) = node
+        .open_seeded_maintained_subscription_view(
+            &shape,
+            &binding,
+            identity,
+            tier,
+            &crate::protocol::ReadViewSpec::default(),
+        )
+        .unwrap();
+    let rows = maintained
+        .active_result_members()
+        .iter()
+        .filter_map(crate::protocol::ResultMemberEntry::as_row)
+        .filter_map(|(table, row_uuid, _)| (table.as_str() == "docs").then_some(row_uuid))
+        .collect();
+    node.unsubscribe_groove_subscription(receiver.id());
+    (rows, node.query_engine_read_metrics().clone())
+}
+
 #[test]
 fn history_complete_query_ignores_stale_settled_result_membership() {
     let schema = access_path_schema();
@@ -180,15 +217,86 @@ fn indexed_read_policy_matches_local_scan_for_allowed_and_denied_identities() {
     assert_eq!(global_allowed, vec![first]);
     assert_eq!(global_denied, local_denied);
     assert!(global_denied.is_empty());
-    assert!(
-        global_allowed_metrics.source_index_probes >= 1,
-        "the eligible global policy must use its declared owner index"
-    );
-    assert_eq!(global_allowed_metrics.source_full_scans, 0);
+    // Prepared AppRows/policy dependencies are reused across identities. Their
+    // claim-shaped cache key must not retain this owner's concrete secondary
+    // index prefix; only the per-identity maintained root may specialize it.
+    assert_eq!(global_allowed_metrics.source_index_probes, 0);
+    assert!(global_allowed_metrics.source_full_scans >= 1);
     assert!(local_allowed_metrics.source_full_scans >= 1);
     assert_eq!(edge_allowed_metrics.source_index_probes, 0);
     assert!(edge_allowed_metrics.source_full_scans >= 1);
-    assert!(global_denied_metrics.source_index_probes >= 1);
+    assert_eq!(global_denied_metrics.source_index_probes, 0);
+
+    // Exercise the reverse cache population order too: a denied identity must
+    // not leave a reusable empty authorization graph that hides a later owner.
+    let schema = policy_indexed_access_path_schema(public_claim_eq("owner", "sub"));
+    let (_reverse_writer_dir, mut reverse_writer) = open_node_with_schema(node(10), schema.clone());
+    let (_reverse_core_dir, mut reverse_core) = open_node_with_schema(node(11), schema);
+    let (reverse_first, _reverse_second, reverse_owner) =
+        seed_access_path_docs(&mut reverse_writer, &mut reverse_core);
+    let reverse_denied = user(0xd4);
+    let (denied_first, _) = query_rows_by_uuid_for_identity(
+        &mut reverse_core,
+        Query::from("docs"),
+        DurabilityTier::Global,
+        reverse_denied,
+    );
+    let (allowed_after_denied, _) = query_rows_by_uuid_for_identity(
+        &mut reverse_core,
+        Query::from("docs"),
+        DurabilityTier::Global,
+        reverse_owner,
+    );
+    assert!(denied_first.is_empty());
+    assert_eq!(allowed_after_denied, vec![reverse_first]);
+}
+
+#[test]
+fn maintained_policy_index_reads_are_isolated_between_identities() {
+    let schema = policy_indexed_access_path_schema(public_claim_eq("owner", "sub"));
+    let (_writer_dir, mut writer) = open_node_with_schema(node(12), schema.clone());
+    let (_core_dir, mut core) = open_node_with_schema(node(13), schema);
+    let (first, _second, owner) = seed_access_path_docs(&mut writer, &mut core);
+    let denied = user(0xe5);
+
+    // The maintained root may specialize its own source with the authenticated
+    // identity, but its cached policy dependencies must not leak that prefix
+    // into a later subscriber.
+    let (allowed_first, _) = maintained_rows_by_uuid_for_identity(
+        &mut core,
+        Query::from("docs"),
+        DurabilityTier::Global,
+        owner,
+    );
+    let (denied_after_allowed, _) = maintained_rows_by_uuid_for_identity(
+        &mut core,
+        Query::from("docs"),
+        DurabilityTier::Global,
+        denied,
+    );
+    assert_eq!(allowed_first, vec![first]);
+    assert!(denied_after_allowed.is_empty());
+
+    let schema = policy_indexed_access_path_schema(public_claim_eq("owner", "sub"));
+    let (_reverse_writer_dir, mut reverse_writer) = open_node_with_schema(node(14), schema.clone());
+    let (_reverse_core_dir, mut reverse_core) = open_node_with_schema(node(15), schema);
+    let (reverse_first, _reverse_second, reverse_owner) =
+        seed_access_path_docs(&mut reverse_writer, &mut reverse_core);
+    let reverse_denied = user(0xf6);
+    let (denied_first, _) = maintained_rows_by_uuid_for_identity(
+        &mut reverse_core,
+        Query::from("docs"),
+        DurabilityTier::Global,
+        reverse_denied,
+    );
+    let (allowed_after_denied, _) = maintained_rows_by_uuid_for_identity(
+        &mut reverse_core,
+        Query::from("docs"),
+        DurabilityTier::Global,
+        reverse_owner,
+    );
+    assert!(denied_first.is_empty());
+    assert_eq!(allowed_after_denied, vec![reverse_first]);
 }
 
 #[test]

--- a/dev/benchmarks/SELECTIVE_GLOBAL_HYDRATION.md
+++ b/dev/benchmarks/SELECTIVE_GLOBAL_HYDRATION.md
@@ -28,10 +28,11 @@ alongside query wall time. Logical reads are the primary mechanism evidence;
 wall time is directional because the same-process seed leaves operating-system
 cache state uncontrolled.
 
-The default ladder is 1,000 / 10,000 / 100,000 total rows. Override it for a
+The default ladder is 10,000 / 100,000 / 1,000,000 total rows. Override it for a
 bounded smoke run:
 
 ```sh
+JAZZ_SELECTIVE_HYDRATION_RECEIPT=1 \
 JAZZ_SELECTIVE_HYDRATION_ROWS=1000,10000 \
   cargo bench -p jazz --features testing \
   --bench selective_global_hydration --quiet

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -1113,6 +1113,47 @@ describe("SharedWorker bridge with IndexedDB", () => {
     unsub();
   });
 
+  it("maintains an IndexedDB-backed equality window across a tombstone", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: {
+          type: "persistent",
+          dbName: uniqueDbName("maintained-equality-window-tombstone"),
+        },
+      }),
+    );
+    const openWindow = app.todos.where({ done: false }).orderBy("title", "asc").limit(2);
+    const snapshots: Todo[][] = [];
+    const unsubscribe = trackSubscription(
+      db.subscribe(openWindow, (rows) => snapshots.push(rows), { tier: "local" }),
+    );
+
+    const alpha = await db.insert(todos, { title: "alpha", done: false }).wait({ tier: "local" });
+    await db.insert(todos, { title: "bravo", done: false }).wait({ tier: "local" });
+    await db.insert(todos, { title: "charlie", done: false }).wait({ tier: "local" });
+
+    await waitForCondition(
+      async () =>
+        snapshots.some((rows) => rows.map((row) => row.title).join(",") === "alpha,bravo"),
+      8_000,
+      "maintained equality query should retain its ordered local window",
+    );
+
+    await db.delete(todos, alpha.id).wait({ tier: "local" });
+    await waitForCondition(
+      async () =>
+        snapshots.some((rows) => rows.map((row) => row.title).join(",") === "bravo,charlie"),
+      8_000,
+      "tombstoning the first window member should promote the next equality match",
+    );
+    expect((await db.all(openWindow, { tier: "local" })).map((row) => row.title)).toEqual([
+      "bravo",
+      "charlie",
+    ]);
+    unsubscribe();
+  });
+
   it("tiered subscriptions gate the first callback until the worker's settled snapshot content is local", async () => {
     const syncServer = await publishSyncServerSchemaAndPermissions("subscribe-global-gated");
     const sharedLocalAuthToken = generateAuthSecret();


### PR DESCRIPTION
🤖 ## Before

A maintained filtered subscription always hydrated from the complete physical-current table. Even when `WHERE team = $team` had an equality index, first attachment grew with every unrelated row. Intersected equality probes could not use the one-shot fused index source because that source had no live-update semantics.

Example: with 500 owned rows, `WHERE ownerId = session.user` took roughly the same one-shot work at 10k and 100k total rows, while the maintained subscription grew from about 160 ms to 1.2 s.

## After

Maintained equality access paths use the same IVM program for hydration and later deltas:

- one equality becomes a live `variant_index_scan` source;
- multiple equalities become live index sources joined by ordinary IVM semi-joins;
- Local and Edge reads still include the complete ahead overlay before winner selection;
- no separate snapshot RPC or continuation path is introduced.

An initially empty indexed prefix remains live and delivers its first matching insert exactly once. A row entering or leaving either side of an intersected equality query updates membership through the same graph.

## Current verification

- focused maintained-view and public database tests pass;
- new receipts cover empty-prefix first insertion and enter/leave through either equality index;
- the lane is adding Global/async-storage coverage and fixed-cardinality 10k/100k/1M CodSpeed receipts before this leaves draft.

This is the first coherent checkpoint for #2077 and is intentionally draft while hosted performance evidence and the remaining acceptance matrix run.