### PR TITLE
Guard stack operations from dirty worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,16 @@ handoff cases. For nuanced or large changes, make these concrete enough for an
 adversarial reviewer to verify the behavior and for a future reader to recover
 the decision without reconstructing it from the diff or conversation history.
 
+### Stack and restack preflight
+
+Before every `gh stack link`, `gh stack submit`, rebase, merge-based restack,
+or branch propagation, run `dev/gates/require-clean-worktree.sh <checkout>`
+against every checkout that the operation will mutate. It rejects staged index
+changes, unstaged tracked changes, and non-ignored untracked files. Do not
+interpret a clean `git diff` as sufficient: it deliberately does not report a
+dirty index. Preserve or commit the state first; never let a stack operation
+implicitly carry it across branches.
+
 **Testing:** prefer black-boxed integration tests over unit tests or white-box tests.
 Do not use JSON-like schema/permissions/query definitions. Always use the public API to build them in the tests.
 Before writing any test in Rust crates, always read `crates/jazz/TESTING_GUIDELINES.md` in full and follow it.

--- a/dev/gates/require-clean-worktree.sh
+++ b/dev/gates/require-clean-worktree.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Refuse stack/rebase operations against a checkout that has source state not
+# represented by its current commit.  `git diff --quiet` alone misses staged
+# changes, which is how a staged index can accidentally survive a restack.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPOSITORY="${1:-$ROOT}"
+
+git -C "$REPOSITORY" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  echo "stack-preflight: not a Git worktree: $REPOSITORY" >&2
+  exit 2
+}
+
+failed=0
+if ! git -C "$REPOSITORY" diff --cached --quiet; then
+  echo "stack-preflight: staged changes are present; commit, unstage, or preserve them before restacking." >&2
+  failed=1
+fi
+if ! git -C "$REPOSITORY" diff --quiet; then
+  echo "stack-preflight: unstaged tracked changes are present; commit, discard, or preserve them before restacking." >&2
+  failed=1
+fi
+if [[ -n "$(git -C "$REPOSITORY" ls-files --others --exclude-standard)" ]]; then
+  echo "stack-preflight: untracked non-ignored files are present; add, remove, or preserve them before restacking." >&2
+  failed=1
+fi
+
+if (( failed )); then
+  echo "stack-preflight: refusing stack/rebase operation in $REPOSITORY" >&2
+  exit 1
+fi
+
+echo "stack-preflight: clean worktree and index: $REPOSITORY"

--- a/dev/gates/test/require-clean-worktree.test.sh
+++ b/dev/gates/test/require-clean-worktree.test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TEMP="$(mktemp -d "${TMPDIR:-/tmp}/jazz-stack-preflight-test.XXXXXX")"
+trap 'rm -rf "$TEMP" "$TEMP.out"' EXIT
+
+git -C "$TEMP" init -q
+git -C "$TEMP" config user.email test@example.invalid
+git -C "$TEMP" config user.name 'Jazz test'
+printf 'tracked\n' >"$TEMP/file"
+printf 'ignored\n' >"$TEMP/.gitignore"
+git -C "$TEMP" add file .gitignore
+git -C "$TEMP" commit -qm initial
+
+run() {
+  "$ROOT/dev/gates/require-clean-worktree.sh" "$TEMP"
+}
+
+run >/dev/null
+
+printf 'staged\n' >>"$TEMP/file"
+git -C "$TEMP" add file
+if run >"$TEMP.out" 2>&1; then
+  echo 'expected staged changes to fail preflight' >&2
+  exit 1
+fi
+grep -F 'staged changes are present' "$TEMP.out" >/dev/null
+git -C "$TEMP" restore --staged file
+git -C "$TEMP" restore file
+
+printf 'unstaged\n' >>"$TEMP/file"
+if run >"$TEMP.out" 2>&1; then
+  echo 'expected unstaged tracked changes to fail preflight' >&2
+  exit 1
+fi
+grep -F 'unstaged tracked changes are present' "$TEMP.out" >/dev/null
+git -C "$TEMP" restore file
+
+printf 'untracked\n' >"$TEMP/untracked"
+if run >"$TEMP.out" 2>&1; then
+  echo 'expected untracked files to fail preflight' >&2
+  exit 1
+fi
+grep -F 'untracked non-ignored files are present' "$TEMP.out" >/dev/null
+rm "$TEMP/untracked"
+
+printf 'cache\n' >"$TEMP/ignored"
+run >/dev/null
+
+echo 'stack clean-worktree preflight checks passed'

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "oxlint . --ignore-path .oxlintignore && cargo clippy --workspace -- -D warnings",
     "test:tooling": "sh dev/scripts/clippy-staged.test.sh && bash dev/scripts/publish-crates-alpha.test.sh",
     "test:focused-rust": "bash dev/gates/test/dev-t.test.sh",
+    "test:stack-preflight": "bash dev/gates/test/require-clean-worktree.test.sh",
     "test:vercel-preview-skip": "node --test dev/scripts/skip-new-core-vercel-preview.test.mjs",
     "test:turbo-cache-inputs": "node dev/gates/test/turbo-cache-inputs.test.mjs",
     "test:tooling:real": "sh dev/scripts/clippy-staged.real.test.sh",


### PR DESCRIPTION
🤖 Prevent stack propagation, rebasing, or submission from silently carrying a dirty index or worktree into another branch.

## Before

Lane 1 was reused during sequential restacking while its index still contained staged content. Later checkouts and merges preserved that index, leaving 22 staged changes that collectively reversed already-published #2341 scheduler work and #2351 browser-storage isolation work. A normal conflict-free restack therefore looked successful while the lane held a latent regression.

## After

- `dev/gates/require-clean-worktree.sh <checkout>` rejects staged changes, unstaged tracked changes, and non-ignored untracked files separately.
- ignored build/cache outputs remain allowed;
- `pnpm test:stack-preflight` exercises every state in a temporary repository;
- `AGENTS.md` requires the preflight immediately before stack linking/submission, rebases, and manual restack propagation.

Example:

```sh
dev/gates/require-clean-worktree.sh /work/lane-2
gh stack submit
```

The helper is intentionally independent of `gh-stack`: it can guard the manual merge-based restacks we also use, without changing stack semantics.

## Verification

- `pnpm test:stack-preflight`
- planted staged, unstaged, and untracked states each fail closed;
- an ignored artifact succeeds.
