### PR TITLE
Materialize simple maintained results from storage

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -150,7 +150,11 @@ jobs:
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: walltime
-          run: JAZZ_ROUTE_CURVE_ROUTES=100 cargo codspeed run --package jazz --features testing --bench route_subscription_curve
+          # Features are selected at `cargo codspeed build` time. `run` only
+          # executes that copied target; passing Cargo feature flags here is
+          # rejected by cargo-codspeed and used to leave this job reporting no
+          # walltime benchmarks.
+          run: cargo codspeed run --package jazz --bench route_subscription_curve
 
   maintained-selective-hydration-walltime:
     # This is the direct receipt for #2077: fixed owner/result cardinality

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -118,6 +118,40 @@ jobs:
           mode: walltime
           run: cargo codspeed run --package jazz-example-benchmark-w1 --bench reads_memory_walltime --bench reads_rocksdb_walltime
 
+  route-subscription-walltime:
+    # #2129: this is the production-shaped same-query/many-binding receipt.
+    # Keep the issue's 100 bindings: it is large enough to expose accidental
+    # source-witness multiplication while remaining comfortably inside the
+    # hosted macro-run budget.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark')
+    name: Route subscription wall time
+    runs-on: codspeed-macro
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.93.1
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-bin: true
+          shared-key: codspeed-route-subscription-walltime-${{ runner.arch }}-v1
+          workspaces: . -> target
+
+      - name: Install cargo-codspeed
+        run: cargo install cargo-codspeed --version 5.0.1 --locked
+
+      - name: Build route subscription wall-time benchmark
+        run: cargo codspeed build --measurement-mode walltime --package jazz --features testing --bench route_subscription_curve
+
+      - name: Run route subscription wall-time benchmark
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
+        with:
+          mode: walltime
+          run: JAZZ_ROUTE_CURVE_ROUTES=100 cargo codspeed run --package jazz --features testing --bench route_subscription_curve
+
   maintained-selective-hydration-walltime:
     # This is the direct receipt for #2077: fixed owner/result cardinality
     # while the persisted current table grows. Keep the deep 1M rung as an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
+dependencies = [
+ "object 0.39.1",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,7 +274,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.37.3",
  "rustc-demangle",
  "windows-link",
 ]
@@ -2048,6 +2057,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
+ "stacker",
  "tar",
  "tempfile",
  "thiserror",
@@ -3010,6 +3020,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,6 +3461,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -4296,6 +4325,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"

--- a/crates/groove/src/chunks.rs
+++ b/crates/groove/src/chunks.rs
@@ -886,6 +886,14 @@ impl From<ChunkStorageError> for ChunkError {
 pub trait ChunkProvider {
     fn get(&self, request: ChunkRequest) -> ChunkFuture<'_, Result<Bytes, ChunkError>>;
 
+    /// Whether a request that deliberately yields once can be polled once
+    /// more within the same runtime turn without waiting for external I/O.
+    /// The conservative default keeps network- and host-driven providers
+    /// parked for their durable runtime owner.
+    fn permits_eager_read_retry(&self) -> bool {
+        false
+    }
+
     fn get_with_install_observer(
         &self,
         request: ChunkRequest,
@@ -1287,6 +1295,10 @@ impl OwnedChunkProvider {
         }
     }
 
+    pub(crate) fn permits_eager_read_retry(&self) -> bool {
+        self.provider.permits_eager_read_retry()
+    }
+
     /// Start an exclusive reclamation pass only when no request or verified
     /// lease can still depend on a descendant that has not been fetched yet.
     /// New requests wait until the guard is dropped.
@@ -1541,6 +1553,10 @@ impl TestChunkProvider {
 }
 
 impl ChunkProvider for TestChunkProvider {
+    fn permits_eager_read_retry(&self) -> bool {
+        true
+    }
+
     fn get(&self, request: ChunkRequest) -> ChunkFuture<'_, Result<Bytes, ChunkError>> {
         let chunks = Rc::clone(&self.chunks);
         let resident = Rc::clone(&self.resident);

--- a/crates/groove/src/ivm/runtime/evaluation_session.rs
+++ b/crates/groove/src/ivm/runtime/evaluation_session.rs
@@ -238,8 +238,12 @@ impl<'a> EvaluationRequests<'a> {
         if self.pending.contains_key(&key) || self.ready.contains_key(&key) {
             return false;
         }
-        let eager_retry_safe = matches!(key, EvaluationRequestKey::Storage(_))
-            && storage.as_ref().permits_eager_read_retry();
+        let eager_retry_safe = match key {
+            EvaluationRequestKey::Storage(_) => storage.as_ref().permits_eager_read_retry(),
+            EvaluationRequestKey::Chunk(_) => {
+                chunks.is_some_and(OwnedChunkProvider::permits_eager_read_retry)
+            }
+        };
         let future = match &key {
             EvaluationRequestKey::Storage(StorageRequestKey::Get { family, key }) => {
                 let future = storage.get(family.clone(), key.clone());
@@ -629,7 +633,7 @@ fn indexed_primary_keys(
 mod tests {
     use std::cell::Cell;
     use std::rc::Rc;
-    use std::task::Context;
+    use std::task::{Context, Poll};
 
     use futures::task::noop_waker;
 
@@ -647,6 +651,37 @@ mod tests {
             self.calls.set(self.calls.get() + 1);
             let bytes = self.bytes.clone();
             Box::pin(async move { Ok(bytes) })
+        }
+    }
+
+    /// A provider whose future stays cold for a precisely controlled number of
+    /// polls. This makes the bounded eager retry observable without depending
+    /// on executor wake timing.
+    struct RetryChunkProvider {
+        polls: Rc<Cell<usize>>,
+        bytes: bytes::Bytes,
+        eager_retry_safe: bool,
+        ready_on_poll: usize,
+    }
+
+    impl ChunkProvider for RetryChunkProvider {
+        fn permits_eager_read_retry(&self) -> bool {
+            self.eager_retry_safe
+        }
+
+        fn get(&self, _request: ChunkRequest) -> ChunkFuture<'_, Result<bytes::Bytes, ChunkError>> {
+            let polls = Rc::clone(&self.polls);
+            let bytes = self.bytes.clone();
+            let ready_on_poll = self.ready_on_poll;
+            Box::pin(std::future::poll_fn(move |_| {
+                let poll = polls.get() + 1;
+                polls.set(poll);
+                if poll >= ready_on_poll {
+                    Poll::Ready(Ok(bytes.clone()))
+                } else {
+                    Poll::Pending
+                }
+            }))
         }
     }
 
@@ -711,5 +746,72 @@ mod tests {
             panic!("expected chunk output");
         };
         assert_eq!(loaded.bytes.bytes(), &chunk);
+    }
+
+    #[test]
+    fn eager_chunk_retries_are_marked_and_bounded_to_one_extra_poll() {
+        let (storage, _) = TestStorage::controlled(&["rows"]);
+        let storage = OwnedStorage::new(Rc::new(storage));
+        let schema = DatabaseSchema::new([]);
+        let chunk = bytes::Bytes::from_static(b"chunk");
+        let key = EvaluationRequestKey::Chunk(ChunkRequest {
+            object_hash: crate::large_values::object_hash(&chunk).0,
+            locator: crate::large_values::Locator::from_seed(b"opaque-locator"),
+        });
+        let waker = noop_waker();
+        let mut context = Context::from_waker(&waker);
+
+        // A marked cold provider becomes ready only on the one permitted
+        // follow-up poll.
+        let marked_polls = Rc::new(Cell::new(0));
+        let marked = OwnedChunkProvider::new(Rc::new(RetryChunkProvider {
+            polls: Rc::clone(&marked_polls),
+            bytes: chunk.clone(),
+            eager_retry_safe: true,
+            ready_on_poll: 2,
+        }));
+        let mut marked_requests = EvaluationRequests::new();
+        assert!(marked_requests.request(key.clone(), &storage, Some(&marked), &schema));
+        assert_eq!(marked_requests.poll(&mut context), 0);
+        assert_eq!(marked_polls.get(), 1);
+        assert_eq!(marked_requests.poll_eager_retry(&mut context), 1);
+        assert_eq!(marked_polls.get(), 2);
+        assert!(matches!(
+            marked_requests.take(&key).unwrap().unwrap(),
+            EvaluationRequestOutput::Chunk(_)
+        ));
+
+        // An ordinary provider is never retried by this in-turn fast path.
+        let unmarked_polls = Rc::new(Cell::new(0));
+        let unmarked = OwnedChunkProvider::new(Rc::new(RetryChunkProvider {
+            polls: Rc::clone(&unmarked_polls),
+            bytes: chunk.clone(),
+            eager_retry_safe: false,
+            ready_on_poll: 2,
+        }));
+        let mut unmarked_requests = EvaluationRequests::new();
+        assert!(unmarked_requests.request(key.clone(), &storage, Some(&unmarked), &schema));
+        assert_eq!(unmarked_requests.poll(&mut context), 0);
+        assert_eq!(unmarked_polls.get(), 1);
+        assert_eq!(unmarked_requests.poll_eager_retry(&mut context), 0);
+        assert_eq!(unmarked_polls.get(), 1);
+        assert!(unmarked_requests.has_pending());
+
+        // Even a marked provider that remains cold is polled no more than
+        // once by an eager retry invocation.
+        let pending_polls = Rc::new(Cell::new(0));
+        let still_pending = OwnedChunkProvider::new(Rc::new(RetryChunkProvider {
+            polls: Rc::clone(&pending_polls),
+            bytes: chunk,
+            eager_retry_safe: true,
+            ready_on_poll: usize::MAX,
+        }));
+        let mut pending_requests = EvaluationRequests::new();
+        assert!(pending_requests.request(key, &storage, Some(&still_pending), &schema));
+        assert_eq!(pending_requests.poll(&mut context), 0);
+        assert_eq!(pending_polls.get(), 1);
+        assert_eq!(pending_requests.poll_eager_retry(&mut context), 0);
+        assert_eq!(pending_polls.get(), 2);
+        assert!(pending_requests.has_pending());
     }
 }

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -44,6 +44,7 @@ serde_bytes = "0.11"
 jsonschema = { version = "0.42", default-features = false }
 internment = "0.8"
 smallvec = { version = "1.11", features = ["serde"] }
+stacker = "0.1"
 sha2 = "0.10"
 tokio = { version = "1", features = ["macros", "net", "rt", "sync", "time"], optional = true }
 jsonwebtoken = { version = "10.4", default-features = false, features = [

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -54,6 +54,7 @@ base64 = "0.22"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 
 [dev-dependencies]
+divan.workspace = true
 groove = { workspace = true, default-features = false, features = ["test"] }
 jazz-benchmark-guard = { path = "../benchmark-guard" }
 jazz-testkit = { path = "../jazz-testkit", default-features = false }

--- a/crates/jazz/benches/route_subscription_curve.rs
+++ b/crates/jazz/benches/route_subscription_curve.rs
@@ -108,22 +108,140 @@ struct RetainedReceipt {
 
 fn main() {
     jazz_benchmark_guard::refuse_contaminated_measurement();
-    let routes = env_usize("JAZZ_ROUTE_CURVE_ROUTES", 100);
+    // Keep the original receipt available for focused diagnosis, but make the
+    // normal benchmark entrypoint a Divan suite.  `cargo codspeed` only
+    // records annotated Divan functions; a custom `main` which prints one
+    // receipt is invisible to its wall-clock collector.
+    if std::env::var_os("JAZZ_ROUTE_CURVE_RECEIPT").is_some() {
+        let receipt = run(configured_routes());
+        println!(
+            "{}",
+            serde_json::to_string(&receipt).expect("serialize route curve receipt")
+        );
+        assert!(receipt.ok, "route curve correctness gate failed");
+        return;
+    }
+
+    // The complete receipt remains the semantic canary: it checks the exact
+    // initial windows, matching delta, unrelated/below-boundary quietness, and
+    // storage-backed witness-free retained state before timing the same setup.
     assert!(
-        (1..=MAX_ROUTES).contains(&routes),
-        "JAZZ_ROUTE_CURVE_ROUTES must be between 1 and {MAX_ROUTES}"
+        run(ROUTE_BENCH_BINDINGS).ok,
+        "route curve correctness gate failed"
     );
-    let receipt = run(routes);
-    println!(
-        "{}",
-        serde_json::to_string(&receipt).expect("serialize route curve receipt")
-    );
-    assert!(receipt.ok, "route curve correctness gate failed");
+    divan::main();
 }
 
 #[allow(dead_code)]
 pub(crate) fn correctness_smoke() {
     assert!(run(1).ok, "route curve correctness gate failed");
+}
+
+const ROUTE_BENCH_BINDINGS: usize = 100;
+
+/// Time subscription attachment only. Fixture seeding is generated outside
+/// Divan's timed closure, so this stays comparable even when the corpus grows.
+#[divan::bench(args = [ROUTE_BENCH_BINDINGS], sample_count = 3)]
+fn attach_route_bindings(bencher: divan::Bencher<'_, '_>, routes: usize) {
+    bencher
+        .with_inputs(|| RouteFixture::seeded(routes))
+        .bench_local_values(|fixture| fixture.attach_all().runtime.active_subscriptions);
+}
+
+/// Time the fanout work for one matching write after the same fixed 100-route
+/// binding set has already hydrated. The fixture and streams are consumed so
+/// every sample starts from an identical pre-write state.
+#[divan::bench(args = [ROUTE_BENCH_BINDINGS], sample_count = 3)]
+fn matching_write_fanout(bencher: divan::Bencher<'_, '_>, routes: usize) {
+    bencher
+        .with_inputs(|| RouteFixture::seeded(routes).attach_all())
+        .bench_local_values(|attached| attached.matching_write());
+}
+
+struct RouteFixture {
+    db: BenchDb,
+    routes: usize,
+    query: Query,
+}
+
+struct AttachedRoutes {
+    fixture: RouteFixture,
+    streams: Vec<SubscriptionStream>,
+    runtime: RuntimeReceipt,
+    retained: RetainedReceipt,
+}
+
+impl RouteFixture {
+    fn seeded(routes: usize) -> Self {
+        assert!((1..=MAX_ROUTES).contains(&routes));
+        let db = open_db(routes as u64);
+        seed_fixture(&db);
+        Self {
+            db,
+            routes,
+            query: route_query(),
+        }
+    }
+
+    fn attach_all(self) -> AttachedRoutes {
+        let mut streams = Vec::with_capacity(self.routes);
+        let mut shape_id = None;
+        for team in 0..self.routes {
+            let prepared = self
+                .db
+                .prepare_query_bound(
+                    &self.query,
+                    BTreeMap::from([("team".to_owned(), Value::Uuid(team_row(team).0))]),
+                )
+                .expect("prepare route binding");
+            if let Some(expected_shape) = shape_id {
+                assert_eq!(prepared.shape().shape_id(), expected_shape);
+            } else {
+                shape_id = Some(prepared.shape().shape_id());
+            }
+            let mut stream =
+                block_on(self.db.subscribe(&prepared, local_opts())).expect("subscribe route");
+            assert_eq!(take_initial_reset(&mut stream), expected_initial_rows(team));
+            streams.push(stream);
+        }
+        let runtime = runtime_receipt(&self.db);
+        let retained = retained_receipt(&self.db);
+        assert_eq!(runtime.active_subscriptions, self.routes);
+        assert_eq!(retained.subscriptions, self.routes);
+        assert_eq!(retained.version_identities, 0);
+        assert_eq!(retained.replacement_entries, 0);
+        assert_eq!(retained.versions_bytes, 0);
+        assert_eq!(retained.replacements_bytes, 0);
+        AttachedRoutes {
+            fixture: self,
+            streams,
+            runtime,
+            retained,
+        }
+    }
+}
+
+impl AttachedRoutes {
+    fn matching_write(mut self) -> Self {
+        let matching_row = document_row(0, HOT_TEAM_DOCUMENTS + 1);
+        insert_document(
+            &self.fixture.db,
+            matching_row,
+            0,
+            HOT_TEAM_DOCUMENTS as u64 + 1,
+        );
+        let matching_events = drain_events(&mut self.streams);
+        assert!(matching_events.first().is_some_and(|delta| {
+            delta.events == 1
+                && delta.added == BTreeSet::from([matching_row])
+                && delta.removed
+                    == BTreeSet::from([document_row(0, HOT_TEAM_DOCUMENTS - PAGE_SIZE)])
+                && delta.updated.is_empty()
+                && !delta.reset
+        }));
+        assert!(matching_events.iter().skip(1).all(Delta::is_quiet));
+        self
+    }
 }
 
 fn run(routes: usize) -> Receipt {
@@ -133,10 +251,7 @@ fn run(routes: usize) -> Receipt {
     let seed_us = micros(seed_started.elapsed());
     let rss_kib_after_seed = proc_status_kib("VmRSS:");
 
-    let query = Query::from(DOCUMENTS)
-        .filter(eq(col("team"), param("team")))
-        .order_by("updated_at", OrderDirection::Desc)
-        .limit(PAGE_SIZE);
+    let query = route_query();
     let mut streams = Vec::with_capacity(routes);
     let mut prepare_samples = Vec::with_capacity(routes);
     let mut subscribe_samples = Vec::with_capacity(routes);
@@ -501,6 +616,22 @@ fn env_usize(name: &str, default: usize) -> usize {
                 .unwrap_or_else(|_| panic!("{name} must be an unsigned integer"))
         })
         .unwrap_or(default)
+}
+
+fn configured_routes() -> usize {
+    let routes = env_usize("JAZZ_ROUTE_CURVE_ROUTES", ROUTE_BENCH_BINDINGS);
+    assert!(
+        (1..=MAX_ROUTES).contains(&routes),
+        "JAZZ_ROUTE_CURVE_ROUTES must be between 1 and {MAX_ROUTES}"
+    );
+    routes
+}
+
+fn route_query() -> Query {
+    Query::from(DOCUMENTS)
+        .filter(eq(col("team"), param("team")))
+        .order_by("updated_at", OrderDirection::Desc)
+        .limit(PAGE_SIZE)
 }
 
 fn proc_status_kib(label: &str) -> Option<u64> {

--- a/crates/jazz/benches/route_subscription_curve.rs
+++ b/crates/jazz/benches/route_subscription_curve.rs
@@ -139,9 +139,10 @@ pub(crate) fn correctness_smoke() {
 
 const ROUTE_BENCH_BINDINGS: usize = 100;
 
-/// Time subscription attachment only. Fixture seeding is generated outside
-/// Divan's timed closure, so this stays comparable even when the corpus grows.
-#[divan::bench(args = [ROUTE_BENCH_BINDINGS], sample_count = 3)]
+/// Time subscription attachment only. Fixture seeding and `Drop` are setup,
+/// not attachment work; `skip_ext_time` is essential because the CodSpeed
+/// Divan compatibility layer otherwise includes both in wall time.
+#[divan::bench(args = [ROUTE_BENCH_BINDINGS], sample_count = 3, skip_ext_time)]
 fn attach_route_bindings(bencher: divan::Bencher<'_, '_>, routes: usize) {
     bencher
         .with_inputs(|| RouteFixture::seeded(routes))
@@ -150,8 +151,9 @@ fn attach_route_bindings(bencher: divan::Bencher<'_, '_>, routes: usize) {
 
 /// Time the fanout work for one matching write after the same fixed 100-route
 /// binding set has already hydrated. The fixture and streams are consumed so
-/// every sample starts from an identical pre-write state.
-#[divan::bench(args = [ROUTE_BENCH_BINDINGS], sample_count = 3)]
+/// every sample starts from an identical pre-write state. Setup and teardown
+/// are explicitly outside CodSpeed's wall-time measurement.
+#[divan::bench(args = [ROUTE_BENCH_BINDINGS], sample_count = 3, skip_ext_time)]
 fn matching_write_fanout(bencher: divan::Bencher<'_, '_>, routes: usize) {
     bencher
         .with_inputs(|| RouteFixture::seeded(routes).attach_all())

--- a/crates/jazz/benches/route_subscription_curve.rs
+++ b/crates/jazz/benches/route_subscription_curve.rs
@@ -55,6 +55,7 @@ struct Receipt {
     matching_write_us: u64,
     unrelated_write_us: u64,
     below_boundary_write_us: u64,
+    storage_backed_witness_free: bool,
     exact_initial: bool,
     exact_matching_delta: bool,
     unrelated_quiet: bool,
@@ -196,11 +197,16 @@ fn run(routes: usize) -> Receipt {
     insert_document(&db, document_row(0, HOT_TEAM_DOCUMENTS + 2), 0, 0);
     let below_boundary_write_us = micros(below_boundary_started.elapsed());
     let below_boundary_quiet = drain_events(&mut streams).iter().all(Delta::is_quiet);
+    let storage_backed_witness_free = retained.version_identities == 0
+        && retained.replacement_entries == 0
+        && retained.versions_bytes == 0
+        && retained.replacements_bytes == 0;
 
     let ok = exact_initial
         && exact_matching_delta
         && unrelated_quiet
         && below_boundary_quiet
+        && storage_backed_witness_free
         && runtime.active_subscriptions == routes
         && retained.subscriptions == routes;
 
@@ -223,6 +229,7 @@ fn run(routes: usize) -> Receipt {
         matching_write_us,
         unrelated_write_us,
         below_boundary_write_us,
+        storage_backed_witness_free,
         exact_initial,
         exact_matching_delta,
         unrelated_quiet,

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -789,6 +789,7 @@ where
         self.node.tick().await
     }
 
+    #[allow(dead_code)]
     pub(super) async fn refresh_subscriptions(&self) -> Result<usize, Error> {
         let refreshed = self.node.refresh_subscriptions().await?;
         if refreshed > 0 {

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -2635,10 +2635,9 @@ where
     ) -> Result<WriteHandle<S>, Error> {
         let tx_id = published.tx_id;
         let local_tier = if self.node.defer_local_persistence.get() {
-            // Publication is the synchronous visibility boundary. Refresh
-            // resident subscribers before returning, then let the host tick
-            // own suspendable persistence and later peer visibility.
-            self.refresh_subscriptions().await?;
+            // Admission stays synchronous, but maintained-view refresh can
+            // suspend on storage. The scheduled owner turn publishes it after
+            // persistence rather than polling cold query work in this write.
             self.node.queue_local_publication(published, None);
             DurabilityTier::None
         } else {
@@ -2666,6 +2665,9 @@ where
             } = outcome;
             loop {
                 if !publications.is_empty() {
+                    // Resident maintained terminals publish their immediate
+                    // local delta at the write boundary. Cold work is owned
+                    // by the scheduled runtime turn after this publication.
                     self.refresh_subscriptions().await?;
                     let mut persisted = Vec::with_capacity(publications.len());
                     for publication in &publications {

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -725,6 +725,7 @@ where
             });
     }
 
+    #[allow(dead_code)]
     pub(super) async fn refresh_subscriptions(&self) -> Result<usize, Error> {
         let progress_waker = self.query_runtime_waker();
         refresh_subscriptions_in(

--- a/crates/jazz/src/db/reads.rs
+++ b/crates/jazz/src/db/reads.rs
@@ -237,6 +237,20 @@ where
             .map_err(Into::into)
     }
 
+    /// Resolve provenance after a storage-suspended node turn releases its
+    /// owner mutex.
+    pub async fn row_provenance_async(
+        &self,
+        row: &CurrentRow,
+    ) -> Result<Option<RowProvenance>, Error> {
+        self.node
+            .node
+            .lock()
+            .await
+            .row_provenance(row)
+            .map_err(Into::into)
+    }
+
     /// Read local settled history at an exact global timestamp cut.
     ///
     /// History-incomplete facades return `HistoricalReadRequiresServer` from

--- a/crates/jazz/src/db/tests/mutations.rs
+++ b/crates/jazz/src/db/tests/mutations.rs
@@ -715,6 +715,13 @@ fn high_level_large_value_apis_keep_descriptors_private_and_publish_edits() {
     let prepared = db.prepare_query(&db.table("todos")).unwrap();
     let mut subscription = block_on(db.subscribe(&prepared, ReadOpts::default())).unwrap();
     let mut event = block_on(subscription.next_raw()).unwrap();
+    // Storage-backed maintained roots retain only an exact `(table, row, tx)`
+    // identity internally and may therefore carry an indirect descriptor in
+    // this raw event. Bindings always cross the explicit hydration boundary
+    // before exposing it to application code; keep the public assertion below
+    // on that boundary rather than requiring opening to synchronously fetch a
+    // cold chunk (which would deadlock an edge before its I/O pump starts).
+    block_on(db.hydrate_subscription_event_for_binding(&mut event)).unwrap();
     let (descriptor, title_index, terminal_value) = {
         let SubscriptionEvent::Delta { added, .. } = &mut event else {
             panic!("expected opening subscription delta");

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -143,13 +143,22 @@ fn large_value_pushes_through_edge_then_pulls_from_core_after_edge_chunk_evictio
     let mut received = None;
     let mut snapshot = RelationSnapshot::default();
     let mut pull_messages = Vec::new();
+    let mut pending_event = None;
     for _ in 0..128 {
         upload_edge.tick().unwrap();
         pull_messages.extend(upload_edge_to_core.borrow().iter().cloned());
         core.tick().unwrap();
         upload_edge.tick().unwrap();
-        while let Some(event) = subscription.try_next_event() {
-            apply_subscription_event(&mut snapshot, event);
+        if pending_event.is_none() {
+            pending_event = subscription.try_next_event();
+        }
+        if pull_messages
+            .iter()
+            .any(|message| matches!(message, SyncMessage::ChunkRequestBatch(_)))
+            && let Some(event) = pending_event.as_mut()
+        {
+            crate::db::block_on(upload_edge.hydrate_subscription_event_for_binding(event)).unwrap();
+            apply_subscription_event(&mut snapshot, pending_event.take().unwrap());
         }
         received = snapshot.rows.first().and_then(|row| row.cell_at(0));
         if received == Some(Value::String(title.clone())) {

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -551,7 +551,6 @@ where
             .await?;
         let tx_id = published.tx_id;
         if self.node.defer_local_persistence.get() {
-            self.refresh_subscriptions().await?;
             self.node.queue_local_publication(published, None);
         } else {
             self.finish_publication_outcome(PublicationOutcome::published((), published))
@@ -975,7 +974,6 @@ where
     ) -> Result<TxId, Error> {
         let tx_id = published.tx_id;
         if self.node.defer_local_persistence.get() {
-            self.refresh_subscriptions().await?;
             self.node.queue_local_publication(published, Some(unit));
         } else {
             self.finish_publication_outcome(PublicationOutcome::published((), published))

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -71,6 +71,10 @@ pub(crate) struct MaintainedSubscriptionView {
     /// collector. Flat unordered subscriptions release it after their reset;
     /// subsequent terminal deltas must not rebuild the duplicate state.
     retains_structured_app_rows: bool,
+    /// This binding retains only result membership. Its exact content bodies
+    /// are loaded from immutable node storage on entry instead of being held
+    /// as source-wide version/replacement terminal witnesses.
+    storage_backed_result_materialization: bool,
     versions: WeightedVersionIndex,
     replacements: ReplacementIndex,
 }
@@ -85,6 +89,7 @@ impl Default for MaintainedSubscriptionView {
             structured_app_rows: BTreeMap::new(),
             structured_app_row_descriptor: None,
             retains_structured_app_rows: true,
+            storage_backed_result_materialization: false,
             versions: WeightedVersionIndex::default(),
             replacements: ReplacementIndex::default(),
         }
@@ -248,6 +253,14 @@ enum NetEvent {
 }
 
 impl MaintainedSubscriptionView {
+    pub(crate) fn uses_storage_backed_result_materialization(&self) -> bool {
+        self.storage_backed_result_materialization
+    }
+
+    pub(crate) fn enable_storage_backed_result_materialization(&mut self) {
+        self.storage_backed_result_materialization = true;
+    }
+
     pub(crate) fn terminal_schemas_for_program(
         program: &QueryProgram,
     ) -> MaintainedTerminalSchemas {

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -75,6 +75,10 @@ pub(crate) struct MaintainedSubscriptionView {
     /// are loaded from immutable node storage on entry instead of being held
     /// as source-wide version/replacement terminal witnesses.
     storage_backed_result_materialization: bool,
+    /// Frozen branch bases are static graph inputs with an exact immutable
+    /// version identity. They do not emit a live Stream-B witness when a head
+    /// deletion or rejection exposes the inherited member.
+    inline_content_branch_keys: BTreeSet<Vec<u8>>,
     versions: WeightedVersionIndex,
     replacements: ReplacementIndex,
 }
@@ -90,6 +94,7 @@ impl Default for MaintainedSubscriptionView {
             structured_app_row_descriptor: None,
             retains_structured_app_rows: true,
             storage_backed_result_materialization: false,
+            inline_content_branch_keys: BTreeSet::new(),
             versions: WeightedVersionIndex::default(),
             replacements: ReplacementIndex::default(),
         }
@@ -259,6 +264,11 @@ impl MaintainedSubscriptionView {
 
     pub(crate) fn enable_storage_backed_result_materialization(&mut self) {
         self.storage_backed_result_materialization = true;
+    }
+
+    pub(crate) fn enable_inline_content_branch_key(&mut self, branch_key: &BranchKey) {
+        self.inline_content_branch_keys
+            .insert(branch_key.canonical_bytes());
     }
 
     pub(crate) fn terminal_schemas_for_program(
@@ -717,6 +727,7 @@ impl MaintainedSubscriptionView {
             .filter(|(member, weight)| {
                 **weight > 0
                     && (self.storage_backed_result_materialization
+                        || self.result_member_has_inline_content_source(member)
                         || self.result_member_has_bundle_witness(member, node_aliases))
             })
             .map(|(member, _)| member.clone())
@@ -775,6 +786,13 @@ impl MaintainedSubscriptionView {
             .is_some_and(|version| {
                 version_tx_id_from_aliases(&version, node_aliases) == Some(tx_id)
             })
+    }
+
+    fn result_member_has_inline_content_source(&self, member: &ResultMemberEntry) -> bool {
+        member
+            .as_real_row()
+            .and_then(|row| row.branch_or_prefix.as_ref())
+            .is_some_and(|branch_key| self.inline_content_branch_keys.contains(branch_key))
     }
 
     fn apply_result_delta(

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -715,7 +715,9 @@ impl MaintainedSubscriptionView {
             .result_weights
             .iter()
             .filter(|(member, weight)| {
-                **weight > 0 && self.result_member_has_bundle_witness(member, node_aliases)
+                **weight > 0
+                    && (self.storage_backed_result_materialization
+                        || self.result_member_has_bundle_witness(member, node_aliases))
             })
             .map(|(member, _)| member.clone())
             .collect::<BTreeSet<_>>();
@@ -2956,6 +2958,26 @@ mod tests {
         assert_eq!(third.removes, vec![member]);
         assert!(third.result_payload_adds.is_empty());
         assert!(third.result_payload_removes.is_empty());
+    }
+
+    #[test]
+    fn storage_backed_membership_publishes_without_bundle_witness() {
+        // This must remain an internal receipt: public test routes cannot
+        // synthesize the deliberately omitted Stream B terminal. The
+        // storage-backed subset instead resolves the exact member `(table,
+        // row, tx)` from node storage at materialization time.
+        let aliases = aliases();
+        let member = ResultMemberEntry::from(result(row(2), 20));
+        let mut maintained = MaintainedSubscriptionView::default();
+        maintained.enable_storage_backed_result_materialization();
+
+        let mut transitions = maintained
+            .apply_decoded_deltas([(result_current(member.clone()), 1)], &aliases)
+            .unwrap();
+        maintained.finalize_multisink_transitions(&mut transitions, &aliases);
+
+        assert_eq!(transitions.adds, vec![member]);
+        assert!(transitions.removes.is_empty());
     }
 
     #[test]

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -21,6 +21,7 @@ use super::maintained_subscription_view::{MaintainedSubscriptionView, Maintained
 use super::maintained_subscription_view::{
     MaintainedSubscriptionViewFootprint, MaintainedTerminalSchemasFootprint,
 };
+use super::query_engine::BranchViewSourceBase;
 use super::query_engine::{
     AggregateExpr as NormalizedAggregateExpr, AggregateFunction as NormalizedAggregateFunction,
     AppProjectionTree, AppRowOutputRequest, AppRowSchema, CapabilityReport, ClaimPath, ClosurePath,
@@ -896,8 +897,20 @@ where
                 )
             })
             .flatten();
+        let query_schema = self
+            .catalogue
+            .catalogue_schemas
+            .get(&shape.schema_version())
+            .ok_or(Error::InvalidStoredValue("query schema version is unknown"))?;
+        let root_has_read_policy = query_schema
+            .schema
+            .tables
+            .iter()
+            .find(|table| table.name == shape.query().table)
+            .is_some_and(|table| table.read_policy.is_some());
         let storage_backed_result_materialization =
             matches!(output, CurrentQueryProgramOutput::MaintainedView)
+                && !root_has_read_policy
                 && self.storage_backed_maintained_root_has_identity_table_mapping(
                     shape.schema_version(),
                     &shape.query().table,
@@ -920,11 +933,6 @@ where
             )?,
             shape: input_shape,
         };
-        let query_schema = self
-            .catalogue
-            .catalogue_schemas
-            .get(&shape.schema_version())
-            .ok_or(Error::InvalidStoredValue("query schema version is unknown"))?;
         let mut output_request =
             current_query_output_request(output, shape.query(), &query_schema.schema);
         if storage_backed_result_materialization {
@@ -3315,6 +3323,20 @@ where
                 .output
                 .facts
                 .contains(&ProgramFactKey::ReplacementWitnesses);
+        let inline_content_branch_keys = program
+            .request
+            .reads
+            .primary
+            .sources
+            .values()
+            .filter_map(|source| match source {
+                SourceExpr::BranchView {
+                    base: Some(BranchViewSourceBase::Snapshot(branch_key, _)),
+                    ..
+                } => Some(branch_key.clone()),
+                _ => None,
+            })
+            .collect::<BTreeSet<_>>();
         let subscription = self
             .subscribe_lowered_program(
                 program,
@@ -3337,6 +3359,9 @@ where
         let mut maintained = MaintainedSubscriptionView::default();
         if storage_backed_result_materialization {
             maintained.enable_storage_backed_result_materialization();
+        }
+        for branch_key in &inline_content_branch_keys {
+            maintained.enable_inline_content_branch_key(branch_key);
         }
         let mut transitions = super::maintained_subscription_view::ResultTransitions::default();
         let snapshot_transitions = maintained.apply_multisink_deltas(

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -3346,16 +3346,6 @@ where
                 progress_waker,
             )
             .await?;
-        // Opening a maintained view is an async ownership boundary: one
-        // stream cannot be published while another is still hydrating its
-        // content witnesses. The bounded opening poll may leave cold storage
-        // pending, but this future remains the real owner until it receives
-        // the complete initial multisink snapshot.
-        let initial_snapshot = self
-            .database
-            .next_multisink_subscription(&subscription)
-            .await
-            .map_err(Error::Groove)?;
         let mut maintained = MaintainedSubscriptionView::default();
         if storage_backed_result_materialization {
             maintained.enable_storage_backed_result_materialization();
@@ -3364,55 +3354,72 @@ where
             maintained.enable_inline_content_branch_key(branch_key);
         }
         let mut transitions = super::maintained_subscription_view::ResultTransitions::default();
-        let snapshot_transitions = maintained.apply_multisink_deltas(
-            initial_snapshot,
-            &terminal_schemas,
-            &tables,
-            &self.node_aliases,
-        )?;
-        transitions.adds.extend(snapshot_transitions.adds);
-        transitions.removes.extend(snapshot_transitions.removes);
-        transitions
-            .result_payload_adds
-            .extend(snapshot_transitions.result_payload_adds);
-        transitions
-            .result_payload_removes
-            .extend(snapshot_transitions.result_payload_removes);
-        transitions
-            .program_fact_adds
-            .extend(snapshot_transitions.program_fact_adds);
-        transitions
-            .program_fact_removes
-            .extend(snapshot_transitions.program_fact_removes);
-        loop {
-            match subscription.try_recv() {
-                Ok(deltas) => {
-                    let delta_transitions = maintained.apply_multisink_deltas(
-                        deltas,
-                        &terminal_schemas,
-                        &tables,
-                        &self.node_aliases,
-                    )?;
-                    transitions.adds.extend(delta_transitions.adds);
-                    transitions.removes.extend(delta_transitions.removes);
-                    transitions
-                        .result_payload_adds
-                        .extend(delta_transitions.result_payload_adds);
-                    transitions
-                        .result_payload_removes
-                        .extend(delta_transitions.result_payload_removes);
-                    transitions
-                        .program_fact_adds
-                        .extend(delta_transitions.program_fact_adds);
-                    transitions
-                        .program_fact_removes
-                        .extend(delta_transitions.program_fact_removes);
-                }
-                Err(std::sync::mpsc::TryRecvError::Empty) => break,
-                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                    return Err(Error::InvalidStoredValue(
-                        "seeded maintained subscription disconnected",
-                    ));
+        // A cold opening may depend on a peer that can only be advanced after
+        // this call returns. Keep Stream A unpublished until the first
+        // complete Stream B snapshot arrives; publication drains this same
+        // subscription and gates ViewUpdate on `initial_received`.
+        let initial_received = match subscription.try_recv() {
+            Ok(snapshot) => {
+                let snapshot_transitions = maintained.apply_multisink_deltas(
+                    snapshot,
+                    &terminal_schemas,
+                    &tables,
+                    &self.node_aliases,
+                )?;
+                transitions.adds.extend(snapshot_transitions.adds);
+                transitions.removes.extend(snapshot_transitions.removes);
+                transitions
+                    .result_payload_adds
+                    .extend(snapshot_transitions.result_payload_adds);
+                transitions
+                    .result_payload_removes
+                    .extend(snapshot_transitions.result_payload_removes);
+                transitions
+                    .program_fact_adds
+                    .extend(snapshot_transitions.program_fact_adds);
+                transitions
+                    .program_fact_removes
+                    .extend(snapshot_transitions.program_fact_removes);
+                true
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => false,
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                return Err(Error::InvalidStoredValue(
+                    "seeded maintained subscription disconnected",
+                ));
+            }
+        };
+        if initial_received {
+            loop {
+                match subscription.try_recv() {
+                    Ok(deltas) => {
+                        let delta_transitions = maintained.apply_multisink_deltas(
+                            deltas,
+                            &terminal_schemas,
+                            &tables,
+                            &self.node_aliases,
+                        )?;
+                        transitions.adds.extend(delta_transitions.adds);
+                        transitions.removes.extend(delta_transitions.removes);
+                        transitions
+                            .result_payload_adds
+                            .extend(delta_transitions.result_payload_adds);
+                        transitions
+                            .result_payload_removes
+                            .extend(delta_transitions.result_payload_removes);
+                        transitions
+                            .program_fact_adds
+                            .extend(delta_transitions.program_fact_adds);
+                        transitions
+                            .program_fact_removes
+                            .extend(delta_transitions.program_fact_removes);
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        return Err(Error::InvalidStoredValue(
+                            "seeded maintained subscription disconnected",
+                        ));
+                    }
                 }
             }
         }
@@ -3422,7 +3429,7 @@ where
             terminal_schemas,
             transitions,
             tables,
-            true,
+            initial_received,
         ))
     }
 

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -883,6 +883,27 @@ where
             .catalogue_schemas
             .get(&shape.schema_version())
             .ok_or(Error::InvalidStoredValue("query schema version is unknown"))?;
+        let storage_backed_result_materialization =
+            matches!(output, CurrentQueryProgramOutput::MaintainedView)
+                && storage_backed_maintained_view_eligible(shape.query(), read_view);
+        let mut output_request =
+            current_query_output_request(output, shape.query(), &query_schema.schema);
+        if storage_backed_result_materialization {
+            // A simple current root query carries the exact visible content
+            // transaction in its result-member terminal.  Keeping every
+            // source version/replacement body in every binding merely so the
+            // facade can re-read that immutable version multiplies retained
+            // state by source rows × bindings.  The member's exact identity
+            // is enough to load the immutable body from the node store on
+            // entry; deletion/restore removals need only retire the old
+            // occurrence, never materialize a newer winner.
+            output_request
+                .facts
+                .remove(&ProgramFactKey::VersionWitnesses);
+            output_request
+                .facts
+                .remove(&ProgramFactKey::ReplacementWitnesses);
+        }
         Ok(QueryProgramRequest {
             authorization_mode,
             reads: query_read_set_for_read_view(
@@ -897,7 +918,7 @@ where
             )?,
             policy,
             input,
-            output: current_query_output_request(output, shape.query(), &query_schema.schema),
+            output: output_request,
         })
     }
 
@@ -3245,6 +3266,16 @@ where
                     &program.lowered.parameters,
                 ))
             });
+        let storage_backed_result_materialization = !program
+            .request
+            .output
+            .facts
+            .contains(&ProgramFactKey::VersionWitnesses)
+            && !program
+                .request
+                .output
+                .facts
+                .contains(&ProgramFactKey::ReplacementWitnesses);
         let subscription = self
             .subscribe_lowered_program(
                 program,
@@ -3265,6 +3296,9 @@ where
             .await
             .map_err(Error::Groove)?;
         let mut maintained = MaintainedSubscriptionView::default();
+        if storage_backed_result_materialization {
+            maintained.enable_storage_backed_result_materialization();
+        }
         let mut transitions = super::maintained_subscription_view::ResultTransitions::default();
         let snapshot_transitions = maintained.apply_multisink_deltas(
             initial_snapshot,

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -730,6 +730,36 @@ where
         )
     }
 
+    /// The storage-backed maintained subset retrieves omitted witnesses by the
+    /// result table name at the wire boundary.  A table-rename lens breaks
+    /// that identity: its result member is named with the projected table but
+    /// its persisted history is named with the authored table.  Keep such
+    /// shapes on the self-contained witness path until the fallback resolves
+    /// canonical physical identities end-to-end.
+    fn storage_backed_maintained_root_has_identity_table_mapping(
+        &self,
+        schema_version: SchemaVersionId,
+        table: &str,
+    ) -> bool {
+        if schema_version != self.catalogue.current_schema_version_id {
+            return false;
+        }
+        let Some(table_id) = self
+            .catalogue
+            .physical_mappings
+            .get(&schema_version)
+            .and_then(|mapping| mapping.tables.get(table))
+            .map(|mapping| mapping.table_id)
+        else {
+            return false;
+        };
+        self.catalogue.physical_mappings.values().all(|mapping| {
+            mapping.tables.iter().all(|(candidate_name, candidate)| {
+                candidate.table_id != table_id || candidate_name == table
+            })
+        })
+    }
+
     fn current_query_program_request_with_prepared_claim_mode(
         &self,
         shape: &ValidatedQuery,
@@ -868,7 +898,16 @@ where
             .flatten();
         let storage_backed_result_materialization =
             matches!(output, CurrentQueryProgramOutput::MaintainedView)
-                && storage_backed_maintained_view_eligible(shape.query(), read_view, &input_shape);
+                && self.storage_backed_maintained_root_has_identity_table_mapping(
+                    shape.schema_version(),
+                    &shape.query().table,
+                )
+                && storage_backed_maintained_view_eligible(
+                    shape.query(),
+                    tier,
+                    read_view,
+                    &input_shape,
+                );
         let input = RowSetProgramInput {
             binding: self.program_binding_for_shape_and_policy_with_prepared_claim_mode(
                 shape,

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -866,6 +866,9 @@ where
                 )
             })
             .flatten();
+        let storage_backed_result_materialization =
+            matches!(output, CurrentQueryProgramOutput::MaintainedView)
+                && storage_backed_maintained_view_eligible(shape.query(), read_view, &input_shape);
         let input = RowSetProgramInput {
             binding: self.program_binding_for_shape_and_policy_with_prepared_claim_mode(
                 shape,
@@ -883,9 +886,6 @@ where
             .catalogue_schemas
             .get(&shape.schema_version())
             .ok_or(Error::InvalidStoredValue("query schema version is unknown"))?;
-        let storage_backed_result_materialization =
-            matches!(output, CurrentQueryProgramOutput::MaintainedView)
-                && storage_backed_maintained_view_eligible(shape.query(), read_view);
         let mut output_request =
             current_query_output_request(output, shape.query(), &query_schema.schema);
         if storage_backed_result_materialization {

--- a/crates/jazz/src/node/query_eval/materialization.rs
+++ b/crates/jazz/src/node/query_eval/materialization.rs
@@ -548,9 +548,19 @@ where
                 // bundle; use that member's exact `(table, row, tx)` witness
                 // to materialize the newly admitted row. This is payload
                 // lookup, not a facade-side query or recompute.
-                let tx_versions = self
-                    .storage_backed_maintained_result_versions(entry.0.as_str(), entry.1, entry.2)
-                    .await?;
+                let tx_versions = if local
+                    .maintained
+                    .uses_storage_backed_result_materialization()
+                {
+                    self.storage_backed_maintained_result_versions(
+                        entry.0.as_str(),
+                        entry.1,
+                        entry.2,
+                    )
+                    .await?
+                } else {
+                    self.query_versions_for_tx(entry.2).await?
+                };
                 let Some(version) = self.maintained_witness_for_result_member(
                     &tx_versions,
                     local.result_schema_version,
@@ -628,9 +638,15 @@ where
         )? {
             version.clone()
         } else {
-            let tx_versions = self
-                .storage_backed_maintained_result_versions(entry.0.as_str(), entry.1, entry.2)
-                .await?;
+            let tx_versions = if local
+                .maintained
+                .uses_storage_backed_result_materialization()
+            {
+                self.storage_backed_maintained_result_versions(entry.0.as_str(), entry.1, entry.2)
+                    .await?
+            } else {
+                self.query_versions_for_tx(entry.2).await?
+            };
             let Some(version) = self.maintained_witness_for_result_member(
                 &tx_versions,
                 local.result_schema_version,

--- a/crates/jazz/src/node/query_eval/materialization.rs
+++ b/crates/jazz/src/node/query_eval/materialization.rs
@@ -411,6 +411,17 @@ where
         local: &LocalMaintainedViewSubscription,
     ) -> Result<LocalMaintainedMaterializationCache, Error> {
         let mut cache = LocalMaintainedMaterializationCache::default();
+        // Storage-backed root subscriptions carry exact result-member
+        // identities, not a source-wide witness cache. Loading the whole
+        // transaction set here would silently recreate the retained-source
+        // cost at every reset; the per-member path below performs an exact
+        // `(table, row, tx)` lookup instead.
+        if local
+            .maintained
+            .uses_storage_backed_result_materialization()
+        {
+            return Ok(cache);
+        }
         let mut tx_ids = BTreeSet::new();
         for member in &local.result_set {
             let Some((_, _, tx_id)) = member.as_row() else {
@@ -537,7 +548,9 @@ where
                 // bundle; use that member's exact `(table, row, tx)` witness
                 // to materialize the newly admitted row. This is payload
                 // lookup, not a facade-side query or recompute.
-                let tx_versions = self.query_versions_for_tx(entry.2).await?;
+                let tx_versions = self
+                    .storage_backed_maintained_result_versions(entry.0.as_str(), entry.1, entry.2)
+                    .await?;
                 let Some(version) = self.maintained_witness_for_result_member(
                     &tx_versions,
                     local.result_schema_version,
@@ -615,7 +628,9 @@ where
         )? {
             version.clone()
         } else {
-            let tx_versions = self.query_versions_for_tx(entry.2).await?;
+            let tx_versions = self
+                .storage_backed_maintained_result_versions(entry.0.as_str(), entry.1, entry.2)
+                .await?;
             let Some(version) = self.maintained_witness_for_result_member(
                 &tx_versions,
                 local.result_schema_version,
@@ -645,6 +660,28 @@ where
             .entry(tx_id)
             .or_insert_with(|| local.maintained.versions_by_tx(tx_id))
             .as_slice()
+    }
+
+    /// Load only the immutable content/deletion cells for one delivered
+    /// result-member identity.  This is deliberately narrower than
+    /// `query_versions_for_tx`: a multi-row transaction must not turn a
+    /// one-row subscription entry into a whole-transaction materialization.
+    async fn storage_backed_maintained_result_versions(
+        &mut self,
+        table: &str,
+        row_uuid: RowUuid,
+        tx_id: TxId,
+    ) -> Result<Vec<VersionRow>, Error> {
+        let stored_tx = self
+            .query_transaction(tx_id)
+            .await?
+            .ok_or(Error::MissingTransaction(tx_id))?;
+        self.query_versions_for_tx_rows_by_alias(
+            tx_id,
+            stored_tx.node_alias,
+            &BTreeSet::from([(table.to_owned(), row_uuid)]),
+        )
+        .await
     }
 
     async fn preload_tx_versions_for_materialization(

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -89,6 +89,32 @@ pub(super) fn current_query_output_request(
     }
 }
 
+/// Whether a maintained current-read can retain only its delivered result
+/// members and re-load their immutable content bodies from storage.
+///
+/// This is intentionally a proof for the small common case, not a heuristic:
+/// one default-view root table, no relation/recursive/output expansion, and
+/// no aggregate.  Direct predicate-only policy alternatives are safe because
+/// their membership decision remains entirely in the root result terminal.
+/// Any shape that needs source provenance beyond that terminal keeps the
+/// self-contained version/replacement witness path.
+pub(super) fn storage_backed_maintained_view_eligible(
+    query: &JazzQuery,
+    read_view: &ReadViewSpec,
+) -> bool {
+    read_view.is_default()
+        && query.joins.is_empty()
+        && query.flat_join.is_none()
+        && query.reachable.is_empty()
+        && query.inherits.is_empty()
+        && query.includes.is_empty()
+        && query.array_subqueries.is_empty()
+        && query.aggregate.is_none()
+        && query.policy_branches.iter().all(|branch| {
+            branch.joins.is_empty() && branch.reachable.is_empty() && branch.inherits.is_empty()
+        })
+}
+
 fn app_row_payload_projection(
     query: &JazzQuery,
     schema: &RuntimeSchema,

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -93,11 +93,10 @@ pub(super) fn current_query_output_request(
 /// members and re-load their immutable content bodies from storage.
 ///
 /// This is intentionally a proof for the small common case, not a heuristic:
-/// one default-view root table, no relation/recursive/output expansion, and
-/// no aggregate.  Direct predicate-only policy alternatives are safe because
-/// their membership decision remains entirely in the root result terminal.
-/// Any shape that needs source provenance beyond that terminal keeps the
-/// self-contained version/replacement witness path.
+/// one default-view root table without a read-policy proof, relation/recursive
+/// output expansion, or aggregate. A policy-bearing root keeps its complete
+/// source witnesses: membership alone cannot preserve the policy's deletion
+/// and replacement liveness across a seeded maintained view.
 pub(super) fn storage_backed_maintained_view_eligible(
     query: &JazzQuery,
     tier: DurabilityTier,
@@ -113,9 +112,7 @@ pub(super) fn storage_backed_maintained_view_eligible(
         && query.includes.is_empty()
         && query.array_subqueries.is_empty()
         && query.aggregate.is_none()
-        && query.policy_branches.iter().all(|branch| {
-            branch.joins.is_empty() && branch.reachable.is_empty() && branch.inherits.is_empty()
-        })
+        && query.policy_branches.is_empty()
         // `JazzQuery::includes` captures only caller-requested includes.
         // Normalization also injects the default root-reference closure for
         // reference-bearing tables, and that auxiliary source needs its

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -101,6 +101,7 @@ pub(super) fn current_query_output_request(
 pub(super) fn storage_backed_maintained_view_eligible(
     query: &JazzQuery,
     read_view: &ReadViewSpec,
+    normalized: &NormalizedRowSetShape,
 ) -> bool {
     read_view.is_default()
         && query.joins.is_empty()
@@ -113,6 +114,16 @@ pub(super) fn storage_backed_maintained_view_eligible(
         && query.policy_branches.iter().all(|branch| {
             branch.joins.is_empty() && branch.reachable.is_empty() && branch.inherits.is_empty()
         })
+        // `JazzQuery::includes` captures only caller-requested includes.
+        // Normalization also injects the default root-reference closure for
+        // reference-bearing tables, and that auxiliary source needs its
+        // version/replacement witnesses on a separate receiving node.  The
+        // storage-backed subset is consequently a proof over the normalized
+        // program, not a surface-query shortcut.
+        && normalized.closure_paths.is_empty()
+        && normalized.auxiliary_sources.is_empty()
+        && normalized.join_contributions.is_empty()
+        && normalized.reachable_contributions.is_empty()
 }
 
 fn app_row_payload_projection(

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -100,10 +100,16 @@ pub(super) fn current_query_output_request(
 /// self-contained version/replacement witness path.
 pub(super) fn storage_backed_maintained_view_eligible(
     query: &JazzQuery,
+    tier: DurabilityTier,
     read_view: &ReadViewSpec,
     normalized: &NormalizedRowSetShape,
 ) -> bool {
-    read_view.is_default()
+    // The fallback reads the settled physical register to recover an omitted
+    // deletion/restore winner.  Edge and Local have separate ahead-current
+    // visibility rules, so they retain their self-contained witnesses until
+    // that fallback has an equally exact physical resolver.
+    tier == DurabilityTier::Global
+        && read_view.is_default()
         && query.joins.is_empty()
         && query.flat_join.is_none()
         && query.reachable.is_empty()

--- a/crates/jazz/src/node/query_eval/normalization.rs
+++ b/crates/jazz/src/node/query_eval/normalization.rs
@@ -104,11 +104,7 @@ pub(super) fn storage_backed_maintained_view_eligible(
     read_view: &ReadViewSpec,
     normalized: &NormalizedRowSetShape,
 ) -> bool {
-    // The fallback reads the settled physical register to recover an omitted
-    // deletion/restore winner.  Edge and Local have separate ahead-current
-    // visibility rules, so they retain their self-contained witnesses until
-    // that fallback has an equally exact physical resolver.
-    tier == DurabilityTier::Global
+    tier != DurabilityTier::None
         && read_view.is_default()
         && query.joins.is_empty()
         && query.flat_join.is_none()

--- a/crates/jazz/src/node/query_eval/tests/maintained_views.rs
+++ b/crates/jazz/src/node/query_eval/tests/maintained_views.rs
@@ -2,11 +2,11 @@
 
 use super::*;
 
-/// A direct maintained-view opening must retain its async owner through a
-/// cold, yielding local scan. Returning an empty Stream A snapshot here lets
-/// a serving peer emit membership before Stream B has its content witness.
+/// A direct maintained-view opening must not wait for a cold source that may
+/// require peer progress after this call returns. The publication owner keeps
+/// Stream A gated until it receives the first complete Stream B snapshot.
 #[test]
-fn maintained_open_awaits_cold_multisink_witnesses() {
+fn maintained_open_defers_cold_multisink_witnesses_to_its_publication_owner() {
     let test_schema = schema();
     let column_families = test_schema.column_families();
     let families = column_families
@@ -63,9 +63,9 @@ fn maintained_open_awaits_cold_multisink_witnesses() {
             Some(plan),
             QueryAuthorizationMode::ClientLocal,
         )
-        .expect("await complete cold maintained snapshot");
-    assert!(local.initial_received);
-    assert_eq!(initial.root_count, 1);
+        .expect("open cold maintained snapshot without waiting for a peer turn");
+    assert!(!local.initial_received);
+    assert_eq!(initial.root_count, 0);
 }
 
 #[test]

--- a/crates/jazz/src/node/query_eval/tests/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/tests/subscriptions.rs
@@ -101,6 +101,168 @@ fn maintained_physical_point_hydration_uses_only_its_current_row_source() {
 }
 
 #[test]
+fn storage_backed_maintained_delivery_keeps_implicit_reference_witnesses_and_rehydrates_scalar_rows()
+ {
+    // A public query without `.include()` can still carry an implicit root
+    // reference closure.  It is not safe to drop witnesses for that shape:
+    // a separate receiver needs the referenced user body to render an issue.
+    let (_issue_dir, mut issue_node) = open_node();
+    let issue_shape = Query::from("issues")
+        .filter(eq(col("assignee"), param("user")))
+        .validate(&issue_node.catalogue.schema)
+        .expect("validate reference-bearing query");
+    let issue_binding = issue_shape
+        .bind(BTreeMap::from([(
+            "user".to_owned(),
+            Value::Uuid(author(1).test_uuid()),
+        )]))
+        .expect("bind reference-bearing query");
+    let issue_program = issue_node
+        .compile_current_query_program_for_read_view(
+            &issue_shape,
+            &issue_binding,
+            DurabilityTier::Global,
+            AuthorSubject::SYSTEM,
+            CurrentQueryProgramOutput::MaintainedView,
+            &ReadViewSpec::default(),
+        )
+        .expect("compile reference-bearing maintained query");
+    assert!(
+        issue_program
+            .request
+            .output
+            .facts
+            .contains(&crate::node::query_engine::ProgramFactKey::VersionWitnesses),
+        "implicit normalized reference closures keep self-contained witnesses"
+    );
+
+    // The optimized path remains available to a genuinely scalar root table,
+    // including the actual remote initial and incremental receiver path.
+    let scalar_schema = public_query_eval_schema(
+        PublicSchemaBuilder::new()
+            .table(PublicTableSchemaBuilder::new("notes").column("title", PublicColumnType::Text)),
+    );
+    let (_server_dir, mut server) =
+        open_node_with_uuid(NodeUuid::from_bytes([0x41; 16]), scalar_schema.clone());
+    let (_reader_dir, mut reader) =
+        open_node_with_uuid(NodeUuid::from_bytes([0x42; 16]), scalar_schema);
+    let shape = Query::from("notes")
+        .validate(&server.catalogue.schema)
+        .expect("validate scalar query");
+    let binding = shape.bind(BTreeMap::new()).expect("bind scalar query");
+    let program = server
+        .compile_current_query_program_for_read_view(
+            &shape,
+            &binding,
+            DurabilityTier::Global,
+            AuthorSubject::SYSTEM,
+            CurrentQueryProgramOutput::MaintainedView,
+            &ReadViewSpec::default(),
+        )
+        .expect("compile scalar maintained query");
+    assert!(
+        !program
+            .request
+            .output
+            .facts
+            .contains(&crate::node::query_engine::ProgramFactKey::VersionWitnesses),
+        "scalar root query uses storage-backed result materialization"
+    );
+    for node in [&mut server, &mut reader] {
+        register_query_shape(node, &shape, RegisterShapeOptions::default());
+        subscribe_query_binding(node, &shape, &binding);
+    }
+    commit_global_cells(
+        &mut server,
+        "notes",
+        row(0),
+        BTreeMap::from([("title".to_owned(), Value::String("first".to_owned()))]),
+        1,
+        1,
+    );
+    let mut peer = PeerState::new();
+    let initial = peer
+        .rehydrate_query(&mut server, &shape, &binding)
+        .expect("serve scalar initial update");
+    reader
+        .apply_sync_message_settled(initial)
+        .expect("separate reader applies scalar initial update");
+    commit_global_cells(
+        &mut server,
+        "notes",
+        row(1),
+        BTreeMap::from([("title".to_owned(), Value::String("second".to_owned()))]),
+        2,
+        2,
+    );
+    let delta = peer
+        .query_update(&mut server, &shape, &binding)
+        .expect("serve scalar incremental update");
+    reader
+        .apply_sync_message_settled(delta)
+        .expect("separate reader applies scalar incremental update");
+    assert_eq!(
+        reader
+            .query_rows(&shape, &binding, DurabilityTier::Global)
+            .expect("read separately materialized scalar rows")
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([row(0), row(1)])
+    );
+
+    // Stream B removals never need to load a newer winner, while restoration
+    // must load exactly the restored content witness from the authoritative
+    // store. Exercise both across the separate receiver boundary.
+    delete_global(&mut server, "notes", row(0), 3, 3);
+    let removal = peer
+        .query_update(&mut server, &shape, &binding)
+        .expect("serve scalar removal update");
+    reader
+        .apply_sync_message_settled(removal)
+        .expect("separate reader applies scalar removal update");
+    assert_eq!(
+        reader
+            .query_rows(&shape, &binding, DurabilityTier::Global)
+            .expect("read scalar rows after deletion")
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([row(1)])
+    );
+    let restore_tx = server
+        .commit_mergeable_settled(
+            MergeableCommit::new("notes", row(0), 4)
+                .made_by(AuthorSubject::SYSTEM)
+                .deletion(crate::tx::DeletionEvent::Restored),
+        )
+        .expect("restore scalar row");
+    server
+        .apply_fate_update(
+            restore_tx,
+            Fate::Accepted,
+            Some(GlobalTime(4)),
+            Some(DurabilityTier::Global),
+        )
+        .expect("accept scalar restore");
+    let restore = peer
+        .query_update(&mut server, &shape, &binding)
+        .expect("serve scalar restoration update");
+    reader
+        .apply_sync_message_settled(restore)
+        .expect("separate reader applies scalar restoration update");
+    assert_eq!(
+        reader
+            .query_rows(&shape, &binding, DurabilityTier::Global)
+            .expect("read scalar rows after restoration")
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([row(0), row(1)])
+    );
+}
+
+#[test]
 fn relay_authority_session_key_is_explicit_and_does_not_replace_direct_edge_source() {
     let (_dir, mut node) = open_node();
     let shape = Query::from("issues")

--- a/crates/jazz/src/node/query_eval/tests/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/tests/subscriptions.rs
@@ -367,15 +367,8 @@ fn storage_backed_maintained_deletion_winners_follow_local_and_edge_frontiers() 
         let initial_tx = commit(&mut server, 1, None);
         let mut peer = PeerState::new();
         let initial = peer
-            .rehydrate_query_for_subscription_with_opts(
-                &mut server,
-                subscription,
-                &shape,
-                &binding,
-                opts.clone(),
-            )
-            .expect("serve initial tiered update")
-            .expect("initial tiered update is ready");
+            .rehydrate_query_with_opts(&mut server, &shape, &binding, opts.clone())
+            .expect("serve initial tiered update");
         reader
             .apply_sync_message_settled(initial)
             .expect("reader applies tiered initial update");
@@ -499,6 +492,134 @@ fn storage_backed_maintained_deletion_winners_follow_local_and_edge_frontiers() 
 
         assert_ne!(initial_tx, deletion_tx, "tiered transition tx ids differ");
     }
+}
+
+/// A fresh Edge reader must receive the earlier Edge-visible restore even when
+/// a newer Local-only register event occupies the raw ahead-current key.
+///
+/// server: Global delete t2 ──► Edge restore t3 ──► Local delete t4
+///                                     │                   │
+///                                     └────fresh Edge reader sees t3─────┘
+#[test]
+fn storage_backed_edge_restore_filters_before_ahead_current_winner_selection() {
+    let scalar_schema = public_query_eval_schema(
+        PublicSchemaBuilder::new()
+            .table(PublicTableSchemaBuilder::new("notes").column("title", PublicColumnType::Text)),
+    );
+    let (_server_dir, mut server) =
+        open_node_with_uuid(NodeUuid::from_bytes([0x73; 16]), scalar_schema.clone());
+    let shape = Query::from("notes")
+        .validate(&server.catalogue.schema)
+        .expect("validate Edge shadow query");
+    let binding = shape.bind(BTreeMap::new()).expect("bind Edge shadow query");
+    let edge_opts = RegisterShapeOptions {
+        tier: DurabilityTier::Edge,
+        ..RegisterShapeOptions::default()
+    };
+    register_query_shape(&mut server, &shape, edge_opts.clone());
+    subscribe_query_binding_with_opts(&mut server, &shape, &binding, edge_opts.clone());
+
+    let content_tx = server
+        .commit_mergeable_settled(
+            MergeableCommit::new("notes", row(0), 1)
+                .made_by(AuthorSubject::SYSTEM)
+                .cells(BTreeMap::from([(
+                    "title".to_owned(),
+                    Value::String("visible".to_owned()),
+                )])),
+        )
+        .expect("commit global content");
+    server
+        .apply_fate_update(
+            content_tx,
+            Fate::Accepted,
+            Some(GlobalTime(1)),
+            Some(DurabilityTier::Global),
+        )
+        .expect("accept global content");
+    let global_delete_tx = server
+        .commit_mergeable_settled(
+            MergeableCommit::new("notes", row(0), 2)
+                .made_by(AuthorSubject::SYSTEM)
+                .deletion(crate::tx::DeletionEvent::Deleted),
+        )
+        .expect("commit global deletion");
+    server
+        .apply_fate_update(
+            global_delete_tx,
+            Fate::Accepted,
+            Some(GlobalTime(2)),
+            Some(DurabilityTier::Global),
+        )
+        .expect("accept global deletion");
+    let edge_restore_tx = server
+        .commit_mergeable_settled(
+            MergeableCommit::new("notes", row(0), 3)
+                .made_by(AuthorSubject::SYSTEM)
+                .deletion(crate::tx::DeletionEvent::Restored),
+        )
+        .expect("commit Edge restore");
+    server
+        .apply_fate_update(
+            edge_restore_tx,
+            Fate::Accepted,
+            None,
+            Some(DurabilityTier::Edge),
+        )
+        .expect("accept Edge restore");
+    let local_delete_tx = server
+        .commit_mergeable_settled(
+            MergeableCommit::new("notes", row(0), 4)
+                .made_by(AuthorSubject::SYSTEM)
+                .deletion(crate::tx::DeletionEvent::Deleted),
+        )
+        .expect("commit Local-only deletion");
+    server
+        .apply_fate_update(
+            local_delete_tx,
+            Fate::Accepted,
+            None,
+            Some(DurabilityTier::Local),
+        )
+        .expect("accept Local-only deletion");
+
+    let (_reader_dir, mut reader) =
+        open_node_with_uuid(NodeUuid::from_bytes([0x74; 16]), scalar_schema);
+    register_query_shape(&mut reader, &shape, edge_opts.clone());
+    subscribe_query_binding_with_opts(&mut reader, &shape, &binding, edge_opts.clone());
+    let update = PeerState::new()
+        .rehydrate_query_with_opts(&mut server, &shape, &binding, edge_opts)
+        .expect("serve fresh Edge hydration");
+    let bundles = match &update {
+        SyncMessage::ViewUpdate(payload) => {
+            crate::protocol::expand_version_carriers(&payload.version_carriers)
+                .expect("fresh Edge carriers should expand")
+        }
+        _ => panic!("fresh Edge scalar subscription must produce a view update"),
+    };
+    assert!(
+        bundles.iter().any(|bundle| {
+            bundle.tx.tx_id == edge_restore_tx
+                && bundle.versions.iter().any(|version| {
+                    version.row_uuid() == row(0)
+                        && version.deletion() == Some(crate::tx::DeletionEvent::Restored)
+                })
+        }),
+        "fresh Edge hydration ships t3 instead of the Global t2 deletion or Local t4 deletion"
+    );
+    reader
+        .apply_sync_message_settled(update)
+        .expect("fresh reader applies Edge hydration");
+    assert_eq!(
+        reader
+            .query_rows(&shape, &binding, DurabilityTier::Edge)
+            .expect("fresh reader Edge lookup")
+            .into_iter()
+            .map(|row| row.row_uuid())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([row(0)]),
+        "fresh reader matches the source's filter-before-argmax Edge view"
+    );
 }
 
 #[test]

--- a/crates/jazz/src/node/query_eval/tests/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/tests/subscriptions.rs
@@ -285,6 +285,222 @@ fn storage_backed_maintained_delivery_keeps_implicit_reference_witnesses_and_reh
     );
 }
 
+/// Storage-backed scalar subscriptions resolve deletion/restore winners at
+/// their own Local or Edge current frontier instead of accidentally reading
+/// the Global register.
+///
+/// server ──tier-accepted insert/delete/restore──► peer ──ViewUpdate──► reader
+/// server ──later Local delete (Edge only)───────► Edge frontier unchanged
+#[test]
+fn storage_backed_maintained_deletion_winners_follow_local_and_edge_frontiers() {
+    for tier in [DurabilityTier::Local, DurabilityTier::Edge] {
+        let scalar_schema =
+            public_query_eval_schema(PublicSchemaBuilder::new().table(
+                PublicTableSchemaBuilder::new("notes").column("title", PublicColumnType::Text),
+            ));
+        let (_server_dir, mut server) = open_node_with_uuid(
+            NodeUuid::from_bytes([0x50 + tier as u8; 16]),
+            scalar_schema.clone(),
+        );
+        let (_reader_dir, mut reader) =
+            open_node_with_uuid(NodeUuid::from_bytes([0x60 + tier as u8; 16]), scalar_schema);
+        let shape = Query::from("notes")
+            .validate(&server.catalogue.schema)
+            .expect("validate scalar tier query");
+        let binding = shape.bind(BTreeMap::new()).expect("bind scalar tier query");
+        let program = server
+            .compile_current_query_program_for_read_view(
+                &shape,
+                &binding,
+                tier,
+                AuthorSubject::SYSTEM,
+                CurrentQueryProgramOutput::MaintainedView,
+                &ReadViewSpec::default(),
+            )
+            .expect("compile tiered scalar maintained query");
+        assert!(
+            !program
+                .request
+                .output
+                .facts
+                .contains(&crate::node::query_engine::ProgramFactKey::VersionWitnesses)
+                && !program
+                    .request
+                    .output
+                    .facts
+                    .contains(&crate::node::query_engine::ProgramFactKey::ReplacementWitnesses),
+            "{tier:?} scalar maintained view uses storage-backed witnesses"
+        );
+        let opts = RegisterShapeOptions {
+            tier,
+            ..RegisterShapeOptions::default()
+        };
+        let subscription = SubscriptionKey {
+            shape_id: shape.shape_id(),
+            binding_id: binding.binding_id(),
+            read_view: opts.read_view_key(),
+        };
+        for node in [&mut server, &mut reader] {
+            register_query_shape(node, &shape, opts.clone());
+            subscribe_query_binding_with_opts(node, &shape, &binding, opts.clone());
+        }
+
+        let commit = |node: &mut NodeState<RocksDbStorage>, now_ms, deletion| {
+            let mut write =
+                MergeableCommit::new("notes", row(0), now_ms).made_by(AuthorSubject::SYSTEM);
+            if let Some(deletion) = deletion {
+                write = write.deletion(deletion);
+            } else {
+                write = write.cells(BTreeMap::from([(
+                    "title".to_owned(),
+                    Value::String("tiered".to_owned()),
+                )]));
+            }
+            let tx_id = node
+                .commit_mergeable_settled(write)
+                .expect("commit tiered row");
+            node.apply_fate_update(tx_id, Fate::Accepted, None, Some(tier))
+                .expect("accept tiered row");
+            tx_id
+        };
+
+        let initial_tx = commit(&mut server, 1, None);
+        let mut peer = PeerState::new();
+        let initial = peer
+            .rehydrate_query_for_subscription_with_opts(
+                &mut server,
+                subscription,
+                &shape,
+                &binding,
+                opts.clone(),
+            )
+            .expect("serve initial tiered update")
+            .expect("initial tiered update is ready");
+        reader
+            .apply_sync_message_settled(initial)
+            .expect("reader applies tiered initial update");
+
+        let deletion_tx = commit(&mut server, 2, Some(crate::tx::DeletionEvent::Deleted));
+        let deletion = peer
+            .query_update_for_subscription_with_opts(
+                &mut server,
+                subscription,
+                &shape,
+                &binding,
+                opts.clone(),
+            )
+            .expect("serve tiered deletion update")
+            .expect("tiered deletion changes membership");
+        reader
+            .apply_sync_message_settled(deletion)
+            .expect("reader applies tiered deletion update");
+        assert!(
+            reader
+                .query_rows(&shape, &binding, tier)
+                .expect("read tiered deletion")
+                .is_empty(),
+            "{tier:?} deletion hides the scalar row"
+        );
+
+        let restore_tx = commit(&mut server, 3, Some(crate::tx::DeletionEvent::Restored));
+        let restored = peer
+            .query_update_for_subscription_with_opts(
+                &mut server,
+                subscription,
+                &shape,
+                &binding,
+                opts.clone(),
+            )
+            .expect("serve tiered restore update")
+            .expect("tiered restore changes membership");
+        let restored_bundles = match &restored {
+            SyncMessage::ViewUpdate(payload) => {
+                crate::protocol::expand_version_carriers(&payload.version_carriers)
+                    .expect("tiered restore carriers should expand")
+            }
+            _ => panic!("tiered scalar subscription must produce a view update"),
+        };
+        assert!(
+            restored_bundles.iter().any(|bundle| {
+                bundle.tx.tx_id == restore_tx
+                    && bundle.versions.iter().any(|version| {
+                        version.row_uuid() == row(0)
+                            && version.deletion() == Some(crate::tx::DeletionEvent::Restored)
+                    })
+            }),
+            "{tier:?} restore ships its visible register winner"
+        );
+        reader
+            .apply_sync_message_settled(restored)
+            .expect("reader applies tiered restore update");
+        assert_eq!(
+            reader
+                .query_rows(&shape, &binding, tier)
+                .expect("read restored tiered row")
+                .into_iter()
+                .map(|row| row.row_uuid())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([row(0)]),
+            "{tier:?} ordinary reader lookup agrees with restored membership"
+        );
+
+        if tier == DurabilityTier::Edge {
+            let local_delete = server
+                .commit_mergeable_settled(
+                    MergeableCommit::new("notes", row(0), 4)
+                        .made_by(AuthorSubject::SYSTEM)
+                        .deletion(crate::tx::DeletionEvent::Deleted),
+                )
+                .expect("commit Local-only deletion");
+            server
+                .apply_fate_update(
+                    local_delete,
+                    Fate::Accepted,
+                    None,
+                    Some(DurabilityTier::Local),
+                )
+                .expect("accept Local-only deletion");
+            // This deliberately overwrites the ahead-current register at
+            // Local. Edge's executable source filters it out and sees no
+            // membership transition; its materialized reader stays visible.
+            if let Some(edge_after_local) = peer
+                .query_update_for_subscription_with_opts(
+                    &mut server,
+                    subscription,
+                    &shape,
+                    &binding,
+                    opts,
+                )
+                .expect("evaluate Edge after Local-only register write")
+            {
+                let SyncMessage::ViewUpdate(payload) = &edge_after_local else {
+                    panic!("Edge scalar subscription must produce a view update");
+                };
+                assert!(
+                    payload.result_member_adds.is_empty()
+                        && payload.result_member_removes.is_empty(),
+                    "a Local-only deletion must not change Edge result membership"
+                );
+                reader
+                    .apply_sync_message_settled(edge_after_local)
+                    .expect("reader applies no-op Edge update");
+            }
+            assert_eq!(
+                reader
+                    .query_rows(&shape, &binding, DurabilityTier::Edge)
+                    .expect("read Edge after Local-only register write")
+                    .into_iter()
+                    .map(|row| row.row_uuid())
+                    .collect::<BTreeSet<_>>(),
+                BTreeSet::from([row(0)]),
+                "Edge remains at its prior visible register frontier"
+            );
+        }
+
+        assert_ne!(initial_tx, deletion_tx, "tiered transition tx ids differ");
+    }
+}
+
 #[test]
 fn relay_authority_session_key_is_explicit_and_does_not_replace_direct_edge_source() {
     let (_dir, mut node) = open_node();

--- a/crates/jazz/src/node/query_eval/tests/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/tests/subscriptions.rs
@@ -718,7 +718,7 @@ fn relay_authority_source_selection_requires_read_policy_for_exact_id() {
 #[test]
 fn maintained_policy_point_subscription_keeps_full_current_source_for_deletion_liveness() {
     let schema = owner_policy_schema();
-    let (_dir, node) = open_node_with_uuid(NodeUuid::from_bytes([0xc2; 16]), schema.clone());
+    let (_dir, mut node) = open_node_with_uuid(NodeUuid::from_bytes([0xc2; 16]), schema.clone());
     let target = row(0x71);
     let shape = Query::from("issues")
         .filter(eq(col("id"), lit(Value::Uuid(target.0))))
@@ -731,6 +731,24 @@ fn maintained_policy_point_subscription_keeps_full_current_source_for_deletion_l
             .unwrap()
             .is_empty(),
         "policy-scoped maintained rows must retain their full source so deletion markers can remove them"
+    );
+    let program = node
+        .compile_current_query_program_for_read_view(
+            &shape,
+            &binding,
+            DurabilityTier::Global,
+            AuthorSubject::SYSTEM,
+            CurrentQueryProgramOutput::MaintainedView,
+            &ReadViewSpec::default(),
+        )
+        .unwrap();
+    assert!(
+        program
+            .request
+            .output
+            .facts
+            .contains(&ProgramFactKey::VersionWitnesses),
+        "a configured root read policy must keep Stream-B witnesses even for a System seed"
     );
 }
 

--- a/crates/jazz/src/node/query_eval/tests/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/tests/subscriptions.rs
@@ -100,6 +100,11 @@ fn maintained_physical_point_hydration_uses_only_its_current_row_source() {
     node.unsubscribe_groove_subscription(receiver.id());
 }
 
+/// Storage-backed scalar membership ships the exact deletion-register winner
+/// alongside a restored row, so a separate reader's later ordinary lookup
+/// agrees with the subscription.
+///
+/// server ──insert/delete/restore──► peer ──ViewUpdate──► reader
 #[test]
 fn storage_backed_maintained_delivery_keeps_implicit_reference_witnesses_and_rehydrates_scalar_rows()
  {
@@ -248,6 +253,24 @@ fn storage_backed_maintained_delivery_keeps_implicit_reference_witnesses_and_reh
     let restore = peer
         .query_update(&mut server, &shape, &binding)
         .expect("serve scalar restoration update");
+    let restore_bundles = match &restore {
+        SyncMessage::ViewUpdate(payload) => {
+            crate::protocol::expand_version_carriers(&payload.version_carriers)
+                .expect("restore update carriers should expand")
+        }
+        _ => panic!("scalar subscription must produce a view update"),
+    };
+    assert!(
+        restore_bundles.iter().any(|bundle| {
+            bundle.tx.tx_id == restore_tx
+                && bundle.versions.iter().any(|version| {
+                    version.table() == "notes"
+                        && version.row_uuid() == row(0)
+                        && version.deletion() == Some(crate::tx::DeletionEvent::Restored)
+                })
+        }),
+        "the storage-backed restore must ship its deletion-register winner, not merely re-add the old content member"
+    );
     reader
         .apply_sync_message_settled(restore)
         .expect("separate reader applies scalar restoration update");

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -252,6 +252,14 @@ struct ViewBundlePreflight {
     persisted_tx_ids: BTreeSet<TxId>,
 }
 
+/// Provenance of version rows selected for a maintained-view wire bundle.
+/// Only exact immutable-store reads may skip witness canonicalization.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MaintainedBundleVersionSource {
+    IvmWitness,
+    ExactStorage,
+}
+
 impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
@@ -966,12 +974,29 @@ where
                 if filtered_tx_versions.is_empty() {
                     continue;
                 }
-                let bundle = self
-                    .version_bundle_for_maintained_view_versions_with_tx(
+                // Storage-backed result membership loaded these exact
+                // immutable history records by `(table, row, tx)` above. Do
+                // not immediately reload them merely to canonicalize an IVM
+                // witness: unlike a graph-projected witness, these are
+                // already authored history rows. Keeping that distinction
+                // here preserves the cold current-row O(1) read receipt.
+                let bundle = if maintained_facts.uses_storage_backed_result_materialization()
+                    && needs_storage_fallback
+                    && self
+                        .exact_storage_maintained_versions_are_unambiguous(&filtered_tx_versions)?
+                {
+                    self.version_bundle_for_exact_storage_maintained_view_versions_with_tx(
                         &stored_tx,
                         &filtered_tx_versions,
                     )
-                    .await?;
+                    .await?
+                } else {
+                    self.version_bundle_for_maintained_view_versions_with_tx(
+                        &stored_tx,
+                        &filtered_tx_versions,
+                    )
+                    .await?
+                };
                 version_bundles.push(bundle);
                 record_maintained_view_stream_b_add_bundle();
                 continue;
@@ -1966,6 +1991,64 @@ where
         stored_tx: &StoredTransaction,
         tx_versions: &[VersionRow],
     ) -> Result<VersionBundle, Error> {
+        self.version_bundle_for_maintained_view_versions_with_tx_and_source(
+            stored_tx,
+            tx_versions,
+            MaintainedBundleVersionSource::IvmWitness,
+        )
+        .await
+    }
+
+    /// Build a maintained-view bundle from rows that were loaded directly
+    /// from the immutable history store by their exact storage identities.
+    ///
+    /// This is intentionally narrower than the ordinary maintained-witness
+    /// path: graph-projected versions still need canonicalization before
+    /// serialization. Callers may use this only for the result of an exact
+    /// `query_versions_for_tx_rows_by_alias` lookup, never for an IVM
+    /// witness.
+    async fn version_bundle_for_exact_storage_maintained_view_versions_with_tx(
+        &mut self,
+        stored_tx: &StoredTransaction,
+        tx_versions: &[VersionRow],
+    ) -> Result<VersionBundle, Error> {
+        self.version_bundle_for_maintained_view_versions_with_tx_and_source(
+            stored_tx,
+            tx_versions,
+            MaintainedBundleVersionSource::ExactStorage,
+        )
+        .await
+    }
+
+    /// Whether these direct immutable-store reads can be serialized without
+    /// the normal maintained-witness canonicalization. Logical names can be
+    /// reused by different physical tables across schema history, so an exact
+    /// `(table, row, tx)` lookup alone is not enough: every row must resolve
+    /// to the sole physical table ever named by that logical label. Otherwise
+    /// use the ordinary fail-closed canonicalization path.
+    fn exact_storage_maintained_versions_are_unambiguous(
+        &self,
+        versions: &[VersionRow],
+    ) -> Result<bool, Error> {
+        versions.iter().try_fold(true, |all_unambiguous, version| {
+            let version_table_id = self.physical_table_id_for_version(version)?;
+            let table_ids = self
+                .catalogue
+                .physical_mappings
+                .values()
+                .filter_map(|mapping| mapping.tables.get(version.table()))
+                .map(|mapping| mapping.table_id)
+                .collect::<BTreeSet<_>>();
+            Ok(all_unambiguous && table_ids.len() == 1 && table_ids.contains(&version_table_id))
+        })
+    }
+
+    async fn version_bundle_for_maintained_view_versions_with_tx_and_source(
+        &mut self,
+        stored_tx: &StoredTransaction,
+        tx_versions: &[VersionRow],
+        source: MaintainedBundleVersionSource,
+    ) -> Result<VersionBundle, Error> {
         let Transaction {
             tx_id,
             kind,
@@ -2008,9 +2091,12 @@ where
             // query output. Resolve its identity back to the stored authored
             // row before crossing the wire boundary (INV-DATA-16/18,
             // INV-SYNC-16, and C.3's byte-fidelity rule).
-            let canonical = self
-                .canonical_history_version_for_maintained_witness(version)
-                .await?;
+            let canonical = if source == MaintainedBundleVersionSource::ExactStorage {
+                version.clone()
+            } else {
+                self.canonical_history_version_for_maintained_witness(version)
+                    .await?
+            };
             versions.push(self.version_record_from_row(&canonical)?);
         }
         Ok(VersionBundle {

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -294,27 +294,54 @@ where
         Ok(())
     }
 
-    /// Recover the current global deletion-register winner for an optimized
-    /// scalar root.  Result membership tells us that the row is visible, but
-    /// not whether that visibility is due to a later `Restored` register
-    /// event; the receiver must learn that event to keep its own register
-    /// current for later ordinary reads.
-    async fn storage_backed_maintained_global_deletion_winner(
+    /// Recover the deletion-register winner currently visible at the
+    /// subscription tier for an optimized scalar root. Result membership tells
+    /// us that the row is visible, but not whether that visibility is due to a
+    /// later `Restored` register event; the receiver must learn that event to
+    /// keep its own register current for later ordinary reads.
+    async fn storage_backed_maintained_deletion_winner(
         &mut self,
         table: &str,
         row_uuid: RowUuid,
+        tier: DurabilityTier,
         context: &mut ViewEvaluationContext,
     ) -> Result<Option<VersionRow>, Error> {
         let table_id =
             self.physical_table_id_for_schema(self.catalogue.current_schema_version_id, table)?;
-        let Some(tx_id) = self
+        let global = self
             .visible_global_layer_tx_id_for_physical_table_now(
                 table_id,
                 row_uuid,
                 VersionLayer::Deletion,
             )
-            .await
-        else {
+            .await;
+        let tx_id = match tier {
+            // Global current storage already represents the settled winner.
+            DurabilityTier::Global => global,
+            // Local reads select the greatest global/ahead register winner.
+            DurabilityTier::Local => self.local_deletion_winner_tx_id(table, row_uuid).await?,
+            // Edge has the same current tables as Local, but an ahead winner
+            // only participates after Edge acceptance. If an unaccepted/local
+            // ahead winner shadows that table's current row, the executable
+            // Edge graph likewise falls back to the global winner.
+            DurabilityTier::Edge => {
+                match self.local_deletion_winner_tx_id(table, row_uuid).await? {
+                    Some(local) => match self.query_transaction_memo(local, context).await? {
+                        Some(stored)
+                            if matches!(stored.fate, Fate::Accepted)
+                                && stored.durability >= DurabilityTier::Edge =>
+                        {
+                            Some(local)
+                        }
+                        _ => global,
+                    },
+                    None => global,
+                }
+            }
+            // No-tier reads do not have a settled maintained source.
+            DurabilityTier::None => None,
+        };
+        let Some(tx_id) = tx_id else {
             return Ok(None);
         };
         let stored_tx = self
@@ -895,10 +922,11 @@ where
                 maintained_facts.replacement_for(entry_table, *row_uuid);
             let deletion_winner = match retained_deletion_winner {
                 Some(winner) => Some(winner),
-                None if allow_storage_witness_fallback && tier == DurabilityTier::Global => {
-                    self.storage_backed_maintained_global_deletion_winner(
+                None if allow_storage_witness_fallback => {
+                    self.storage_backed_maintained_deletion_winner(
                         entry_table,
                         *row_uuid,
+                        tier,
                         &mut context,
                     )
                     .await?
@@ -954,10 +982,11 @@ where
                 maintained_facts.replacement_for(entry_table, *row_uuid);
             let deletion_winner = match retained_deletion_winner {
                 Some(winner) => Some(winner),
-                None if allow_storage_witness_fallback && tier == DurabilityTier::Global => {
-                    self.storage_backed_maintained_global_deletion_winner(
+                None if allow_storage_witness_fallback => {
+                    self.storage_backed_maintained_deletion_winner(
                         entry_table,
                         *row_uuid,
+                        tier,
                         &mut context,
                     )
                     .await?

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -11,6 +11,7 @@ use super::policy::ViewEvaluationContext;
 use super::*;
 use crate::ids::SchemaVersionId;
 use crate::node::maintained_subscription_view::MaintainedSubscriptionView;
+use crate::node::query_engine::left_field;
 use crate::protocol::{
     ContributingMembersEntry, KnownStateDeclaration, PeerPayloadInventory, ProgramFactEntry,
     RealRowMemberEntry, ResultMemberEntry, RowVersionRef, VersionBundle, VersionBundleRef,
@@ -320,23 +321,12 @@ where
             DurabilityTier::Global => global,
             // Local reads select the greatest global/ahead register winner.
             DurabilityTier::Local => self.local_deletion_winner_tx_id(table, row_uuid).await?,
-            // Edge has the same current tables as Local, but an ahead winner
-            // only participates after Edge acceptance. If an unaccepted/local
-            // ahead winner shadows that table's current row, the executable
-            // Edge graph likewise falls back to the global winner.
+            // Edge filters ahead candidates before selecting a winner. A
+            // later Local register event must not shadow an earlier
+            // Edge-accepted event in that filter/argmax ordering.
             DurabilityTier::Edge => {
-                match self.local_deletion_winner_tx_id(table, row_uuid).await? {
-                    Some(local) => match self.query_transaction_memo(local, context).await? {
-                        Some(stored)
-                            if matches!(stored.fate, Fate::Accepted)
-                                && stored.durability >= DurabilityTier::Edge =>
-                        {
-                            Some(local)
-                        }
-                        _ => global,
-                    },
-                    None => global,
-                }
+                self.edge_visible_deletion_winner_tx_id(table_id, table, row_uuid)
+                    .await?
             }
             // No-tier reads do not have a settled maintained source.
             DurabilityTier::None => None,
@@ -354,6 +344,80 @@ where
             .await?
             .into_iter()
             .find(|version| version.deletion().is_some()))
+    }
+
+    /// Mirror the Edge deletion source exactly: filter accepted
+    /// Edge-or-Global ahead entries first, then select the winner with the
+    /// settled global register.  This cannot be implemented by validating the
+    /// raw Local argmax afterwards because that loses an older visible ahead
+    /// row when a newer Local-only row shares the current key.
+    async fn edge_visible_deletion_winner_tx_id(
+        &mut self,
+        table_id: PhysicalTableId,
+        table: &str,
+        row_uuid: RowUuid,
+    ) -> Result<Option<TxId>, Error> {
+        use groove::ivm::{LiteralValue, StaticScanSpec};
+
+        let scan = StaticScanSpec::Point(vec![
+            LiteralValue::from(Value::Bytes(BranchKey::default().canonical_bytes())),
+            LiteralValue::from(Value::Uuid(row_uuid.0)),
+        ]);
+        let fields = ["row_uuid", "tx_time", "tx_node_id"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        let global = GraphBuilder::table_scan(
+            physical_register_global_current_table_name(table_id),
+            scan.clone(),
+        )
+        .project(fields.clone());
+        let ahead =
+            GraphBuilder::table_scan(physical_register_ahead_current_table_name(table_id), scan);
+        let edge_ahead = GraphBuilder::join(
+            ahead.project(fields.clone()),
+            GraphBuilder::table("jazz_transactions")
+                .filter(
+                    PredicateExpr::And(vec![
+                        PredicateExpr::eq("fate", Value::EnumTag(FateTag::Accepted as u8)),
+                        PredicateExpr::Or(vec![
+                            PredicateExpr::eq("durability", Value::EnumTag(2)),
+                            PredicateExpr::eq("durability", Value::EnumTag(3)),
+                        ])
+                        .canonicalize(),
+                    ])
+                    .canonicalize(),
+                )
+                .project(["time", "node_id"]),
+            ["tx_time", "tx_node_id"],
+            ["time", "node_id"],
+        )
+        .project_fields(
+            fields
+                .into_iter()
+                .map(|field| ProjectField::renamed(left_field(&field), field)),
+        );
+        let result = self
+            .database
+            .query_graph(GraphBuilder::arg_max_by(
+                GraphBuilder::union([global, edge_ahead]),
+                ["row_uuid"],
+                ["tx_time", "tx_node_id"],
+            ))
+            .await
+            .map_err(|error| Self::malformed_current_query_error(table, row_uuid, error))?;
+        let Some(delta) = result.deltas.into_iter().find(|delta| delta.weight > 0) else {
+            return Ok(None);
+        };
+        let record = BorrowedRecord::new(&delta.record, &result.descriptor);
+        let time = TxTime(record.get_u64(1)?);
+        let node_alias = NodeAlias(record.get_u64(2)?);
+        let node = self
+            .node_for_alias(node_alias)
+            .ok_or(Error::InvalidStoredValue(
+                "Edge deletion winner references an unknown node alias",
+            ))?;
+        Ok(Some(TxId::new(time, node)))
     }
 
     async fn preflight_view_bundle_conflicts(

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -255,6 +255,80 @@ impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
 {
+    /// Add one exact winner to the per-update bundle cache when the small
+    /// storage-backed maintained subset deliberately omitted its source-wide
+    /// replacement witnesses.  This is a wire-payload fallback only: the
+    /// maintained program still retains no per-binding replacement state.
+    async fn ensure_maintained_view_winner_in_bundle_cache(
+        &mut self,
+        tx_versions_cache: &mut BTreeMap<TxId, Vec<VersionRow>>,
+        winner: &VersionRow,
+        allow_storage_witness_fallback: bool,
+        context: &mut ViewEvaluationContext,
+    ) -> Result<(), Error> {
+        let tx_id = self.version_tx_id(winner)?;
+        if tx_versions_cache
+            .get(&tx_id)
+            .is_some_and(|versions| maintained_view_tx_versions_contain_winner(versions, winner))
+        {
+            return Ok(());
+        }
+        if !allow_storage_witness_fallback {
+            return Ok(());
+        }
+
+        let stored_tx = self
+            .query_transaction_memo(tx_id, context)
+            .await?
+            .ok_or(Error::MissingTransaction(tx_id))?;
+        let wanted_row = BTreeSet::from([(winner.table().to_owned(), winner.row_uuid())]);
+        let stored_versions = self
+            .query_versions_for_tx_rows_by_alias(tx_id, stored_tx.node_alias, &wanted_row)
+            .await?;
+        let cached = tx_versions_cache.entry(tx_id).or_default();
+        for stored in stored_versions {
+            if !cached.iter().any(|existing| existing == &stored) {
+                cached.push(stored);
+            }
+        }
+        Ok(())
+    }
+
+    /// Recover the current global deletion-register winner for an optimized
+    /// scalar root.  Result membership tells us that the row is visible, but
+    /// not whether that visibility is due to a later `Restored` register
+    /// event; the receiver must learn that event to keep its own register
+    /// current for later ordinary reads.
+    async fn storage_backed_maintained_global_deletion_winner(
+        &mut self,
+        table: &str,
+        row_uuid: RowUuid,
+        context: &mut ViewEvaluationContext,
+    ) -> Result<Option<VersionRow>, Error> {
+        let table_id =
+            self.physical_table_id_for_schema(self.catalogue.current_schema_version_id, table)?;
+        let Some(tx_id) = self
+            .visible_global_layer_tx_id_for_physical_table_now(
+                table_id,
+                row_uuid,
+                VersionLayer::Deletion,
+            )
+            .await
+        else {
+            return Ok(None);
+        };
+        let stored_tx = self
+            .query_transaction_memo(tx_id, context)
+            .await?
+            .ok_or(Error::MissingTransaction(tx_id))?;
+        let wanted_row = BTreeSet::from([(table.to_owned(), row_uuid)]);
+        Ok(self
+            .query_versions_for_tx_rows_by_alias(tx_id, stored_tx.node_alias, &wanted_row)
+            .await?
+            .into_iter()
+            .find(|version| version.deletion().is_some()))
+    }
+
     async fn preflight_view_bundle_conflicts(
         &mut self,
         bundles: &[VersionBundleRef<'_>],
@@ -536,7 +610,7 @@ where
             previous_program_facts,
             flat_tuple_source_tables,
             identity: _identity,
-            tier: _tier,
+            tier,
             maintained_facts,
             allow_storage_witness_fallback,
         } = inputs;
@@ -817,7 +891,20 @@ where
             ));
         }
         for (entry_table, row_uuid, content_tx_id) in &row_result_adds {
-            let (_, deletion_winner) = maintained_facts.replacement_for(entry_table, *row_uuid);
+            let (_, retained_deletion_winner) =
+                maintained_facts.replacement_for(entry_table, *row_uuid);
+            let deletion_winner = match retained_deletion_winner {
+                Some(winner) => Some(winner),
+                None if allow_storage_witness_fallback && tier == DurabilityTier::Global => {
+                    self.storage_backed_maintained_global_deletion_winner(
+                        entry_table,
+                        *row_uuid,
+                        &mut context,
+                    )
+                    .await?
+                }
+                None => None,
+            };
             let Some(version) = deletion_winner.as_ref() else {
                 continue;
             };
@@ -829,9 +916,19 @@ where
                 peer_payload_inventory_refs.push(tx_id);
                 record_maintained_view_removal_stream_bundle();
             } else {
-                let tx_versions = tx_versions_cache
+                tx_versions_cache
                     .entry(tx_id)
                     .or_insert_with(|| maintained_facts.versions_by_tx(tx_id));
+                self.ensure_maintained_view_winner_in_bundle_cache(
+                    &mut tx_versions_cache,
+                    version,
+                    allow_storage_witness_fallback,
+                    &mut context,
+                )
+                .await?;
+                let tx_versions = tx_versions_cache
+                    .get(&tx_id)
+                    .expect("winner fallback must preserve the transaction cache entry");
                 if maintained_view_tx_versions_contain_winner(tx_versions, version) {
                     let stored_tx = self
                         .query_transaction_memo(tx_id, &mut context)
@@ -853,8 +950,20 @@ where
             }
         }
         for (entry_table, row_uuid, old_tx_id) in &row_result_removes {
-            let (content_winner, deletion_winner) =
+            let (content_winner, retained_deletion_winner) =
                 maintained_facts.replacement_for(entry_table, *row_uuid);
+            let deletion_winner = match retained_deletion_winner {
+                Some(winner) => Some(winner),
+                None if allow_storage_witness_fallback && tier == DurabilityTier::Global => {
+                    self.storage_backed_maintained_global_deletion_winner(
+                        entry_table,
+                        *row_uuid,
+                        &mut context,
+                    )
+                    .await?
+                }
+                None => None,
+            };
             for (version, missing_witness) in [
                 (
                     content_winner.as_ref(),
@@ -877,9 +986,19 @@ where
                     record_maintained_view_removal_stream_bundle();
                     continue;
                 }
-                let tx_versions = tx_versions_cache
+                tx_versions_cache
                     .entry(tx_id)
                     .or_insert_with(|| maintained_facts.versions_by_tx(tx_id));
+                self.ensure_maintained_view_winner_in_bundle_cache(
+                    &mut tx_versions_cache,
+                    version,
+                    allow_storage_witness_fallback,
+                    &mut context,
+                )
+                .await?;
+                let tx_versions = tx_versions_cache
+                    .get(&tx_id)
+                    .expect("winner fallback must preserve the transaction cache entry");
                 if !maintained_view_tx_versions_contain_winner(tx_versions, version) {
                     return Err(Error::MaintainedViewMissingBundleWitness(missing_witness));
                 }

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -540,6 +540,14 @@ where
             maintained_facts,
             allow_storage_witness_fallback,
         } = inputs;
+        // The storage-backed maintained subset deliberately omits the
+        // source-wide terminal witnesses. Its result-member identity is still
+        // exact, so Stream B must retrieve that immutable payload from the
+        // authoritative node store when shipping a newly admitted member.
+        // Keep callers' explicit fallback flag for the legacy cases that
+        // already use it.
+        let allow_storage_witness_fallback = allow_storage_witness_fallback
+            || maintained_facts.uses_storage_backed_result_materialization();
         program_fact_adds.extend(maintained_facts.payload_facts_for_members(&result_member_adds));
         let tuple_source_versions = maintained_facts.tuple_source_versions_for_members(
             &maintained_facts.active_result_members(),

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -3022,8 +3022,13 @@ fn maintained_subscription_view_hit_metrics_and_footprint_update() {
     assert_eq!(metrics.footprint.result_rows, 1);
     assert_eq!(metrics.footprint.structured_app_rows, 0);
     assert_eq!(metrics.footprint.structured_app_rows_bytes, 0);
-    assert!(metrics.footprint.version_identities >= 1);
-    assert!(metrics.footprint.version_tx_entries >= 1);
+    // Simple default-view root queries retain only delivered membership. The
+    // exact immutable content body is loaded by `(table, row, tx)` when it
+    // enters the result, rather than retaining every source witness per
+    // binding.
+    assert_eq!(metrics.footprint.version_identities, 0);
+    assert_eq!(metrics.footprint.version_tx_entries, 0);
+    assert_eq!(metrics.footprint.replacement_entries, 0);
 
     // Flat subscriptions release this duplicate collector after the reset, but
     // membership/version witnesses must still publish a later removal and a
@@ -3060,6 +3065,33 @@ fn maintained_subscription_view_hit_metrics_and_footprint_update() {
     let metrics = peer.maintained_subscription_view_metrics();
     assert_eq!(metrics.footprint.structured_app_rows, 0);
     assert_eq!(metrics.footprint.structured_app_rows_bytes, 0);
+
+    // The storage-backed path never needs to read a newer content winner to
+    // retract a deleted row. A restore re-enters through its exact original
+    // content transaction and is shipped from immutable storage.
+    let deleted_tx = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row(0x51), 1_003).deletion(DeletionEvent::Deleted),
+        )
+        .unwrap();
+    accept_global(&mut core, deleted_tx, 4);
+    assert_view_update_rows(
+        peer.query_update(&mut core, &shape, &binding).unwrap(),
+        vec![],
+        vec![("todos", row(0x51), restored_tx)],
+    );
+    let re_restored_tx = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row(0x51), 1_004)
+                .deletion(DeletionEvent::Restored),
+        )
+        .unwrap();
+    accept_global(&mut core, re_restored_tx, 5);
+    assert_view_update_rows(
+        peer.query_update(&mut core, &shape, &binding).unwrap(),
+        vec![("todos", row(0x51), restored_tx)],
+        vec![],
+    );
 }
 
 #[test]

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -4,7 +4,9 @@
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap};
+use std::future::Future;
 use std::ops::Deref;
+use std::pin::Pin;
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -67,6 +69,31 @@ const DEFAULT_TEST_WAIT_TIMEOUT_MULTIPLIER: u32 = 8;
 const MAX_TICK_DRIVER_RECOVERY_ATTEMPTS: u32 = 12;
 const TICK_DRIVER_RETRY_BASE_DELAY: Duration = Duration::from_millis(50);
 const TICK_DRIVER_RETRY_MAX_DELAY: Duration = Duration::from_secs(2);
+
+struct StackSafeFuture<F> {
+    inner: Pin<Box<F>>,
+}
+
+impl<F> StackSafeFuture<F> {
+    fn new(inner: F) -> Self {
+        Self {
+            inner: Box::pin(inner),
+        }
+    }
+}
+
+impl<F: Future> Future for StackSafeFuture<F> {
+    type Output = F::Output;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        stacker::maybe_grow(4 * 1024 * 1024, 8 * 1024 * 1024, || {
+            self.inner.as_mut().poll(context)
+        })
+    }
+}
 
 fn load_tolerant_test_timeout(timeout: Duration) -> Duration {
     let multiplier = std::env::var("JAZZ_TOOLS_TEST_WAIT_TIMEOUT_MULTIPLIER")
@@ -359,7 +386,7 @@ impl Backend {
         identity: CoreDbIdentity,
     ) -> Result<Self> {
         Ok(Self(Rc::new(
-            CoreDb::open(CoreDbConfig::new(schema, storage, identity))
+            StackSafeFuture::new(CoreDb::open(CoreDbConfig::new(schema, storage, identity)))
                 .await
                 .map_err(|error| JazzError::Connection(error.to_string()))?,
         )))
@@ -370,8 +397,7 @@ impl Backend {
     }
 
     async fn close(&self) -> Result<()> {
-        self.0
-            .close()
+        StackSafeFuture::new(self.0.close())
             .await
             .map_err(|error| JazzError::Connection(error.to_string()))?;
         #[cfg(test)]
@@ -380,7 +406,7 @@ impl Backend {
     }
 
     async fn connect_upstream(&self, transport: Box<dyn CoreTransport>) -> BackendConnection {
-        self.0.connect_upstream(transport).await
+        StackSafeFuture::new(self.0.connect_upstream(transport)).await
     }
 
     fn detach_connection(&self, connection: &BackendConnection) -> bool {
@@ -392,8 +418,8 @@ impl Backend {
             .set_identity_claims(identity, claims.into_iter().collect());
     }
 
-    fn tick(&self) -> std::result::Result<(), CoreDbError> {
-        crate::db::block_on(self.0.tick())
+    async fn tick(&self) -> std::result::Result<(), CoreDbError> {
+        StackSafeFuture::new(self.0.tick()).await
     }
 
     fn insert(
@@ -575,25 +601,33 @@ impl Backend {
         self.0.row_provenance(row)
     }
 
+    async fn row_provenance_for_subscription(
+        &self,
+        row: &crate::node::CurrentRow,
+    ) -> std::result::Result<Option<crate::node::RowProvenance>, CoreDbError> {
+        StackSafeFuture::new(self.0.row_provenance_async(row)).await
+    }
+
     async fn all(
         &self,
         prepared: &crate::db::PreparedQuery,
         opts: CoreReadOpts,
     ) -> std::result::Result<Vec<crate::node::CurrentRow>, CoreDbError> {
-        self.0.all(prepared, opts).await
+        StackSafeFuture::new(self.0.all(prepared, opts)).await
     }
 
-    fn transaction_all_for_identity(
+    async fn transaction_all_for_identity(
         &self,
         tx_id: OpenTransactionId,
         prepared: &crate::db::PreparedQuery,
         author: CoreAuthorSubject,
         opts: CoreReadOpts,
     ) -> std::result::Result<Vec<crate::node::CurrentRow>, CoreDbError> {
-        crate::db::block_on(
+        StackSafeFuture::new(
             self.0
                 .transaction_all_for_identity(tx_id, prepared, author, opts),
         )
+        .await
     }
 
     async fn subscribe(
@@ -601,7 +635,7 @@ impl Backend {
         prepared: &crate::db::PreparedQuery,
         opts: CoreReadOpts,
     ) -> std::result::Result<crate::db::SubscriptionStream, CoreDbError> {
-        self.0.subscribe(prepared, opts).await
+        StackSafeFuture::new(self.0.subscribe(prepared, opts)).await
     }
 
     fn write_state(
@@ -612,7 +646,7 @@ impl Backend {
     }
 
     async fn next_write_state_change(&self, tx_id: CoreTxId) {
-        self.0.next_write_state_change(tx_id).await;
+        StackSafeFuture::new(self.0.next_write_state_change(tx_id)).await;
     }
 
     fn begin_exclusive(&self, id: OpenTransactionId) -> std::result::Result<(), CoreDbError> {
@@ -910,7 +944,7 @@ impl ClientDb {
         ClientDbInner::handle_query(&self.inner, query, opts, table, wait_for_coverage).await
     }
 
-    fn query_transaction_rows(
+    async fn query_transaction_rows(
         &self,
         query: crate::query::Query,
         opts: CoreReadOpts,
@@ -925,14 +959,15 @@ impl ClientDb {
                 .prepare_query(&query)
                 .map_err(|error| JazzError::Query(error.to_string()))?
         };
-        let rows = {
+        let backend = {
             let inner = self.inner.borrow();
             inner.ensure_transaction_open(transaction_id)?;
-            inner
-                .backend()?
-                .transaction_all_for_identity(transaction_id, &prepared, author, opts)
-                .map_err(|error| JazzError::Query(error.to_string()))?
+            inner.backend_clone()?
         };
+        let rows = backend
+            .transaction_all_for_identity(transaction_id, &prepared, author, opts)
+            .await
+            .map_err(|error| JazzError::Query(error.to_string()))?;
         self.inner.borrow_mut().remember_rows(&table, &rows);
         Ok(rows)
     }
@@ -1297,10 +1332,11 @@ impl ClientDb {
                     } else if urgency == TickUrgency::AfterCurrentTurn {
                         tokio::task::yield_now().await;
                     }
-                    let tick_result = match inner.borrow().backend() {
-                        Ok(db) => db.tick(),
+                    let backend = match inner.borrow().backend_clone() {
+                        Ok(db) => db,
                         Err(_) => return,
                     };
+                    let tick_result = backend.tick().await;
                     match tick_result {
                         Ok(()) => recovery_attempts = 0,
                         Err(error) => {
@@ -1718,16 +1754,22 @@ impl ClientDbInner {
                             normalize_subscription_updates(surviving_rows, added, updated, |row| {
                                 &row.occurrence_id
                             });
-                        let change_delta = (!reset_replaces_initial_view).then(|| {
-                            query_decoder.core_subscription_change_delta(
-                                &db,
-                                &query,
-                                &current_rows,
-                                &effective_added,
-                                &effective_updated,
-                                &removed,
+                        let change_delta = if reset_replaces_initial_view {
+                            None
+                        } else {
+                            Some(
+                                query_decoder
+                                    .core_subscription_change_delta(
+                                        &db,
+                                        &query,
+                                        &current_rows,
+                                        &effective_added,
+                                        &effective_updated,
+                                        &removed,
+                                    )
+                                    .await,
                             )
-                        });
+                        };
                         PublicQueryDecoder::apply_core_subscription_rows(
                             &mut current_rows,
                             &effective_added,
@@ -1740,12 +1782,14 @@ impl ClientDbInner {
                             .collect::<Vec<_>>();
                         inner.borrow_mut().remember_rows(&table, &rows_for_cache);
                         let delta = if reset_replaces_initial_view {
-                            query_decoder.core_subscription_reset_delta(
-                                &db,
-                                &query,
-                                &previous_rows,
-                                &current_rows,
-                            )
+                            query_decoder
+                                .core_subscription_reset_delta(
+                                    &db,
+                                    &query,
+                                    &previous_rows,
+                                    &current_rows,
+                                )
+                                .await
                         } else {
                             change_delta.expect("non-reset subscription frame has a change delta")
                         };
@@ -2017,7 +2061,10 @@ fn core_author_from_session(session: &Session) -> Result<CoreAuthorSubject> {
     Ok(session.author_subject()?)
 }
 
-fn core_storage(schema: &crate::schema::JazzSchema, context: &AppContext) -> Result<StorageBundle> {
+async fn core_storage(
+    schema: &crate::schema::JazzSchema,
+    context: &AppContext,
+) -> Result<StorageBundle> {
     let column_families = schema.column_families();
     let refs = column_families
         .iter()
@@ -2033,15 +2080,15 @@ fn core_storage(schema: &crate::schema::JazzSchema, context: &AppContext) -> Res
                     "persistent client storage requires a target-shell storage factory".to_string(),
                 )
             })?;
-            crate::db::block_on(
-                factory.open(
+            factory
+                .open(
                     context.data_dir.join("jazz-core.rocksdb"),
                     column_families,
                     epoch_1_storage_codec_profile()
                         .map_err(|error| JazzError::Connection(error.to_string()))?,
-                ),
-            )
-            .map_err(|error| JazzError::Connection(error.to_string()))
+                )
+                .await
+                .map_err(|error| JazzError::Connection(error.to_string()))
         }
     }
 }
@@ -2769,7 +2816,7 @@ impl PublicQueryDecoder {
 }
 
 impl PublicQueryDecoder {
-    fn core_subscription_row_to_public(
+    async fn core_subscription_row_to_public(
         &self,
         db: &Backend,
         query: &Query,
@@ -2779,7 +2826,8 @@ impl PublicQueryDecoder {
         let _ = query;
         let encoded = public_subscription_record(&row.row)?;
         let provenance = db
-            .row_provenance(&row.row)
+            .row_provenance_for_subscription(&row.row)
+            .await
             .map_err(|error| JazzError::Query(error.to_string()))?
             .map(core_row_provenance_to_public)
             .unwrap_or_else(|| {
@@ -2804,31 +2852,28 @@ impl PublicQueryDecoder {
         Ok(public)
     }
 
-    fn core_subscription_snapshot_delta(
+    async fn core_subscription_snapshot_delta(
         &self,
         db: &Backend,
         query: &Query,
         rows: &[CoreSubscriptionOutputRow],
     ) -> Result<OrderedRowDelta> {
-        let added = rows
-            .iter()
-            .enumerate()
-            .map(|(index, row)| {
-                let public = self.core_subscription_row_to_public(db, query, row)?;
-                Ok(OrderedAdded {
-                    id: public.id.clone(),
-                    index,
-                    row: public,
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
+        let mut added = Vec::with_capacity(rows.len());
+        for (index, row) in rows.iter().enumerate() {
+            let public = self.core_subscription_row_to_public(db, query, row).await?;
+            added.push(OrderedAdded {
+                id: public.id.clone(),
+                index,
+                row: public,
+            });
+        }
         Ok(OrderedRowDelta {
             added,
             ..OrderedRowDelta::default()
         })
     }
 
-    fn core_subscription_reset_delta(
+    async fn core_subscription_reset_delta(
         &self,
         db: &Backend,
         query: &Query,
@@ -2844,7 +2889,9 @@ impl PublicQueryDecoder {
                 index,
             })
             .collect();
-        let mut delta = self.core_subscription_snapshot_delta(db, query, rows)?;
+        let mut delta = self
+            .core_subscription_snapshot_delta(db, query, rows)
+            .await?;
         delta.removed = removed;
         Ok(delta)
     }
@@ -2874,7 +2921,7 @@ impl PublicQueryDecoder {
         }
     }
 
-    fn core_subscription_change_delta(
+    async fn core_subscription_change_delta(
         &self,
         db: &Backend,
         query: &Query,
@@ -2883,33 +2930,29 @@ impl PublicQueryDecoder {
         updated_rows: &[CoreSubscriptionOutputRow],
         removed_rows: &[crate::db::RemovedRow],
     ) -> Result<OrderedRowDelta> {
-        let added = added_rows
-            .iter()
-            .map(|row| {
-                let public = self.core_subscription_row_to_public(db, query, row)?;
-                Ok(OrderedAdded {
-                    id: public.id.clone(),
-                    index: row.index,
-                    row: public,
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-        let updated = updated_rows
-            .iter()
-            .map(|row| {
-                let public = self.core_subscription_row_to_public(db, query, row)?;
-                let content_changed = previous_rows
-                    .iter()
-                    .find(|previous| previous.occurrence_id == row.occurrence_id)
-                    .is_none_or(|previous| !previous.row.subscription_equivalent(&row.row));
-                Ok(OrderedUpdated {
-                    id: public.id.clone(),
-                    old_index: row.previous_index.unwrap_or(row.index),
-                    new_index: row.index,
-                    row: content_changed.then_some(public),
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
+        let mut added = Vec::with_capacity(added_rows.len());
+        for row in added_rows {
+            let public = self.core_subscription_row_to_public(db, query, row).await?;
+            added.push(OrderedAdded {
+                id: public.id.clone(),
+                index: row.index,
+                row: public,
+            });
+        }
+        let mut updated = Vec::with_capacity(updated_rows.len());
+        for row in updated_rows {
+            let public = self.core_subscription_row_to_public(db, query, row).await?;
+            let content_changed = previous_rows
+                .iter()
+                .find(|previous| previous.occurrence_id == row.occurrence_id)
+                .is_none_or(|previous| !previous.row.subscription_equivalent(&row.row));
+            updated.push(OrderedUpdated {
+                id: public.id.clone(),
+                old_index: row.previous_index.unwrap_or(row.index),
+                new_index: row.index,
+                row: content_changed.then_some(public),
+            });
+        }
         let removed = removed_rows
             .iter()
             .map(|row| OrderedRemoved {
@@ -3038,7 +3081,7 @@ impl JazzClient {
             let public_schema_convert = crate::schema::JazzSchema::new(&context.schema)
                 .map_err(|error| JazzError::Schema(error.to_string()))?;
             let identity = core_identity(&context, default_session.as_ref())?;
-            let storage = core_storage(&public_schema_convert, &context)?;
+            let storage = core_storage(&public_schema_convert, &context).await?;
             let auth = has_server.then(|| WsAuthConfig {
                 jwt_token: if context.backend_secret.is_some() {
                     None
@@ -3206,7 +3249,8 @@ impl JazzClient {
                 .write_identity()?
                 .unwrap_or_else(|| self.db.inner.borrow().identity.author);
             self.db
-                .query_transaction_rows(query.clone(), opts, transaction_id, table, author)?
+                .query_transaction_rows(query.clone(), opts, transaction_id, table, author)
+                .await?
         } else {
             let wait_for_coverage = matches!(opts.tier, CoreDurabilityTier::Global);
             self.db
@@ -3483,12 +3527,36 @@ impl Drop for JazzClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::groove::storage::{Error as StorageError, StorageFactory, StorageFuture};
     use crate::ids::NodeUuid;
     use crate::tools::AppId;
     use crate::tools::public_schema::Schema;
     use crate::tools::{ClientStorage, ColumnType, SchemaBuilder, TableSchema};
     use serde_json::json;
     use tempfile::TempDir;
+
+    #[derive(Debug)]
+    struct YieldingStorageFactory;
+
+    impl StorageFactory for YieldingStorageFactory {
+        fn open(
+            &self,
+            _path: std::path::PathBuf,
+            column_families: Vec<String>,
+            _codec_profile: crate::groove::storage::StorageCodecProfile,
+        ) -> StorageFuture<'_, std::result::Result<CoreStorage, StorageError>> {
+            Box::pin(async move {
+                // A target storage factory may need an executor turn before it
+                // can hand a boxed store back to the facade.
+                tokio::task::yield_now().await;
+                let refs = column_families
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>();
+                Ok(CoreStorage::new(CoreMemoryStorage::new(&refs)?))
+            })
+        }
+    }
 
     #[test]
     fn query_runtime_waker_enqueues_one_immediate_owner_turn() {
@@ -3500,6 +3568,27 @@ mod tests {
         waker.wake_by_ref();
         assert_eq!(scheduler.take(), Some(TickUrgency::Immediate));
         assert_eq!(scheduler.take(), None, "waking does not create a hot loop");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn persistent_storage_open_yields_without_sync_polling() {
+        let temp_dir = TempDir::new().expect("temp client dir");
+        let mut context = make_offline_context_with_storage(
+            AppId::from_name("yielding-storage-factory"),
+            temp_dir.path().to_path_buf(),
+            declared_todo_schema(),
+            ClientStorage::Persistent,
+        );
+        context.storage_factory = Some(Arc::new(YieldingStorageFactory));
+
+        let client = tokio::time::timeout(Duration::from_secs(1), JazzClient::connect(context))
+            .await
+            .expect("storage factory must resume through the async connect owner turn")
+            .expect("connect yielding persistent storage");
+        client
+            .shutdown()
+            .await
+            .expect("close yielding persistent storage");
     }
 
     /// Product read tiers lower to the unchanged facade durability contract,

--- a/crates/jazz/tests/route_subscription_benchmark_contract.rs
+++ b/crates/jazz/tests/route_subscription_benchmark_contract.rs
@@ -1,0 +1,15 @@
+//! Guards the CodSpeed wall-time boundary for the route subscription receipt.
+
+#[test]
+fn route_curve_codspeed_receipts_exclude_fixture_lifecycle() {
+    // `with_inputs` runs fixture construction before the measured closure.
+    // The vendored CodSpeed Divan collector includes that external time
+    // unless the macro option is present.
+    let source = include_str!("../benches/route_subscription_curve.rs");
+    assert_eq!(source.matches(".with_inputs(").count(), 2);
+    assert_eq!(
+        source.matches("sample_count = 3, skip_ext_time").count(),
+        2,
+        "every RouteFixture receipt must exclude setup and Drop from wall time"
+    );
+}

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1142,6 +1142,21 @@ test("CodSpeed runs nightly on main and only for benchmark-labeled PRs", () => {
   }, /strictly equal/);
 });
 
+test("CodSpeed retains the route subscription binding-scale wall-time receipt", () => {
+  const document = parse(codspeedWorkflow);
+  const job = document.jobs["route-subscription-walltime"];
+  assert.ok(job, "route subscription wall-time job must remain present");
+  assert.equal(
+    job.if,
+    "github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark')",
+  );
+  assert.equal(job["runs-on"], "codspeed-macro");
+  const commands = job.steps.map((step) => step.run).filter(Boolean).join("\n");
+  assert.match(commands, /cargo codspeed build --measurement-mode walltime --package jazz --features testing --bench route_subscription_curve/);
+  const run = job.steps.find((step) => step.with?.run)?.with?.run;
+  assert.match(run, /JAZZ_ROUTE_CURVE_ROUTES=100 cargo codspeed run --package jazz --features testing --bench route_subscription_curve/);
+});
+
 test("React Native artifact builds are explicit same-repository label opt-ins", () => {
   const document = parse(rnNativeArtifactsWorkflow);
   assert.deepEqual(document.on.pull_request, {

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1155,8 +1155,14 @@ test("CodSpeed retains the route subscription binding-scale wall-time receipt", 
     "github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark')",
   );
   assert.equal(job["runs-on"], "codspeed-macro");
-  const commands = job.steps.map((step) => step.run).filter(Boolean).join("\n");
-  assert.match(commands, /cargo codspeed build --measurement-mode walltime --package jazz --features testing --bench route_subscription_curve/);
+  const commands = job.steps
+    .map((step) => step.run)
+    .filter(Boolean)
+    .join("\n");
+  assert.match(
+    commands,
+    /cargo codspeed build --measurement-mode walltime --package jazz --features testing --bench route_subscription_curve/,
+  );
   const run = job.steps.find((step) => step.with?.run)?.with?.run;
   assert.match(run, /^cargo codspeed run --package jazz --bench route_subscription_curve$/m);
   assert.doesNotMatch(run, /--features|JAZZ_ROUTE_CURVE_ROUTES/);

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -33,6 +33,10 @@ const previewBuild = fs.readFileSync(
   "utf8",
 );
 const codspeedWorkflow = fs.readFileSync(path.join(root, ".github/workflows/codspeed.yml"), "utf8");
+const routeSubscriptionCurve = fs.readFileSync(
+  path.join(root, "crates/jazz/benches/route_subscription_curve.rs"),
+  "utf8",
+);
 const realisticWorkflow = fs.readFileSync(
   path.join(root, ".github/workflows/benchmarks.yml"),
   "utf8",
@@ -1154,7 +1158,11 @@ test("CodSpeed retains the route subscription binding-scale wall-time receipt", 
   const commands = job.steps.map((step) => step.run).filter(Boolean).join("\n");
   assert.match(commands, /cargo codspeed build --measurement-mode walltime --package jazz --features testing --bench route_subscription_curve/);
   const run = job.steps.find((step) => step.with?.run)?.with?.run;
-  assert.match(run, /JAZZ_ROUTE_CURVE_ROUTES=100 cargo codspeed run --package jazz --features testing --bench route_subscription_curve/);
+  assert.match(run, /^cargo codspeed run --package jazz --bench route_subscription_curve$/m);
+  assert.doesNotMatch(run, /--features|JAZZ_ROUTE_CURVE_ROUTES/);
+  assert.match(routeSubscriptionCurve, /#\[divan::bench\(args = \[ROUTE_BENCH_BINDINGS\]/);
+  assert.match(routeSubscriptionCurve, /fn attach_route_bindings/);
+  assert.match(routeSubscriptionCurve, /fn matching_write_fanout/);
 });
 
 test("React Native artifact builds are explicit same-repository label opt-ins", () => {


### PR DESCRIPTION
🤖 ## Before

Every binding of a simple maintained query retained source-wide version and replacement witnesses. With one query shape bound to 100 tenants over 2,000 source rows, the same immutable evidence was multiplied into 200,000 version identities and 200,000 replacement entries, consuming about 683 MB of maintained/control heap.

This happened even when each binding delivered only a small bounded result.

## After

For the proved simple subset—default current read, one root table, no relations, recursion, includes, array subqueries, or aggregate, with predicate-only policy branches—the maintained view retains result membership only.

When a row enters the delivered result, Jazz loads its exact immutable `(table, row, tx)` content from authoritative node storage. A deletion removes the old occurrence without reading a newer content winner; a later restore re-enters using the exact original content transaction. Unsupported query shapes keep the existing self-contained witness path.

The 100-binding route receipt now reports:

- `0` retained version identities;
- `0` replacement entries;
- about `606 KB` maintained/control memory versus the issue baseline of `683.39 MB`;
- matching, unrelated-write, and below-window assertions still exact.

## Current verification

The existing `route_subscription_curve` receipt passes with its semantic canaries. Focused differential and authorization coverage is still running, so this PR remains draft. The `performance` label intentionally starts hosted CodSpeed measurement and flamegraph collection at this coherent checkpoint.

Closes #2129 once the remaining acceptance matrix and independent adversarial review are green.