### PR TITLE
Retain async mutation preparation and finalization

### DIFF
--- a/crates/jazz-napi/close-pollable.cjs
+++ b/crates/jazz-napi/close-pollable.cjs
@@ -1,0 +1,8 @@
+async function completePollableClose(pending) {
+  for (;;) {
+    if (pending.poll() !== null) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+module.exports = { completePollableClose };

--- a/crates/jazz-napi/index.cjs
+++ b/crates/jazz-napi/index.cjs
@@ -2,6 +2,7 @@
 // generated loader. It gives a fresh checkout the same deterministic failure
 // as a rebuilt checkout.
 const { nativeBinding, expectedNativeArtifactFingerprint } = require("./native-binding.cjs");
+const { completePollableClose } = require("./close-pollable.cjs");
 
 if (typeof nativeBinding.nativeArtifactFingerprint !== "function") {
   throw new Error(
@@ -25,4 +26,21 @@ if (
       "Rebuild the monorepo binding or reinstall matching package versions.",
   );
 }
+
+const closePollable = nativeBinding.NapiDb.prototype.__closePollable;
+if (typeof closePollable !== "function") {
+  throw new Error(
+    "Jazz NAPI artifact is incomplete despite a matching fingerprint (missing NapiDb close operation). " +
+      "Rebuild the monorepo binding or reinstall matching package versions.",
+  );
+}
+Object.defineProperty(nativeBinding.NapiDb.prototype, "close", {
+  configurable: true,
+  writable: true,
+  value: async function close() {
+    const pending = closePollable.call(this);
+    if (pending instanceof Uint8Array) return undefined;
+    await completePollableClose(pending);
+  },
+});
 module.exports = nativeBinding;

--- a/crates/jazz-napi/package.json
+++ b/crates/jazz-napi/package.json
@@ -12,6 +12,7 @@
     "index.mjs",
     "index.js",
     "index.d.ts",
+    "close-pollable.cjs",
     "native-binding.cjs",
     "native-binding.pointer.cjs",
     "native-loader.cjs",
@@ -37,7 +38,7 @@
     "build:debug": "node scripts/build.js --debug",
     "build:perf": "node scripts/build.js --profile perf",
     "build:perf:sccache": "RUSTC_WRAPPER=sccache node scripts/build.js --profile perf",
-    "test": "pnpm typecheck:consumer",
+    "test": "node --test tests/*.test.cjs && pnpm typecheck:consumer",
     "typecheck:consumer": "tsc --project tests/types/tsconfig.json"
   },
   "devDependencies": {

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1717,16 +1717,19 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.restore(&table, row_id, cells, options))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.restore(&table, row_id, cells, options))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let write = db
+                    .enqueue_restore(table, row_id, cells, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                core_write_memory(Rc::clone(db), write)
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let write = db
+                    .enqueue_restore(table, row_id, cells, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                core_write_persistent(Rc::clone(db), write)
+            }
         }
     }
 

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -3625,30 +3625,26 @@ impl NapiDb {
     }
 
     #[napi]
-    pub fn close(&self, env: Env) -> napi::Result<PromiseRaw<'static, ()>> {
+    pub fn close(&self) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let inner = self.inner.borrow_mut().take();
-        let result = if !self.owns_runtime {
-            Ok(())
-        } else if let Some(inner) = inner {
-            match inner {
-                NapiDbInnerStorage::Memory(db) => {
-                    // Schema views retain this core through their own Rc. Release every
-                    // N-API-owned callback before the fallible async close so a retained
-                    // view cannot keep Node's event loop alive after its owner closes.
-                    db.set_tick_scheduler(None);
-                    db.clear_mutation_error_callback();
-                    core_block_on(db.close())
-                }
-                NapiDbInnerStorage::Persistent(db) => {
-                    db.set_tick_scheduler(None);
-                    db.clear_mutation_error_callback();
-                    core_block_on(db.close())
+        let owns_runtime = self.owns_runtime;
+        native_read_or_pending(Box::pin(async move {
+            if owns_runtime && let Some(inner) = inner {
+                match inner {
+                    NapiDbInnerStorage::Memory(db) => {
+                        db.close().await.map_err(napi_error)?;
+                        db.set_tick_scheduler(None);
+                        db.clear_mutation_error_callback();
+                    }
+                    NapiDbInnerStorage::Persistent(db) => {
+                        db.close().await.map_err(napi_error)?;
+                        db.set_tick_scheduler(None);
+                        db.clear_mutation_error_callback();
+                    }
                 }
             }
-        } else {
-            Ok(())
-        };
-        immediate_promise(env, result)
+            Ok(Uint8Array::new(Vec::new()))
+        }))
     }
 }
 
@@ -4021,21 +4017,6 @@ fn finish_wait_promise(
     result: std::result::Result<TxId, jazz::db::Error>,
 ) {
     finish_immediate_promise(env, deferred, result.map(|_| ()))
-}
-
-fn immediate_promise(
-    env: Env,
-    result: std::result::Result<(), jazz::db::Error>,
-) -> napi::Result<PromiseRaw<'static, ()>> {
-    let mut deferred = std::ptr::null_mut();
-    let mut promise = std::ptr::null_mut();
-    let env = env.raw();
-    let status = unsafe { sys::napi_create_promise(env, &mut deferred, &mut promise) };
-    if status != sys::Status::napi_ok {
-        return Err(napi::Error::from_reason("failed to create close promise"));
-    }
-    finish_immediate_promise(env, deferred, result);
-    Ok(PromiseRaw::new(env, promise))
 }
 
 fn finish_immediate_promise(

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -783,48 +783,6 @@ enum NapiTxKind {
     Exclusive,
 }
 
-macro_rules! with_napi_mergeable_tx {
-    ($transaction:expr, |$tx:ident| $operation:expr) => {{
-        let open_tx = $transaction.open_tx()?;
-        let db = $transaction
-            .db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("transaction is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => {
-                let $tx = db.mergeable_tx_ref(open_tx);
-                core_block_on($operation)
-            }
-            NapiDbInnerStorage::Persistent(db) => {
-                let $tx = db.mergeable_tx_ref(open_tx);
-                core_block_on($operation)
-            }
-        }
-        .map_err(|error: jazz::db::Error| napi::Error::from_reason(error.to_string()))
-    }};
-}
-
-macro_rules! with_napi_exclusive_tx {
-    ($transaction:expr, |$tx:ident| $operation:expr) => {{
-        let open_tx = $transaction.open_tx()?;
-        let db = $transaction
-            .db
-            .as_ref()
-            .ok_or_else(|| napi::Error::from_reason("transaction is closed"))?;
-        match db {
-            NapiDbInnerStorage::Memory(db) => {
-                let $tx = db.exclusive_tx_ref(open_tx);
-                core_block_on($operation)
-            }
-            NapiDbInnerStorage::Persistent(db) => {
-                let $tx = db.exclusive_tx_ref(open_tx);
-                core_block_on($operation)
-            }
-        }
-        .map_err(|error: jazz::db::Error| napi::Error::from_reason(error.to_string()))
-    }};
-}
-
 impl Write {
     fn wait_promise(
         &self,
@@ -1158,14 +1116,20 @@ impl Tx {
         )?;
         let cells = decode_core_cells(&cells)?;
         let options = core_insert_options(options)?;
-        let row_id = match self.kind {
-            NapiTxKind::Mergeable => {
-                with_napi_mergeable_tx!(self, |tx| tx.insert(&table, cells, options))
+        let open_tx = self.open_tx()?;
+        let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("transaction is closed"))?;
+        let row_id = match db {
+            NapiDbInnerStorage::Memory(db) => {
+                db.enqueue_transaction_insert(open_tx, exclusive, table, cells, options)
             }
-            NapiTxKind::Exclusive => {
-                with_napi_exclusive_tx!(self, |tx| tx.insert(&table, cells, options))
+            NapiDbInnerStorage::Persistent(db) => {
+                db.enqueue_transaction_insert(open_tx, exclusive, table, cells, options)
             }
-        }?;
+        };
         Ok(Uint8Array::new(row_id.to_bytes()))
     }
 
@@ -1185,15 +1149,18 @@ impl Tx {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let patch = decode_core_cells(&patch)?;
         let options = core_update_options(options)?;
-        match self.kind {
-            NapiTxKind::Mergeable => {
-                with_napi_mergeable_tx!(self, |tx| tx.update(&table, row_id, patch, options))
+        let open_tx = self.open_tx()?;
+        let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
+        match self.db.as_ref() {
+            Some(NapiDbInnerStorage::Memory(db)) => {
+                db.enqueue_transaction_update(open_tx, exclusive, table, row_id, patch, options)
             }
-            NapiTxKind::Exclusive => {
-                with_napi_exclusive_tx!(self, |tx| tx.update(&table, row_id, patch, options))
+            Some(NapiDbInnerStorage::Persistent(db)) => {
+                db.enqueue_transaction_update(open_tx, exclusive, table, row_id, patch, options)
             }
+            None => return Err(napi::Error::from_reason("transaction is closed")),
         }
-        .map(|_| ())
+        Ok(())
     }
 
     #[napi(js_name = "upsertEncoded")]
@@ -1213,14 +1180,18 @@ impl Tx {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let cells = decode_core_cells(&cells)?;
         let options = core_upsert_options(options)?;
-        match self.kind {
-            NapiTxKind::Mergeable => {
-                with_napi_mergeable_tx!(self, |tx| tx.upsert(&table, row_id, cells, options))
+        let open_tx = self.open_tx()?;
+        let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
+        match self.db.as_ref() {
+            Some(NapiDbInnerStorage::Memory(db)) => {
+                db.enqueue_transaction_upsert(open_tx, exclusive, table, row_id, cells, options)
             }
-            NapiTxKind::Exclusive => {
-                with_napi_exclusive_tx!(self, |tx| tx.upsert(&table, row_id, cells, options))
+            Some(NapiDbInnerStorage::Persistent(db)) => {
+                db.enqueue_transaction_upsert(open_tx, exclusive, table, row_id, cells, options)
             }
+            None => return Err(napi::Error::from_reason("transaction is closed")),
         }
+        Ok(())
     }
 
     #[napi(js_name = "deleteEncoded")]
@@ -1237,14 +1208,18 @@ impl Tx {
         )?;
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let options = core_delete_options(options)?;
-        match self.kind {
-            NapiTxKind::Mergeable => {
-                with_napi_mergeable_tx!(self, |tx| tx.delete(&table, row_id, options))
+        let open_tx = self.open_tx()?;
+        let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
+        match self.db.as_ref() {
+            Some(NapiDbInnerStorage::Memory(db)) => {
+                db.enqueue_transaction_delete(open_tx, exclusive, table, row_id, options)
             }
-            NapiTxKind::Exclusive => {
-                with_napi_exclusive_tx!(self, |tx| tx.delete(&table, row_id, options))
+            Some(NapiDbInnerStorage::Persistent(db)) => {
+                db.enqueue_transaction_delete(open_tx, exclusive, table, row_id, options)
             }
+            None => return Err(napi::Error::from_reason("transaction is closed")),
         }
+        Ok(())
     }
 
     #[napi(js_name = "restoreEncoded")]
@@ -1264,14 +1239,18 @@ impl Tx {
         let row_id = core_row_uuid_from_bytes(&row_id)?;
         let cells = cells.map(|cells| decode_core_cells(&cells)).transpose()?;
         let options = core_restore_options(options)?;
-        match self.kind {
-            NapiTxKind::Mergeable => {
-                with_napi_mergeable_tx!(self, |tx| tx.restore(&table, row_id, cells, options))
+        let open_tx = self.open_tx()?;
+        let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
+        match self.db.as_ref() {
+            Some(NapiDbInnerStorage::Memory(db)) => {
+                db.enqueue_transaction_restore(open_tx, exclusive, table, row_id, cells, options)
             }
-            NapiTxKind::Exclusive => {
-                with_napi_exclusive_tx!(self, |tx| tx.restore(&table, row_id, cells, options))
+            Some(NapiDbInnerStorage::Persistent(db)) => {
+                db.enqueue_transaction_restore(open_tx, exclusive, table, row_id, cells, options)
             }
+            None => return Err(napi::Error::from_reason("transaction is closed")),
         }
+        Ok(())
     }
 
     #[napi]
@@ -2297,37 +2276,22 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         macro_rules! begin {
-            ($db:expr) => {
-                core_block_on(async {
-                    if kind == "mergeable" {
-                        match attribution {
-                            Some(attribution) => {
-                                $db.begin_mergeable_attributed(open_transaction_id, attribution)
-                                    .await
-                            }
-                            None => match author {
-                                Some(author) => {
-                                    $db.begin_mergeable_for_identity(open_transaction_id, author)
-                                        .await
-                                }
-                                None => $db.begin_mergeable(open_transaction_id).await,
-                            },
-                        }
-                    } else {
-                        match author {
-                            Some(author) => {
-                                $db.begin_exclusive_for_identity(open_transaction_id, author)
-                                    .await
-                            }
-                            None => $db.begin_exclusive(open_transaction_id).await,
-                        }
-                    }
-                })
-            };
+            ($db:expr, $drive:expr) => {{
+                let result = if kind == "mergeable" {
+                    $db.enqueue_begin_mergeable(open_transaction_id, author, attribution)
+                } else {
+                    $db.enqueue_begin_exclusive(open_transaction_id, author);
+                    Ok(())
+                };
+                if result.is_ok() && $drive {
+                    $db.drive_queued_mutation_once();
+                }
+                result
+            }};
         }
         let result = match db {
-            NapiDbInnerStorage::Memory(db) => begin!(db),
-            NapiDbInnerStorage::Persistent(db) => begin!(db),
+            NapiDbInnerStorage::Memory(db) => begin!(db, true),
+            NapiDbInnerStorage::Persistent(db) => begin!(db, false),
         };
         result.map_err(|error| napi::Error::from_reason(error.to_string()))?;
         if attribution.is_some() {

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -3633,7 +3633,7 @@ impl NapiDb {
         }
     }
 
-    #[napi(js_name = "__closePollable")]
+    #[napi(js_name = "__closePollable", skip_typescript)]
     pub fn close(&self) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let inner = self.inner.borrow_mut().take();
         let owns_runtime = self.owns_runtime;

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1749,17 +1749,25 @@ impl NapiDb {
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        let options = jazz::db::InsertOptions {
+            row_id: Some(row),
+            identity: jazz::db::WriteIdentity::Attribution(author),
+            ..Default::default()
+        };
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.insert_with_id_attributed(author, &table, row, cells))
-                    .map_err(|e| napi::Error::from_reason(e.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.insert_with_id_attributed(author, &table, row, cells))
-                    .map_err(|e| napi::Error::from_reason(e.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let write = db
+                    .enqueue_insert(table, cells, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                core_write_memory(Rc::clone(db), write)
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let write = db
+                    .enqueue_insert(table, cells, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                core_write_persistent(Rc::clone(db), write)
+            }
         }
     }
 
@@ -1779,17 +1787,24 @@ impl NapiDb {
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        let options = jazz::db::UpdateOptions {
+            identity: jazz::db::WriteIdentity::Attribution(author),
+            ..Default::default()
+        };
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.update_attributed(author, &table, row, patch))
-                    .map_err(|e| napi::Error::from_reason(e.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.update_attributed(author, &table, row, patch))
-                    .map_err(|e| napi::Error::from_reason(e.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let write = db
+                    .enqueue_update(table, row, patch, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                core_write_memory(Rc::clone(db), write)
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let write = db
+                    .enqueue_update(table, row, patch, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                core_write_persistent(Rc::clone(db), write)
+            }
         }
     }
 
@@ -1809,17 +1824,24 @@ impl NapiDb {
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        let options = jazz::db::UpsertOptions {
+            identity: jazz::db::WriteIdentity::Attribution(author),
+            ..Default::default()
+        };
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.upsert_attributed(author, &table, row, cells))
-                    .map_err(|e| napi::Error::from_reason(e.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.upsert_attributed(author, &table, row, cells))
-                    .map_err(|e| napi::Error::from_reason(e.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let write = db
+                    .enqueue_upsert(table, row, cells, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                core_write_memory(Rc::clone(db), write)
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let write = db
+                    .enqueue_upsert(table, row, cells, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                core_write_persistent(Rc::clone(db), write)
+            }
         }
     }
 
@@ -1837,17 +1859,24 @@ impl NapiDb {
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        let options = jazz::db::DeleteOptions {
+            identity: jazz::db::WriteIdentity::Attribution(author),
+            ..Default::default()
+        };
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.delete_attributed(author, &table, row))
-                    .map_err(|e| napi::Error::from_reason(e.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.delete_attributed(author, &table, row))
-                    .map_err(|e| napi::Error::from_reason(e.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let write = db
+                    .enqueue_delete(table, row, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                core_write_memory(Rc::clone(db), write)
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let write = db
+                    .enqueue_delete(table, row, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                core_write_persistent(Rc::clone(db), write)
+            }
         }
     }
 

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1876,17 +1876,24 @@ impl NapiDb {
         let db = db
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        let options = jazz::db::RestoreOptions {
+            identity: jazz::db::WriteIdentity::Attribution(author),
+            ..Default::default()
+        };
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.restore_attributed(author, &table, row, cells))
-                    .map_err(|e| napi::Error::from_reason(e.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.restore_attributed(author, &table, row, cells))
-                    .map_err(|e| napi::Error::from_reason(e.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let write = db
+                    .enqueue_restore(table, row, Some(cells), options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                core_write_memory(Rc::clone(db), write)
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let write = db
+                    .enqueue_restore(table, row, Some(cells), options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                core_write_persistent(Rc::clone(db), write)
+            }
         }
     }
 
@@ -3550,28 +3557,29 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         match db {
-            NapiDbInnerStorage::Memory(db) => Ok(Tx {
-                db: Some(NapiDbInnerStorage::Memory(Rc::clone(db))),
-                kind: NapiTxKind::Mergeable,
-                open_tx: Some({
-                    core_block_on(db.begin_mergeable(open_transaction_id))
-                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-                    open_transaction_id
-                }),
-                owns_lifetime: true,
-                attributed: false,
-            }),
-            NapiDbInnerStorage::Persistent(db) => Ok(Tx {
-                db: Some(NapiDbInnerStorage::Persistent(Rc::clone(db))),
-                kind: NapiTxKind::Mergeable,
-                open_tx: Some({
-                    core_block_on(db.begin_mergeable(open_transaction_id))
-                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-                    open_transaction_id
-                }),
-                owns_lifetime: true,
-                attributed: false,
-            }),
+            NapiDbInnerStorage::Memory(db) => {
+                db.enqueue_begin_mergeable(open_transaction_id, None, None)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                Ok(Tx {
+                    db: Some(NapiDbInnerStorage::Memory(Rc::clone(db))),
+                    kind: NapiTxKind::Mergeable,
+                    open_tx: Some(open_transaction_id),
+                    owns_lifetime: true,
+                    attributed: false,
+                })
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                db.enqueue_begin_mergeable(open_transaction_id, None, None)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                Ok(Tx {
+                    db: Some(NapiDbInnerStorage::Persistent(Rc::clone(db))),
+                    kind: NapiTxKind::Mergeable,
+                    open_tx: Some(open_transaction_id),
+                    owns_lifetime: true,
+                    attributed: false,
+                })
+            }
         }
     }
 
@@ -3590,28 +3598,29 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         match db {
-            NapiDbInnerStorage::Memory(db) => Ok(Tx {
-                db: Some(NapiDbInnerStorage::Memory(Rc::clone(db))),
-                kind: NapiTxKind::Mergeable,
-                open_tx: Some({
-                    core_block_on(db.begin_mergeable_for_identity(open_transaction_id, author))
-                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-                    open_transaction_id
-                }),
-                owns_lifetime: true,
-                attributed: false,
-            }),
-            NapiDbInnerStorage::Persistent(db) => Ok(Tx {
-                db: Some(NapiDbInnerStorage::Persistent(Rc::clone(db))),
-                kind: NapiTxKind::Mergeable,
-                open_tx: Some({
-                    core_block_on(db.begin_mergeable_for_identity(open_transaction_id, author))
-                        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-                    open_transaction_id
-                }),
-                owns_lifetime: true,
-                attributed: false,
-            }),
+            NapiDbInnerStorage::Memory(db) => {
+                db.enqueue_begin_mergeable(open_transaction_id, Some(author), None)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                Ok(Tx {
+                    db: Some(NapiDbInnerStorage::Memory(Rc::clone(db))),
+                    kind: NapiTxKind::Mergeable,
+                    open_tx: Some(open_transaction_id),
+                    owns_lifetime: true,
+                    attributed: false,
+                })
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                db.enqueue_begin_mergeable(open_transaction_id, Some(author), None)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                Ok(Tx {
+                    db: Some(NapiDbInnerStorage::Persistent(Rc::clone(db))),
+                    kind: NapiTxKind::Mergeable,
+                    open_tx: Some(open_transaction_id),
+                    owns_lifetime: true,
+                    attributed: false,
+                })
+            }
         }
     }
 

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -4103,40 +4103,25 @@ fn finish_immediate_promise(
     let _ = unsafe { sys::napi_reject_deferred(env, deferred, rejection) };
 }
 
-fn core_commit_tx<S>(db: &CoreDb<S>, open_tx: CoreOpenTransactionId) -> napi::Result<TxId>
-where
-    S: CoreOrderedKvStorage + CoreReopenableStorage + 'static,
-{
-    core_block_on(db.commit_mergeable_handle(open_tx))
-        .map_err(|error| napi::Error::from_reason(error.to_string()))
-}
-
 fn core_commit_tx_memory(
     db: &Rc<CoreDb<CoreMemoryStorage>>,
     open_tx: CoreOpenTransactionId,
 ) -> napi::Result<Write> {
-    let tx_id = core_commit_tx(db, open_tx)?;
-    core_tx_write(
-        tx_id,
-        Some(NapiWrite::Memory {
-            db: Rc::clone(db),
-            tx_id,
-        }),
-    )
+    let write = db
+        .enqueue_commit_mergeable_handle(open_tx)
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+    db.drive_queued_mutation_once();
+    core_write_memory(Rc::clone(db), write)
 }
 
 fn core_commit_tx_persistent(
     db: &Rc<CoreDb<CoreRocksDbStorage>>,
     open_tx: CoreOpenTransactionId,
 ) -> napi::Result<Write> {
-    let tx_id = core_commit_tx(db, open_tx)?;
-    core_tx_write(
-        tx_id,
-        Some(NapiWrite::Persistent {
-            db: Rc::clone(db),
-            tx_id,
-        }),
-    )
+    let write = db
+        .enqueue_commit_mergeable_handle(open_tx)
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+    core_write_persistent(Rc::clone(db), write)
 }
 
 fn core_commit_exclusive_tx_memory(

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1612,30 +1612,19 @@ impl NapiDb {
             .map(|value| checked_u64(value, "updatedAtMs"))
             .transpose()?;
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                match updated_at_ms {
-                    Some(now_ms) => core_block_on(db.update_with_large_value_mutations_at_ms(
-                        &table, row_id, patch, mutations, now_ms,
-                    )),
-                    None => core_block_on(
-                        db.update_with_large_value_mutations(&table, row_id, patch, mutations),
-                    ),
-                }
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                match updated_at_ms {
-                    Some(now_ms) => core_block_on(db.update_with_large_value_mutations_at_ms(
-                        &table, row_id, patch, mutations, now_ms,
-                    )),
-                    None => core_block_on(
-                        db.update_with_large_value_mutations(&table, row_id, patch, mutations),
-                    ),
-                }
-                .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let write = db
+                    .enqueue_large_value_update(table, row_id, patch, mutations, updated_at_ms)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                core_write_memory(Rc::clone(db), write)
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let write = db
+                    .enqueue_large_value_update(table, row_id, patch, mutations, updated_at_ms)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                core_write_persistent(Rc::clone(db), write)
+            }
         }
     }
 

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1346,10 +1346,13 @@ fn abandon_transaction_handle(
     open_tx: CoreOpenTransactionId,
 ) -> napi::Result<()> {
     match db {
-        NapiDbInnerStorage::Memory(db) => db.abandon_transaction_handle(open_tx),
-        NapiDbInnerStorage::Persistent(db) => db.abandon_transaction_handle(open_tx),
+        NapiDbInnerStorage::Memory(db) => {
+            db.enqueue_abandon_transaction_handle(open_tx);
+            db.drive_queued_mutation_once();
+        }
+        NapiDbInnerStorage::Persistent(db) => db.enqueue_abandon_transaction_handle(open_tx),
     }
-    .map_err(|error| napi::Error::from_reason(error.to_string()))
+    Ok(())
 }
 
 #[napi(js_name = "NapiDb")]

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1124,7 +1124,9 @@ impl Tx {
             .ok_or_else(|| napi::Error::from_reason("transaction is closed"))?;
         let row_id = match db {
             NapiDbInnerStorage::Memory(db) => {
-                db.enqueue_transaction_insert(open_tx, exclusive, table, cells, options)
+                let row = db.enqueue_transaction_insert(open_tx, exclusive, table, cells, options);
+                db.drive_queued_mutation_once();
+                row
             }
             NapiDbInnerStorage::Persistent(db) => {
                 db.enqueue_transaction_insert(open_tx, exclusive, table, cells, options)
@@ -1153,7 +1155,8 @@ impl Tx {
         let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
         match self.db.as_ref() {
             Some(NapiDbInnerStorage::Memory(db)) => {
-                db.enqueue_transaction_update(open_tx, exclusive, table, row_id, patch, options)
+                db.enqueue_transaction_update(open_tx, exclusive, table, row_id, patch, options);
+                db.drive_queued_mutation_once();
             }
             Some(NapiDbInnerStorage::Persistent(db)) => {
                 db.enqueue_transaction_update(open_tx, exclusive, table, row_id, patch, options)
@@ -1184,7 +1187,8 @@ impl Tx {
         let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
         match self.db.as_ref() {
             Some(NapiDbInnerStorage::Memory(db)) => {
-                db.enqueue_transaction_upsert(open_tx, exclusive, table, row_id, cells, options)
+                db.enqueue_transaction_upsert(open_tx, exclusive, table, row_id, cells, options);
+                db.drive_queued_mutation_once();
             }
             Some(NapiDbInnerStorage::Persistent(db)) => {
                 db.enqueue_transaction_upsert(open_tx, exclusive, table, row_id, cells, options)
@@ -1212,7 +1216,8 @@ impl Tx {
         let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
         match self.db.as_ref() {
             Some(NapiDbInnerStorage::Memory(db)) => {
-                db.enqueue_transaction_delete(open_tx, exclusive, table, row_id, options)
+                db.enqueue_transaction_delete(open_tx, exclusive, table, row_id, options);
+                db.drive_queued_mutation_once();
             }
             Some(NapiDbInnerStorage::Persistent(db)) => {
                 db.enqueue_transaction_delete(open_tx, exclusive, table, row_id, options)
@@ -1243,7 +1248,8 @@ impl Tx {
         let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
         match self.db.as_ref() {
             Some(NapiDbInnerStorage::Memory(db)) => {
-                db.enqueue_transaction_restore(open_tx, exclusive, table, row_id, cells, options)
+                db.enqueue_transaction_restore(open_tx, exclusive, table, row_id, cells, options);
+                db.drive_queued_mutation_once();
             }
             Some(NapiDbInnerStorage::Persistent(db)) => {
                 db.enqueue_transaction_restore(open_tx, exclusive, table, row_id, cells, options)

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1533,16 +1533,19 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.insert(&table, cells, options))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.insert(&table, cells, options))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let write = db
+                    .enqueue_insert(table, cells, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                core_write_memory(Rc::clone(db), write)
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let write = db
+                    .enqueue_insert(table, cells, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                core_write_persistent(Rc::clone(db), write)
+            }
         }
     }
 
@@ -1562,16 +1565,19 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.update(&table, row_id, patch, options))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.update(&table, row_id, patch, options))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let write = db
+                    .enqueue_update(table, row_id, patch, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                core_write_memory(Rc::clone(db), write)
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let write = db
+                    .enqueue_update(table, row_id, patch, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                core_write_persistent(Rc::clone(db), write)
+            }
         }
     }
 
@@ -1649,16 +1655,19 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.upsert(&table, row_id, cells, options))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.upsert(&table, row_id, cells, options))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let write = db
+                    .enqueue_upsert(table, row_id, cells, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                core_write_memory(Rc::clone(db), write)
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let write = db
+                    .enqueue_upsert(table, row_id, cells, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                core_write_persistent(Rc::clone(db), write)
+            }
         }
     }
 
@@ -1676,16 +1685,19 @@ impl NapiDb {
             .as_ref()
             .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
         match db {
-            NapiDbInnerStorage::Memory(db) => core_write_memory(
-                Rc::clone(db),
-                core_block_on(db.delete(&table, row_id, options))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
-            NapiDbInnerStorage::Persistent(db) => core_write_persistent(
-                Rc::clone(db),
-                core_block_on(db.delete(&table, row_id, options))
-                    .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-            ),
+            NapiDbInnerStorage::Memory(db) => {
+                let write = db
+                    .enqueue_delete(table, row_id, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                db.drive_queued_mutation_once();
+                core_write_memory(Rc::clone(db), write)
+            }
+            NapiDbInnerStorage::Persistent(db) => {
+                let write = db
+                    .enqueue_delete(table, row_id, options)
+                    .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+                core_write_persistent(Rc::clone(db), write)
+            }
         }
     }
 

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1124,13 +1124,15 @@ impl Tx {
             .ok_or_else(|| napi::Error::from_reason("transaction is closed"))?;
         let row_id = match db {
             NapiDbInnerStorage::Memory(db) => {
-                let row = db.enqueue_transaction_insert(open_tx, exclusive, table, cells, options);
+                let row = db
+                    .enqueue_transaction_insert(open_tx, exclusive, table, cells, options)
+                    .map_err(napi_error)?;
                 db.drive_queued_mutation_once();
                 row
             }
-            NapiDbInnerStorage::Persistent(db) => {
-                db.enqueue_transaction_insert(open_tx, exclusive, table, cells, options)
-            }
+            NapiDbInnerStorage::Persistent(db) => db
+                .enqueue_transaction_insert(open_tx, exclusive, table, cells, options)
+                .map_err(napi_error)?,
         };
         Ok(Uint8Array::new(row_id.to_bytes()))
     }
@@ -1155,11 +1157,13 @@ impl Tx {
         let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
         match self.db.as_ref() {
             Some(NapiDbInnerStorage::Memory(db)) => {
-                db.enqueue_transaction_update(open_tx, exclusive, table, row_id, patch, options);
+                db.enqueue_transaction_update(open_tx, exclusive, table, row_id, patch, options)
+                    .map_err(napi_error)?;
                 db.drive_queued_mutation_once();
             }
             Some(NapiDbInnerStorage::Persistent(db)) => {
                 db.enqueue_transaction_update(open_tx, exclusive, table, row_id, patch, options)
+                    .map_err(napi_error)?;
             }
             None => return Err(napi::Error::from_reason("transaction is closed")),
         }
@@ -1187,11 +1191,13 @@ impl Tx {
         let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
         match self.db.as_ref() {
             Some(NapiDbInnerStorage::Memory(db)) => {
-                db.enqueue_transaction_upsert(open_tx, exclusive, table, row_id, cells, options);
+                db.enqueue_transaction_upsert(open_tx, exclusive, table, row_id, cells, options)
+                    .map_err(napi_error)?;
                 db.drive_queued_mutation_once();
             }
             Some(NapiDbInnerStorage::Persistent(db)) => {
                 db.enqueue_transaction_upsert(open_tx, exclusive, table, row_id, cells, options)
+                    .map_err(napi_error)?;
             }
             None => return Err(napi::Error::from_reason("transaction is closed")),
         }
@@ -1216,11 +1222,13 @@ impl Tx {
         let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
         match self.db.as_ref() {
             Some(NapiDbInnerStorage::Memory(db)) => {
-                db.enqueue_transaction_delete(open_tx, exclusive, table, row_id, options);
+                db.enqueue_transaction_delete(open_tx, exclusive, table, row_id, options)
+                    .map_err(napi_error)?;
                 db.drive_queued_mutation_once();
             }
             Some(NapiDbInnerStorage::Persistent(db)) => {
                 db.enqueue_transaction_delete(open_tx, exclusive, table, row_id, options)
+                    .map_err(napi_error)?;
             }
             None => return Err(napi::Error::from_reason("transaction is closed")),
         }
@@ -1248,11 +1256,13 @@ impl Tx {
         let exclusive = matches!(self.kind, NapiTxKind::Exclusive);
         match self.db.as_ref() {
             Some(NapiDbInnerStorage::Memory(db)) => {
-                db.enqueue_transaction_restore(open_tx, exclusive, table, row_id, cells, options);
+                db.enqueue_transaction_restore(open_tx, exclusive, table, row_id, cells, options)
+                    .map_err(napi_error)?;
                 db.drive_queued_mutation_once();
             }
             Some(NapiDbInnerStorage::Persistent(db)) => {
                 db.enqueue_transaction_restore(open_tx, exclusive, table, row_id, cells, options)
+                    .map_err(napi_error)?;
             }
             None => return Err(napi::Error::from_reason("transaction is closed")),
         }
@@ -2296,8 +2306,7 @@ impl NapiDb {
                 let result = if kind == "mergeable" {
                     $db.enqueue_begin_mergeable(open_transaction_id, author, attribution)
                 } else {
-                    $db.enqueue_begin_exclusive(open_transaction_id, author);
-                    Ok(())
+                    $db.enqueue_begin_exclusive(open_transaction_id, author)
                 };
                 if result.is_ok() && $drive {
                     $db.drive_queued_mutation_once();

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -3994,20 +3994,6 @@ fn core_claim_value_from_json(value: JsonValue) -> napi::Result<CoreValue> {
     })
 }
 
-fn core_tx_write(tx_id: TxId, inner: Option<NapiWrite>) -> napi::Result<Write> {
-    let result = WriteResult {
-        row_id: CoreRowUuid::from_bytes([0; 16]),
-        tx_id,
-    };
-    Ok(Write {
-        payload: postcard::to_allocvec(&result)
-            .map_err(|error| napi::Error::from_reason(error.to_string()))?,
-        row_id: result.row_id,
-        tx_id: TransactionId::from_committed_tx(tx_id),
-        inner,
-    })
-}
-
 fn core_tick_connection<S>(
     connection: &Option<Rc<LocalMutex<CorePeerConnection<S>>>>,
 ) -> napi::Result<u32>
@@ -4128,30 +4114,21 @@ fn core_commit_exclusive_tx_memory(
     db: &Rc<CoreDb<CoreMemoryStorage>>,
     open_tx: CoreOpenTransactionId,
 ) -> napi::Result<Write> {
-    let tx_id = core_block_on(db.commit_exclusive_handle(open_tx))
+    let write = db
+        .enqueue_commit_exclusive_handle(open_tx)
         .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-    core_tx_write(
-        tx_id,
-        Some(NapiWrite::Memory {
-            db: Rc::clone(db),
-            tx_id,
-        }),
-    )
+    db.drive_queued_mutation_once();
+    core_write_memory(Rc::clone(db), write)
 }
 
 fn core_commit_exclusive_tx_persistent(
     db: &Rc<CoreDb<CoreRocksDbStorage>>,
     open_tx: CoreOpenTransactionId,
 ) -> napi::Result<Write> {
-    let tx_id = core_block_on(db.commit_exclusive_handle(open_tx))
+    let write = db
+        .enqueue_commit_exclusive_handle(open_tx)
         .map_err(|error| napi::Error::from_reason(error.to_string()))?;
-    core_tx_write(
-        tx_id,
-        Some(NapiWrite::Persistent {
-            db: Rc::clone(db),
-            tx_id,
-        }),
-    )
+    core_write_persistent(Rc::clone(db), write)
 }
 
 fn core_read_opts_from_json(value: Option<JsonValue>) -> napi::Result<CoreReadOpts> {

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -3633,7 +3633,7 @@ impl NapiDb {
         }
     }
 
-    #[napi]
+    #[napi(js_name = "__closePollable")]
     pub fn close(&self) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
         let inner = self.inner.borrow_mut().take();
         let owns_runtime = self.owns_runtime;

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -3641,20 +3641,41 @@ impl NapiDb {
             if owns_runtime && let Some(inner) = inner {
                 match inner {
                     NapiDbInnerStorage::Memory(db) => {
-                        db.close().await.map_err(napi_error)?;
-                        db.set_tick_scheduler(None);
-                        db.clear_mutation_error_callback();
+                        close_owned_napi_runtime(db).await?;
                     }
                     NapiDbInnerStorage::Persistent(db) => {
-                        db.close().await.map_err(napi_error)?;
-                        db.set_tick_scheduler(None);
-                        db.clear_mutation_error_callback();
+                        close_owned_napi_runtime(db).await?;
                     }
                 }
             }
             Ok(Uint8Array::new(Vec::new()))
         }))
     }
+}
+
+async fn close_owned_napi_runtime<S>(db: Rc<CoreDb<S>>) -> napi::Result<()>
+where
+    S: CoreOrderedKvStorage + CoreReopenableStorage + 'static,
+{
+    let cleanup_db = Rc::clone(&db);
+    close_after_cleanup(
+        move || {
+            cleanup_db.set_tick_scheduler(None);
+            cleanup_db.clear_mutation_error_callback();
+        },
+        async move { db.close().await.map_err(napi_error) },
+    )
+    .await
+}
+
+async fn close_after_cleanup<F>(cleanup: impl FnOnce(), close: F) -> napi::Result<()>
+where
+    F: Future<Output = napi::Result<()>>,
+{
+    // JS resources must not remain retained merely because durable close
+    // fails. Detach them before entering the fallible storage lifecycle.
+    cleanup();
+    close.await
 }
 
 fn unknown_transaction_kind_message(kind: &str) -> String {
@@ -4979,12 +5000,37 @@ mod tests {
         NapiDb, NapiDbInnerStorage, NapiTxKind, PendingNativeRead, PendingNativeSubscriptionBatch,
         PendingSubscriptionBatchOutcome, PendingSubscriptionBatchPoll, PreparedQuery,
         RestoreOptions, Tx, UpdateOptions, UpsertOptions, authority_epoch_from_bigint,
-        core_author_id_from_bytes, core_block_on, core_claim_value_from_json, core_insert_options,
-        core_open_backend_identity, core_open_identity, core_read_opts_from_json,
-        core_read_tier_from_str, core_restore_options, core_subscription_event_to_napi,
-        core_update_options, core_upsert_options, encode_core_subscription_delta,
-        requeue_retryable_subscription_batch, unknown_transaction_kind_message,
+        close_after_cleanup, core_author_id_from_bytes, core_block_on, core_claim_value_from_json,
+        core_insert_options, core_open_backend_identity, core_open_identity,
+        core_read_opts_from_json, core_read_tier_from_str, core_restore_options,
+        core_subscription_event_to_napi, core_update_options, core_upsert_options,
+        encode_core_subscription_delta, requeue_retryable_subscription_batch,
+        unknown_transaction_kind_message,
     };
+
+    #[test]
+    fn failing_close_releases_scheduler_and_mutation_callback() {
+        let scheduler = Rc::new(());
+        let scheduler_weak = Rc::downgrade(&scheduler);
+        let callback = Rc::new(());
+        let callback_weak = Rc::downgrade(&callback);
+        let result = core_block_on(close_after_cleanup(
+            move || {
+                drop(scheduler);
+                drop(callback);
+            },
+            async { Err(napi::Error::from_reason("injected close failure")) },
+        ));
+        assert!(result.is_err());
+        assert!(
+            scheduler_weak.upgrade().is_none(),
+            "a failed storage close must not retain the JS scheduler"
+        );
+        assert!(
+            callback_weak.upgrade().is_none(),
+            "a failed storage close must not retain the JS mutation callback"
+        );
+    }
 
     fn encode_persistent_open_config(author: CoreAuthorSubject) -> Vec<u8> {
         #[derive(serde::Serialize)]

--- a/crates/jazz-napi/tests/close-pollable.test.cjs
+++ b/crates/jazz-napi/tests/close-pollable.test.cjs
@@ -1,0 +1,22 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { completePollableClose } = require("../close-pollable.cjs");
+
+test("a cold native close remains owned until its pollable operation completes", async () => {
+  let polls = 0;
+  let settled = false;
+  const close = completePollableClose({
+    poll() {
+      polls += 1;
+      return polls < 3 ? null : new Uint8Array();
+    },
+  }).then(() => {
+    settled = true;
+  });
+
+  await Promise.resolve();
+  assert.equal(settled, false);
+  await close;
+  assert.equal(polls, 3);
+  assert.equal(settled, true);
+});

--- a/crates/jazz-napi/tests/types/package-consumer.ts
+++ b/crates/jazz-napi/tests/types/package-consumer.ts
@@ -10,3 +10,5 @@ declare const db: NapiDb;
 declare const encodedRow: Uint8Array;
 
 db.insertEncoded("documents", encodedRow, { branch });
+const closeResult: Promise<undefined> = db.close();
+void closeResult;

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -827,9 +827,25 @@ impl WasmDbInner {
         id: OpenTransactionId,
         author: Option<AuthorSubject>,
     ) -> Result<(), jazz::db::Error> {
+        match self {
+            Self::Memory(db) => match author {
+                Some(author) => try_ready(db.begin_exclusive_for_identity(id, author)),
+                None => try_ready(db.begin_exclusive(id)),
+            },
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(_) => Err(jazz::db::Error::cold_mutation_requires_async()),
+            Self::Closed => panic!("WasmDb is closed"),
+        }
+    }
+
+    async fn begin_exclusive_async(
+        &self,
+        id: OpenTransactionId,
+        author: Option<AuthorSubject>,
+    ) -> Result<(), jazz::db::Error> {
         with_wasm_db!(self, |db| match author {
-            Some(author) => block_on(db.begin_exclusive_for_identity(id, author)),
-            None => block_on(db.begin_exclusive(id)),
+            Some(author) => db.begin_exclusive_for_identity(id, author).await,
+            None => db.begin_exclusive(id).await,
         })
     }
 
@@ -899,7 +915,19 @@ impl WasmDbInner {
     }
 
     fn commit_exclusive(&self, tx_id: OpenTransactionId) -> Result<TxId, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(db.commit_exclusive_handle(tx_id)))
+        match self {
+            Self::Memory(db) => try_ready(db.commit_exclusive_handle(tx_id)),
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(_) => Err(jazz::db::Error::cold_mutation_requires_async()),
+            Self::Closed => panic!("WasmDb is closed"),
+        }
+    }
+
+    async fn commit_exclusive_async(
+        &self,
+        tx_id: OpenTransactionId,
+    ) -> Result<TxId, jazz::db::Error> {
+        with_wasm_db!(self, |db| db.commit_exclusive_handle(tx_id).await)
     }
 
     fn commit_mergeable(&self, tx_id: OpenTransactionId) -> Result<TxId, jazz::db::Error> {
@@ -1725,6 +1753,34 @@ impl WasmDb {
         }
     }
 
+    /// Persistent-owner transaction admission. Unlike `beginTransaction`,
+    /// this retains cold storage work until the transaction is actually open.
+    #[wasm_bindgen(js_name = beginTransactionAsync)]
+    pub fn begin_transaction_async(
+        &self,
+        open_transaction_id: String,
+        kind: String,
+        author: Option<Vec<u8>>,
+    ) -> Result<js_sys::Promise, JsValue> {
+        let open_transaction_id = open_transaction_id
+            .parse::<OpenTransactionId>()
+            .map_err(|error| JsValue::from_str(&error))?;
+        let author = author.as_deref().map(author_id_from_bytes).transpose()?;
+        if kind != "exclusive" {
+            return Err(JsValue::from_str(
+                "beginTransactionAsync currently owns only cold-capable exclusive admission",
+            ));
+        }
+        let inner = self.inner.clone();
+        Ok(future_to_promise(async move {
+            inner
+                .begin_exclusive_async(open_transaction_id, author)
+                .await
+                .map_err(to_js_error)?;
+            Ok(JsValue::UNDEFINED)
+        }))
+    }
+
     /// Begin the only supported attributed transaction shape.  It is distinct
     /// from `beginTransaction` so an older binding fails closed rather than
     /// silently converting external provenance into SYSTEM authorship.
@@ -1786,6 +1842,44 @@ impl WasmDb {
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
+    }
+
+    /// Persistent-owner exclusive commit. The promise owns admission,
+    /// publication and finalization across all storage wakes.
+    #[wasm_bindgen(js_name = commitExclusiveTransactionAsync)]
+    pub fn commit_exclusive_transaction_async(
+        &self,
+        open_transaction_id: String,
+    ) -> Result<js_sys::Promise, JsValue> {
+        let open_transaction_id = open_transaction_id
+            .parse::<OpenTransactionId>()
+            .map_err(|error| JsValue::from_str(&error))?;
+        let inner = self.inner.clone();
+        Ok(future_to_promise(async move {
+            let tx_id = inner
+                .commit_exclusive_async(open_transaction_id)
+                .await
+                .map_err(to_js_error)?;
+            let write = match &inner {
+                WasmDbInner::Memory(db) => wasm_tx_write(
+                    tx_id,
+                    Some(WasmWriteInner::MemoryTx {
+                        db: Rc::clone(db),
+                        tx_id,
+                    }),
+                ),
+                #[cfg(target_arch = "wasm32")]
+                WasmDbInner::Browser(db) => wasm_tx_write(
+                    tx_id,
+                    Some(WasmWriteInner::BrowserTx {
+                        db: Rc::clone(db),
+                        tx_id,
+                    }),
+                ),
+                WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
+            }?;
+            Ok(write.into())
+        }))
     }
 
     /// Roll back an owner-wide open transaction by id.
@@ -3111,6 +3205,34 @@ impl WasmTx {
         Ok(row.to_bytes())
     }
 
+    #[wasm_bindgen(js_name = insertEncodedAsync)]
+    pub fn insert_encoded_async(
+        &self,
+        table: String,
+        cells: Vec<u8>,
+        options: JsValue,
+    ) -> Result<js_sys::Promise, JsValue> {
+        let cells = decode_cells(&cells)?;
+        let options = insert_options_from_js(options)?;
+        let open_tx = self.open_tx_for_read()?;
+        let db = self.db.clone();
+        let kind = self.kind;
+        Ok(future_to_promise(async move {
+            let row = with_wasm_db!(&db, |db| match kind {
+                WasmTxKind::Mergeable =>
+                    db.mergeable_tx_ref(open_tx)
+                        .insert(&table, cells, options)
+                        .await,
+                WasmTxKind::Exclusive =>
+                    db.exclusive_tx_ref(open_tx)
+                        .insert(&table, cells, options)
+                        .await,
+            })
+            .map_err(to_js_error)?;
+            Ok(js_sys::Uint8Array::from(row.to_bytes().as_slice()).into())
+        }))
+    }
+
     #[wasm_bindgen(js_name = updateEncoded)]
     pub fn update_encoded_with_options(
         &mut self,
@@ -3134,6 +3256,36 @@ impl WasmTx {
             ),
         })
         .map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = updateEncodedAsync)]
+    pub fn update_encoded_async(
+        &self,
+        table: String,
+        row_id: Vec<u8>,
+        patch: Vec<u8>,
+        options: JsValue,
+    ) -> Result<js_sys::Promise, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let patch = decode_cells(&patch)?;
+        let options = update_options_from_js(options)?;
+        let open_tx = self.open_tx_for_read()?;
+        let db = self.db.clone();
+        let kind = self.kind;
+        Ok(future_to_promise(async move {
+            with_wasm_db!(&db, |db| match kind {
+                WasmTxKind::Mergeable =>
+                    db.mergeable_tx_ref(open_tx)
+                        .update(&table, row_id, patch, options)
+                        .await,
+                WasmTxKind::Exclusive =>
+                    db.exclusive_tx_ref(open_tx)
+                        .update(&table, row_id, patch, options)
+                        .await,
+            })
+            .map_err(to_js_error)?;
+            Ok(JsValue::UNDEFINED)
+        }))
     }
 
     #[wasm_bindgen(js_name = upsertEncoded)]
@@ -3161,6 +3313,36 @@ impl WasmTx {
         .map_err(to_js_error)
     }
 
+    #[wasm_bindgen(js_name = upsertEncodedAsync)]
+    pub fn upsert_encoded_async(
+        &self,
+        table: String,
+        row_id: Vec<u8>,
+        cells: Vec<u8>,
+        options: JsValue,
+    ) -> Result<js_sys::Promise, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let cells = decode_cells(&cells)?;
+        let options = upsert_options_from_js(options)?;
+        let open_tx = self.open_tx_for_read()?;
+        let db = self.db.clone();
+        let kind = self.kind;
+        Ok(future_to_promise(async move {
+            with_wasm_db!(&db, |db| match kind {
+                WasmTxKind::Mergeable =>
+                    db.mergeable_tx_ref(open_tx)
+                        .upsert(&table, row_id, cells, options)
+                        .await,
+                WasmTxKind::Exclusive =>
+                    db.exclusive_tx_ref(open_tx)
+                        .upsert(&table, row_id, cells, options)
+                        .await,
+            })
+            .map_err(to_js_error)?;
+            Ok(JsValue::UNDEFINED)
+        }))
+    }
+
     #[wasm_bindgen(js_name = deleteEncoded)]
     pub fn delete_encoded_with_options(
         &mut self,
@@ -3180,6 +3362,34 @@ impl WasmTx {
             }
         })
         .map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = deleteEncodedAsync)]
+    pub fn delete_encoded_async(
+        &self,
+        table: String,
+        row_id: Vec<u8>,
+        options: JsValue,
+    ) -> Result<js_sys::Promise, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let options = delete_options_from_js(options)?;
+        let open_tx = self.open_tx_for_read()?;
+        let db = self.db.clone();
+        let kind = self.kind;
+        Ok(future_to_promise(async move {
+            with_wasm_db!(&db, |db| match kind {
+                WasmTxKind::Mergeable =>
+                    db.mergeable_tx_ref(open_tx)
+                        .delete(&table, row_id, options)
+                        .await,
+                WasmTxKind::Exclusive =>
+                    db.exclusive_tx_ref(open_tx)
+                        .delete(&table, row_id, options)
+                        .await,
+            })
+            .map_err(to_js_error)?;
+            Ok(JsValue::UNDEFINED)
+        }))
     }
 
     #[wasm_bindgen(js_name = restoreEncoded)]

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -902,8 +902,23 @@ impl WasmDbInner {
         with_wasm_db!(self, |db| block_on(db.commit_exclusive_handle(tx_id)))
     }
 
-    fn commit_mergeable(&self, tx_id: OpenTransactionId) -> Result<TxId, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(db.commit_mergeable_handle(tx_id)))
+    fn commit_mergeable(&self, open_tx_id: OpenTransactionId) -> Result<WasmWrite, JsValue> {
+        match self {
+            Self::Memory(db) => {
+                let write = db
+                    .enqueue_commit_mergeable_handle(open_tx_id)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => wasm_write_browser(
+                Rc::clone(db),
+                db.enqueue_commit_mergeable_handle(open_tx_id)
+                    .map_err(to_js_error)?,
+            ),
+            Self::Closed => Err(JsValue::from_str("WasmDb is closed")),
+        }
     }
 
     async fn all_relation_snapshot(
@@ -1682,8 +1697,10 @@ impl WasmDb {
         let open_transaction_id = open_transaction_id
             .parse::<OpenTransactionId>()
             .map_err(|error| JsValue::from_str(&error))?;
+        if kind.as_deref().unwrap_or("mergeable") == "mergeable" {
+            return self.inner.commit_mergeable(open_transaction_id);
+        }
         let tx_id = match kind.as_deref().unwrap_or("mergeable") {
-            "mergeable" => self.inner.commit_mergeable(open_transaction_id),
             "exclusive" => self.inner.commit_exclusive(open_transaction_id),
             kind => return Err(JsValue::from_str(&unknown_transaction_kind_message(kind))),
         }
@@ -3134,14 +3151,8 @@ impl WasmTx {
         let open_tx = self.open_tx_for_read()?;
         let write = match (&self.db, self.kind) {
             (WasmDbInner::Memory(db), WasmTxKind::Mergeable) => {
-                let tx_id = self.db.commit_mergeable(open_tx).map_err(to_js_error)?;
-                wasm_tx_write(
-                    tx_id,
-                    Some(WasmWriteInner::MemoryTx {
-                        db: Rc::clone(db),
-                        tx_id,
-                    }),
-                )
+                let _ = db;
+                self.db.commit_mergeable(open_tx)
             }
             (WasmDbInner::Memory(db), WasmTxKind::Exclusive) => {
                 let tx_id = self.db.commit_exclusive(open_tx).map_err(to_js_error)?;
@@ -3155,14 +3166,8 @@ impl WasmTx {
             }
             #[cfg(target_arch = "wasm32")]
             (WasmDbInner::Browser(db), WasmTxKind::Mergeable) => {
-                let tx_id = self.db.commit_mergeable(open_tx).map_err(to_js_error)?;
-                wasm_tx_write(
-                    tx_id,
-                    Some(WasmWriteInner::BrowserTx {
-                        db: Rc::clone(db),
-                        tx_id,
-                    }),
-                )
+                let _ = db;
+                self.db.commit_mergeable(open_tx)
             }
             #[cfg(target_arch = "wasm32")]
             (WasmDbInner::Browser(db), WasmTxKind::Exclusive) => {

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -829,13 +829,13 @@ impl WasmDbInner {
     ) -> Result<(), jazz::db::Error> {
         match self {
             Self::Memory(db) => {
-                db.enqueue_begin_exclusive(id, author);
+                db.enqueue_begin_exclusive(id, author)?;
                 db.drive_queued_mutation_once();
                 Ok(())
             }
             #[cfg(target_arch = "wasm32")]
             Self::Browser(db) => {
-                db.enqueue_begin_exclusive(id, author);
+                db.enqueue_begin_exclusive(id, author)?;
                 Ok(())
             }
             Self::Closed => panic!("WasmDb is closed"),
@@ -3070,7 +3070,8 @@ impl WasmTx {
             table,
             cells,
             options,
-        ));
+        ))
+        .map_err(to_js_error)?;
         if let WasmDbInner::Memory(db) = &self.db {
             db.drive_queued_mutation_once();
         }
@@ -3096,7 +3097,8 @@ impl WasmTx {
             row_id,
             patch,
             options,
-        ));
+        ))
+        .map_err(to_js_error)?;
         if let WasmDbInner::Memory(db) = &self.db {
             db.drive_queued_mutation_once();
         }
@@ -3122,7 +3124,8 @@ impl WasmTx {
             row_id,
             cells,
             options,
-        ));
+        ))
+        .map_err(to_js_error)?;
         if let WasmDbInner::Memory(db) = &self.db {
             db.drive_queued_mutation_once();
         }
@@ -3145,7 +3148,8 @@ impl WasmTx {
             table,
             row_id,
             options,
-        ));
+        ))
+        .map_err(to_js_error)?;
         if let WasmDbInner::Memory(db) = &self.db {
             db.drive_queued_mutation_once();
         }
@@ -3171,7 +3175,8 @@ impl WasmTx {
             row_id,
             Some(cells),
             options,
-        ));
+        ))
+        .map_err(to_js_error)?;
         if let WasmDbInner::Memory(db) = &self.db {
             db.drive_queued_mutation_once();
         }

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -18,7 +18,7 @@ use futures_util::{Stream, StreamExt};
 #[cfg(target_arch = "wasm32")]
 use idb_tree::IndexedDbPageStore;
 use jazz::db::{
-    block_on, try_ready, ConnectionSessionContext, Db, DbConfig, DbIdentity, ExclusiveTxOps,
+    block_on, ConnectionSessionContext, Db, DbConfig, DbIdentity, ExclusiveTxOps,
     InitialSyncFlushCadence, LargeValueUpdate, LocalUpdates, MergeableTxOps, MutationErrorCallback,
     PeerConnection, PermissionAdvice, PreparedQuery, Propagation, QueryAttachment, ReadOpts,
     RowCells, SeededRowIdSource, StreamingMutationKind, StreamingValueUpload, SubscriptionEvent,
@@ -827,25 +827,9 @@ impl WasmDbInner {
         id: OpenTransactionId,
         author: Option<AuthorSubject>,
     ) -> Result<(), jazz::db::Error> {
-        match self {
-            Self::Memory(db) => match author {
-                Some(author) => try_ready(db.begin_exclusive_for_identity(id, author)),
-                None => try_ready(db.begin_exclusive(id)),
-            },
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(_) => Err(jazz::db::Error::cold_mutation_requires_async()),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    async fn begin_exclusive_async(
-        &self,
-        id: OpenTransactionId,
-        author: Option<AuthorSubject>,
-    ) -> Result<(), jazz::db::Error> {
         with_wasm_db!(self, |db| match author {
-            Some(author) => db.begin_exclusive_for_identity(id, author).await,
-            None => db.begin_exclusive(id).await,
+            Some(author) => block_on(db.begin_exclusive_for_identity(id, author)),
+            None => block_on(db.begin_exclusive(id)),
         })
     }
 
@@ -915,19 +899,7 @@ impl WasmDbInner {
     }
 
     fn commit_exclusive(&self, tx_id: OpenTransactionId) -> Result<TxId, jazz::db::Error> {
-        match self {
-            Self::Memory(db) => try_ready(db.commit_exclusive_handle(tx_id)),
-            #[cfg(target_arch = "wasm32")]
-            Self::Browser(_) => Err(jazz::db::Error::cold_mutation_requires_async()),
-            Self::Closed => panic!("WasmDb is closed"),
-        }
-    }
-
-    async fn commit_exclusive_async(
-        &self,
-        tx_id: OpenTransactionId,
-    ) -> Result<TxId, jazz::db::Error> {
-        with_wasm_db!(self, |db| db.commit_exclusive_handle(tx_id).await)
+        with_wasm_db!(self, |db| block_on(db.commit_exclusive_handle(tx_id)))
     }
 
     fn commit_mergeable(&self, tx_id: OpenTransactionId) -> Result<TxId, jazz::db::Error> {
@@ -1133,45 +1105,15 @@ impl WasmDb {
         match &self.inner {
             WasmDbInner::Memory(db) => wasm_write_memory(
                 Rc::clone(db),
-                try_ready(db.insert(&table, cells, options)).map_err(to_js_error)?,
+                block_on(db.insert(&table, cells, options)).map_err(to_js_error)?,
             ),
             #[cfg(target_arch = "wasm32")]
-            WasmDbInner::Browser(_) => Err(cold_mutation_requires_async()),
+            WasmDbInner::Browser(db) => wasm_write_browser(
+                Rc::clone(db),
+                block_on(db.insert(&table, cells, options)).map_err(to_js_error)?,
+            ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
-    }
-
-    /// Owner-driven insert for persistent browser storage. The returned
-    /// promise retains the exact Core future across every storage wake.
-    #[wasm_bindgen(js_name = insertEncodedAsync)]
-    pub fn insert_encoded_async(
-        &self,
-        table: String,
-        cells: Vec<u8>,
-        options: JsValue,
-    ) -> Result<js_sys::Promise, JsValue> {
-        let cells = decode_cells(&cells)?;
-        let options = insert_options_from_js(options)?;
-        let inner = self.inner.clone();
-        Ok(future_to_promise(async move {
-            let write = match &inner {
-                WasmDbInner::Memory(db) => wasm_write_memory(
-                    Rc::clone(db),
-                    db.insert(&table, cells, options)
-                        .await
-                        .map_err(to_js_error)?,
-                ),
-                #[cfg(target_arch = "wasm32")]
-                WasmDbInner::Browser(db) => wasm_write_browser(
-                    Rc::clone(db),
-                    db.insert(&table, cells, options)
-                        .await
-                        .map_err(to_js_error)?,
-                ),
-                WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
-            }?;
-            Ok(write.into())
-        }))
     }
 
     #[wasm_bindgen(js_name = updateEncoded)]
@@ -1188,45 +1130,15 @@ impl WasmDb {
         match &self.inner {
             WasmDbInner::Memory(db) => wasm_write_memory(
                 Rc::clone(db),
-                try_ready(db.update(&table, row_id, patch, options)).map_err(to_js_error)?,
+                block_on(db.update(&table, row_id, patch, options)).map_err(to_js_error)?,
             ),
             #[cfg(target_arch = "wasm32")]
-            WasmDbInner::Browser(_) => Err(cold_mutation_requires_async()),
+            WasmDbInner::Browser(db) => wasm_write_browser(
+                Rc::clone(db),
+                block_on(db.update(&table, row_id, patch, options)).map_err(to_js_error)?,
+            ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
-    }
-
-    #[wasm_bindgen(js_name = updateEncodedAsync)]
-    pub fn update_encoded_async(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        patch: Vec<u8>,
-        options: JsValue,
-    ) -> Result<js_sys::Promise, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let patch = decode_cells(&patch)?;
-        let options = update_options_from_js(options)?;
-        let inner = self.inner.clone();
-        Ok(future_to_promise(async move {
-            let write = match &inner {
-                WasmDbInner::Memory(db) => wasm_write_memory(
-                    Rc::clone(db),
-                    db.update(&table, row_id, patch, options)
-                        .await
-                        .map_err(to_js_error)?,
-                ),
-                #[cfg(target_arch = "wasm32")]
-                WasmDbInner::Browser(db) => wasm_write_browser(
-                    Rc::clone(db),
-                    db.update(&table, row_id, patch, options)
-                        .await
-                        .map_err(to_js_error)?,
-                ),
-                WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
-            }?;
-            Ok(write.into())
-        }))
     }
 
     #[wasm_bindgen(js_name = updateLargeValuesEncoded)]
@@ -1294,45 +1206,15 @@ impl WasmDb {
         match &self.inner {
             WasmDbInner::Memory(db) => wasm_write_memory(
                 Rc::clone(db),
-                try_ready(db.upsert(&table, row_id, cells, options)).map_err(to_js_error)?,
+                block_on(db.upsert(&table, row_id, cells, options)).map_err(to_js_error)?,
             ),
             #[cfg(target_arch = "wasm32")]
-            WasmDbInner::Browser(_) => Err(cold_mutation_requires_async()),
+            WasmDbInner::Browser(db) => wasm_write_browser(
+                Rc::clone(db),
+                block_on(db.upsert(&table, row_id, cells, options)).map_err(to_js_error)?,
+            ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
-    }
-
-    #[wasm_bindgen(js_name = upsertEncodedAsync)]
-    pub fn upsert_encoded_async(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        options: JsValue,
-    ) -> Result<js_sys::Promise, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let cells = decode_cells(&cells)?;
-        let options = upsert_options_from_js(options)?;
-        let inner = self.inner.clone();
-        Ok(future_to_promise(async move {
-            let write = match &inner {
-                WasmDbInner::Memory(db) => wasm_write_memory(
-                    Rc::clone(db),
-                    db.upsert(&table, row_id, cells, options)
-                        .await
-                        .map_err(to_js_error)?,
-                ),
-                #[cfg(target_arch = "wasm32")]
-                WasmDbInner::Browser(db) => wasm_write_browser(
-                    Rc::clone(db),
-                    db.upsert(&table, row_id, cells, options)
-                        .await
-                        .map_err(to_js_error)?,
-                ),
-                WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
-            }?;
-            Ok(write.into())
-        }))
     }
 
     #[wasm_bindgen(js_name = deleteEncoded)]
@@ -1347,43 +1229,15 @@ impl WasmDb {
         match &self.inner {
             WasmDbInner::Memory(db) => wasm_write_memory(
                 Rc::clone(db),
-                try_ready(db.delete(&table, row_id, options)).map_err(to_js_error)?,
+                block_on(db.delete(&table, row_id, options)).map_err(to_js_error)?,
             ),
             #[cfg(target_arch = "wasm32")]
-            WasmDbInner::Browser(_) => Err(cold_mutation_requires_async()),
+            WasmDbInner::Browser(db) => wasm_write_browser(
+                Rc::clone(db),
+                block_on(db.delete(&table, row_id, options)).map_err(to_js_error)?,
+            ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
-    }
-
-    #[wasm_bindgen(js_name = deleteEncodedAsync)]
-    pub fn delete_encoded_async(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        options: JsValue,
-    ) -> Result<js_sys::Promise, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let options = delete_options_from_js(options)?;
-        let inner = self.inner.clone();
-        Ok(future_to_promise(async move {
-            let write = match &inner {
-                WasmDbInner::Memory(db) => wasm_write_memory(
-                    Rc::clone(db),
-                    db.delete(&table, row_id, options)
-                        .await
-                        .map_err(to_js_error)?,
-                ),
-                #[cfg(target_arch = "wasm32")]
-                WasmDbInner::Browser(db) => wasm_write_browser(
-                    Rc::clone(db),
-                    db.delete(&table, row_id, options)
-                        .await
-                        .map_err(to_js_error)?,
-                ),
-                WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
-            }?;
-            Ok(write.into())
-        }))
     }
 
     #[wasm_bindgen(js_name = restoreEncoded)]
@@ -1753,34 +1607,6 @@ impl WasmDb {
         }
     }
 
-    /// Persistent-owner transaction admission. Unlike `beginTransaction`,
-    /// this retains cold storage work until the transaction is actually open.
-    #[wasm_bindgen(js_name = beginTransactionAsync)]
-    pub fn begin_transaction_async(
-        &self,
-        open_transaction_id: String,
-        kind: String,
-        author: Option<Vec<u8>>,
-    ) -> Result<js_sys::Promise, JsValue> {
-        let open_transaction_id = open_transaction_id
-            .parse::<OpenTransactionId>()
-            .map_err(|error| JsValue::from_str(&error))?;
-        let author = author.as_deref().map(author_id_from_bytes).transpose()?;
-        if kind != "exclusive" {
-            return Err(JsValue::from_str(
-                "beginTransactionAsync currently owns only cold-capable exclusive admission",
-            ));
-        }
-        let inner = self.inner.clone();
-        Ok(future_to_promise(async move {
-            inner
-                .begin_exclusive_async(open_transaction_id, author)
-                .await
-                .map_err(to_js_error)?;
-            Ok(JsValue::UNDEFINED)
-        }))
-    }
-
     /// Begin the only supported attributed transaction shape.  It is distinct
     /// from `beginTransaction` so an older binding fails closed rather than
     /// silently converting external provenance into SYSTEM authorship.
@@ -1842,44 +1668,6 @@ impl WasmDb {
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
-    }
-
-    /// Persistent-owner exclusive commit. The promise owns admission,
-    /// publication and finalization across all storage wakes.
-    #[wasm_bindgen(js_name = commitExclusiveTransactionAsync)]
-    pub fn commit_exclusive_transaction_async(
-        &self,
-        open_transaction_id: String,
-    ) -> Result<js_sys::Promise, JsValue> {
-        let open_transaction_id = open_transaction_id
-            .parse::<OpenTransactionId>()
-            .map_err(|error| JsValue::from_str(&error))?;
-        let inner = self.inner.clone();
-        Ok(future_to_promise(async move {
-            let tx_id = inner
-                .commit_exclusive_async(open_transaction_id)
-                .await
-                .map_err(to_js_error)?;
-            let write = match &inner {
-                WasmDbInner::Memory(db) => wasm_tx_write(
-                    tx_id,
-                    Some(WasmWriteInner::MemoryTx {
-                        db: Rc::clone(db),
-                        tx_id,
-                    }),
-                ),
-                #[cfg(target_arch = "wasm32")]
-                WasmDbInner::Browser(db) => wasm_tx_write(
-                    tx_id,
-                    Some(WasmWriteInner::BrowserTx {
-                        db: Rc::clone(db),
-                        tx_id,
-                    }),
-                ),
-                WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
-            }?;
-            Ok(write.into())
-        }))
     }
 
     /// Roll back an owner-wide open transaction by id.
@@ -3205,34 +2993,6 @@ impl WasmTx {
         Ok(row.to_bytes())
     }
 
-    #[wasm_bindgen(js_name = insertEncodedAsync)]
-    pub fn insert_encoded_async(
-        &self,
-        table: String,
-        cells: Vec<u8>,
-        options: JsValue,
-    ) -> Result<js_sys::Promise, JsValue> {
-        let cells = decode_cells(&cells)?;
-        let options = insert_options_from_js(options)?;
-        let open_tx = self.open_tx_for_read()?;
-        let db = self.db.clone();
-        let kind = self.kind;
-        Ok(future_to_promise(async move {
-            let row = with_wasm_db!(&db, |db| match kind {
-                WasmTxKind::Mergeable =>
-                    db.mergeable_tx_ref(open_tx)
-                        .insert(&table, cells, options)
-                        .await,
-                WasmTxKind::Exclusive =>
-                    db.exclusive_tx_ref(open_tx)
-                        .insert(&table, cells, options)
-                        .await,
-            })
-            .map_err(to_js_error)?;
-            Ok(js_sys::Uint8Array::from(row.to_bytes().as_slice()).into())
-        }))
-    }
-
     #[wasm_bindgen(js_name = updateEncoded)]
     pub fn update_encoded_with_options(
         &mut self,
@@ -3256,36 +3016,6 @@ impl WasmTx {
             ),
         })
         .map_err(to_js_error)
-    }
-
-    #[wasm_bindgen(js_name = updateEncodedAsync)]
-    pub fn update_encoded_async(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        patch: Vec<u8>,
-        options: JsValue,
-    ) -> Result<js_sys::Promise, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let patch = decode_cells(&patch)?;
-        let options = update_options_from_js(options)?;
-        let open_tx = self.open_tx_for_read()?;
-        let db = self.db.clone();
-        let kind = self.kind;
-        Ok(future_to_promise(async move {
-            with_wasm_db!(&db, |db| match kind {
-                WasmTxKind::Mergeable =>
-                    db.mergeable_tx_ref(open_tx)
-                        .update(&table, row_id, patch, options)
-                        .await,
-                WasmTxKind::Exclusive =>
-                    db.exclusive_tx_ref(open_tx)
-                        .update(&table, row_id, patch, options)
-                        .await,
-            })
-            .map_err(to_js_error)?;
-            Ok(JsValue::UNDEFINED)
-        }))
     }
 
     #[wasm_bindgen(js_name = upsertEncoded)]
@@ -3313,36 +3043,6 @@ impl WasmTx {
         .map_err(to_js_error)
     }
 
-    #[wasm_bindgen(js_name = upsertEncodedAsync)]
-    pub fn upsert_encoded_async(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        cells: Vec<u8>,
-        options: JsValue,
-    ) -> Result<js_sys::Promise, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let cells = decode_cells(&cells)?;
-        let options = upsert_options_from_js(options)?;
-        let open_tx = self.open_tx_for_read()?;
-        let db = self.db.clone();
-        let kind = self.kind;
-        Ok(future_to_promise(async move {
-            with_wasm_db!(&db, |db| match kind {
-                WasmTxKind::Mergeable =>
-                    db.mergeable_tx_ref(open_tx)
-                        .upsert(&table, row_id, cells, options)
-                        .await,
-                WasmTxKind::Exclusive =>
-                    db.exclusive_tx_ref(open_tx)
-                        .upsert(&table, row_id, cells, options)
-                        .await,
-            })
-            .map_err(to_js_error)?;
-            Ok(JsValue::UNDEFINED)
-        }))
-    }
-
     #[wasm_bindgen(js_name = deleteEncoded)]
     pub fn delete_encoded_with_options(
         &mut self,
@@ -3362,34 +3062,6 @@ impl WasmTx {
             }
         })
         .map_err(to_js_error)
-    }
-
-    #[wasm_bindgen(js_name = deleteEncodedAsync)]
-    pub fn delete_encoded_async(
-        &self,
-        table: String,
-        row_id: Vec<u8>,
-        options: JsValue,
-    ) -> Result<js_sys::Promise, JsValue> {
-        let row_id = row_uuid_from_bytes(&row_id)?;
-        let options = delete_options_from_js(options)?;
-        let open_tx = self.open_tx_for_read()?;
-        let db = self.db.clone();
-        let kind = self.kind;
-        Ok(future_to_promise(async move {
-            with_wasm_db!(&db, |db| match kind {
-                WasmTxKind::Mergeable =>
-                    db.mergeable_tx_ref(open_tx)
-                        .delete(&table, row_id, options)
-                        .await,
-                WasmTxKind::Exclusive =>
-                    db.exclusive_tx_ref(open_tx)
-                        .delete(&table, row_id, options)
-                        .await,
-            })
-            .map_err(to_js_error)?;
-            Ok(JsValue::UNDEFINED)
-        }))
     }
 
     #[wasm_bindgen(js_name = restoreEncoded)]
@@ -4478,13 +4150,6 @@ fn call_controller_method(
 
 fn to_js_error(error: impl std::fmt::Display) -> JsValue {
     JsValue::from_str(&error.to_string())
-}
-
-#[cfg(target_arch = "wasm32")]
-fn cold_mutation_requires_async() -> JsValue {
-    JsValue::from_str(
-        "ColdMutationRequiresAsync: internal synchronous mutation wiring was used for a cold-capable browser database",
-    )
 }
 
 fn bytes_to_js(bytes: Vec<u8>) -> Result<JsValue, JsValue> {

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1103,14 +1103,18 @@ impl WasmDb {
         let cells = decode_cells(&cells)?;
         let options = insert_options_from_js(options)?;
         match &self.inner {
-            WasmDbInner::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.insert(&table, cells, options)).map_err(to_js_error)?,
-            ),
+            WasmDbInner::Memory(db) => {
+                let write = db
+                    .enqueue_insert(table, cells, options)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
             #[cfg(target_arch = "wasm32")]
             WasmDbInner::Browser(db) => wasm_write_browser(
                 Rc::clone(db),
-                block_on(db.insert(&table, cells, options)).map_err(to_js_error)?,
+                db.enqueue_insert(table, cells, options)
+                    .map_err(to_js_error)?,
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
@@ -1128,14 +1132,18 @@ impl WasmDb {
         let patch = decode_cells(&patch)?;
         let options = update_options_from_js(options)?;
         match &self.inner {
-            WasmDbInner::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.update(&table, row_id, patch, options)).map_err(to_js_error)?,
-            ),
+            WasmDbInner::Memory(db) => {
+                let write = db
+                    .enqueue_update(table, row_id, patch, options)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
             #[cfg(target_arch = "wasm32")]
             WasmDbInner::Browser(db) => wasm_write_browser(
                 Rc::clone(db),
-                block_on(db.update(&table, row_id, patch, options)).map_err(to_js_error)?,
+                db.enqueue_update(table, row_id, patch, options)
+                    .map_err(to_js_error)?,
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
@@ -1204,14 +1212,18 @@ impl WasmDb {
         let cells = decode_cells(&cells)?;
         let options = upsert_options_from_js(options)?;
         match &self.inner {
-            WasmDbInner::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.upsert(&table, row_id, cells, options)).map_err(to_js_error)?,
-            ),
+            WasmDbInner::Memory(db) => {
+                let write = db
+                    .enqueue_upsert(table, row_id, cells, options)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
             #[cfg(target_arch = "wasm32")]
             WasmDbInner::Browser(db) => wasm_write_browser(
                 Rc::clone(db),
-                block_on(db.upsert(&table, row_id, cells, options)).map_err(to_js_error)?,
+                db.enqueue_upsert(table, row_id, cells, options)
+                    .map_err(to_js_error)?,
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
@@ -1227,14 +1239,18 @@ impl WasmDb {
         let row_id = row_uuid_from_bytes(&row_id)?;
         let options = delete_options_from_js(options)?;
         match &self.inner {
-            WasmDbInner::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.delete(&table, row_id, options)).map_err(to_js_error)?,
-            ),
+            WasmDbInner::Memory(db) => {
+                let write = db
+                    .enqueue_delete(table, row_id, options)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
             #[cfg(target_arch = "wasm32")]
             WasmDbInner::Browser(db) => wasm_write_browser(
                 Rc::clone(db),
-                block_on(db.delete(&table, row_id, options)).map_err(to_js_error)?,
+                db.enqueue_delete(table, row_id, options)
+                    .map_err(to_js_error)?,
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -898,8 +898,23 @@ impl WasmDbInner {
         with_wasm_db!(self, |db| db.abandon_transaction_handle(tx_id))
     }
 
-    fn commit_exclusive(&self, tx_id: OpenTransactionId) -> Result<TxId, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(db.commit_exclusive_handle(tx_id)))
+    fn commit_exclusive(&self, open_tx_id: OpenTransactionId) -> Result<WasmWrite, JsValue> {
+        match self {
+            Self::Memory(db) => {
+                let write = db
+                    .enqueue_commit_exclusive_handle(open_tx_id)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => wasm_write_browser(
+                Rc::clone(db),
+                db.enqueue_commit_exclusive_handle(open_tx_id)
+                    .map_err(to_js_error)?,
+            ),
+            Self::Closed => Err(JsValue::from_str("WasmDb is closed")),
+        }
     }
 
     fn commit_mergeable(&self, open_tx_id: OpenTransactionId) -> Result<WasmWrite, JsValue> {
@@ -1697,31 +1712,10 @@ impl WasmDb {
         let open_transaction_id = open_transaction_id
             .parse::<OpenTransactionId>()
             .map_err(|error| JsValue::from_str(&error))?;
-        if kind.as_deref().unwrap_or("mergeable") == "mergeable" {
-            return self.inner.commit_mergeable(open_transaction_id);
-        }
-        let tx_id = match kind.as_deref().unwrap_or("mergeable") {
+        match kind.as_deref().unwrap_or("mergeable") {
+            "mergeable" => self.inner.commit_mergeable(open_transaction_id),
             "exclusive" => self.inner.commit_exclusive(open_transaction_id),
-            kind => return Err(JsValue::from_str(&unknown_transaction_kind_message(kind))),
-        }
-        .map_err(to_js_error)?;
-        match &self.inner {
-            WasmDbInner::Memory(db) => wasm_tx_write(
-                tx_id,
-                Some(WasmWriteInner::MemoryTx {
-                    db: Rc::clone(db),
-                    tx_id,
-                }),
-            ),
-            #[cfg(target_arch = "wasm32")]
-            WasmDbInner::Browser(db) => wasm_tx_write(
-                tx_id,
-                Some(WasmWriteInner::BrowserTx {
-                    db: Rc::clone(db),
-                    tx_id,
-                }),
-            ),
-            WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
+            kind => Err(JsValue::from_str(&unknown_transaction_kind_message(kind))),
         }
     }
 
@@ -3155,14 +3149,8 @@ impl WasmTx {
                 self.db.commit_mergeable(open_tx)
             }
             (WasmDbInner::Memory(db), WasmTxKind::Exclusive) => {
-                let tx_id = self.db.commit_exclusive(open_tx).map_err(to_js_error)?;
-                wasm_tx_write(
-                    tx_id,
-                    Some(WasmWriteInner::MemoryTx {
-                        db: Rc::clone(db),
-                        tx_id,
-                    }),
-                )
+                let _ = db;
+                self.db.commit_exclusive(open_tx)
             }
             #[cfg(target_arch = "wasm32")]
             (WasmDbInner::Browser(db), WasmTxKind::Mergeable) => {
@@ -3171,14 +3159,8 @@ impl WasmTx {
             }
             #[cfg(target_arch = "wasm32")]
             (WasmDbInner::Browser(db), WasmTxKind::Exclusive) => {
-                let tx_id = self.db.commit_exclusive(open_tx).map_err(to_js_error)?;
-                wasm_tx_write(
-                    tx_id,
-                    Some(WasmWriteInner::BrowserTx {
-                        db: Rc::clone(db),
-                        tx_id,
-                    }),
-                )
+                let _ = db;
+                self.db.commit_exclusive(open_tx)
             }
             (WasmDbInner::Closed, _) => Err(JsValue::from_str("WasmDb is closed")),
         }?;
@@ -3696,19 +3678,6 @@ fn wasm_write_browser(
         row_id: result.row_id,
         tx_id: TransactionId::from_committed_tx(tx_id),
         inner: Some(WasmWriteInner::BrowserTx { db, tx_id }),
-    })
-}
-
-fn wasm_tx_write(tx_id: TxId, inner: Option<WasmWriteInner>) -> Result<WasmWrite, JsValue> {
-    let result = WasmWriteResult {
-        row_id: RowUuid::from_bytes([0; 16]),
-        tx_id,
-    };
-    Ok(WasmWrite {
-        payload: postcard::to_allocvec(&result).map_err(to_js_error)?,
-        row_id: result.row_id,
-        tx_id: TransactionId::from_committed_tx(tx_id),
-        inner,
     })
 }
 

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -18,7 +18,7 @@ use futures_util::{Stream, StreamExt};
 #[cfg(target_arch = "wasm32")]
 use idb_tree::IndexedDbPageStore;
 use jazz::db::{
-    block_on, ConnectionSessionContext, Db, DbConfig, DbIdentity, ExclusiveTxOps,
+    block_on, try_ready, ConnectionSessionContext, Db, DbConfig, DbIdentity, ExclusiveTxOps,
     InitialSyncFlushCadence, LargeValueUpdate, LocalUpdates, MergeableTxOps, MutationErrorCallback,
     PeerConnection, PermissionAdvice, PreparedQuery, Propagation, QueryAttachment, ReadOpts,
     RowCells, SeededRowIdSource, StreamingMutationKind, StreamingValueUpload, SubscriptionEvent,
@@ -1105,15 +1105,45 @@ impl WasmDb {
         match &self.inner {
             WasmDbInner::Memory(db) => wasm_write_memory(
                 Rc::clone(db),
-                block_on(db.insert(&table, cells, options)).map_err(to_js_error)?,
+                try_ready(db.insert(&table, cells, options)).map_err(to_js_error)?,
             ),
             #[cfg(target_arch = "wasm32")]
-            WasmDbInner::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                block_on(db.insert(&table, cells, options)).map_err(to_js_error)?,
-            ),
+            WasmDbInner::Browser(_) => Err(cold_mutation_requires_async()),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
+    }
+
+    /// Owner-driven insert for persistent browser storage. The returned
+    /// promise retains the exact Core future across every storage wake.
+    #[wasm_bindgen(js_name = insertEncodedAsync)]
+    pub fn insert_encoded_async(
+        &self,
+        table: String,
+        cells: Vec<u8>,
+        options: JsValue,
+    ) -> Result<js_sys::Promise, JsValue> {
+        let cells = decode_cells(&cells)?;
+        let options = insert_options_from_js(options)?;
+        let inner = self.inner.clone();
+        Ok(future_to_promise(async move {
+            let write = match &inner {
+                WasmDbInner::Memory(db) => wasm_write_memory(
+                    Rc::clone(db),
+                    db.insert(&table, cells, options)
+                        .await
+                        .map_err(to_js_error)?,
+                ),
+                #[cfg(target_arch = "wasm32")]
+                WasmDbInner::Browser(db) => wasm_write_browser(
+                    Rc::clone(db),
+                    db.insert(&table, cells, options)
+                        .await
+                        .map_err(to_js_error)?,
+                ),
+                WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
+            }?;
+            Ok(write.into())
+        }))
     }
 
     #[wasm_bindgen(js_name = updateEncoded)]
@@ -1130,15 +1160,45 @@ impl WasmDb {
         match &self.inner {
             WasmDbInner::Memory(db) => wasm_write_memory(
                 Rc::clone(db),
-                block_on(db.update(&table, row_id, patch, options)).map_err(to_js_error)?,
+                try_ready(db.update(&table, row_id, patch, options)).map_err(to_js_error)?,
             ),
             #[cfg(target_arch = "wasm32")]
-            WasmDbInner::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                block_on(db.update(&table, row_id, patch, options)).map_err(to_js_error)?,
-            ),
+            WasmDbInner::Browser(_) => Err(cold_mutation_requires_async()),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
+    }
+
+    #[wasm_bindgen(js_name = updateEncodedAsync)]
+    pub fn update_encoded_async(
+        &self,
+        table: String,
+        row_id: Vec<u8>,
+        patch: Vec<u8>,
+        options: JsValue,
+    ) -> Result<js_sys::Promise, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let patch = decode_cells(&patch)?;
+        let options = update_options_from_js(options)?;
+        let inner = self.inner.clone();
+        Ok(future_to_promise(async move {
+            let write = match &inner {
+                WasmDbInner::Memory(db) => wasm_write_memory(
+                    Rc::clone(db),
+                    db.update(&table, row_id, patch, options)
+                        .await
+                        .map_err(to_js_error)?,
+                ),
+                #[cfg(target_arch = "wasm32")]
+                WasmDbInner::Browser(db) => wasm_write_browser(
+                    Rc::clone(db),
+                    db.update(&table, row_id, patch, options)
+                        .await
+                        .map_err(to_js_error)?,
+                ),
+                WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
+            }?;
+            Ok(write.into())
+        }))
     }
 
     #[wasm_bindgen(js_name = updateLargeValuesEncoded)]
@@ -1206,15 +1266,45 @@ impl WasmDb {
         match &self.inner {
             WasmDbInner::Memory(db) => wasm_write_memory(
                 Rc::clone(db),
-                block_on(db.upsert(&table, row_id, cells, options)).map_err(to_js_error)?,
+                try_ready(db.upsert(&table, row_id, cells, options)).map_err(to_js_error)?,
             ),
             #[cfg(target_arch = "wasm32")]
-            WasmDbInner::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                block_on(db.upsert(&table, row_id, cells, options)).map_err(to_js_error)?,
-            ),
+            WasmDbInner::Browser(_) => Err(cold_mutation_requires_async()),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
+    }
+
+    #[wasm_bindgen(js_name = upsertEncodedAsync)]
+    pub fn upsert_encoded_async(
+        &self,
+        table: String,
+        row_id: Vec<u8>,
+        cells: Vec<u8>,
+        options: JsValue,
+    ) -> Result<js_sys::Promise, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let cells = decode_cells(&cells)?;
+        let options = upsert_options_from_js(options)?;
+        let inner = self.inner.clone();
+        Ok(future_to_promise(async move {
+            let write = match &inner {
+                WasmDbInner::Memory(db) => wasm_write_memory(
+                    Rc::clone(db),
+                    db.upsert(&table, row_id, cells, options)
+                        .await
+                        .map_err(to_js_error)?,
+                ),
+                #[cfg(target_arch = "wasm32")]
+                WasmDbInner::Browser(db) => wasm_write_browser(
+                    Rc::clone(db),
+                    db.upsert(&table, row_id, cells, options)
+                        .await
+                        .map_err(to_js_error)?,
+                ),
+                WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
+            }?;
+            Ok(write.into())
+        }))
     }
 
     #[wasm_bindgen(js_name = deleteEncoded)]
@@ -1229,15 +1319,43 @@ impl WasmDb {
         match &self.inner {
             WasmDbInner::Memory(db) => wasm_write_memory(
                 Rc::clone(db),
-                block_on(db.delete(&table, row_id, options)).map_err(to_js_error)?,
+                try_ready(db.delete(&table, row_id, options)).map_err(to_js_error)?,
             ),
             #[cfg(target_arch = "wasm32")]
-            WasmDbInner::Browser(db) => wasm_write_browser(
-                Rc::clone(db),
-                block_on(db.delete(&table, row_id, options)).map_err(to_js_error)?,
-            ),
+            WasmDbInner::Browser(_) => Err(cold_mutation_requires_async()),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
+    }
+
+    #[wasm_bindgen(js_name = deleteEncodedAsync)]
+    pub fn delete_encoded_async(
+        &self,
+        table: String,
+        row_id: Vec<u8>,
+        options: JsValue,
+    ) -> Result<js_sys::Promise, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let options = delete_options_from_js(options)?;
+        let inner = self.inner.clone();
+        Ok(future_to_promise(async move {
+            let write = match &inner {
+                WasmDbInner::Memory(db) => wasm_write_memory(
+                    Rc::clone(db),
+                    db.delete(&table, row_id, options)
+                        .await
+                        .map_err(to_js_error)?,
+                ),
+                #[cfg(target_arch = "wasm32")]
+                WasmDbInner::Browser(db) => wasm_write_browser(
+                    Rc::clone(db),
+                    db.delete(&table, row_id, options)
+                        .await
+                        .map_err(to_js_error)?,
+                ),
+                WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
+            }?;
+            Ok(write.into())
+        }))
     }
 
     #[wasm_bindgen(js_name = restoreEncoded)]
@@ -4150,6 +4268,13 @@ fn call_controller_method(
 
 fn to_js_error(error: impl std::fmt::Display) -> JsValue {
     JsValue::from_str(&error.to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn cold_mutation_requires_async() -> JsValue {
+    JsValue::from_str(
+        "ColdMutationRequiresAsync: persistent browser mutations must use the owner-driven asynchronous mutation API",
+    )
 }
 
 fn bytes_to_js(bytes: Vec<u8>) -> Result<JsValue, JsValue> {

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -4273,7 +4273,7 @@ fn to_js_error(error: impl std::fmt::Display) -> JsValue {
 #[cfg(target_arch = "wasm32")]
 fn cold_mutation_requires_async() -> JsValue {
     JsValue::from_str(
-        "ColdMutationRequiresAsync: persistent browser mutations must use the owner-driven asynchronous mutation API",
+        "ColdMutationRequiresAsync: internal synchronous mutation wiring was used for a cold-capable browser database",
     )
 }
 

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -3071,6 +3071,9 @@ impl WasmTx {
             cells,
             options,
         ));
+        if let WasmDbInner::Memory(db) = &self.db {
+            db.drive_queued_mutation_once();
+        }
         Ok(row.to_bytes())
     }
 
@@ -3094,6 +3097,9 @@ impl WasmTx {
             patch,
             options,
         ));
+        if let WasmDbInner::Memory(db) = &self.db {
+            db.drive_queued_mutation_once();
+        }
         Ok(())
     }
 
@@ -3117,6 +3123,9 @@ impl WasmTx {
             cells,
             options,
         ));
+        if let WasmDbInner::Memory(db) = &self.db {
+            db.drive_queued_mutation_once();
+        }
         Ok(())
     }
 
@@ -3137,6 +3146,9 @@ impl WasmTx {
             row_id,
             options,
         ));
+        if let WasmDbInner::Memory(db) = &self.db {
+            db.drive_queued_mutation_once();
+        }
         Ok(())
     }
 
@@ -3160,6 +3172,9 @@ impl WasmTx {
             Some(cells),
             options,
         ));
+        if let WasmDbInner::Memory(db) = &self.db {
+            db.drive_queued_mutation_once();
+        }
         Ok(())
     }
 

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -827,10 +827,19 @@ impl WasmDbInner {
         id: OpenTransactionId,
         author: Option<AuthorSubject>,
     ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| match author {
-            Some(author) => block_on(db.begin_exclusive_for_identity(id, author)),
-            None => block_on(db.begin_exclusive(id)),
-        })
+        match self {
+            Self::Memory(db) => {
+                db.enqueue_begin_exclusive(id, author);
+                db.drive_queued_mutation_once();
+                Ok(())
+            }
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => {
+                db.enqueue_begin_exclusive(id, author);
+                Ok(())
+            }
+            Self::Closed => panic!("WasmDb is closed"),
+        }
     }
 
     fn begin_mergeable(
@@ -838,10 +847,16 @@ impl WasmDbInner {
         id: OpenTransactionId,
         author: Option<AuthorSubject>,
     ) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| match author {
-            Some(author) => block_on(db.begin_mergeable_for_identity(id, author)),
-            None => block_on(db.begin_mergeable(id)),
-        })
+        match self {
+            Self::Memory(db) => {
+                db.enqueue_begin_mergeable(id, author, None)?;
+                db.drive_queued_mutation_once();
+                Ok(())
+            }
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => db.enqueue_begin_mergeable(id, author, None),
+            Self::Closed => panic!("WasmDb is closed"),
+        }
     }
 
     fn exclusive_all_for_identity(
@@ -1691,11 +1706,16 @@ impl WasmDb {
         let attribution = author_id_from_bytes(&attribution)?;
         match &self.inner {
             WasmDbInner::Memory(db) => {
-                block_on(db.begin_mergeable_attributed(open_transaction_id, attribution))
+                let result =
+                    db.enqueue_begin_mergeable(open_transaction_id, None, Some(attribution));
+                if result.is_ok() {
+                    db.drive_queued_mutation_once();
+                }
+                result
             }
             #[cfg(target_arch = "wasm32")]
             WasmDbInner::Browser(db) => {
-                block_on(db.begin_mergeable_attributed(open_transaction_id, attribution))
+                db.enqueue_begin_mergeable(open_transaction_id, None, Some(attribution))
             }
             WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
         }
@@ -3032,13 +3052,13 @@ impl WasmTx {
         let cells = decode_cells(&cells)?;
         let options = insert_options_from_js(options)?;
         let open_tx = self.open_tx_for_read()?;
-        let row = with_wasm_db!(&self.db, |db| match self.kind {
-            WasmTxKind::Mergeable =>
-                block_on(db.mergeable_tx_ref(open_tx).insert(&table, cells, options,)),
-            WasmTxKind::Exclusive =>
-                block_on(db.exclusive_tx_ref(open_tx).insert(&table, cells, options,)),
-        })
-        .map_err(to_js_error)?;
+        let row = with_wasm_db!(&self.db, |db| db.enqueue_transaction_insert(
+            open_tx,
+            matches!(self.kind, WasmTxKind::Exclusive),
+            table,
+            cells,
+            options,
+        ));
         Ok(row.to_bytes())
     }
 
@@ -3054,17 +3074,15 @@ impl WasmTx {
         let patch = decode_cells(&patch)?;
         let options = update_options_from_js(options)?;
         let open_tx = self.open_tx_for_read()?;
-        with_wasm_db!(&self.db, |db| match self.kind {
-            WasmTxKind::Mergeable => block_on(
-                db.mergeable_tx_ref(open_tx)
-                    .update(&table, row_id, patch, options,)
-            ),
-            WasmTxKind::Exclusive => block_on(
-                db.exclusive_tx_ref(open_tx)
-                    .update(&table, row_id, patch, options,)
-            ),
-        })
-        .map_err(to_js_error)
+        with_wasm_db!(&self.db, |db| db.enqueue_transaction_update(
+            open_tx,
+            matches!(self.kind, WasmTxKind::Exclusive),
+            table,
+            row_id,
+            patch,
+            options,
+        ));
+        Ok(())
     }
 
     #[wasm_bindgen(js_name = upsertEncoded)]
@@ -3079,17 +3097,15 @@ impl WasmTx {
         let cells = decode_cells(&cells)?;
         let options = upsert_options_from_js(options)?;
         let open_tx = self.open_tx_for_read()?;
-        with_wasm_db!(&self.db, |db| match self.kind {
-            WasmTxKind::Mergeable => block_on(
-                db.mergeable_tx_ref(open_tx)
-                    .upsert(&table, row_id, cells, options,)
-            ),
-            WasmTxKind::Exclusive => block_on(
-                db.exclusive_tx_ref(open_tx)
-                    .upsert(&table, row_id, cells, options,)
-            ),
-        })
-        .map_err(to_js_error)
+        with_wasm_db!(&self.db, |db| db.enqueue_transaction_upsert(
+            open_tx,
+            matches!(self.kind, WasmTxKind::Exclusive),
+            table,
+            row_id,
+            cells,
+            options,
+        ));
+        Ok(())
     }
 
     #[wasm_bindgen(js_name = deleteEncoded)]
@@ -3102,15 +3118,14 @@ impl WasmTx {
         let row_id = row_uuid_from_bytes(&row_id)?;
         let options = delete_options_from_js(options)?;
         let open_tx = self.open_tx_for_read()?;
-        with_wasm_db!(&self.db, |db| match self.kind {
-            WasmTxKind::Mergeable => {
-                block_on(db.mergeable_tx_ref(open_tx).delete(&table, row_id, options))
-            }
-            WasmTxKind::Exclusive => {
-                block_on(db.exclusive_tx_ref(open_tx).delete(&table, row_id, options))
-            }
-        })
-        .map_err(to_js_error)
+        with_wasm_db!(&self.db, |db| db.enqueue_transaction_delete(
+            open_tx,
+            matches!(self.kind, WasmTxKind::Exclusive),
+            table,
+            row_id,
+            options,
+        ));
+        Ok(())
     }
 
     #[wasm_bindgen(js_name = restoreEncoded)]
@@ -3125,19 +3140,15 @@ impl WasmTx {
         let cells = decode_cells(&cells)?;
         let options = restore_options_from_js(options)?;
         let open_tx = self.open_tx_for_read()?;
-        with_wasm_db!(&self.db, |db| match self.kind {
-            WasmTxKind::Mergeable =>
-                block_on(
-                    db.mergeable_tx_ref(open_tx)
-                        .restore(&table, row_id, Some(cells), options,)
-                ),
-            WasmTxKind::Exclusive =>
-                block_on(
-                    db.exclusive_tx_ref(open_tx)
-                        .restore(&table, row_id, Some(cells), options,)
-                ),
-        })
-        .map_err(to_js_error)
+        with_wasm_db!(&self.db, |db| db.enqueue_transaction_restore(
+            open_tx,
+            matches!(self.kind, WasmTxKind::Exclusive),
+            table,
+            row_id,
+            Some(cells),
+            options,
+        ));
+        Ok(())
     }
 
     #[wasm_bindgen(js_name = commit)]

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -910,7 +910,19 @@ impl WasmDbInner {
     }
 
     fn abandon_transaction(&self, tx_id: OpenTransactionId) -> Result<(), jazz::db::Error> {
-        with_wasm_db!(self, |db| db.abandon_transaction_handle(tx_id))
+        match self {
+            Self::Memory(db) => {
+                db.enqueue_abandon_transaction_handle(tx_id);
+                db.drive_queued_mutation_once();
+                Ok(())
+            }
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => {
+                db.enqueue_abandon_transaction_handle(tx_id);
+                Ok(())
+            }
+            Self::Closed => panic!("WasmDb is closed"),
+        }
     }
 
     fn commit_exclusive(&self, open_tx_id: OpenTransactionId) -> Result<WasmWrite, JsValue> {

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1164,37 +1164,22 @@ impl WasmDb {
             serde_wasm_bindgen::from_value(mutations).map_err(|error| {
                 JsValue::from_str(&format!("invalid partial-value update descriptor: {error}"))
             })?;
+        let updated_at_ms = updated_at_ms
+            .map(|value| checked_js_u64(value, "updatedAtMs"))
+            .transpose()?;
         match &self.inner {
-            WasmDbInner::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                match updated_at_ms
-                    .map(|value| checked_js_u64(value, "updatedAtMs"))
-                    .transpose()?
-                {
-                    Some(now_ms) => block_on(db.update_with_large_value_mutations_at_ms(
-                        &table, row_id, patch, mutations, now_ms,
-                    )),
-                    None => block_on(
-                        db.update_with_large_value_mutations(&table, row_id, patch, mutations),
-                    ),
-                }
-                .map_err(to_js_error)?,
-            ),
+            WasmDbInner::Memory(db) => {
+                let write = db
+                    .enqueue_large_value_update(table, row_id, patch, mutations, updated_at_ms)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
             #[cfg(target_arch = "wasm32")]
             WasmDbInner::Browser(db) => wasm_write_browser(
                 Rc::clone(db),
-                match updated_at_ms
-                    .map(|value| checked_js_u64(value, "updatedAtMs"))
-                    .transpose()?
-                {
-                    Some(now_ms) => block_on(db.update_with_large_value_mutations_at_ms(
-                        &table, row_id, patch, mutations, now_ms,
-                    )),
-                    None => block_on(
-                        db.update_with_large_value_mutations(&table, row_id, patch, mutations),
-                    ),
-                }
-                .map_err(to_js_error)?,
+                db.enqueue_large_value_update(table, row_id, patch, mutations, updated_at_ms)
+                    .map_err(to_js_error)?,
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1268,14 +1268,18 @@ impl WasmDb {
         let cells = decode_cells(&cells)?;
         let options = restore_options_from_js(options)?;
         match &self.inner {
-            WasmDbInner::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.restore(&table, row_id, Some(cells), options)).map_err(to_js_error)?,
-            ),
+            WasmDbInner::Memory(db) => {
+                let write = db
+                    .enqueue_restore(table, row_id, Some(cells), options)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
             #[cfg(target_arch = "wasm32")]
             WasmDbInner::Browser(db) => wasm_write_browser(
                 Rc::clone(db),
-                block_on(db.restore(&table, row_id, Some(cells), options)).map_err(to_js_error)?,
+                db.enqueue_restore(table, row_id, Some(cells), options)
+                    .map_err(to_js_error)?,
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
@@ -1295,16 +1299,23 @@ impl WasmDb {
         let row_id = row_uuid_from_bytes(&row_id)?;
         let cells = decode_cells(&cells)?;
         let author = author_id_from_bytes(&author)?;
+        let options = jazz::db::InsertOptions {
+            row_id: Some(row_id),
+            identity: jazz::db::WriteIdentity::Attribution(author),
+            ..Default::default()
+        };
         match &self.inner {
-            WasmDbInner::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.insert_with_id_attributed(author, &table, row_id, cells))
-                    .map_err(to_js_error)?,
-            ),
+            WasmDbInner::Memory(db) => {
+                let write = db
+                    .enqueue_insert(table, cells, options)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
             #[cfg(target_arch = "wasm32")]
             WasmDbInner::Browser(db) => wasm_write_browser(
                 Rc::clone(db),
-                block_on(db.insert_with_id_attributed(author, &table, row_id, cells))
+                db.enqueue_insert(table, cells, options)
                     .map_err(to_js_error)?,
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
@@ -1323,16 +1334,22 @@ impl WasmDb {
         let row_id = row_uuid_from_bytes(&row_id)?;
         let patch = decode_cells(&patch)?;
         let author = author_id_from_bytes(&author)?;
+        let options = jazz::db::UpdateOptions {
+            identity: jazz::db::WriteIdentity::Attribution(author),
+            ..Default::default()
+        };
         match &self.inner {
-            WasmDbInner::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.update_attributed(author, &table, row_id, patch))
-                    .map_err(to_js_error)?,
-            ),
+            WasmDbInner::Memory(db) => {
+                let write = db
+                    .enqueue_update(table, row_id, patch, options)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
             #[cfg(target_arch = "wasm32")]
             WasmDbInner::Browser(db) => wasm_write_browser(
                 Rc::clone(db),
-                block_on(db.update_attributed(author, &table, row_id, patch))
+                db.enqueue_update(table, row_id, patch, options)
                     .map_err(to_js_error)?,
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
@@ -1351,16 +1368,22 @@ impl WasmDb {
         let row_id = row_uuid_from_bytes(&row_id)?;
         let cells = decode_cells(&cells)?;
         let author = author_id_from_bytes(&author)?;
+        let options = jazz::db::UpsertOptions {
+            identity: jazz::db::WriteIdentity::Attribution(author),
+            ..Default::default()
+        };
         match &self.inner {
-            WasmDbInner::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.upsert_attributed(author, &table, row_id, cells))
-                    .map_err(to_js_error)?,
-            ),
+            WasmDbInner::Memory(db) => {
+                let write = db
+                    .enqueue_upsert(table, row_id, cells, options)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
             #[cfg(target_arch = "wasm32")]
             WasmDbInner::Browser(db) => wasm_write_browser(
                 Rc::clone(db),
-                block_on(db.upsert_attributed(author, &table, row_id, cells))
+                db.enqueue_upsert(table, row_id, cells, options)
                     .map_err(to_js_error)?,
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
@@ -1377,15 +1400,23 @@ impl WasmDb {
         self.require_trusted_backend()?;
         let row_id = row_uuid_from_bytes(&row_id)?;
         let author = author_id_from_bytes(&author)?;
+        let options = jazz::db::DeleteOptions {
+            identity: jazz::db::WriteIdentity::Attribution(author),
+            ..Default::default()
+        };
         match &self.inner {
-            WasmDbInner::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.delete_attributed(author, &table, row_id)).map_err(to_js_error)?,
-            ),
+            WasmDbInner::Memory(db) => {
+                let write = db
+                    .enqueue_delete(table, row_id, options)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
             #[cfg(target_arch = "wasm32")]
             WasmDbInner::Browser(db) => wasm_write_browser(
                 Rc::clone(db),
-                block_on(db.delete_attributed(author, &table, row_id)).map_err(to_js_error)?,
+                db.enqueue_delete(table, row_id, options)
+                    .map_err(to_js_error)?,
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
         }
@@ -1403,16 +1434,22 @@ impl WasmDb {
         let row_id = row_uuid_from_bytes(&row_id)?;
         let cells = decode_cells(&cells)?;
         let author = author_id_from_bytes(&author)?;
+        let options = jazz::db::RestoreOptions {
+            identity: jazz::db::WriteIdentity::Attribution(author),
+            ..Default::default()
+        };
         match &self.inner {
-            WasmDbInner::Memory(db) => wasm_write_memory(
-                Rc::clone(db),
-                block_on(db.restore_attributed(author, &table, row_id, cells))
-                    .map_err(to_js_error)?,
-            ),
+            WasmDbInner::Memory(db) => {
+                let write = db
+                    .enqueue_restore(table, row_id, Some(cells), options)
+                    .map_err(to_js_error)?;
+                db.drive_queued_mutation_once();
+                wasm_write_memory(Rc::clone(db), write)
+            }
             #[cfg(target_arch = "wasm32")]
             WasmDbInner::Browser(db) => wasm_write_browser(
                 Rc::clone(db),
-                block_on(db.restore_attributed(author, &table, row_id, cells))
+                db.enqueue_restore(table, row_id, Some(cells), options)
                     .map_err(to_js_error)?,
             ),
             WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1454,6 +1454,9 @@ where
     next_now_ms: Rc<Cell<u64>>,
     /// Set only on the private clone owned by one queued mutation operation.
     reserved_tx_id: Option<TxId>,
+    /// True only for a future accepted while the shared owner was Open. Such
+    /// futures must remain executable while close drains the accepted FIFO.
+    owner_operation_admitted: bool,
     // Minted only by the explicitly unsafe trusted-backend open path. SYSTEM
     // itself is an admission identity, not proof that a Db may forge external
     // row provenance.

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1452,6 +1452,8 @@ where
     row_id_source: Rc<RefCell<Box<dyn RowIdSource>>>,
     row_id_source_guarantees_fresh: bool,
     next_now_ms: Rc<Cell<u64>>,
+    /// Set only on the private clone owned by one queued mutation operation.
+    reserved_tx_id: Option<TxId>,
     // Minted only by the explicitly unsafe trusted-backend open path. SYSTEM
     // itself is an admission identity, not proof that a Db may forge external
     // row provenance.
@@ -1504,6 +1506,19 @@ type RelayUpstreamSubscriptionOwners =
 type PendingRelaySubscriptionRejections =
     Rc<RefCell<BTreeMap<u64, VecDeque<RelaySubscriptionRejection>>>>;
 type SharedTickScheduler = Rc<RefCell<Option<Rc<dyn TickScheduler>>>>;
+type QueuedMutationFuture = Pin<Box<dyn Future<Output = Result<(), Error>> + 'static>>;
+
+struct QueuedMutationOperation {
+    tx_id: TxId,
+    future: QueuedMutationFuture,
+    status: Rc<RefCell<QueuedMutationStatus>>,
+}
+
+enum QueuedMutationStatus {
+    Pending,
+    Published,
+    Failed(Error),
+}
 
 /// Authenticated logical destination for an upstream upload retry.
 ///
@@ -2439,7 +2454,7 @@ pub enum Propagation {
 }
 
 /// Public API error with stable machine-readable codes.
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Error {
     /// Stable error code.
     pub code: ErrorCode,
@@ -3645,6 +3660,7 @@ where
     row_uuid: RowUuid,
     tx_id: TxId,
     local_tier: DurabilityTier,
+    queued_status: Option<Rc<RefCell<QueuedMutationStatus>>>,
 }
 
 impl<S> WriteHandle<S>
@@ -3721,6 +3737,19 @@ where
 
     /// Return the locally observed fate and durability for this write.
     pub async fn write_state(&self) -> Result<WriteState, Error> {
+        if let Some(status) = &self.queued_status {
+            match &*status.borrow() {
+                QueuedMutationStatus::Pending => {
+                    return Ok(WriteState {
+                        fate: Fate::Pending,
+                        global_time: None,
+                        durability: DurabilityTier::None,
+                    });
+                }
+                QueuedMutationStatus::Failed(error) => return Err(error.clone()),
+                QueuedMutationStatus::Published => {}
+            }
+        }
         let Some(node) = self.node.upgrade() else {
             return Err(Error::new(
                 ErrorCode::NotObserved,

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1453,10 +1453,7 @@ where
     let mut future = pin!(future);
     match future.as_mut().poll(&mut context) {
         Poll::Ready(result) => result,
-        Poll::Pending => Err(Error::new(
-            ErrorCode::ColdMutationRequiresAsync,
-            "internal resident-only mutation boundary reached non-resident state",
-        )),
+        Poll::Pending => Err(Error::cold_mutation_requires_async()),
     }
 }
 
@@ -2511,6 +2508,16 @@ impl Error {
             code,
             message: message.into(),
         }
+    }
+
+    /// Internal binding assertion used when a cold-capable database is wired
+    /// through a resident-only synchronous mutation surface.
+    #[doc(hidden)]
+    pub fn cold_mutation_requires_async() -> Self {
+        Self::new(
+            ErrorCode::ColdMutationRequiresAsync,
+            "internal resident-only mutation boundary reached non-resident state",
+        )
     }
 }
 

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -3709,7 +3709,11 @@ where
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub async fn wait(&self, tier: DurabilityTier) -> Result<TxId, Error> {
-        if tier <= self.local_tier {
+        let reservation_is_pending = self
+            .queued_status
+            .as_ref()
+            .is_some_and(|status| matches!(*status.borrow(), QueuedMutationStatus::Pending));
+        if tier <= self.local_tier && !reservation_is_pending {
             return Ok(self.tx_id);
         }
         let state = self.write_state().await?;

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1438,6 +1438,51 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
     }
 }
 
+/// Complete an operation only when every dependency is already resident.
+///
+/// This is the compatibility boundary for synchronous host facades. Unlike
+/// [`block_on`], it never spins a thread-affine future after that future has
+/// reported `Pending`: persistent hosts must retain and drive the equivalent
+/// async operation from their owner turn instead.
+pub fn try_ready<F, T>(future: F) -> Result<T, Error>
+where
+    F: Future<Output = Result<T, Error>>,
+{
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    let mut future = pin!(future);
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => Err(Error::new(
+            ErrorCode::ColdMutationRequiresAsync,
+            "mutation requires non-resident state; retry through the asynchronous mutation API",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod synchronous_facade_tests {
+    use super::{ErrorCode, try_ready};
+    use std::cell::Cell;
+    use std::future::poll_fn;
+    use std::rc::Rc;
+    use std::task::Poll;
+
+    #[test]
+    fn synchronous_facade_does_not_spin_or_repoll_cold_work() {
+        let polls = Rc::new(Cell::new(0));
+        let observed = Rc::clone(&polls);
+        let error = try_ready(poll_fn(move |_| {
+            observed.set(observed.get() + 1);
+            Poll::<Result<(), super::Error>>::Pending
+        }))
+        .expect_err("cold work must be rejected by the synchronous facade");
+
+        assert_eq!(error.code, ErrorCode::ColdMutationRequiresAsync);
+        assert_eq!(polls.get(), 1, "the cold future must not be spun");
+    }
+}
+
 /// Thread-affine high-level database handle.
 pub struct Db<S>
 where
@@ -2504,6 +2549,9 @@ pub enum ErrorCode {
     Backpressure,
     /// Requested observation is not locally available in this slice.
     NotObserved,
+    /// A synchronous mutation reached non-resident state and must be retried
+    /// through an owner-driven asynchronous host operation.
+    ColdMutationRequiresAsync,
     /// Historical read must be evaluated by a complete-history server.
     HistoricalReadRequiresServer,
 }

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1438,12 +1438,12 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
     }
 }
 
-/// Complete an operation only when every dependency is already resident.
+/// Assert that an internal resident-only operation completes in one poll.
 ///
-/// This is the compatibility boundary for synchronous host facades. Unlike
-/// [`block_on`], it never spins a thread-affine future after that future has
-/// reported `Pending`: persistent hosts must retain and drive the equivalent
-/// async operation from their owner turn instead.
+/// Unlike [`block_on`], it never spins a thread-affine future after that future
+/// has reported `Pending`. Cold-capable hosts must expose and await an async
+/// operation instead of using this as a retry protocol.
+#[doc(hidden)]
 pub fn try_ready<F, T>(future: F) -> Result<T, Error>
 where
     F: Future<Output = Result<T, Error>>,
@@ -1455,7 +1455,7 @@ where
         Poll::Ready(result) => result,
         Poll::Pending => Err(Error::new(
             ErrorCode::ColdMutationRequiresAsync,
-            "mutation requires non-resident state; retry through the asynchronous mutation API",
+            "internal resident-only mutation boundary reached non-resident state",
         )),
     }
 }
@@ -2549,8 +2549,7 @@ pub enum ErrorCode {
     Backpressure,
     /// Requested observation is not locally available in this slice.
     NotObserved,
-    /// A synchronous mutation reached non-resident state and must be retried
-    /// through an owner-driven asynchronous host operation.
+    /// An internal resident-only mutation assertion reached non-resident state.
     ColdMutationRequiresAsync,
     /// Historical read must be evaluated by a complete-history server.
     HistoricalReadRequiresServer,

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1438,48 +1438,6 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
     }
 }
 
-/// Assert that an internal resident-only operation completes in one poll.
-///
-/// Unlike [`block_on`], it never spins a thread-affine future after that future
-/// has reported `Pending`. Cold-capable hosts must expose and await an async
-/// operation instead of using this as a retry protocol.
-#[doc(hidden)]
-pub fn try_ready<F, T>(future: F) -> Result<T, Error>
-where
-    F: Future<Output = Result<T, Error>>,
-{
-    let waker = Waker::noop();
-    let mut context = Context::from_waker(waker);
-    let mut future = pin!(future);
-    match future.as_mut().poll(&mut context) {
-        Poll::Ready(result) => result,
-        Poll::Pending => Err(Error::cold_mutation_requires_async()),
-    }
-}
-
-#[cfg(test)]
-mod synchronous_facade_tests {
-    use super::{ErrorCode, try_ready};
-    use std::cell::Cell;
-    use std::future::poll_fn;
-    use std::rc::Rc;
-    use std::task::Poll;
-
-    #[test]
-    fn synchronous_facade_does_not_spin_or_repoll_cold_work() {
-        let polls = Rc::new(Cell::new(0));
-        let observed = Rc::clone(&polls);
-        let error = try_ready(poll_fn(move |_| {
-            observed.set(observed.get() + 1);
-            Poll::<Result<(), super::Error>>::Pending
-        }))
-        .expect_err("cold work must be rejected by the synchronous facade");
-
-        assert_eq!(error.code, ErrorCode::ColdMutationRequiresAsync);
-        assert_eq!(polls.get(), 1, "the cold future must not be spun");
-    }
-}
-
 /// Thread-affine high-level database handle.
 pub struct Db<S>
 where
@@ -2509,16 +2467,6 @@ impl Error {
             message: message.into(),
         }
     }
-
-    /// Internal binding assertion used when a cold-capable database is wired
-    /// through a resident-only synchronous mutation surface.
-    #[doc(hidden)]
-    pub fn cold_mutation_requires_async() -> Self {
-        Self::new(
-            ErrorCode::ColdMutationRequiresAsync,
-            "internal resident-only mutation boundary reached non-resident state",
-        )
-    }
 }
 
 fn row_already_deleted(row: RowUuid) -> Error {
@@ -2556,8 +2504,6 @@ pub enum ErrorCode {
     Backpressure,
     /// Requested observation is not locally available in this slice.
     NotObserved,
-    /// An internal resident-only mutation assertion reached non-resident state.
-    ColdMutationRequiresAsync,
     /// Historical read must be evaluated by a complete-history server.
     HistoricalReadRequiresServer,
 }

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1509,9 +1509,10 @@ type SharedTickScheduler = Rc<RefCell<Option<Rc<dyn TickScheduler>>>>;
 type QueuedMutationFuture = Pin<Box<dyn Future<Output = Result<(), Error>> + 'static>>;
 
 struct QueuedMutationOperation {
-    tx_id: TxId,
+    tx_id: Option<TxId>,
+    open_tx_id: Option<OpenTransactionId>,
     future: QueuedMutationFuture,
-    status: Rc<RefCell<QueuedMutationStatus>>,
+    status: Option<Rc<RefCell<QueuedMutationStatus>>>,
 }
 
 enum QueuedMutationStatus {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1507,6 +1507,7 @@ type PendingRelaySubscriptionRejections =
     Rc<RefCell<BTreeMap<u64, VecDeque<RelaySubscriptionRejection>>>>;
 type SharedTickScheduler = Rc<RefCell<Option<Rc<dyn TickScheduler>>>>;
 type QueuedMutationFuture = Pin<Box<dyn Future<Output = Result<(), Error>> + 'static>>;
+type TransactionWaitObserver = Pin<Box<dyn Future<Output = ()> + 'static>>;
 
 struct QueuedMutationOperation {
     tx_id: Option<TxId>,
@@ -1989,7 +1990,6 @@ struct WriteStateWaiter {
 
 enum WriteStateWaiterNotify {
     Future(oneshot::Sender<()>),
-    Callback(Box<dyn FnOnce()>),
 }
 
 #[derive(Default)]

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1509,6 +1509,12 @@ type SharedTickScheduler = Rc<RefCell<Option<Rc<dyn TickScheduler>>>>;
 type QueuedMutationFuture = Pin<Box<dyn Future<Output = Result<(), Error>> + 'static>>;
 type TransactionWaitObserver = Pin<Box<dyn Future<Output = ()> + 'static>>;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MutationOwnerLifecycle {
+    Open,
+    Closing,
+}
+
 struct QueuedMutationOperation {
     tx_id: Option<TxId>,
     open_tx_id: Option<OpenTransactionId>,

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -85,6 +85,7 @@ where
             )),
             row_id_source_guarantees_fresh,
             next_now_ms: Rc::new(Cell::new(1)),
+            reserved_tx_id: None,
             backend_attribution: false,
         })
     }
@@ -134,6 +135,7 @@ where
             )),
             row_id_source_guarantees_fresh,
             next_now_ms: Rc::new(Cell::new(1)),
+            reserved_tx_id: None,
             backend_attribution: false,
         };
         Ok((db, receipt))
@@ -170,6 +172,7 @@ where
             )),
             row_id_source_guarantees_fresh,
             next_now_ms: Rc::new(Cell::new(1)),
+            reserved_tx_id: None,
             backend_attribution: false,
         })
     }
@@ -222,6 +225,7 @@ where
             )),
             row_id_source_guarantees_fresh,
             next_now_ms: Rc::new(Cell::new(1)),
+            reserved_tx_id: None,
             backend_attribution: false,
         })
     }
@@ -333,6 +337,7 @@ where
             row_id_source: Rc::clone(&self.row_id_source),
             row_id_source_guarantees_fresh: self.row_id_source_guarantees_fresh,
             next_now_ms: Rc::clone(&self.next_now_ms),
+            reserved_tx_id: None,
             backend_attribution: self.backend_attribution,
         })
     }
@@ -471,6 +476,22 @@ where
         self.node.reserve_transaction_id(now_ms)
     }
 
+    pub(super) fn clone_for_reserved_transaction(&self, tx_id: TxId) -> Self {
+        Self {
+            schema: self.schema.clone(),
+            schema_version_id: self.schema_version_id,
+            schema_view_is_fixed: self.schema_view_is_fixed,
+            schema_views: Rc::clone(&self.schema_views),
+            identity: self.identity,
+            node: Rc::clone(&self.node),
+            row_id_source: Rc::clone(&self.row_id_source),
+            row_id_source_guarantees_fresh: self.row_id_source_guarantees_fresh,
+            next_now_ms: Rc::clone(&self.next_now_ms),
+            reserved_tx_id: Some(tx_id),
+            backend_attribution: self.backend_attribution,
+        }
+    }
+
     /// Configure this durable process as the internal browser relay that owns
     /// fresh upstream authority sessions for client Edge reads.
     #[doc(hidden)]
@@ -582,6 +603,9 @@ where
 
     /// Return the locally observed fate and durability for a write transaction.
     pub fn write_state(&self, tx_id: TxId) -> Result<WriteState, Error> {
+        if let Some(state) = self.node.queued_mutation_write_state(tx_id) {
+            return state;
+        }
         let Some((fate, global_time, durability)) =
             crate::db::block_on(self.node.node.borrow_mut().transaction_state(tx_id))
         else {
@@ -784,6 +808,7 @@ where
     /// Service every connection once (a convenience over
     /// [`PeerConnection::tick`] for the common single-upstream client).
     pub async fn tick(&self) -> Result<(), Error> {
+        self.node.poll_queued_mutation_once();
         self.node.drain_subscription_finalizations().await?;
         self.node.settle_local_publications().await?;
         self.node.tick().await.map(|_| ())
@@ -791,6 +816,7 @@ where
 
     /// Service every connection once and return binding-observable wake counts.
     pub async fn tick_stats(&self) -> Result<DbTickStats, Error> {
+        self.node.poll_queued_mutation_once();
         self.node.drain_subscription_finalizations().await?;
         self.node.settle_local_publications().await?;
         self.node.tick().await

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -430,10 +430,16 @@ where
         if self.schema_view_is_fixed {
             return Ok(());
         }
+        self.node.begin_mutation_shutdown();
         // Mutation admission belongs to the binding-facing owner. Once that
         // owner enters Closing it retains this Db and awaits every operation
         // it already accepted, in FIFO order, before storage is retired.
         self.node.drain_queued_mutations().await;
+        // Local waits that became satisfied during the drain complete
+        // normally. Higher-tier waits cannot make further progress after
+        // retirement, so the shared Closing state terminalizes them instead
+        // of leaving binding promises parked forever.
+        self.node.drain_transaction_wait_observers().await;
         // Close finalization admission before the first await. This makes the
         // queued retirement set and durable close one lifecycle transition:
         // a stream dropped while storage is shutting down is either in this
@@ -658,17 +664,7 @@ where
         tx_id: TxId,
         tier: DurabilityTier,
     ) -> Result<TxId, Error> {
-        loop {
-            if let Some(outcome) = self.node.transaction_wait_outcome(tx_id, tier).await {
-                return outcome;
-            }
-            let state_change = self.node.register_write_state_waiter(tx_id);
-            if let Some(outcome) = self.node.transaction_wait_outcome(tx_id, tier).await {
-                drop(state_change);
-                return outcome;
-            }
-            state_change.await;
-        }
+        self.node.wait_for_transaction(tx_id, tier).await
     }
 
     /// Callback form of [`Db::wait_for_transaction`] for bindings that cannot

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -86,6 +86,7 @@ where
             row_id_source_guarantees_fresh,
             next_now_ms: Rc::new(Cell::new(1)),
             reserved_tx_id: None,
+            owner_operation_admitted: false,
             backend_attribution: false,
         })
     }
@@ -136,6 +137,7 @@ where
             row_id_source_guarantees_fresh,
             next_now_ms: Rc::new(Cell::new(1)),
             reserved_tx_id: None,
+            owner_operation_admitted: false,
             backend_attribution: false,
         };
         Ok((db, receipt))
@@ -173,6 +175,7 @@ where
             row_id_source_guarantees_fresh,
             next_now_ms: Rc::new(Cell::new(1)),
             reserved_tx_id: None,
+            owner_operation_admitted: false,
             backend_attribution: false,
         })
     }
@@ -226,6 +229,7 @@ where
             row_id_source_guarantees_fresh,
             next_now_ms: Rc::new(Cell::new(1)),
             reserved_tx_id: None,
+            owner_operation_admitted: false,
             backend_attribution: false,
         })
     }
@@ -338,6 +342,7 @@ where
             row_id_source_guarantees_fresh: self.row_id_source_guarantees_fresh,
             next_now_ms: Rc::clone(&self.next_now_ms),
             reserved_tx_id: None,
+            owner_operation_admitted: false,
             backend_attribution: self.backend_attribution,
         })
     }
@@ -504,6 +509,7 @@ where
             row_id_source_guarantees_fresh: self.row_id_source_guarantees_fresh,
             next_now_ms: Rc::clone(&self.next_now_ms),
             reserved_tx_id: Some(tx_id),
+            owner_operation_admitted: true,
             backend_attribution: self.backend_attribution,
         }
     }
@@ -520,7 +526,16 @@ where
             row_id_source_guarantees_fresh: self.row_id_source_guarantees_fresh,
             next_now_ms: Rc::clone(&self.next_now_ms),
             reserved_tx_id: None,
+            owner_operation_admitted: true,
             backend_attribution: self.backend_attribution,
+        }
+    }
+
+    pub(super) fn ensure_mutation_operation_admitted(&self) -> Result<(), Error> {
+        if self.owner_operation_admitted {
+            Ok(())
+        } else {
+            self.node.ensure_mutation_admission_open()
         }
     }
 

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -655,11 +655,11 @@ where
         tier: DurabilityTier,
     ) -> Result<TxId, Error> {
         loop {
-            if let Some(outcome) = self.node.transaction_wait_outcome(tx_id, tier) {
+            if let Some(outcome) = self.node.transaction_wait_outcome(tx_id, tier).await {
                 return outcome;
             }
             let state_change = self.node.register_write_state_waiter(tx_id);
-            if let Some(outcome) = self.node.transaction_wait_outcome(tx_id, tier) {
+            if let Some(outcome) = self.node.transaction_wait_outcome(tx_id, tier).await {
                 drop(state_change);
                 return outcome;
             }
@@ -831,17 +831,23 @@ where
     /// [`PeerConnection::tick`] for the common single-upstream client).
     pub async fn tick(&self) -> Result<(), Error> {
         self.node.poll_queued_mutation_once();
+        self.node.poll_transaction_wait_observers();
         self.node.drain_subscription_finalizations().await?;
         self.node.settle_local_publications().await?;
-        self.node.tick().await.map(|_| ())
+        self.node.tick().await?;
+        self.node.poll_transaction_wait_observers();
+        Ok(())
     }
 
     /// Service every connection once and return binding-observable wake counts.
     pub async fn tick_stats(&self) -> Result<DbTickStats, Error> {
         self.node.poll_queued_mutation_once();
+        self.node.poll_transaction_wait_observers();
         self.node.drain_subscription_finalizations().await?;
         self.node.settle_local_publications().await?;
-        self.node.tick().await
+        let stats = self.node.tick().await?;
+        self.node.poll_transaction_wait_observers();
+        Ok(stats)
     }
 
     #[allow(dead_code)]

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -498,6 +498,22 @@ where
         }
     }
 
+    pub(super) fn clone_for_owner_operation(&self) -> Self {
+        Self {
+            schema: self.schema.clone(),
+            schema_version_id: self.schema_version_id,
+            schema_view_is_fixed: self.schema_view_is_fixed,
+            schema_views: Rc::clone(&self.schema_views),
+            identity: self.identity,
+            node: Rc::clone(&self.node),
+            row_id_source: Rc::clone(&self.row_id_source),
+            row_id_source_guarantees_fresh: self.row_id_source_guarantees_fresh,
+            next_now_ms: Rc::clone(&self.next_now_ms),
+            reserved_tx_id: None,
+            backend_attribution: self.backend_attribution,
+        }
+    }
+
     /// Configure this durable process as the internal browser relay that owns
     /// fresh upstream authority sessions for client Edge reads.
     #[doc(hidden)]

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -476,6 +476,12 @@ where
         self.node.reserve_transaction_id(now_ms)
     }
 
+    /// Drive one bounded resident mutation turn without awaiting cold work.
+    #[doc(hidden)]
+    pub fn drive_queued_mutation_once(&self) {
+        self.node.poll_queued_mutation_once();
+    }
+
     pub(super) fn clone_for_reserved_transaction(&self, tx_id: TxId) -> Self {
         Self {
             schema: self.schema.clone(),

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -464,6 +464,13 @@ where
             .seed_tx_time_high_water(high_water);
     }
 
+    /// Reserve a definitive local transaction identity for an owner-retained
+    /// mutation before its asynchronous preparation begins.
+    #[doc(hidden)]
+    pub fn reserve_transaction_id_at_ms(&self, now_ms: u64) -> Result<TxId, Error> {
+        self.node.reserve_transaction_id(now_ms)
+    }
+
     /// Configure this durable process as the internal browser relay that owns
     /// fresh upstream authority sessions for client Edge reads.
     #[doc(hidden)]

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -430,6 +430,10 @@ where
         if self.schema_view_is_fixed {
             return Ok(());
         }
+        // Mutation admission belongs to the binding-facing owner. Once that
+        // owner enters Closing it retains this Db and awaits every operation
+        // it already accepted, in FIFO order, before storage is retired.
+        self.node.drain_queued_mutations().await;
         // Close finalization admission before the first await. This makes the
         // queued retirement set and durable close one lifecycle transition:
         // a stream dropped while storage is shutting down is either in this

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -724,6 +724,7 @@ where
         column: &str,
         bytes: Vec<u8>,
     ) -> Result<WriteHandle<S>, Error> {
+        self.ensure_mutation_operation_admitted()?;
         let (value, nullable) =
             unwrap_present_nullable(self.authorized_physical_cell(table, row, column).await?);
         match value {
@@ -782,6 +783,7 @@ where
         delete_length: u64,
         insert: Vec<u8>,
     ) -> Result<WriteHandle<S>, Error> {
+        self.ensure_mutation_operation_admitted()?;
         let (value, nullable) =
             unwrap_present_nullable(self.authorized_physical_cell(table, row, column).await?);
         match value {
@@ -1601,6 +1603,7 @@ where
         cells: &RowCells,
         column: &str,
     ) -> Result<StreamingValueUpload, Error> {
+        self.ensure_mutation_operation_admitted()?;
         let (kind, _) = self.validate_streaming_column(table, cells, column)?;
         let emitted = Rc::new(RefCell::new(Vec::new()));
         let emitted_for_stage = Rc::clone(&emitted);
@@ -1626,6 +1629,7 @@ where
         upload: &mut StreamingValueUpload,
         bytes: &[u8],
     ) -> Result<(), Error> {
+        self.ensure_mutation_operation_admitted()?;
         let initialized_now = !upload.initialized;
         if !upload.initialized {
             self.node
@@ -1682,6 +1686,7 @@ where
         &self,
         mut upload: StreamingValueUpload,
     ) -> Result<(), Error> {
+        self.ensure_mutation_operation_admitted()?;
         upload.preparation.take();
         self.node
             .node
@@ -1708,6 +1713,7 @@ where
         base: Option<BranchViewBase>,
         attribution: Option<AuthorSubject>,
     ) -> Result<WriteHandle<S>, Error> {
+        self.ensure_mutation_operation_admitted()?;
         let attribution_rejection = match attribution {
             Some(author) if author != self.identity.author && !self.backend_attribution => {
                 Some("attribution requires a trusted serving node")

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -473,7 +473,7 @@ impl<S> Db<S>
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
 {
-    fn queued_write_handle(
+    pub(super) fn queued_write_handle(
         &self,
         row: RowUuid,
         tx_id: TxId,

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -841,6 +841,7 @@ where
         patch: RowCells,
         mutations: Vec<LargeValueUpdate>,
     ) -> Result<WriteHandle<S>, Error> {
+        self.ensure_mutation_operation_admitted()?;
         self.update_with_large_value_mutations_at_ms_option(table, row, patch, mutations, None)
             .await
     }
@@ -855,6 +856,7 @@ where
         mutations: Vec<LargeValueUpdate>,
         now_ms: u64,
     ) -> Result<WriteHandle<S>, Error> {
+        self.ensure_mutation_operation_admitted()?;
         self.update_with_large_value_mutations_at_ms_option(
             table,
             row,
@@ -1397,6 +1399,7 @@ where
         cells: RowCells,
         options: InsertOptions,
     ) -> Result<WriteHandle<S>, Error> {
+        self.ensure_mutation_operation_admitted()?;
         let InsertOptions {
             row_id,
             identity,
@@ -2148,6 +2151,7 @@ where
         patch: RowCells,
         options: UpdateOptions,
     ) -> Result<WriteHandle<S>, Error> {
+        self.ensure_mutation_operation_admitted()?;
         let UpdateOptions {
             identity,
             target,
@@ -2304,6 +2308,7 @@ where
         cells: RowCells,
         options: UpsertOptions,
     ) -> Result<WriteHandle<S>, Error> {
+        self.ensure_mutation_operation_admitted()?;
         let UpsertOptions {
             identity,
             target,
@@ -2440,6 +2445,7 @@ where
         row: RowUuid,
         options: DeleteOptions,
     ) -> Result<WriteHandle<S>, Error> {
+        self.ensure_mutation_operation_admitted()?;
         let DeleteOptions {
             identity,
             target,
@@ -2632,6 +2638,7 @@ where
         cells: Option<RowCells>,
         options: RestoreOptions,
     ) -> Result<WriteHandle<S>, Error> {
+        self.ensure_mutation_operation_admitted()?;
         let RestoreOptions {
             identity,
             target,

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -473,6 +473,119 @@ impl<S> Db<S>
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
 {
+    fn queued_write_handle(
+        &self,
+        row: RowUuid,
+        tx_id: TxId,
+        queued_status: Rc<RefCell<QueuedMutationStatus>>,
+    ) -> WriteHandle<S> {
+        WriteHandle {
+            node: Rc::downgrade(&self.node.node),
+            row_uuid: row,
+            tx_id,
+            local_tier: DurabilityTier::None,
+            queued_status: Some(queued_status),
+        }
+    }
+
+    /// Synchronously reserve identity and enqueue an owner-retained insert.
+    #[doc(hidden)]
+    pub fn enqueue_insert(
+        &self,
+        table: String,
+        cells: RowCells,
+        mut options: InsertOptions,
+    ) -> Result<WriteHandle<S>, Error> {
+        validate_updated_at_ms(options.updated_at_ms)?;
+        let row = options
+            .row_id
+            .unwrap_or_else(|| self.row_id_source.borrow_mut().next_row_id());
+        let now_ms = options.updated_at_ms.unwrap_or_else(|| self.next_now_ms());
+        options.row_id = Some(row);
+        options.updated_at_ms = Some(now_ms);
+        let tx_id = self.reserve_transaction_id_at_ms(now_ms)?;
+        let db = self.clone_for_reserved_transaction(tx_id);
+        let status = self.node.enqueue_mutation(
+            tx_id,
+            Box::pin(async move {
+                let write = db.insert(&table, cells, options).await?;
+                debug_assert_eq!(write.mergeable_tx_id(), tx_id);
+                Ok(())
+            }),
+        );
+        Ok(self.queued_write_handle(row, tx_id, status))
+    }
+
+    #[doc(hidden)]
+    pub fn enqueue_update(
+        &self,
+        table: String,
+        row: RowUuid,
+        patch: RowCells,
+        mut options: UpdateOptions,
+    ) -> Result<WriteHandle<S>, Error> {
+        validate_updated_at_ms(options.updated_at_ms)?;
+        let now_ms = options.updated_at_ms.unwrap_or_else(|| self.next_now_ms());
+        options.updated_at_ms = Some(now_ms);
+        let tx_id = self.reserve_transaction_id_at_ms(now_ms)?;
+        let db = self.clone_for_reserved_transaction(tx_id);
+        let status = self.node.enqueue_mutation(
+            tx_id,
+            Box::pin(async move {
+                let write = db.update(&table, row, patch, options).await?;
+                debug_assert_eq!(write.mergeable_tx_id(), tx_id);
+                Ok(())
+            }),
+        );
+        Ok(self.queued_write_handle(row, tx_id, status))
+    }
+
+    #[doc(hidden)]
+    pub fn enqueue_upsert(
+        &self,
+        table: String,
+        row: RowUuid,
+        cells: RowCells,
+        mut options: UpsertOptions,
+    ) -> Result<WriteHandle<S>, Error> {
+        validate_updated_at_ms(options.updated_at_ms)?;
+        let now_ms = options.updated_at_ms.unwrap_or_else(|| self.next_now_ms());
+        options.updated_at_ms = Some(now_ms);
+        let tx_id = self.reserve_transaction_id_at_ms(now_ms)?;
+        let db = self.clone_for_reserved_transaction(tx_id);
+        let status = self.node.enqueue_mutation(
+            tx_id,
+            Box::pin(async move {
+                let write = db.upsert(&table, row, cells, options).await?;
+                debug_assert_eq!(write.mergeable_tx_id(), tx_id);
+                Ok(())
+            }),
+        );
+        Ok(self.queued_write_handle(row, tx_id, status))
+    }
+
+    #[doc(hidden)]
+    pub fn enqueue_delete(
+        &self,
+        table: String,
+        row: RowUuid,
+        mut options: DeleteOptions,
+    ) -> Result<WriteHandle<S>, Error> {
+        validate_updated_at_ms(options.updated_at_ms)?;
+        let now_ms = options.updated_at_ms.unwrap_or_else(|| self.next_now_ms());
+        options.updated_at_ms = Some(now_ms);
+        let tx_id = self.reserve_transaction_id_at_ms(now_ms)?;
+        let db = self.clone_for_reserved_transaction(tx_id);
+        let status = self.node.enqueue_mutation(
+            tx_id,
+            Box::pin(async move {
+                let write = db.delete(&table, row, options).await?;
+                debug_assert_eq!(write.mergeable_tx_id(), tx_id);
+                Ok(())
+            }),
+        );
+        Ok(self.queued_write_handle(row, tx_id, status))
+    }
     /// Read a byte range from an ordinary bytes or string cell without
     /// exposing its physical representation. Inline and indirect cells share
     /// this API; only the intersecting chunk paths are requested.
@@ -1144,8 +1257,17 @@ where
                     self.schema_version_id,
                 )
                 .await?;
-            node.commit_mergeable_in_schema(self.schema_version_id, commit)
+            if let Some(reserved) = self.reserved_tx_id {
+                node.commit_mergeable_many_in_schema_at(
+                    self.schema_version_id,
+                    vec![commit],
+                    reserved,
+                )
                 .await?
+            } else {
+                node.commit_mergeable_in_schema(self.schema_version_id, commit)
+                    .await?
+            }
         };
         self.finish_published_write(row, published).await
     }
@@ -1904,8 +2026,17 @@ where
                 .seal_inherited_large_values(commit, self.schema_version_id, true)
                 .await?
                 .staged_large_cell(column, staged, nullable);
-            node.commit_mergeable_in_schema(self.schema_version_id, commit)
+            if let Some(reserved) = self.reserved_tx_id {
+                node.commit_mergeable_many_in_schema_at(
+                    self.schema_version_id,
+                    vec![commit],
+                    reserved,
+                )
                 .await?
+            } else {
+                node.commit_mergeable_in_schema(self.schema_version_id, commit)
+                    .await?
+            }
         };
         self.finish_published_write(row, published).await
     }
@@ -2506,13 +2637,16 @@ where
                 .cells(BTreeMap::<String, Value>::new())
                 .deletion(DeletionEvent::Restored),
         ));
-        let published = self
-            .node
-            .node
-            .lock()
-            .await
-            .commit_mergeable_many_in_schema(self.schema_version_id, commits)
-            .await?;
+        let published = {
+            let mut node = self.node.node.lock().await;
+            if let Some(reserved) = self.reserved_tx_id {
+                node.commit_mergeable_many_in_schema_at(self.schema_version_id, commits, reserved)
+                    .await?
+            } else {
+                node.commit_mergeable_many_in_schema(self.schema_version_id, commits)
+                    .await?
+            }
+        };
         self.finish_published_write(row, published).await
     }
 
@@ -2622,8 +2756,17 @@ where
                     allow_inherited_descriptors,
                 )
                 .await?;
-            node.commit_mergeable_in_schema(self.schema_version_id, commit)
+            if let Some(reserved) = self.reserved_tx_id {
+                node.commit_mergeable_many_in_schema_at(
+                    self.schema_version_id,
+                    vec![commit],
+                    reserved,
+                )
                 .await?
+            } else {
+                node.commit_mergeable_in_schema(self.schema_version_id, commit)
+                    .await?
+            }
         };
         self.finish_published_write(row, published).await
     }
@@ -2650,6 +2793,7 @@ where
             row_uuid: row,
             tx_id,
             local_tier,
+            queued_status: None,
         })
     }
 
@@ -3106,6 +3250,7 @@ where
             row_uuid: row,
             tx_id,
             local_tier,
+            queued_status: None,
         })
     }
 
@@ -3134,6 +3279,7 @@ where
             row_uuid: row,
             tx_id,
             local_tier,
+            queued_status: None,
         })
     }
 

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -586,6 +586,30 @@ where
         );
         Ok(self.queued_write_handle(row, tx_id, status))
     }
+
+    #[doc(hidden)]
+    pub fn enqueue_restore(
+        &self,
+        table: String,
+        row: RowUuid,
+        cells: Option<RowCells>,
+        mut options: RestoreOptions,
+    ) -> Result<WriteHandle<S>, Error> {
+        validate_updated_at_ms(options.updated_at_ms)?;
+        let now_ms = options.updated_at_ms.unwrap_or_else(|| self.next_now_ms());
+        options.updated_at_ms = Some(now_ms);
+        let tx_id = self.reserve_transaction_id_at_ms(now_ms)?;
+        let db = self.clone_for_reserved_transaction(tx_id);
+        let status = self.node.enqueue_mutation(
+            tx_id,
+            Box::pin(async move {
+                let write = db.restore(&table, row, cells, options).await?;
+                debug_assert_eq!(write.mergeable_tx_id(), tx_id);
+                Ok(())
+            }),
+        );
+        Ok(self.queued_write_handle(row, tx_id, status))
+    }
     /// Read a byte range from an ordinary bytes or string cell without
     /// exposing its physical representation. Inline and indirect cells share
     /// this API; only the intersecting chunk paths are requested.

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -610,6 +610,32 @@ where
         );
         Ok(self.queued_write_handle(row, tx_id, status))
     }
+
+    #[doc(hidden)]
+    pub fn enqueue_large_value_update(
+        &self,
+        table: String,
+        row: RowUuid,
+        patch: RowCells,
+        mutations: Vec<LargeValueUpdate>,
+        updated_at_ms: Option<u64>,
+    ) -> Result<WriteHandle<S>, Error> {
+        validate_updated_at_ms(updated_at_ms)?;
+        let now_ms = updated_at_ms.unwrap_or_else(|| self.next_now_ms());
+        let tx_id = self.reserve_transaction_id_at_ms(now_ms)?;
+        let db = self.clone_for_reserved_transaction(tx_id);
+        let status = self.node.enqueue_mutation(
+            tx_id,
+            Box::pin(async move {
+                let write = db
+                    .update_with_large_value_mutations_at_ms(&table, row, patch, mutations, now_ms)
+                    .await?;
+                debug_assert_eq!(write.mergeable_tx_id(), tx_id);
+                Ok(())
+            }),
+        );
+        Ok(self.queued_write_handle(row, tx_id, status))
+    }
     /// Read a byte range from an ordinary bytes or string cell without
     /// exposing its physical representation. Inline and indirect cells share
     /// this API; only the intersecting chunk paths are requested.
@@ -925,8 +951,17 @@ where
                     node.seal_large_value_updates(commit, &staged, self.schema_version_id)
                         .await?
                 };
-                node.commit_mergeable_in_schema(self.schema_version_id, commit)
+                if let Some(reserved) = self.reserved_tx_id {
+                    node.commit_mergeable_many_in_schema_at(
+                        self.schema_version_id,
+                        vec![commit],
+                        reserved,
+                    )
                     .await?
+                } else {
+                    node.commit_mergeable_in_schema(self.schema_version_id, commit)
+                        .await?
+                }
             };
             Ok::<_, Error>(published)
         }

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -211,6 +211,18 @@ where
         status
     }
 
+    pub(super) fn enqueue_transaction_cleanup(&self, future: QueuedMutationFuture) {
+        self.queued_mutations
+            .borrow_mut()
+            .push_back(QueuedMutationOperation {
+                tx_id: None,
+                open_tx_id: None,
+                future,
+                status: None,
+            });
+        self.schedule_tick(TickUrgency::Immediate);
+    }
+
     pub(super) fn poll_queued_mutation_once(&self) {
         use std::task::{Context, Poll, Waker};
 
@@ -266,6 +278,13 @@ where
                             }
                         }
                     }
+                }
+                if operation.tx_id.is_some()
+                    && let Some(open_tx_id) = operation.open_tx_id
+                {
+                    self.queued_open_transaction_failures
+                        .borrow_mut()
+                        .remove(&open_tx_id);
                 }
                 if !self.queued_mutations.borrow().is_empty() {
                     self.schedule_tick(TickUrgency::Immediate);

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -24,6 +24,7 @@ where
     pub(super) pending_local_publications: PendingLocalPublications,
     queued_mutations: RefCell<VecDeque<QueuedMutationOperation>>,
     queued_mutation_failures: RefCell<BTreeMap<TxId, Error>>,
+    queued_open_transaction_failures: RefCell<BTreeMap<OpenTransactionId, Error>>,
     reserved_mutations: RefCell<BTreeSet<TxId>>,
     pub(super) local_publication_settler: Rc<futures::lock::Mutex<()>>,
     pub(super) upstream_subscriptions: PendingUpstreamCommands,
@@ -101,6 +102,7 @@ where
             pending_local_publications: Rc::new(RefCell::new(VecDeque::new())),
             queued_mutations: RefCell::new(VecDeque::new()),
             queued_mutation_failures: RefCell::new(BTreeMap::new()),
+            queued_open_transaction_failures: RefCell::new(BTreeMap::new()),
             reserved_mutations: RefCell::new(BTreeSet::new()),
             local_publication_settler: Rc::new(futures::lock::Mutex::new(())),
             upstream_subscriptions: Rc::new(RefCell::new(Vec::new())),
@@ -164,9 +166,46 @@ where
         self.queued_mutations
             .borrow_mut()
             .push_back(QueuedMutationOperation {
-                tx_id,
+                tx_id: Some(tx_id),
+                open_tx_id: None,
                 future,
-                status: Rc::clone(&status),
+                status: Some(Rc::clone(&status)),
+            });
+        self.schedule_tick(TickUrgency::Immediate);
+        status
+    }
+
+    pub(super) fn enqueue_transaction_operation(
+        &self,
+        open_tx_id: OpenTransactionId,
+        future: QueuedMutationFuture,
+    ) {
+        self.queued_mutations
+            .borrow_mut()
+            .push_back(QueuedMutationOperation {
+                tx_id: None,
+                open_tx_id: Some(open_tx_id),
+                future,
+                status: None,
+            });
+        self.schedule_tick(TickUrgency::Immediate);
+    }
+
+    pub(super) fn enqueue_transaction_commit(
+        &self,
+        open_tx_id: OpenTransactionId,
+        tx_id: TxId,
+        future: QueuedMutationFuture,
+    ) -> Rc<RefCell<QueuedMutationStatus>> {
+        let status = Rc::new(RefCell::new(QueuedMutationStatus::Pending));
+        self.reserved_mutations.borrow_mut().insert(tx_id);
+        self.queued_mutations
+            .borrow_mut()
+            .push_back(QueuedMutationOperation {
+                tx_id: Some(tx_id),
+                open_tx_id: Some(open_tx_id),
+                future,
+                status: Some(Rc::clone(&status)),
             });
         self.schedule_tick(TickUrgency::Immediate);
         status
@@ -181,35 +220,50 @@ where
         let owned_waker = self.query_runtime_waker();
         let waker = owned_waker.as_ref().unwrap_or_else(|| Waker::noop());
         let mut context = Context::from_waker(waker);
-        match operation.future.as_mut().poll(&mut context) {
+        let poisoned = operation.open_tx_id.and_then(|open_tx_id| {
+            self.queued_open_transaction_failures
+                .borrow()
+                .get(&open_tx_id)
+                .cloned()
+        });
+        let outcome = match poisoned {
+            Some(error) => Poll::Ready(Err(error)),
+            None => operation.future.as_mut().poll(&mut context),
+        };
+        match outcome {
             Poll::Pending => {
                 self.queued_mutations.borrow_mut().push_front(operation);
             }
             Poll::Ready(result) => {
-                self.reserved_mutations
-                    .borrow_mut()
-                    .remove(&operation.tx_id);
-                match result {
-                    Ok(()) => *operation.status.borrow_mut() = QueuedMutationStatus::Published,
-                    Err(error) => {
-                        *operation.status.borrow_mut() =
-                            QueuedMutationStatus::Failed(error.clone());
-                        self.queued_mutation_failures
-                            .borrow_mut()
-                            .insert(operation.tx_id, error);
-                    }
+                if let Some(tx_id) = operation.tx_id {
+                    self.reserved_mutations.borrow_mut().remove(&tx_id);
                 }
-                if let Some(waiters) = self
-                    .write_state_waiters
-                    .borrow_mut()
-                    .remove(&operation.tx_id)
+                if let Err(error) = &result
+                    && let Some(open_tx_id) = operation.open_tx_id
                 {
-                    for waiter in waiters {
-                        match waiter.notify {
-                            WriteStateWaiterNotify::Future(sender) => {
-                                let _ = sender.send(());
+                    self.queued_open_transaction_failures
+                        .borrow_mut()
+                        .entry(open_tx_id)
+                        .or_insert_with(|| error.clone());
+                }
+                if let (Some(tx_id), Some(status)) = (operation.tx_id, operation.status) {
+                    match result {
+                        Ok(()) => *status.borrow_mut() = QueuedMutationStatus::Published,
+                        Err(error) => {
+                            *status.borrow_mut() = QueuedMutationStatus::Failed(error.clone());
+                            self.queued_mutation_failures
+                                .borrow_mut()
+                                .insert(tx_id, error);
+                        }
+                    }
+                    if let Some(waiters) = self.write_state_waiters.borrow_mut().remove(&tx_id) {
+                        for waiter in waiters {
+                            match waiter.notify {
+                                WriteStateWaiterNotify::Future(sender) => {
+                                    let _ = sender.send(());
+                                }
+                                WriteStateWaiterNotify::Callback(callback) => callback(),
                             }
-                            WriteStateWaiterNotify::Callback(callback) => callback(),
                         }
                     }
                 }

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -872,6 +872,13 @@ where
         tier: DurabilityTier,
         callback: Box<dyn FnOnce(Result<TxId, Error>)>,
     ) {
+        if self.mutation_owner_lifecycle.get() == MutationOwnerLifecycle::Closing {
+            callback(Err(Error::new(
+                ErrorCode::NotObserved,
+                format!("database is closed; transaction {tx_id:?} cannot be observed"),
+            )));
+            return;
+        }
         let node = Rc::clone(self);
         self.transaction_wait_observers
             .borrow_mut()

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -248,60 +248,82 @@ where
             Poll::Pending => {
                 self.queued_mutations.borrow_mut().push_front(operation);
             }
-            Poll::Ready(result) => {
-                if let Some(tx_id) = operation.tx_id {
-                    self.reserved_mutations.borrow_mut().remove(&tx_id);
-                }
-                if let Err(error) = &result
-                    && let Some(open_tx_id) = operation.open_tx_id
-                {
-                    self.queued_open_transaction_failures
+            Poll::Ready(result) => self.finish_queued_mutation(operation, result),
+        }
+    }
+
+    fn finish_queued_mutation(
+        &self,
+        operation: QueuedMutationOperation,
+        result: Result<(), Error>,
+    ) {
+        if let Some(tx_id) = operation.tx_id {
+            self.reserved_mutations.borrow_mut().remove(&tx_id);
+        }
+        if let Err(error) = &result
+            && let Some(open_tx_id) = operation.open_tx_id
+        {
+            self.queued_open_transaction_failures
+                .borrow_mut()
+                .entry(open_tx_id)
+                .or_insert_with(|| error.clone());
+        }
+        if let (Some(tx_id), Some(status)) = (operation.tx_id, operation.status) {
+            let terminal_failed = result.is_err();
+            match result {
+                Ok(()) => *status.borrow_mut() = QueuedMutationStatus::Published,
+                Err(error) => {
+                    *status.borrow_mut() = QueuedMutationStatus::Failed(error.clone());
+                    self.queued_mutation_failures
                         .borrow_mut()
-                        .entry(open_tx_id)
-                        .or_insert_with(|| error.clone());
-                }
-                if let (Some(tx_id), Some(status)) = (operation.tx_id, operation.status) {
-                    let terminal_failed = result.is_err();
-                    match result {
-                        Ok(()) => *status.borrow_mut() = QueuedMutationStatus::Published,
-                        Err(error) => {
-                            *status.borrow_mut() = QueuedMutationStatus::Failed(error.clone());
-                            self.queued_mutation_failures
-                                .borrow_mut()
-                                .insert(tx_id, error);
-                        }
-                    }
-                    if let Some(waiters) = self.write_state_waiters.borrow_mut().remove(&tx_id) {
-                        for waiter in waiters {
-                            match waiter.notify {
-                                WriteStateWaiterNotify::Future(sender) => {
-                                    let _ = sender.send(());
-                                }
-                            }
-                        }
-                    }
-                    if terminal_failed && let Some(open_tx_id) = operation.open_tx_id {
-                        let node = Rc::clone(&self.node);
-                        self.enqueue_transaction_cleanup(Box::pin(async move {
-                            let mut node = node.lock().await;
-                            match node.abandon_tx(open_tx_id) {
-                                Ok(()) | Err(crate::node::Error::MissingOpenBatch(_)) => Ok(()),
-                                Err(error) => Err(error.into()),
-                            }
-                        }));
-                    }
-                }
-                if operation.tx_id.is_some()
-                    && let Some(open_tx_id) = operation.open_tx_id
-                {
-                    self.queued_open_transaction_failures
-                        .borrow_mut()
-                        .remove(&open_tx_id);
-                }
-                if !self.queued_mutations.borrow().is_empty() {
-                    self.schedule_tick(TickUrgency::Immediate);
+                        .insert(tx_id, error);
                 }
             }
+            if let Some(waiters) = self.write_state_waiters.borrow_mut().remove(&tx_id) {
+                for waiter in waiters {
+                    let WriteStateWaiterNotify::Future(sender) = waiter.notify;
+                    let _ = sender.send(());
+                }
+            }
+            if terminal_failed && let Some(open_tx_id) = operation.open_tx_id {
+                let node = Rc::clone(&self.node);
+                self.enqueue_transaction_cleanup(Box::pin(async move {
+                    let mut node = node.lock().await;
+                    match node.abandon_tx(open_tx_id) {
+                        Ok(()) | Err(crate::node::Error::MissingOpenBatch(_)) => Ok(()),
+                        Err(error) => Err(error.into()),
+                    }
+                }));
+            }
+        }
+        if operation.tx_id.is_some()
+            && let Some(open_tx_id) = operation.open_tx_id
+        {
+            self.queued_open_transaction_failures
+                .borrow_mut()
+                .remove(&open_tx_id);
+        }
+        if !self.queued_mutations.borrow().is_empty() {
+            self.schedule_tick(TickUrgency::Immediate);
+        }
+    }
+
+    pub(super) async fn drain_queued_mutations(&self) {
+        loop {
+            let Some(mut operation) = self.queued_mutations.borrow_mut().pop_front() else {
+                return;
+            };
+            let poisoned = operation.open_tx_id.and_then(|open_tx_id| {
+                self.queued_open_transaction_failures
+                    .borrow()
+                    .get(&open_tx_id)
+                    .cloned()
+            });
+            let result = match poisoned {
+                Some(error) => Err(error),
+                None => operation.future.as_mut().await,
+            };
+            self.finish_queued_mutation(operation, result);
         }
     }
 

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -8,6 +8,7 @@ use super::peer_connection::{
     mutation_error_event, take_pending_mutation_error_delivery,
 };
 use super::*;
+use crate::time::TxTime;
 
 /// Node-owned participant surface for upstream and subscriber connections.
 pub struct Node<S>
@@ -15,6 +16,8 @@ where
     S: OrderedKvStorage,
 {
     pub(super) node: SharedNodeState<S>,
+    tx_time_reservation_clock: Rc<Cell<TxTime>>,
+    node_uuid: NodeUuid,
     receives_commits_as_local: bool,
     pub(super) subscriptions: SubscriptionList,
     pub(super) outbox: Outbox,
@@ -74,6 +77,8 @@ where
         let receives_commits_as_local = !node.is_history_complete();
         let chunk_resolver = PeerChunkResolver::default();
         let local_chunk_reader = node.local_chunk_reader_handle();
+        let tx_time_reservation_clock = node.tx_time_reservation_clock();
+        let node_uuid = node.node_uuid();
         node.set_missing_chunk_resolver(Rc::new(chunk_resolver.clone()));
         let pending_mutation_errors = node
             .rejected_transactions()
@@ -85,6 +90,8 @@ where
             .collect();
         Self {
             node: Rc::new(futures::lock::Mutex::new(node)),
+            tx_time_reservation_clock,
+            node_uuid,
             receives_commits_as_local,
             subscriptions: Rc::new(RefCell::new(Vec::new())),
             outbox: Rc::new(RefCell::new(UploadOutbox::default())),
@@ -128,6 +135,17 @@ where
             local_chunk_reader,
             observed_chunk_completion_generation: Cell::new(0),
         }
+    }
+
+    /// Reserve a definitive local transaction identity without borrowing the
+    /// async storage-owning node. The shared high-water mirror is advanced by
+    /// every ordinary mint and remote observation as well.
+    pub(super) fn reserve_transaction_id(&self, now_ms: u64) -> Result<TxId, Error> {
+        let made_at = TxTime::tick(self.tx_time_reservation_clock.get(), now_ms)
+            .map_err(crate::node::Error::from)
+            .map_err(Error::from)?;
+        self.tx_time_reservation_clock.set(made_at);
+        Ok(TxId::new(made_at, self.node_uuid))
     }
 
     pub(super) fn upstream_register_shape_options(

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -760,7 +760,7 @@ where
             return Some(Err(error.clone()));
         }
         if self.reserved_mutations.borrow().contains(&tx_id) {
-            return (tier <= DurabilityTier::None).then_some(Ok(tx_id));
+            return None;
         }
         let state = crate::db::block_on(self.node.borrow_mut().transaction_state(tx_id));
         let Some((fate, global_time, durability)) = state else {

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -22,6 +22,9 @@ where
     pub(super) subscriptions: SubscriptionList,
     pub(super) outbox: Outbox,
     pub(super) pending_local_publications: PendingLocalPublications,
+    queued_mutations: RefCell<VecDeque<QueuedMutationOperation>>,
+    queued_mutation_failures: RefCell<BTreeMap<TxId, Error>>,
+    reserved_mutations: RefCell<BTreeSet<TxId>>,
     pub(super) local_publication_settler: Rc<futures::lock::Mutex<()>>,
     pub(super) upstream_subscriptions: PendingUpstreamCommands,
     pub(super) pending_subscription_finalizations: PendingSubscriptionFinalizations,
@@ -96,6 +99,9 @@ where
             subscriptions: Rc::new(RefCell::new(Vec::new())),
             outbox: Rc::new(RefCell::new(UploadOutbox::default())),
             pending_local_publications: Rc::new(RefCell::new(VecDeque::new())),
+            queued_mutations: RefCell::new(VecDeque::new()),
+            queued_mutation_failures: RefCell::new(BTreeMap::new()),
+            reserved_mutations: RefCell::new(BTreeSet::new()),
             local_publication_settler: Rc::new(futures::lock::Mutex::new(())),
             upstream_subscriptions: Rc::new(RefCell::new(Vec::new())),
             pending_subscription_finalizations: Rc::new(RefCell::new(VecDeque::new())),
@@ -146,6 +152,72 @@ where
             .map_err(Error::from)?;
         self.tx_time_reservation_clock.set(made_at);
         Ok(TxId::new(made_at, self.node_uuid))
+    }
+
+    pub(super) fn enqueue_mutation(
+        &self,
+        tx_id: TxId,
+        future: QueuedMutationFuture,
+    ) -> Rc<RefCell<QueuedMutationStatus>> {
+        let status = Rc::new(RefCell::new(QueuedMutationStatus::Pending));
+        self.reserved_mutations.borrow_mut().insert(tx_id);
+        self.queued_mutations
+            .borrow_mut()
+            .push_back(QueuedMutationOperation {
+                tx_id,
+                future,
+                status: Rc::clone(&status),
+            });
+        self.schedule_tick(TickUrgency::Immediate);
+        status
+    }
+
+    pub(super) fn poll_queued_mutation_once(&self) {
+        use std::task::{Context, Poll, Waker};
+
+        let Some(mut operation) = self.queued_mutations.borrow_mut().pop_front() else {
+            return;
+        };
+        let owned_waker = self.query_runtime_waker();
+        let waker = owned_waker.as_ref().unwrap_or_else(|| Waker::noop());
+        let mut context = Context::from_waker(waker);
+        match operation.future.as_mut().poll(&mut context) {
+            Poll::Pending => {
+                self.queued_mutations.borrow_mut().push_front(operation);
+            }
+            Poll::Ready(result) => {
+                self.reserved_mutations
+                    .borrow_mut()
+                    .remove(&operation.tx_id);
+                match result {
+                    Ok(()) => *operation.status.borrow_mut() = QueuedMutationStatus::Published,
+                    Err(error) => {
+                        *operation.status.borrow_mut() =
+                            QueuedMutationStatus::Failed(error.clone());
+                        self.queued_mutation_failures
+                            .borrow_mut()
+                            .insert(operation.tx_id, error);
+                    }
+                }
+                if let Some(waiters) = self
+                    .write_state_waiters
+                    .borrow_mut()
+                    .remove(&operation.tx_id)
+                {
+                    for waiter in waiters {
+                        match waiter.notify {
+                            WriteStateWaiterNotify::Future(sender) => {
+                                let _ = sender.send(());
+                            }
+                            WriteStateWaiterNotify::Callback(callback) => callback(),
+                        }
+                    }
+                }
+                if !self.queued_mutations.borrow().is_empty() {
+                    self.schedule_tick(TickUrgency::Immediate);
+                }
+            }
+        }
     }
 
     pub(super) fn upstream_register_shape_options(
@@ -611,6 +683,12 @@ where
         tx_id: TxId,
         tier: DurabilityTier,
     ) -> Option<Result<TxId, Error>> {
+        if let Some(error) = self.queued_mutation_failures.borrow().get(&tx_id) {
+            return Some(Err(error.clone()));
+        }
+        if self.reserved_mutations.borrow().contains(&tx_id) {
+            return (tier <= DurabilityTier::None).then_some(Ok(tx_id));
+        }
         let state = crate::db::block_on(self.node.borrow_mut().transaction_state(tx_id));
         let Some((fate, global_time, durability)) = state else {
             return Some(Err(Error::new(
@@ -629,6 +707,23 @@ where
             Fate::Pending | Fate::Accepted if satisfied => Some(Ok(tx_id)),
             Fate::Pending | Fate::Accepted => None,
         }
+    }
+
+    pub(super) fn queued_mutation_write_state(
+        &self,
+        tx_id: TxId,
+    ) -> Option<Result<WriteState, Error>> {
+        if let Some(error) = self.queued_mutation_failures.borrow().get(&tx_id) {
+            return Some(Err(error.clone()));
+        }
+        self.reserved_mutations
+            .borrow()
+            .contains(&tx_id)
+            .then_some(Ok(WriteState {
+                fate: Fate::Pending,
+                global_time: None,
+                durability: DurabilityTier::None,
+            }))
     }
 
     pub(super) fn wait_for_transaction_with(

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -16,6 +16,7 @@ where
     S: OrderedKvStorage,
 {
     pub(super) node: SharedNodeState<S>,
+    mutation_owner_lifecycle: Cell<MutationOwnerLifecycle>,
     tx_time_reservation_clock: Rc<Cell<TxTime>>,
     node_uuid: NodeUuid,
     receives_commits_as_local: bool,
@@ -95,6 +96,7 @@ where
             .collect();
         Self {
             node: Rc::new(futures::lock::Mutex::new(node)),
+            mutation_owner_lifecycle: Cell::new(MutationOwnerLifecycle::Open),
             tx_time_reservation_clock,
             node_uuid,
             receives_commits_as_local,
@@ -151,11 +153,40 @@ where
     /// async storage-owning node. The shared high-water mirror is advanced by
     /// every ordinary mint and remote observation as well.
     pub(super) fn reserve_transaction_id(&self, now_ms: u64) -> Result<TxId, Error> {
+        self.ensure_mutation_admission_open()?;
         let made_at = TxTime::tick(self.tx_time_reservation_clock.get(), now_ms)
             .map_err(crate::node::Error::from)
             .map_err(Error::from)?;
         self.tx_time_reservation_clock.set(made_at);
         Ok(TxId::new(made_at, self.node_uuid))
+    }
+
+    pub(super) fn begin_mutation_shutdown(&self) {
+        self.mutation_owner_lifecycle
+            .set(MutationOwnerLifecycle::Closing);
+        // Wait observers may be parked on a state-change channel even when
+        // there is no queued mutation left to wake them. Closing is itself a
+        // terminal observation boundary, so wake every waiter to let it
+        // either observe its requested tier or report that the runtime closed
+        // first.
+        let waiters = std::mem::take(&mut *self.write_state_waiters.borrow_mut());
+        for (_, waiters) in waiters {
+            for waiter in waiters {
+                let WriteStateWaiterNotify::Future(sender) = waiter.notify;
+                let _ = sender.send(());
+            }
+        }
+    }
+
+    pub(super) fn ensure_mutation_admission_open(&self) -> Result<(), Error> {
+        if self.mutation_owner_lifecycle.get() == MutationOwnerLifecycle::Open {
+            Ok(())
+        } else {
+            Err(Error::new(
+                ErrorCode::WriteRejected,
+                "database mutation owner is closing",
+            ))
+        }
     }
 
     pub(super) fn enqueue_mutation(
@@ -181,7 +212,8 @@ where
         &self,
         open_tx_id: OpenTransactionId,
         future: QueuedMutationFuture,
-    ) {
+    ) -> Result<(), Error> {
+        self.ensure_mutation_admission_open()?;
         self.queued_mutations
             .borrow_mut()
             .push_back(QueuedMutationOperation {
@@ -191,6 +223,7 @@ where
                 status: None,
             });
         self.schedule_tick(TickUrgency::Immediate);
+        Ok(())
     }
 
     pub(super) fn enqueue_transaction_commit(
@@ -848,15 +881,36 @@ where
         self.schedule_tick(TickUrgency::Immediate);
     }
 
-    async fn wait_for_transaction(&self, tx_id: TxId, tier: DurabilityTier) -> Result<TxId, Error> {
+    pub(super) async fn wait_for_transaction(
+        &self,
+        tx_id: TxId,
+        tier: DurabilityTier,
+    ) -> Result<TxId, Error> {
         loop {
             if let Some(outcome) = self.transaction_wait_outcome(tx_id, tier).await {
                 return outcome;
+            }
+            if self.mutation_owner_lifecycle.get() == MutationOwnerLifecycle::Closing
+                && !self.reserved_mutations.borrow().contains(&tx_id)
+            {
+                return Err(Error::new(
+                    ErrorCode::NotObserved,
+                    format!("database closed before transaction {tx_id:?} reached {tier:?}"),
+                ));
             }
             let state_change = self.register_write_state_waiter(tx_id);
             if let Some(outcome) = self.transaction_wait_outcome(tx_id, tier).await {
                 drop(state_change);
                 return outcome;
+            }
+            if self.mutation_owner_lifecycle.get() == MutationOwnerLifecycle::Closing
+                && !self.reserved_mutations.borrow().contains(&tx_id)
+            {
+                drop(state_change);
+                return Err(Error::new(
+                    ErrorCode::NotObserved,
+                    format!("database closed before transaction {tx_id:?} reached {tier:?}"),
+                ));
             }
             state_change.await;
         }
@@ -873,6 +927,23 @@ where
         self.transaction_wait_observers
             .borrow_mut()
             .splice(0..0, observers);
+    }
+
+    pub(super) async fn drain_transaction_wait_observers(&self) {
+        std::future::poll_fn(|context| {
+            let mut observers = std::mem::take(&mut *self.transaction_wait_observers.borrow_mut());
+            observers.retain_mut(|observer| observer.as_mut().poll(context) == Poll::Pending);
+            let empty = observers.is_empty();
+            self.transaction_wait_observers
+                .borrow_mut()
+                .splice(0..0, observers);
+            if empty {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await
     }
 
     fn deliver_pending_mutation_errors(&self) {

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -23,6 +23,7 @@ where
     pub(super) outbox: Outbox,
     pub(super) pending_local_publications: PendingLocalPublications,
     queued_mutations: RefCell<VecDeque<QueuedMutationOperation>>,
+    transaction_wait_observers: RefCell<Vec<TransactionWaitObserver>>,
     queued_mutation_failures: RefCell<BTreeMap<TxId, Error>>,
     queued_open_transaction_failures: RefCell<BTreeMap<OpenTransactionId, Error>>,
     reserved_mutations: RefCell<BTreeSet<TxId>>,
@@ -101,6 +102,7 @@ where
             outbox: Rc::new(RefCell::new(UploadOutbox::default())),
             pending_local_publications: Rc::new(RefCell::new(VecDeque::new())),
             queued_mutations: RefCell::new(VecDeque::new()),
+            transaction_wait_observers: RefCell::new(Vec::new()),
             queued_mutation_failures: RefCell::new(BTreeMap::new()),
             queued_open_transaction_failures: RefCell::new(BTreeMap::new()),
             reserved_mutations: RefCell::new(BTreeSet::new()),
@@ -275,7 +277,6 @@ where
                                 WriteStateWaiterNotify::Future(sender) => {
                                     let _ = sender.send(());
                                 }
-                                WriteStateWaiterNotify::Callback(callback) => callback(),
                             }
                         }
                     }
@@ -753,16 +754,16 @@ where
         }
     }
 
-    fn consume_mutation_error(&self, tx_id: TxId) -> Result<bool, Error> {
+    async fn consume_mutation_error(&self, tx_id: TxId) -> Result<bool, Error> {
         let pending = self.mutation_errors.borrow_mut().pending.remove(&tx_id);
         let retained = self.node.borrow().rejected_transaction(tx_id).is_some();
         if retained {
-            crate::db::block_on(self.node.borrow_mut().discard_rejection(tx_id))?;
+            self.node.lock().await.discard_rejection(tx_id).await?;
         }
         Ok(pending.is_some() || retained)
     }
 
-    pub(super) fn transaction_wait_outcome(
+    pub(super) async fn transaction_wait_outcome(
         &self,
         tx_id: TxId,
         tier: DurabilityTier,
@@ -773,7 +774,7 @@ where
         if self.reserved_mutations.borrow().contains(&tx_id) {
             return None;
         }
-        let state = crate::db::block_on(self.node.borrow_mut().transaction_state(tx_id));
+        let state = self.node.lock().await.transaction_state(tx_id).await;
         let Some((fate, global_time, durability)) = state else {
             return Some(Err(Error::new(
                 ErrorCode::NotObserved,
@@ -783,7 +784,7 @@ where
         let satisfied = transaction_satisfies_wait(&fate, global_time, durability, tier);
         match fate {
             Fate::Rejected(reason) => {
-                if let Err(error) = self.consume_mutation_error(tx_id) {
+                if let Err(error) = self.consume_mutation_error(tx_id).await {
                     tracing::warn!(?tx_id, %error, "failed to consume waited mutation error");
                 }
                 Some(Err(write_rejected(tx_id, reason)))
@@ -816,15 +817,40 @@ where
         tier: DurabilityTier,
         callback: Box<dyn FnOnce(Result<TxId, Error>)>,
     ) {
-        if let Some(outcome) = self.transaction_wait_outcome(tx_id, tier) {
-            callback(outcome);
-            return;
-        }
         let node = Rc::clone(self);
-        self.register_write_state_callback(
-            tx_id,
-            Box::new(move || node.wait_for_transaction_with(tx_id, tier, callback)),
-        );
+        self.transaction_wait_observers
+            .borrow_mut()
+            .push(Box::pin(async move {
+                callback(node.wait_for_transaction(tx_id, tier).await);
+            }));
+        self.schedule_tick(TickUrgency::Immediate);
+    }
+
+    async fn wait_for_transaction(&self, tx_id: TxId, tier: DurabilityTier) -> Result<TxId, Error> {
+        loop {
+            if let Some(outcome) = self.transaction_wait_outcome(tx_id, tier).await {
+                return outcome;
+            }
+            let state_change = self.register_write_state_waiter(tx_id);
+            if let Some(outcome) = self.transaction_wait_outcome(tx_id, tier).await {
+                drop(state_change);
+                return outcome;
+            }
+            state_change.await;
+        }
+    }
+
+    pub(super) fn poll_transaction_wait_observers(&self) {
+        use std::task::{Context, Poll, Waker};
+
+        let owned_waker = self.query_runtime_waker();
+        let waker = owned_waker.as_ref().unwrap_or_else(|| Waker::noop());
+        let mut context = Context::from_waker(waker);
+        let mut observers = std::mem::take(&mut *self.transaction_wait_observers.borrow_mut());
+        observers.retain_mut(|observer| observer.as_mut().poll(&mut context) == Poll::Pending);
+        self.transaction_wait_observers
+            .borrow_mut()
+            .splice(0..0, observers);
     }
 
     fn deliver_pending_mutation_errors(&self) {
@@ -906,20 +932,6 @@ where
             waiter_id,
             receiver,
         }
-    }
-
-    fn register_write_state_callback(&self, tx_id: TxId, callback: Box<dyn FnOnce()>) {
-        let waiter_id = self.next_write_state_waiter_id.get();
-        self.next_write_state_waiter_id
-            .set(waiter_id.wrapping_add(1).max(1));
-        self.write_state_waiters
-            .borrow_mut()
-            .entry(tx_id)
-            .or_default()
-            .push(WriteStateWaiter {
-                id: waiter_id,
-                notify: WriteStateWaiterNotify::Callback(callback),
-            });
     }
 
     #[allow(dead_code)]

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -259,6 +259,7 @@ where
                         .or_insert_with(|| error.clone());
                 }
                 if let (Some(tx_id), Some(status)) = (operation.tx_id, operation.status) {
+                    let terminal_failed = result.is_err();
                     match result {
                         Ok(()) => *status.borrow_mut() = QueuedMutationStatus::Published,
                         Err(error) => {
@@ -277,6 +278,16 @@ where
                                 WriteStateWaiterNotify::Callback(callback) => callback(),
                             }
                         }
+                    }
+                    if terminal_failed && let Some(open_tx_id) = operation.open_tx_id {
+                        let node = Rc::clone(&self.node);
+                        self.enqueue_transaction_cleanup(Box::pin(async move {
+                            let mut node = node.lock().await;
+                            match node.abandon_tx(open_tx_id) {
+                                Ok(()) | Err(crate::node::Error::MissingOpenBatch(_)) => Ok(()),
+                                Err(error) => Err(error.into()),
+                            }
+                        }));
                     }
                 }
                 if operation.tx_id.is_some()

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -5144,10 +5144,6 @@ fn notify_write_state_waiters(waiters: &WriteStateWaiters, tx_id: TxId) -> bool 
                     handled_mutation_error = true;
                 }
             }
-            WriteStateWaiterNotify::Callback(callback) => {
-                callback();
-                handled_mutation_error = true;
-            }
         }
     }
     handled_mutation_error

--- a/crates/jazz/src/db/tests/lifecycle.rs
+++ b/crates/jazz/src/db/tests/lifecycle.rs
@@ -113,3 +113,33 @@ fn foreground_handoff_high_water_includes_an_unsubmitted_public_write() {
         .unwrap();
     assert!(second_write.mergeable_tx_id().time > first_tx.time);
 }
+
+#[test]
+fn synchronous_reservations_are_definitive_and_advance_the_shared_hlc() {
+    let db = doctest_support::block_on(doctest_support::open_todos_db()).unwrap();
+    let floor = TxTime::new(1_000_000, 41);
+    doctest_support::block_on(db.seed_foreground_tx_time_high_water(floor));
+
+    let first = db.reserve_transaction_id_at_ms(1_000_000).unwrap();
+    let second = db.reserve_transaction_id_at_ms(1_000_000).unwrap();
+    assert_eq!(first.node, second.node);
+    assert!(first.time > floor);
+    assert!(second.time > first.time);
+    assert_eq!(
+        doctest_support::block_on(db.foreground_tx_time_high_water()),
+        second.time,
+        "clean handoff must include identities reserved before async admission",
+    );
+
+    let committed = db
+        .insert(
+            "todos",
+            doctest_support::todo_cells("after reservations", false),
+            Default::default(),
+        )
+        .unwrap();
+    assert!(
+        committed.mergeable_tx_id().time > second.time,
+        "ordinary minting must share the reservation high-water clock",
+    );
+}

--- a/crates/jazz/src/db/tests/mutations.rs
+++ b/crates/jazz/src/db/tests/mutations.rs
@@ -1882,6 +1882,7 @@ fn session_upload_rejects_forged_made_by_without_ingesting_rows() {
         row_uuid: row(0xf1),
         tx_id,
         local_tier: DurabilityTier::Local,
+        queued_status: None,
     };
     let err = block_on(handle.wait(DurabilityTier::Global)).unwrap_err();
     assert_eq!(err.code, ErrorCode::WriteRejected);

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -1,6 +1,81 @@
 //! Shared node scheduling, dirty-generation cascades, and connection servicing tests.
 
 use super::*;
+use groove::storage::{TestStorage, TestStorageOperation};
+
+#[test]
+fn reopened_wait_observer_yields_instead_of_sync_polling_cold_storage() {
+    let schema = schema();
+    let author = AuthorSubject::for_test_bytes([0xc9; 16]);
+    let column_families = schema.column_families();
+    let column_family_refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let (storage, _) = TestStorage::controlled(&column_family_refs);
+    let reopen_handle = storage.clone();
+    let db = block_on(Db::open(DbConfig {
+        schema: schema.clone(),
+        storage,
+        identity: DbIdentity {
+            node: NodeUuid::from_bytes([0xc9; 16]),
+            author,
+        },
+        id_source: Some(Box::new(SeededRowIdSource::new(0xc9))),
+    }))
+    .unwrap();
+    let tx_id = db
+        .insert(
+            "todos",
+            cells("cold reopened wait", false, author),
+            Default::default(),
+        )
+        .unwrap()
+        .mergeable_tx_id();
+    block_on(db.close()).unwrap();
+    drop(db);
+
+    let reopened_storage = block_on(reopen_handle.reopen(column_families)).unwrap();
+    let control = reopened_storage.control();
+    let eviction_handle = reopened_storage.clone();
+    let reopened = block_on(Db::open(DbConfig {
+        schema: schema.clone(),
+        storage: reopened_storage,
+        identity: DbIdentity {
+            node: NodeUuid::from_bytes([0xc9; 16]),
+            author,
+        },
+        id_source: Some(Box::new(SeededRowIdSource::new(0xca))),
+    }))
+    .unwrap();
+    eviction_handle.evict_all();
+    control.pause_on(TestStorageOperation::ScanOpen);
+    control.pause_on(TestStorageOperation::Get);
+
+    let observed = Rc::new(RefCell::new(None));
+    let callback_observed = Rc::clone(&observed);
+    reopened.wait_for_transaction_with(
+        tx_id,
+        DurabilityTier::Local,
+        move |result: Result<TxId, Error>| {
+            *callback_observed.borrow_mut() = Some(result);
+        },
+    );
+    reopened.node.poll_transaction_wait_observers();
+    assert!(
+        observed.borrow().is_none(),
+        "a cold wait observation must yield to the owner instead of completing from reservation or synchronously polling storage"
+    );
+
+    control.resume();
+    for _ in 0..4 {
+        reopened.node.poll_transaction_wait_observers();
+        if observed.borrow().is_some() {
+            break;
+        }
+    }
+    assert_eq!(observed.borrow_mut().take().unwrap().unwrap(), tx_id);
+}
 
 #[test]
 fn large_write_pushes_staging_before_syncing_its_referencing_row() {
@@ -807,18 +882,22 @@ fn pending_global_state_does_not_complete_remote_wait_or_prune_upload() {
     assert_eq!(state.fate, Fate::Pending);
     assert_eq!(state.durability, DurabilityTier::Global);
     assert!(
-        client
-            .node
-            .transaction_wait_outcome(tx_id, DurabilityTier::Global)
-            .is_none(),
+        block_on(
+            client
+                .node
+                .transaction_wait_outcome(tx_id, DurabilityTier::Global)
+        )
+        .is_none(),
         "a hydration-only durability claim must not complete a remote transaction wait"
     );
     assert_eq!(
-        client
-            .node
-            .transaction_wait_outcome(tx_id, DurabilityTier::Local)
-            .expect("local persistence completes independently of authority fate")
-            .unwrap(),
+        block_on(
+            client
+                .node
+                .transaction_wait_outcome(tx_id, DurabilityTier::Local)
+        )
+        .expect("local persistence completes independently of authority fate")
+        .unwrap(),
         tx_id
     );
 
@@ -864,18 +943,22 @@ fn global_wait_requires_authority_timestamp_after_accepted_global_durability() {
     assert_eq!(state.global_time, None);
     assert_eq!(state.durability, DurabilityTier::Global);
     assert!(
-        client
-            .node
-            .transaction_wait_outcome(tx_id, DurabilityTier::Global)
-            .is_none(),
+        block_on(
+            client
+                .node
+                .transaction_wait_outcome(tx_id, DurabilityTier::Global)
+        )
+        .is_none(),
         "Accepted+Global without an authority timestamp cannot complete Global wait"
     );
     assert_eq!(
-        client
-            .node
-            .transaction_wait_outcome(tx_id, DurabilityTier::Edge)
-            .expect("Accepted Edge durability does not require a Global timestamp")
-            .unwrap(),
+        block_on(
+            client
+                .node
+                .transaction_wait_outcome(tx_id, DurabilityTier::Edge)
+        )
+        .expect("Accepted Edge durability does not require a Global timestamp")
+        .unwrap(),
         tx_id
     );
 
@@ -895,11 +978,13 @@ fn global_wait_requires_authority_timestamp_after_accepted_global_durability() {
         Some(GlobalTime(7))
     );
     assert_eq!(
-        client
-            .node
-            .transaction_wait_outcome(tx_id, DurabilityTier::Global)
-            .expect("authority timestamp completes Global wait")
-            .unwrap(),
+        block_on(
+            client
+                .node
+                .transaction_wait_outcome(tx_id, DurabilityTier::Global)
+        )
+        .expect("authority timestamp completes Global wait")
+        .unwrap(),
         tx_id
     );
 }

--- a/crates/jazz/src/db/tests/support.rs
+++ b/crates/jazz/src/db/tests/support.rs
@@ -1866,6 +1866,7 @@ impl CoreDb {
             row_uuid: row,
             tx_id,
             local_tier: DurabilityTier::Global,
+            queued_status: None,
         })
     }
 
@@ -1894,6 +1895,7 @@ impl CoreDb {
             row_uuid: row,
             tx_id,
             local_tier: DurabilityTier::Global,
+            queued_status: None,
         })
     }
 
@@ -1947,6 +1949,7 @@ impl CoreDb {
             row_uuid: row,
             tx_id,
             local_tier: DurabilityTier::Global,
+            queued_status: None,
         })
     }
 
@@ -2006,6 +2009,7 @@ impl CoreDb {
             row_uuid: row,
             tx_id,
             local_tier: DurabilityTier::Global,
+            queued_status: None,
         })
     }
 

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -158,8 +158,7 @@ where
                     (None, None) => db.begin_mergeable(id).await,
                 }
             }),
-        );
-        Ok(())
+        )
     }
 
     /// Return a non-owning operations handle for an already-open mergeable transaction.
@@ -697,7 +696,11 @@ where
 
     /// Queue exclusive snapshot admission behind earlier owner operations.
     #[doc(hidden)]
-    pub fn enqueue_begin_exclusive(&self, id: OpenTransactionId, author: Option<AuthorSubject>) {
+    pub fn enqueue_begin_exclusive(
+        &self,
+        id: OpenTransactionId,
+        author: Option<AuthorSubject>,
+    ) -> Result<(), Error> {
         let db = self.clone_for_owner_operation();
         self.node.enqueue_transaction_operation(
             id,
@@ -707,7 +710,7 @@ where
                     None => db.begin_exclusive(id).await,
                 }
             }),
-        );
+        )
     }
 
     /// Return a non-owning operations handle for an already-open exclusive transaction.
@@ -728,7 +731,7 @@ where
         table: String,
         cells: RowCells,
         mut options: InsertOptions,
-    ) -> RowUuid {
+    ) -> Result<RowUuid, Error> {
         let row = options
             .row_id
             .unwrap_or_else(|| self.row_id_source.borrow_mut().next_row_id());
@@ -748,8 +751,8 @@ where
                 }
                 Ok(())
             }),
-        );
-        row
+        )?;
+        Ok(row)
     }
 
     #[doc(hidden)]
@@ -761,7 +764,7 @@ where
         row: RowUuid,
         patch: RowCells,
         options: UpdateOptions,
-    ) {
+    ) -> Result<(), Error> {
         let db = self.clone_for_owner_operation();
         self.node.enqueue_transaction_operation(
             id,
@@ -776,7 +779,7 @@ where
                         .await
                 }
             }),
-        );
+        )
     }
 
     #[doc(hidden)]
@@ -788,7 +791,7 @@ where
         row: RowUuid,
         cells: RowCells,
         options: UpsertOptions,
-    ) {
+    ) -> Result<(), Error> {
         let db = self.clone_for_owner_operation();
         self.node.enqueue_transaction_operation(
             id,
@@ -803,7 +806,7 @@ where
                         .await
                 }
             }),
-        );
+        )
     }
 
     #[doc(hidden)]
@@ -814,7 +817,7 @@ where
         table: String,
         row: RowUuid,
         options: DeleteOptions,
-    ) {
+    ) -> Result<(), Error> {
         let db = self.clone_for_owner_operation();
         self.node.enqueue_transaction_operation(
             id,
@@ -825,7 +828,7 @@ where
                     db.mergeable_tx_ref(id).delete(&table, row, options).await
                 }
             }),
-        );
+        )
     }
 
     #[doc(hidden)]
@@ -837,7 +840,7 @@ where
         row: RowUuid,
         cells: Option<RowCells>,
         options: RestoreOptions,
-    ) {
+    ) -> Result<(), Error> {
         let db = self.clone_for_owner_operation();
         self.node.enqueue_transaction_operation(
             id,
@@ -852,7 +855,7 @@ where
                         .await
                 }
             }),
-        );
+        )
     }
 
     pub(super) async fn transaction_read(

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -76,6 +76,7 @@ where
     /// foreign-function call. Rust callers that want RAII should use
     /// [`Db::mergeable_tx`] instead.
     pub async fn begin_mergeable(&self, id: OpenTransactionId) -> Result<(), Error> {
+        self.ensure_mutation_operation_admitted()?;
         self.node
             .node
             .lock()
@@ -93,6 +94,7 @@ where
         id: OpenTransactionId,
         author: AuthorSubject,
     ) -> Result<(), Error> {
+        self.ensure_mutation_operation_admitted()?;
         self.node
             .node
             .lock()
@@ -110,6 +112,7 @@ where
         id: OpenTransactionId,
         made_by: AuthorSubject,
     ) -> Result<(), Error> {
+        self.ensure_mutation_operation_admitted()?;
         if made_by != self.identity.author && !self.backend_attribution {
             return Err(Error::new(
                 ErrorCode::WriteRejected,
@@ -678,6 +681,7 @@ where
     /// [`ExclusiveTxRef`]. Rust callers that want RAII should use
     /// [`Db::exclusive_tx`] instead.
     pub async fn begin_exclusive(&self, id: OpenTransactionId) -> Result<(), Error> {
+        self.ensure_mutation_operation_admitted()?;
         self.open_exclusive_handle(id).await
     }
 
@@ -691,6 +695,7 @@ where
         id: OpenTransactionId,
         author: AuthorSubject,
     ) -> Result<(), Error> {
+        self.ensure_mutation_operation_admitted()?;
         self.open_exclusive_handle_for_identity(id, author).await
     }
 

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -642,6 +642,20 @@ where
             .map_err(Into::into)
     }
 
+    /// Queue rollback after all earlier admission/staging work. Missing state
+    /// is accepted because a failed queued begin is already terminal.
+    #[doc(hidden)]
+    pub fn enqueue_abandon_transaction_handle(&self, open_tx_id: OpenTransactionId) {
+        let db = self.clone_for_owner_operation();
+        self.node.enqueue_transaction_cleanup(Box::pin(async move {
+            let mut node = db.node.node.lock().await;
+            match node.abandon_tx(open_tx_id) {
+                Ok(()) | Err(crate::node::Error::MissingOpenBatch(_)) => Ok(()),
+                Err(error) => Err(error.into()),
+            }
+        }));
+    }
+
     /// Open an exclusive transaction over the current local snapshot.
     ///
     /// This is the owning, RAII flavour. It abandons an uncommitted transaction

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -560,6 +560,41 @@ where
         Ok(tx_id)
     }
 
+    /// Reserve the final identity and retain mergeable commit/finalization on
+    /// the node owner. Binding callers use this after synchronous staging so
+    /// cold parent refresh or persistence cannot strand the commit future.
+    #[doc(hidden)]
+    pub fn enqueue_commit_mergeable_handle(
+        &self,
+        open_tx_id: OpenTransactionId,
+    ) -> Result<WriteHandle<S>, Error> {
+        let now_ms = self.next_now_ms();
+        let tx_id = self.reserve_transaction_id_at_ms(now_ms)?;
+        let db = self.clone_for_reserved_transaction(tx_id);
+        let status = self.node.enqueue_mutation(
+            tx_id,
+            Box::pin(async move {
+                let published = db
+                    .node
+                    .node
+                    .lock()
+                    .await
+                    .commit_mergeable_open_at(open_tx_id, tx_id, || now_ms)
+                    .await?;
+                debug_assert_eq!(published.tx_id, tx_id);
+                if db.node.defer_local_persistence.get() {
+                    db.node.queue_local_publication(published, None);
+                } else {
+                    db.finish_publication_outcome(PublicationOutcome::published((), published))
+                        .await?;
+                    db.finalize_local_commit(tx_id)?;
+                }
+                Ok(())
+            }),
+        );
+        Ok(self.queued_write_handle(RowUuid::from_bytes([0; 16]), tx_id, status))
+    }
+
     /// Abandon an owned open transaction handle.
     pub fn abandon_transaction_handle(&self, open_tx_id: OpenTransactionId) -> Result<(), Error> {
         self.node

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -981,6 +981,35 @@ where
         self.finish_exclusive_publication(published, unit).await
     }
 
+    /// Reserve the final identity and retain exclusive serializability,
+    /// publication, and finalization on the node owner.
+    #[doc(hidden)]
+    pub fn enqueue_commit_exclusive_handle(
+        &self,
+        open_tx_id: OpenTransactionId,
+    ) -> Result<WriteHandle<S>, Error> {
+        let now_ms = self.next_now_ms();
+        let tx_id = self.reserve_transaction_id_at_ms(now_ms)?;
+        let db = self.clone_for_reserved_transaction(tx_id);
+        let status = self.node.enqueue_mutation(
+            tx_id,
+            Box::pin(async move {
+                let (published, unit) = db
+                    .node
+                    .node
+                    .lock()
+                    .await
+                    .commit_exclusive_bound_at(open_tx_id, tx_id)
+                    .await?;
+                debug_assert_eq!(published.tx_id, tx_id);
+                let committed = db.finish_exclusive_publication(published, unit).await?;
+                debug_assert_eq!(committed, tx_id);
+                Ok(())
+            }),
+        );
+        Ok(self.queued_write_handle(RowUuid::from_bytes([0; 16]), tx_id, status))
+    }
+
     /// Commit an owned exclusive transaction as an explicit policy identity.
     ///
     /// Bindings that expose session-scoped transactions use this rather than

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -125,6 +125,43 @@ where
             .map_err(Into::into)
     }
 
+    /// Queue mergeable transaction admission behind earlier owner operations.
+    #[doc(hidden)]
+    pub fn enqueue_begin_mergeable(
+        &self,
+        id: OpenTransactionId,
+        author: Option<AuthorSubject>,
+        attribution: Option<AuthorSubject>,
+    ) -> Result<(), Error> {
+        if attribution.is_some() && author.is_some() {
+            return Err(Error::new(
+                ErrorCode::WriteRejected,
+                "attributed transaction cannot override admission identity",
+            ));
+        }
+        if let Some(made_by) = attribution
+            && made_by != self.identity.author
+            && !self.backend_attribution
+        {
+            return Err(Error::new(
+                ErrorCode::WriteRejected,
+                "attribution requires a trusted serving node",
+            ));
+        }
+        let db = self.clone_for_owner_operation();
+        self.node.enqueue_transaction_operation(
+            id,
+            Box::pin(async move {
+                match (author, attribution) {
+                    (_, Some(attribution)) => db.begin_mergeable_attributed(id, attribution).await,
+                    (Some(author), None) => db.begin_mergeable_for_identity(id, author).await,
+                    (None, None) => db.begin_mergeable(id).await,
+                }
+            }),
+        );
+        Ok(())
+    }
+
     /// Return a non-owning operations handle for an already-open mergeable transaction.
     ///
     /// This handle never closes the transaction when dropped, so it is suitable
@@ -571,7 +608,8 @@ where
         let now_ms = self.next_now_ms();
         let tx_id = self.reserve_transaction_id_at_ms(now_ms)?;
         let db = self.clone_for_reserved_transaction(tx_id);
-        let status = self.node.enqueue_mutation(
+        let status = self.node.enqueue_transaction_commit(
+            open_tx_id,
             tx_id,
             Box::pin(async move {
                 let published = db
@@ -643,6 +681,21 @@ where
         self.open_exclusive_handle_for_identity(id, author).await
     }
 
+    /// Queue exclusive snapshot admission behind earlier owner operations.
+    #[doc(hidden)]
+    pub fn enqueue_begin_exclusive(&self, id: OpenTransactionId, author: Option<AuthorSubject>) {
+        let db = self.clone_for_owner_operation();
+        self.node.enqueue_transaction_operation(
+            id,
+            Box::pin(async move {
+                match author {
+                    Some(author) => db.begin_exclusive_for_identity(id, author).await,
+                    None => db.begin_exclusive(id).await,
+                }
+            }),
+        );
+    }
+
     /// Return a non-owning operations handle for an already-open exclusive transaction.
     ///
     /// This handle never closes the transaction when dropped, so it is suitable
@@ -651,6 +704,141 @@ where
     /// [`ExclusiveTx`] handle.
     pub fn exclusive_tx_ref(&self, tx_id: OpenTransactionId) -> ExclusiveTxRef<'_, S> {
         ExclusiveTxRef { db: self, tx_id }
+    }
+
+    #[doc(hidden)]
+    pub fn enqueue_transaction_insert(
+        &self,
+        id: OpenTransactionId,
+        exclusive: bool,
+        table: String,
+        cells: RowCells,
+        mut options: InsertOptions,
+    ) -> RowUuid {
+        let row = options
+            .row_id
+            .unwrap_or_else(|| self.row_id_source.borrow_mut().next_row_id());
+        options.row_id = Some(row);
+        let db = self.clone_for_owner_operation();
+        self.node.enqueue_transaction_operation(
+            id,
+            Box::pin(async move {
+                if exclusive {
+                    db.exclusive_tx_ref(id)
+                        .insert(&table, cells, options)
+                        .await?;
+                } else {
+                    db.mergeable_tx_ref(id)
+                        .insert(&table, cells, options)
+                        .await?;
+                }
+                Ok(())
+            }),
+        );
+        row
+    }
+
+    #[doc(hidden)]
+    pub fn enqueue_transaction_update(
+        &self,
+        id: OpenTransactionId,
+        exclusive: bool,
+        table: String,
+        row: RowUuid,
+        patch: RowCells,
+        options: UpdateOptions,
+    ) {
+        let db = self.clone_for_owner_operation();
+        self.node.enqueue_transaction_operation(
+            id,
+            Box::pin(async move {
+                if exclusive {
+                    db.exclusive_tx_ref(id)
+                        .update(&table, row, patch, options)
+                        .await
+                } else {
+                    db.mergeable_tx_ref(id)
+                        .update(&table, row, patch, options)
+                        .await
+                }
+            }),
+        );
+    }
+
+    #[doc(hidden)]
+    pub fn enqueue_transaction_upsert(
+        &self,
+        id: OpenTransactionId,
+        exclusive: bool,
+        table: String,
+        row: RowUuid,
+        cells: RowCells,
+        options: UpsertOptions,
+    ) {
+        let db = self.clone_for_owner_operation();
+        self.node.enqueue_transaction_operation(
+            id,
+            Box::pin(async move {
+                if exclusive {
+                    db.exclusive_tx_ref(id)
+                        .upsert(&table, row, cells, options)
+                        .await
+                } else {
+                    db.mergeable_tx_ref(id)
+                        .upsert(&table, row, cells, options)
+                        .await
+                }
+            }),
+        );
+    }
+
+    #[doc(hidden)]
+    pub fn enqueue_transaction_delete(
+        &self,
+        id: OpenTransactionId,
+        exclusive: bool,
+        table: String,
+        row: RowUuid,
+        options: DeleteOptions,
+    ) {
+        let db = self.clone_for_owner_operation();
+        self.node.enqueue_transaction_operation(
+            id,
+            Box::pin(async move {
+                if exclusive {
+                    db.exclusive_tx_ref(id).delete(&table, row, options).await
+                } else {
+                    db.mergeable_tx_ref(id).delete(&table, row, options).await
+                }
+            }),
+        );
+    }
+
+    #[doc(hidden)]
+    pub fn enqueue_transaction_restore(
+        &self,
+        id: OpenTransactionId,
+        exclusive: bool,
+        table: String,
+        row: RowUuid,
+        cells: Option<RowCells>,
+        options: RestoreOptions,
+    ) {
+        let db = self.clone_for_owner_operation();
+        self.node.enqueue_transaction_operation(
+            id,
+            Box::pin(async move {
+                if exclusive {
+                    db.exclusive_tx_ref(id)
+                        .restore(&table, row, cells, options)
+                        .await
+                } else {
+                    db.mergeable_tx_ref(id)
+                        .restore(&table, row, cells, options)
+                        .await
+                }
+            }),
+        );
     }
 
     pub(super) async fn transaction_read(
@@ -991,7 +1179,8 @@ where
         let now_ms = self.next_now_ms();
         let tx_id = self.reserve_transaction_id_at_ms(now_ms)?;
         let db = self.clone_for_reserved_transaction(tx_id);
-        let status = self.node.enqueue_mutation(
+        let status = self.node.enqueue_transaction_commit(
+            open_tx_id,
             tx_id,
             Box::pin(async move {
                 let (published, unit) = db

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -6,7 +6,7 @@
 //! [`views`] for sync view payloads. In the layer map it is the core between the
 //! `Db` facade and groove storage/IVM.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -633,6 +633,9 @@ pub(crate) enum CatalogueBootstrapState {
 struct Clock {
     /// Highest local transaction timestamp observed or minted by this node.
     tx_time: TxTime,
+    /// Synchronously reservable high-water mirror shared with the host-facing
+    /// node wrapper. Every mint/merge path advances both clocks.
+    reservation_high_water: Rc<Cell<TxTime>>,
     /// Highest authority settlement timestamp observed or minted by this node.
     global_time_register: GlobalTime,
     /// Authority timestamps allocated here and awaiting accepted application.
@@ -667,7 +670,7 @@ where
 
     fn allocate_global_time_for_test(&mut self) -> GlobalTime {
         self.clock
-            .allocate_global_time(self.clock.tx_time.physical_ms())
+            .allocate_global_time(self.tx_time_high_water().physical_ms())
             .expect("test global HLC must have capacity")
     }
 

--- a/crates/jazz/src/node/open_tx.rs
+++ b/crates/jazz/src/node/open_tx.rs
@@ -768,12 +768,45 @@ where
         self.commit_exclusive(open_batch_id, author, now_ms).await
     }
 
+    /// Commit a bound exclusive transaction at a synchronously reserved local
+    /// identity after all cold serializability and large-value checks finish.
+    pub(crate) async fn commit_exclusive_bound_at(
+        &mut self,
+        open_batch_id: OpenTransactionId,
+        reserved: TxId,
+    ) -> Result<(PublishedTransaction, SyncMessage), Error> {
+        let OpenTransactionKind::Exclusive {
+            bound_author: Some(author),
+        } = self.open_tx(open_batch_id)?.kind
+        else {
+            return Err(Error::OpenTransactionIdentityMismatch);
+        };
+        self.commit_exclusive_inner(
+            open_batch_id,
+            author,
+            reserved.time.physical_ms(),
+            Some(reserved),
+        )
+        .await
+    }
+
     /// Commit an exclusive transaction and return its sync commit unit.
     pub async fn commit_exclusive(
         &mut self,
         open_batch_id: OpenTransactionId,
         made_by: AuthorSubject,
         now_ms: u64,
+    ) -> Result<(PublishedTransaction, SyncMessage), Error> {
+        self.commit_exclusive_inner(open_batch_id, made_by, now_ms, None)
+            .await
+    }
+
+    async fn commit_exclusive_inner(
+        &mut self,
+        open_batch_id: OpenTransactionId,
+        made_by: AuthorSubject,
+        now_ms: u64,
+        reserved: Option<TxId>,
     ) -> Result<(PublishedTransaction, SyncMessage), Error> {
         let made_by = match self.open_tx(open_batch_id)?.kind {
             OpenTransactionKind::Exclusive {
@@ -813,8 +846,28 @@ where
         for parent in open_tx.writes.iter().flat_map(|write| write.parents.iter()) {
             self.merge_tx_time(parent.time);
         }
-        let made_at = self.mint_tx_time(now_ms)?;
-        let tx_id = TxId::new(made_at, self.node_uuid);
+        let tx_id = match reserved {
+            Some(reserved) => {
+                if reserved.node != self.node_uuid {
+                    return Err(Error::InvalidMergeableCommit(
+                        "reserved transaction identity belongs to another node",
+                    ));
+                }
+                if open_tx
+                    .writes
+                    .iter()
+                    .flat_map(|write| write.parents.iter())
+                    .any(|parent| parent.time >= reserved.time)
+                {
+                    return Err(Error::InvalidMergeableCommit(
+                        "reserved transaction identity must dominate every parent",
+                    ));
+                }
+                self.merge_tx_time(reserved.time);
+                reserved
+            }
+            None => TxId::new(self.mint_tx_time(now_ms)?, self.node_uuid),
+        };
         let provenance_snapshot = open_tx.base_snapshot.clone();
         let mut versions = Vec::with_capacity(open_tx.writes.len());
         for write in open_tx.writes {

--- a/crates/jazz/src/node/open_tx.rs
+++ b/crates/jazz/src/node/open_tx.rs
@@ -987,6 +987,28 @@ where
         open_batch_id: OpenTransactionId,
         mut next_now_ms: impl FnMut() -> u64,
     ) -> Result<PublishedTransaction, Error> {
+        self.commit_mergeable_open_inner(open_batch_id, &mut next_now_ms, None)
+            .await
+    }
+
+    /// Commit an open mergeable transaction at an identity synchronously
+    /// reserved by the owning runtime before cold preparation begins.
+    pub(crate) async fn commit_mergeable_open_at(
+        &mut self,
+        open_batch_id: OpenTransactionId,
+        reserved: TxId,
+        mut next_now_ms: impl FnMut() -> u64,
+    ) -> Result<PublishedTransaction, Error> {
+        self.commit_mergeable_open_inner(open_batch_id, &mut next_now_ms, Some(reserved))
+            .await
+    }
+
+    async fn commit_mergeable_open_inner(
+        &mut self,
+        open_batch_id: OpenTransactionId,
+        next_now_ms: &mut impl FnMut() -> u64,
+        reserved: Option<TxId>,
+    ) -> Result<PublishedTransaction, Error> {
         if !matches!(
             self.open_tx(open_batch_id)?.kind,
             OpenTransactionKind::Mergeable { .. }
@@ -1055,7 +1077,7 @@ where
             let mut commit = MergeableCommit::new(
                 &write.table,
                 write.row_uuid,
-                write.now_ms.unwrap_or_else(&mut next_now_ms),
+                write.now_ms.unwrap_or_else(&mut *next_now_ms),
             )
             .branch(write.branch)
             .made_by(made_by)
@@ -1095,7 +1117,27 @@ where
                 self.merge_tx_time(parent.time);
             }
         }
-        let made_at = self.mint_tx_time(first.1.now_ms)?;
+        let made_at = match reserved {
+            Some(reserved) => {
+                if reserved.node != self.node_uuid {
+                    return Err(Error::InvalidMergeableCommit(
+                        "reserved transaction identity belongs to another node",
+                    ));
+                }
+                if commits
+                    .iter()
+                    .flat_map(|(_, commit)| commit.parents.iter())
+                    .any(|parent| parent.time >= reserved.time)
+                {
+                    return Err(Error::InvalidMergeableCommit(
+                        "reserved transaction identity must dominate every parent",
+                    ));
+                }
+                self.merge_tx_time(reserved.time);
+                reserved.time
+            }
+            None => self.mint_tx_time(first.1.now_ms)?,
+        };
         let committed = self
             .commit_mergeable_many_at_with_schema_versions(commits, made_at)
             .await?;

--- a/crates/jazz/src/node/open_tx.rs
+++ b/crates/jazz/src/node/open_tx.rs
@@ -129,7 +129,7 @@ where
         {
             return Err(Error::DuplicateOpenBatch(id));
         }
-        let local_base = self.clock.tx_time;
+        let local_base = self.tx_time_high_water();
         let mut dots = Vec::with_capacity(self.clock.applied_global_times_after_frontier.len());
         for global_time in self.clock.applied_global_times_after_frontier.clone() {
             dots.extend(self.transaction_ids_for_global_time(global_time).await?);
@@ -1116,7 +1116,7 @@ where
 
     /// Return whether local transaction time advanced after this transaction opened.
     pub fn open_exclusive_snapshot_moved(&self, tx_id: OpenTransactionId) -> Result<bool, Error> {
-        Ok(self.clock.tx_time > self.open_tx(tx_id)?.base_snapshot.local_base)
+        Ok(self.tx_time_high_water() > self.open_tx(tx_id)?.base_snapshot.local_base)
     }
 
     pub(super) fn open_tx(&self, tx_id: OpenTransactionId) -> Result<&OpenTransaction, Error> {

--- a/crates/jazz/src/node/state/commit.rs
+++ b/crates/jazz/src/node/state/commit.rs
@@ -212,6 +212,54 @@ where
         .await
     }
 
+    /// Commit prepared local writes under a transaction identity reserved by
+    /// the host before asynchronous preparation began.
+    pub(crate) async fn commit_mergeable_many_in_schema_at(
+        &mut self,
+        schema_version: SchemaVersionId,
+        commits: Vec<MergeableCommit>,
+        reserved: TxId,
+    ) -> Result<PublishedTransaction, Error> {
+        if reserved.node != self.node_uuid {
+            return Err(Error::InvalidMergeableCommit(
+                "reserved transaction belongs to another node",
+            ));
+        }
+        self.require_catalogue_ready()?;
+        if !self.catalogue.catalogue_schemas.contains_key(&schema_version) {
+            return Err(Error::InvalidMergeableCommit(
+                "authored schema version is not admitted",
+            ));
+        }
+        if commits.is_empty() {
+            return Err(Error::InvalidMergeableCommit(
+                "mergeable transaction requires at least one write",
+            ));
+        }
+        for commit in &commits {
+            commit.validate()?;
+            if commit.effective_permission_subject() != commits[0].effective_permission_subject() {
+                return Err(Error::InvalidMergeableCommit(
+                    "mergeable transaction permission subjects must match",
+                ));
+            }
+            if commit.parents.iter().any(|parent| parent.time >= reserved.time) {
+                return Err(Error::InvalidMergeableCommit(
+                    "reserved transaction does not dominate its prepared parents",
+                ));
+            }
+        }
+        self.merge_tx_time(reserved.time);
+        self.commit_mergeable_many_at_with_schema_versions(
+            commits
+                .into_iter()
+                .map(|commit| (schema_version, commit))
+                .collect(),
+            reserved.time,
+        )
+        .await
+    }
+
     fn merge_commit_parent_times(&mut self, commits: &[MergeableCommit]) -> Result<(), Error> {
         for commit in commits {
             if !commit.parents.is_empty() {

--- a/crates/jazz/src/node/state/lifecycle.rs
+++ b/crates/jazz/src/node/state/lifecycle.rs
@@ -541,6 +541,7 @@ where
             catalogue_bootstrap_marker,
             clock: Clock {
                 tx_time: TxTime::default(),
+                reservation_high_water: Rc::new(Cell::new(TxTime::default())),
                 global_time_register: GlobalTime::default(),
                 locally_minted_global_times: BTreeSet::new(),
                 committed_global_time: GlobalTime(0),
@@ -707,7 +708,13 @@ where
     /// identity to its pool.  It intentionally includes identities allocated
     /// for transactions that were later rolled back or never submitted.
     pub(crate) fn tx_time_high_water(&self) -> TxTime {
-        self.clock.tx_time
+        self.clock
+            .tx_time
+            .max(self.clock.reservation_high_water.get())
+    }
+
+    pub(crate) fn tx_time_reservation_clock(&self) -> Rc<Cell<TxTime>> {
+        Rc::clone(&self.clock.reservation_high_water)
     }
 
     /// Establish a durable-owner supplied lower bound before this runtime can

--- a/crates/jazz/src/node/state/read_payload.rs
+++ b/crates/jazz/src/node/state/read_payload.rs
@@ -682,12 +682,21 @@ where
     }
 
     fn mint_tx_time(&mut self, now_ms: u64) -> Result<TxTime, Error> {
-        let made_at = TxTime::tick(self.clock.tx_time, now_ms)?;
+        let made_at = TxTime::tick(
+            self.clock
+                .tx_time
+                .max(self.clock.reservation_high_water.get()),
+            now_ms,
+        )?;
         self.clock.tx_time = made_at;
+        self.clock.reservation_high_water.set(made_at);
         Ok(made_at)
     }
 
     fn merge_tx_time(&mut self, observed: TxTime) {
         self.clock.tx_time = self.clock.tx_time.max(observed);
+        self.clock
+            .reservation_high_water
+            .set(self.clock.reservation_high_water.get().max(observed));
     }
 }

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -4,7 +4,7 @@ use std::task::{Context, Poll};
 
 use futures::executor::block_on;
 use futures::task::noop_waker;
-use jazz::db::{Db, DbConfig, DbIdentity, ErrorCode, ReadOpts, try_ready};
+use jazz::db::{Db, DbConfig, DbIdentity, ErrorCode, ReadOpts};
 use jazz::groove::storage::{TestStorage, TestStorageOperation};
 use jazz::ids::{AuthorSubject, NodeUuid};
 use jazz::row;
@@ -216,56 +216,4 @@ fn cancelled_started_deferred_persistence_poison_requires_reopen() {
             .any(|row| row.row_uuid() == durable_seed.row_uuid())
     );
     assert!(rows.iter().any(|row| row.row_uuid() == fresh.row_uuid()));
-}
-
-#[test]
-fn cold_sync_update_fails_before_mutation_and_async_update_resumes() {
-    let schema = schema();
-    let families = schema.column_families();
-    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
-    let (storage, control) = TestStorage::controlled(&family_refs);
-    let storage_control = storage.clone();
-    let db = block_on(Db::open(DbConfig::new(
-        schema,
-        storage,
-        DbIdentity {
-            node: NodeUuid::from_bytes([0x53; 16]),
-            author: AuthorSubject::for_test_bytes([0x63; 16]),
-        },
-    )))
-    .expect("open yielding database");
-    let seeded = block_on(db.insert("todos", row! { title: "before" }, Default::default()))
-        .expect("seed row");
-    block_on(seeded.wait(DurabilityTier::Local)).expect("seed is durable");
-
-    storage_control.evict_all();
-    control.pause_on(TestStorageOperation::Get);
-    control.pause_on(TestStorageOperation::ScanOpen);
-    let error = match try_ready(db.update(
-        "todos",
-        seeded.row_uuid(),
-        row! { title: "must not publish" },
-        Default::default(),
-    )) {
-        Ok(_) => panic!("resident-only wiring must reject the cold update"),
-        Err(error) => error,
-    };
-    assert_eq!(error.code, ErrorCode::ColdMutationRequiresAsync);
-
-    control.resume();
-    let query = db.prepare_query(&db.table("todos")).expect("prepare query");
-    let rows = block_on(db.all(&query, ReadOpts::default())).expect("read unchanged row");
-    assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].cell_at(0), Some("before".into()));
-
-    let update = block_on(db.update(
-        "todos",
-        seeded.row_uuid(),
-        row! { title: "after" },
-        Default::default(),
-    ))
-    .expect("owner-retained async update resumes");
-    block_on(update.wait(DurabilityTier::Local)).expect("async update is durable");
-    let rows = block_on(db.all(&query, ReadOpts::default())).expect("read updated row");
-    assert_eq!(rows[0].cell_at(0), Some("after".into()));
 }

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -4,7 +4,7 @@ use std::task::{Context, Poll};
 
 use futures::executor::block_on;
 use futures::task::noop_waker;
-use jazz::db::{Db, DbConfig, DbIdentity, ErrorCode, ExclusiveTxOps, MergeableTxOps, ReadOpts};
+use jazz::db::{Db, DbConfig, DbIdentity, ErrorCode, MergeableTxOps, ReadOpts};
 use jazz::groove::storage::{TestStorage, TestStorageOperation};
 use jazz::ids::{AuthorSubject, NodeUuid};
 use jazz::row;
@@ -469,12 +469,19 @@ fn queued_mergeable_commit_retains_cold_parent_refresh_and_exact_identity() {
 
     let waker = noop_waker();
     let mut context = Context::from_waker(&waker);
-    let mut first_turn = Box::pin(db.tick());
-    assert!(matches!(
-        first_turn.as_mut().poll(&mut context),
-        Poll::Pending
-    ));
-    drop(first_turn);
+    let mut reached_cold_commit = false;
+    for _ in 0..3 {
+        let mut turn = Box::pin(db.tick());
+        reached_cold_commit |= matches!(turn.as_mut().poll(&mut context), Poll::Pending);
+        drop(turn);
+        if reached_cold_commit {
+            break;
+        }
+    }
+    assert!(
+        reached_cold_commit,
+        "bounded owner turns must reach the planted cold mergeable parent refresh",
+    );
     assert_eq!(queued.mergeable_tx_id(), reserved);
     assert_eq!(
         block_on(queued.write_state())
@@ -524,17 +531,18 @@ fn queued_exclusive_commit_retains_cold_serializability_and_exact_identity() {
     block_on(seed.wait(DurabilityTier::Local)).expect("seed is durable");
 
     let open_tx = OpenTransactionId::new();
-    block_on(db.begin_exclusive(open_tx)).expect("begin exclusive transaction");
-    block_on(db.exclusive_tx_ref(open_tx).update(
-        "todos",
-        seed.row_uuid(),
-        row! { title: "after" },
-        Default::default(),
-    ))
-    .expect("stage exclusive update");
     storage_control.evict_all();
     control.pause_on(TestStorageOperation::Get);
     control.pause_on(TestStorageOperation::ScanOpen);
+    db.enqueue_begin_exclusive(open_tx, None);
+    db.enqueue_transaction_update(
+        open_tx,
+        true,
+        "todos".to_owned(),
+        seed.row_uuid(),
+        row! { title: "after" },
+        Default::default(),
+    );
     let queued = db
         .enqueue_commit_exclusive_handle(open_tx)
         .expect("reserve final transaction identity");
@@ -542,12 +550,19 @@ fn queued_exclusive_commit_retains_cold_serializability_and_exact_identity() {
 
     let waker = noop_waker();
     let mut context = Context::from_waker(&waker);
-    let mut first_turn = Box::pin(db.tick());
-    assert!(matches!(
-        first_turn.as_mut().poll(&mut context),
-        Poll::Pending
-    ));
-    drop(first_turn);
+    let mut reached_cold_stage = false;
+    for _ in 0..3 {
+        let mut turn = Box::pin(db.tick());
+        reached_cold_stage |= matches!(turn.as_mut().poll(&mut context), Poll::Pending);
+        drop(turn);
+        if reached_cold_stage {
+            break;
+        }
+    }
+    assert!(
+        reached_cold_stage,
+        "bounded owner turns must reach the planted cold exclusive staging read",
+    );
     assert_eq!(queued.mergeable_tx_id(), reserved);
     assert_eq!(
         block_on(queued.write_state())

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -4,7 +4,7 @@ use std::task::{Context, Poll};
 
 use futures::executor::block_on;
 use futures::task::noop_waker;
-use jazz::db::{Db, DbConfig, DbIdentity, ErrorCode, ReadOpts};
+use jazz::db::{Db, DbConfig, DbIdentity, ErrorCode, ReadOpts, try_ready};
 use jazz::groove::storage::{TestStorage, TestStorageOperation};
 use jazz::ids::{AuthorSubject, NodeUuid};
 use jazz::row;
@@ -216,4 +216,56 @@ fn cancelled_started_deferred_persistence_poison_requires_reopen() {
             .any(|row| row.row_uuid() == durable_seed.row_uuid())
     );
     assert!(rows.iter().any(|row| row.row_uuid() == fresh.row_uuid()));
+}
+
+#[test]
+fn cold_sync_update_fails_before_mutation_and_async_update_resumes() {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = TestStorage::controlled(&family_refs);
+    let storage_control = storage.clone();
+    let db = block_on(Db::open(DbConfig::new(
+        schema,
+        storage,
+        DbIdentity {
+            node: NodeUuid::from_bytes([0x53; 16]),
+            author: AuthorSubject::for_test_bytes([0x63; 16]),
+        },
+    )))
+    .expect("open yielding database");
+    let seeded = block_on(db.insert("todos", row! { title: "before" }, Default::default()))
+        .expect("seed row");
+    block_on(seeded.wait(DurabilityTier::Local)).expect("seed is durable");
+
+    storage_control.evict_all();
+    control.pause_on(TestStorageOperation::Get);
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let error = match try_ready(db.update(
+        "todos",
+        seeded.row_uuid(),
+        row! { title: "must not publish" },
+        Default::default(),
+    )) {
+        Ok(_) => panic!("resident-only wiring must reject the cold update"),
+        Err(error) => error,
+    };
+    assert_eq!(error.code, ErrorCode::ColdMutationRequiresAsync);
+
+    control.resume();
+    let query = db.prepare_query(&db.table("todos")).expect("prepare query");
+    let rows = block_on(db.all(&query, ReadOpts::default())).expect("read unchanged row");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].cell_at(0), Some("before".into()));
+
+    let update = block_on(db.update(
+        "todos",
+        seeded.row_uuid(),
+        row! { title: "after" },
+        Default::default(),
+    ))
+    .expect("owner-retained async update resumes");
+    block_on(update.wait(DurabilityTier::Local)).expect("async update is durable");
+    let rows = block_on(db.all(&query, ReadOpts::default())).expect("read updated row");
+    assert_eq!(rows[0].cell_at(0), Some("after".into()));
 }

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -6,7 +6,9 @@ use std::task::{Context, Poll};
 
 use futures::executor::block_on;
 use futures::task::noop_waker;
-use jazz::db::{Db, DbConfig, DbIdentity, ErrorCode, MergeableTxOps, ReadOpts};
+use jazz::db::{
+    Db, DbConfig, DbIdentity, ErrorCode, MergeableTxOps, ReadOpts, StreamingMutationKind,
+};
 use jazz::groove::storage::{ReopenableStorage, TestStorage, TestStorageOperation};
 use jazz::ids::{AuthorSubject, NodeUuid};
 use jazz::row;
@@ -569,6 +571,122 @@ fn close_owns_and_drains_cold_failed_and_following_fifo_mutations() {
     let rows = block_on(reopened.all(&query, ReadOpts::default())).expect("read drained writes");
     let titles = rows.iter().map(|row| row.cell_at(0)).collect::<Vec<_>>();
     assert_eq!(titles, vec![Some("second".into()), Some("third".into())]);
+}
+
+#[test]
+fn retained_streaming_uploads_cannot_mutate_storage_after_sibling_owner_close_starts() {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = TestStorage::controlled(&family_refs);
+    let storage_control = storage.clone();
+    let owner = block_on(Db::open_history_complete(DbConfig::new(
+        empty_schema(),
+        storage,
+        DbIdentity {
+            node: NodeUuid::from_bytes([0x5a; 16]),
+            author: AuthorSubject::for_test_bytes([0x6a; 16]),
+        },
+    )))
+    .expect("open yielding owner");
+    let db = block_on(owner.register_schema_view(schema)).expect("register sibling schema view");
+    let cells = Default::default();
+
+    let mut push_upload = db
+        .begin_streaming_value_upload("todos", &cells, "title")
+        .expect("begin retained push upload");
+    let mut finish_upload = db
+        .begin_streaming_value_upload("todos", &cells, "title")
+        .expect("begin retained finish upload");
+    let mut abort_upload = db
+        .begin_streaming_value_upload("todos", &cells, "title")
+        .expect("begin retained abort upload");
+    block_on(db.push_streaming_value_upload(&mut push_upload, b"before close"))
+        .expect("initialize push upload");
+    block_on(db.push_streaming_value_upload(&mut finish_upload, b"before close"))
+        .expect("initialize finish upload");
+    block_on(db.push_streaming_value_upload(&mut abort_upload, b"before close"))
+        .expect("initialize abort upload");
+
+    storage_control.evict_all();
+    control.pause_on(TestStorageOperation::Get);
+    control.pause_on(TestStorageOperation::ScanOpen);
+    db.enqueue_update(
+        "todos".to_owned(),
+        jazz::ids::RowUuid::from_bytes([0x7a; 16]),
+        row! { title: "cold close head" },
+        Default::default(),
+    )
+    .expect("queue cold head");
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    let mut close = Box::pin(owner.close());
+    assert!(matches!(close.as_mut().poll(&mut context), Poll::Pending));
+    control.take_observed();
+
+    let begin_error = match db.begin_streaming_value_upload("todos", &cells, "title") {
+        Ok(_) => panic!("streaming begin after close unexpectedly succeeded"),
+        Err(error) => error,
+    };
+    assert_eq!(begin_error.code, ErrorCode::WriteRejected);
+    let mut append = Box::pin(db.append_value(
+        "todos",
+        jazz::ids::RowUuid::from_bytes([0x7c; 16]),
+        "title",
+        b"after close".to_vec(),
+    ));
+    let Poll::Ready(Err(append_error)) = append.as_mut().poll(&mut context) else {
+        panic!("append after close must reject before touching cold storage");
+    };
+    assert_eq!(append_error.code, ErrorCode::WriteRejected);
+    let mut splice = Box::pin(db.splice_value(
+        "todos",
+        jazz::ids::RowUuid::from_bytes([0x7d; 16]),
+        "title",
+        0,
+        0,
+        b"after close".to_vec(),
+    ));
+    let Poll::Ready(Err(splice_error)) = splice.as_mut().poll(&mut context) else {
+        panic!("splice after close must reject before touching cold storage");
+    };
+    assert_eq!(splice_error.code, ErrorCode::WriteRejected);
+    assert_eq!(
+        block_on(db.push_streaming_value_upload(&mut push_upload, b"after close"))
+            .expect_err("retained push after close must fail")
+            .code,
+        ErrorCode::WriteRejected,
+    );
+    let finish_error = match block_on(db.finish_streaming_value_upload(
+        finish_upload,
+        StreamingMutationKind::Insert,
+        "todos",
+        jazz::ids::RowUuid::from_bytes([0x7b; 16]),
+        cells.clone(),
+        "title",
+        None,
+        None,
+        None,
+        None,
+        None,
+    )) {
+        Ok(_) => panic!("retained finish after close unexpectedly published"),
+        Err(error) => error,
+    };
+    assert_eq!(finish_error.code, ErrorCode::WriteRejected);
+    assert_eq!(
+        block_on(db.abort_streaming_value_upload(abort_upload))
+            .expect_err("retained abort after close must fail")
+            .code,
+        ErrorCode::WriteRejected,
+    );
+    assert!(
+        control.observed().is_empty(),
+        "post-close streaming calls must not touch journal, chunks, or roots"
+    );
+
+    control.resume();
+    while close.as_mut().poll(&mut context).is_pending() {}
 }
 
 #[test]

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -5,7 +5,7 @@ use std::task::{Context, Poll};
 use futures::executor::block_on;
 use futures::task::noop_waker;
 use jazz::db::{Db, DbConfig, DbIdentity, ErrorCode, MergeableTxOps, ReadOpts};
-use jazz::groove::storage::{TestStorage, TestStorageOperation};
+use jazz::groove::storage::{ReopenableStorage, TestStorage, TestStorageOperation};
 use jazz::ids::{AuthorSubject, NodeUuid};
 use jazz::row;
 use jazz::schema::JazzSchema;
@@ -360,6 +360,24 @@ fn queued_mutations_are_fifo_owned_and_surface_preparation_failures() {
     );
 
     control.resume();
+    let mut first_terminal_before_second = false;
+    for _ in 0..4_096 {
+        let mut turn = Box::pin(db.tick());
+        let _ = turn.as_mut().poll(&mut context);
+        drop(turn);
+        let first_terminal = block_on(rejected.write_state()).is_err();
+        let second_published = db
+            .write_state(accepted_tx)
+            .is_ok_and(|state| state.durability >= DurabilityTier::Local);
+        if first_terminal || second_published {
+            first_terminal_before_second = first_terminal && !second_published;
+            break;
+        }
+    }
+    assert!(
+        first_terminal_before_second,
+        "resuming a cold head must terminalize it before the following operation; requeueing Pending at the back overtakes this receipt",
+    );
     for _ in 0..4_096 {
         let mut turn = Box::pin(db.tick());
         let _ = turn.as_mut().poll(&mut context);
@@ -382,6 +400,85 @@ fn queued_mutations_are_fifo_owned_and_surface_preparation_failures() {
     let rows = block_on(db.all(&query, ReadOpts::default())).expect("read inserted row");
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].row_uuid(), accepted_row);
+}
+
+#[test]
+fn close_owns_and_drains_cold_failed_and_following_fifo_mutations() {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = TestStorage::controlled(&family_refs);
+    let reopen_handle = storage.clone();
+    let db = block_on(Db::open(DbConfig::new(
+        schema.clone(),
+        storage,
+        DbIdentity {
+            node: NodeUuid::from_bytes([0x59; 16]),
+            author: AuthorSubject::for_test_bytes([0x69; 16]),
+        },
+    )))
+    .expect("open yielding database");
+
+    reopen_handle.evict_all();
+    control.pause_on(TestStorageOperation::Get);
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let failed = db
+        .enqueue_update(
+            "todos".to_owned(),
+            jazz::ids::RowUuid::from_bytes([0x79; 16]),
+            row! { title: "missing" },
+            Default::default(),
+        )
+        .expect("reserve failing head");
+    db.enqueue_insert(
+        "todos".to_owned(),
+        row! { title: "second" },
+        Default::default(),
+    )
+    .expect("reserve second");
+    db.enqueue_insert(
+        "todos".to_owned(),
+        row! { title: "third" },
+        Default::default(),
+    )
+    .expect("reserve third");
+
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    let mut close = Box::pin(db.close());
+    assert!(matches!(close.as_mut().poll(&mut context), Poll::Pending));
+    control.resume();
+    let close_result = loop {
+        if let Poll::Ready(result) = close.as_mut().poll(&mut context) {
+            break result;
+        }
+    };
+    close_result.expect("close drains every accepted operation before storage retirement");
+    assert_eq!(
+        block_on(failed.write_state())
+            .expect_err("failed queued operation remains terminally observable")
+            .code,
+        ErrorCode::WriteRejected,
+    );
+    drop(close);
+    drop(db);
+
+    let reopened_storage = block_on(reopen_handle.reopen(families)).expect("reopen drained store");
+    let reopened = block_on(Db::open(DbConfig::new(
+        schema,
+        reopened_storage,
+        DbIdentity {
+            node: NodeUuid::from_bytes([0x59; 16]),
+            author: AuthorSubject::for_test_bytes([0x69; 16]),
+        },
+    )))
+    .expect("reopen database after close");
+    let query = reopened
+        .prepare_query(&reopened.table("todos"))
+        .expect("prepare reopened query");
+    let rows = block_on(reopened.all(&query, ReadOpts::default())).expect("read drained writes");
+    let titles = rows.iter().map(|row| row.cell_at(0)).collect::<Vec<_>>();
+    assert_eq!(titles, vec![Some("second".into()), Some("third".into())]);
 }
 
 #[test]

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -217,3 +217,82 @@ fn cancelled_started_deferred_persistence_poison_requires_reopen() {
     );
     assert!(rows.iter().any(|row| row.row_uuid() == fresh.row_uuid()));
 }
+
+#[test]
+fn queued_update_retains_cold_preparation_and_its_definitive_identity() {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = TestStorage::controlled(&family_refs);
+    let storage_control = storage.clone();
+    let db = block_on(Db::open(DbConfig::new(
+        schema,
+        storage,
+        DbIdentity {
+            node: NodeUuid::from_bytes([0x54; 16]),
+            author: AuthorSubject::for_test_bytes([0x64; 16]),
+        },
+    )))
+    .expect("open yielding database");
+    let seeded = block_on(db.insert("todos", row! { title: "before" }, Default::default()))
+        .expect("seed row");
+    block_on(seeded.wait(DurabilityTier::Local)).expect("seed is durable");
+
+    storage_control.evict_all();
+    control.pause_on(TestStorageOperation::Get);
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let queued = db
+        .enqueue_update(
+            "todos".to_owned(),
+            seeded.row_uuid(),
+            row! { title: "after" },
+            Default::default(),
+        )
+        .expect("synchronous facade reserves and queues");
+    let reserved = queued.mergeable_tx_id();
+    let state = block_on(queued.write_state()).expect("reserved state is observable");
+    assert_eq!(state.durability, DurabilityTier::None);
+
+    let mut first_turn = Box::pin(db.tick());
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    assert!(matches!(
+        first_turn.as_mut().poll(&mut context),
+        Poll::Pending
+    ));
+    drop(first_turn);
+    assert!(
+        control.observed().iter().any(|operation| matches!(
+            operation,
+            TestStorageOperation::Get | TestStorageOperation::ScanOpen
+        )),
+        "the queued owner future must reach the planted cold read",
+    );
+    assert_eq!(queued.mergeable_tx_id(), reserved);
+
+    control.resume();
+    for _ in 0..4_096 {
+        let mut turn = Box::pin(db.tick());
+        let _ = turn.as_mut().poll(&mut context);
+        drop(turn);
+        if block_on(queued.write_state())
+            .is_ok_and(|state| state.durability >= DurabilityTier::Local)
+        {
+            break;
+        }
+    }
+    let resumed_state = block_on(queued.write_state());
+    assert!(
+        resumed_state
+            .as_ref()
+            .is_ok_and(|state| state.durability >= DurabilityTier::Local),
+        "bounded owner turns must finish the resumed queued mutation: {resumed_state:?}",
+    );
+    assert_eq!(
+        block_on(queued.wait(DurabilityTier::Local)).expect("queued write settles"),
+        reserved,
+    );
+    let query = db.prepare_query(&db.table("todos")).expect("prepare query");
+    let rows = block_on(db.all(&query, ReadOpts::default())).expect("read updated row");
+    assert_eq!(rows[0].cell_at(0), Some("after".into()));
+}

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -252,10 +252,16 @@ fn queued_update_retains_cold_preparation_and_its_definitive_identity() {
     let reserved = queued.mergeable_tx_id();
     let state = block_on(queued.write_state()).expect("reserved state is observable");
     assert_eq!(state.durability, DurabilityTier::None);
-
-    let mut first_turn = Box::pin(db.tick());
+    let mut resident_wait = Box::pin(db.wait_for_transaction(reserved, DurabilityTier::None));
     let waker = noop_waker();
     let mut context = Context::from_waker(&waker);
+    assert!(
+        matches!(resident_wait.as_mut().poll(&mut context), Poll::Pending),
+        "identity reservation alone is not the resident publication milestone",
+    );
+    drop(resident_wait);
+
+    let mut first_turn = Box::pin(db.tick());
     assert!(matches!(
         first_turn.as_mut().poll(&mut context),
         Poll::Pending

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -296,3 +296,84 @@ fn queued_update_retains_cold_preparation_and_its_definitive_identity() {
     let rows = block_on(db.all(&query, ReadOpts::default())).expect("read updated row");
     assert_eq!(rows[0].cell_at(0), Some("after".into()));
 }
+
+#[test]
+fn queued_mutations_are_fifo_owned_and_surface_preparation_failures() {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = TestStorage::controlled(&family_refs);
+    let storage_control = storage.clone();
+    let db = block_on(Db::open(DbConfig::new(
+        schema,
+        storage,
+        DbIdentity {
+            node: NodeUuid::from_bytes([0x55; 16]),
+            author: AuthorSubject::for_test_bytes([0x65; 16]),
+        },
+    )))
+    .expect("open yielding database");
+
+    storage_control.evict_all();
+    control.pause_on(TestStorageOperation::Get);
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let missing = jazz::ids::RowUuid::from_bytes([0x75; 16]);
+    let rejected = db
+        .enqueue_update(
+            "todos".to_owned(),
+            missing,
+            row! { title: "cannot update missing row" },
+            Default::default(),
+        )
+        .expect("first operation reserves an identity");
+    let accepted = db
+        .enqueue_insert(
+            "todos".to_owned(),
+            row! { title: "second" },
+            Default::default(),
+        )
+        .expect("second operation reserves an identity");
+    let accepted_row = accepted.row_uuid();
+    let accepted_tx = accepted.mergeable_tx_id();
+    drop(accepted);
+
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    let mut first_turn = Box::pin(db.tick());
+    assert!(matches!(
+        first_turn.as_mut().poll(&mut context),
+        Poll::Pending
+    ));
+    drop(first_turn);
+    assert_eq!(
+        db.write_state(accepted_tx)
+            .expect("the second reservation remains observable")
+            .durability,
+        DurabilityTier::None,
+        "the FIFO owner must not overtake a cold first operation",
+    );
+
+    control.resume();
+    for _ in 0..4_096 {
+        let mut turn = Box::pin(db.tick());
+        let _ = turn.as_mut().poll(&mut context);
+        drop(turn);
+        if db
+            .write_state(accepted_tx)
+            .is_ok_and(|state| state.durability >= DurabilityTier::Local)
+        {
+            break;
+        }
+    }
+    let error = block_on(rejected.write_state()).expect_err("missing-row update must fail");
+    assert_eq!(error.code, ErrorCode::WriteRejected);
+    assert!(
+        db.write_state(accepted_tx)
+            .is_ok_and(|state| state.durability >= DurabilityTier::Local),
+        "the owner must continue with the next operation after a terminal preparation error",
+    );
+    let query = db.prepare_query(&db.table("todos")).expect("prepare query");
+    let rows = block_on(db.all(&query, ReadOpts::default())).expect("read inserted row");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].row_uuid(), accepted_row);
+}

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -4,12 +4,12 @@ use std::task::{Context, Poll};
 
 use futures::executor::block_on;
 use futures::task::noop_waker;
-use jazz::db::{Db, DbConfig, DbIdentity, ErrorCode, ReadOpts};
+use jazz::db::{Db, DbConfig, DbIdentity, ErrorCode, MergeableTxOps, ReadOpts};
 use jazz::groove::storage::{TestStorage, TestStorageOperation};
 use jazz::ids::{AuthorSubject, NodeUuid};
 use jazz::row;
 use jazz::schema::JazzSchema;
-use jazz::tools::{ColumnType, SchemaBuilder, TableSchemaBuilder};
+use jazz::tools::{ColumnType, OpenTransactionId, SchemaBuilder, TableSchemaBuilder};
 use jazz::tx::DurabilityTier;
 use jazz_storage_rocksdb::RocksDbStorage;
 
@@ -428,4 +428,77 @@ fn reopened_reservation_clock_dominates_durable_local_history() {
         second_write.mergeable_tx_id().time > first_tx.time,
         "the synchronously returned identity must dominate durable history for the reused node",
     );
+}
+
+#[test]
+fn queued_mergeable_commit_retains_cold_parent_refresh_and_exact_identity() {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = TestStorage::controlled(&family_refs);
+    let storage_control = storage.clone();
+    let db = block_on(Db::open(DbConfig::new(
+        schema,
+        storage,
+        DbIdentity {
+            node: NodeUuid::from_bytes([0x57; 16]),
+            author: AuthorSubject::for_test_bytes([0x67; 16]),
+        },
+    )))
+    .expect("open yielding database");
+    let seed = block_on(db.insert("todos", row! { title: "before" }, Default::default()))
+        .expect("seed row");
+    block_on(seed.wait(DurabilityTier::Local)).expect("seed is durable");
+
+    let open_tx = OpenTransactionId::new();
+    block_on(db.begin_mergeable(open_tx)).expect("begin mergeable transaction");
+    block_on(db.mergeable_tx_ref(open_tx).update(
+        "todos",
+        seed.row_uuid(),
+        row! { title: "after" },
+        Default::default(),
+    ))
+    .expect("stage update");
+    storage_control.evict_all();
+    control.pause_on(TestStorageOperation::Get);
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let queued = db
+        .enqueue_commit_mergeable_handle(open_tx)
+        .expect("reserve final transaction identity");
+    let reserved = queued.mergeable_tx_id();
+
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    let mut first_turn = Box::pin(db.tick());
+    assert!(matches!(
+        first_turn.as_mut().poll(&mut context),
+        Poll::Pending
+    ));
+    drop(first_turn);
+    assert_eq!(queued.mergeable_tx_id(), reserved);
+    assert_eq!(
+        block_on(queued.write_state())
+            .expect("reservation remains observable")
+            .durability,
+        DurabilityTier::None,
+    );
+
+    control.resume();
+    for _ in 0..4_096 {
+        let mut turn = Box::pin(db.tick());
+        let _ = turn.as_mut().poll(&mut context);
+        drop(turn);
+        if block_on(queued.write_state())
+            .is_ok_and(|state| state.durability >= DurabilityTier::Local)
+        {
+            break;
+        }
+    }
+    assert_eq!(
+        block_on(queued.wait(DurabilityTier::Local)).expect("queued transaction settles"),
+        reserved,
+    );
+    let query = db.prepare_query(&db.table("todos")).expect("prepare query");
+    let rows = block_on(db.all(&query, ReadOpts::default())).expect("read committed row");
+    assert_eq!(rows[0].cell_at(0), Some("after".into()));
 }

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -590,3 +590,60 @@ fn queued_exclusive_commit_retains_cold_serializability_and_exact_identity() {
     let rows = block_on(db.all(&query, ReadOpts::default())).expect("read committed row");
     assert_eq!(rows[0].cell_at(0), Some("after".into()));
 }
+
+#[test]
+fn queued_transaction_stage_failure_poison_prevents_partial_commit() {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let storage =
+        jazz::groove::storage::MemoryStorage::new(&family_refs).expect("open memory storage");
+    let db = block_on(Db::open(DbConfig::new(
+        schema,
+        storage,
+        DbIdentity {
+            node: NodeUuid::from_bytes([0x59; 16]),
+            author: AuthorSubject::for_test_bytes([0x69; 16]),
+        },
+    )))
+    .expect("open database");
+    let open_tx = OpenTransactionId::new();
+    db.enqueue_begin_mergeable(open_tx, None, None)
+        .expect("queue begin");
+    db.enqueue_transaction_insert(
+        open_tx,
+        false,
+        "missing_table".to_owned(),
+        row! { title: "invalid" },
+        Default::default(),
+    );
+    db.enqueue_transaction_insert(
+        open_tx,
+        false,
+        "todos".to_owned(),
+        row! { title: "must not commit" },
+        Default::default(),
+    );
+    let commit = db
+        .enqueue_commit_mergeable_handle(open_tx)
+        .expect("reserve final identity");
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    for _ in 0..32 {
+        let mut turn = Box::pin(db.tick());
+        let _ = turn.as_mut().poll(&mut context);
+        drop(turn);
+        if block_on(commit.write_state()).is_err() {
+            break;
+        }
+    }
+    let error = block_on(commit.write_state()).expect_err("stage error poisons the commit");
+    assert_eq!(error.code, ErrorCode::Schema);
+    let query = db.prepare_query(&db.table("todos")).expect("prepare query");
+    assert!(
+        block_on(db.all(&query, ReadOpts::default()))
+            .expect("read rows")
+            .is_empty(),
+        "a later valid stage must not survive an earlier terminal stage error",
+    );
+}

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -4,7 +4,7 @@ use std::task::{Context, Poll};
 
 use futures::executor::block_on;
 use futures::task::noop_waker;
-use jazz::db::{Db, DbConfig, DbIdentity, ErrorCode, MergeableTxOps, ReadOpts};
+use jazz::db::{Db, DbConfig, DbIdentity, ErrorCode, ExclusiveTxOps, MergeableTxOps, ReadOpts};
 use jazz::groove::storage::{TestStorage, TestStorageOperation};
 use jazz::ids::{AuthorSubject, NodeUuid};
 use jazz::row;
@@ -464,6 +464,79 @@ fn queued_mergeable_commit_retains_cold_parent_refresh_and_exact_identity() {
     control.pause_on(TestStorageOperation::ScanOpen);
     let queued = db
         .enqueue_commit_mergeable_handle(open_tx)
+        .expect("reserve final transaction identity");
+    let reserved = queued.mergeable_tx_id();
+
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    let mut first_turn = Box::pin(db.tick());
+    assert!(matches!(
+        first_turn.as_mut().poll(&mut context),
+        Poll::Pending
+    ));
+    drop(first_turn);
+    assert_eq!(queued.mergeable_tx_id(), reserved);
+    assert_eq!(
+        block_on(queued.write_state())
+            .expect("reservation remains observable")
+            .durability,
+        DurabilityTier::None,
+    );
+
+    control.resume();
+    for _ in 0..4_096 {
+        let mut turn = Box::pin(db.tick());
+        let _ = turn.as_mut().poll(&mut context);
+        drop(turn);
+        if block_on(queued.write_state())
+            .is_ok_and(|state| state.durability >= DurabilityTier::Local)
+        {
+            break;
+        }
+    }
+    assert_eq!(
+        block_on(queued.wait(DurabilityTier::Local)).expect("queued transaction settles"),
+        reserved,
+    );
+    let query = db.prepare_query(&db.table("todos")).expect("prepare query");
+    let rows = block_on(db.all(&query, ReadOpts::default())).expect("read committed row");
+    assert_eq!(rows[0].cell_at(0), Some("after".into()));
+}
+
+#[test]
+fn queued_exclusive_commit_retains_cold_serializability_and_exact_identity() {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = TestStorage::controlled(&family_refs);
+    let storage_control = storage.clone();
+    let db = block_on(Db::open(DbConfig::new(
+        schema,
+        storage,
+        DbIdentity {
+            node: NodeUuid::from_bytes([0x58; 16]),
+            author: AuthorSubject::for_test_bytes([0x68; 16]),
+        },
+    )))
+    .expect("open yielding database");
+    let seed = block_on(db.insert("todos", row! { title: "before" }, Default::default()))
+        .expect("seed row");
+    block_on(seed.wait(DurabilityTier::Local)).expect("seed is durable");
+
+    let open_tx = OpenTransactionId::new();
+    block_on(db.begin_exclusive(open_tx)).expect("begin exclusive transaction");
+    block_on(db.exclusive_tx_ref(open_tx).update(
+        "todos",
+        seed.row_uuid(),
+        row! { title: "after" },
+        Default::default(),
+    ))
+    .expect("stage exclusive update");
+    storage_control.evict_all();
+    control.pause_on(TestStorageOperation::Get);
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let queued = db
+        .enqueue_commit_exclusive_handle(open_tx)
         .expect("reserve final transaction identity");
     let reserved = queued.mergeable_tx_id();
 

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -377,3 +377,55 @@ fn queued_mutations_are_fifo_owned_and_surface_preparation_failures() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].row_uuid(), accepted_row);
 }
+
+#[test]
+fn reopened_reservation_clock_dominates_durable_local_history() {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let directory = tempfile::tempdir().expect("temporary RocksDB directory");
+    let identity = DbIdentity {
+        node: NodeUuid::from_bytes([0x56; 16]),
+        author: AuthorSubject::for_test_bytes([0x66; 16]),
+    };
+    let storage = RocksDbStorage::open(directory.path(), &family_refs).expect("open RocksDB");
+    let first = block_on(Db::open(DbConfig::new(
+        schema.clone(),
+        storage,
+        identity.clone(),
+    )))
+    .expect("open first database");
+    let first_write = first
+        .enqueue_insert(
+            "todos".to_owned(),
+            row! { title: "before restart" },
+            jazz::db::InsertOptions {
+                updated_at_ms: Some(7),
+                ..Default::default()
+            },
+        )
+        .expect("reserve first identity");
+    let first_tx = first_write.mergeable_tx_id();
+    first.drive_queued_mutation_once();
+    block_on(first_write.wait(DurabilityTier::Local)).expect("first write is durable");
+    block_on(first.close()).expect("close first database");
+    drop(first);
+
+    let storage = RocksDbStorage::open(directory.path(), &family_refs).expect("reopen RocksDB");
+    let reopened =
+        block_on(Db::open(DbConfig::new(schema, storage, identity))).expect("reopen database");
+    let second_write = reopened
+        .enqueue_insert(
+            "todos".to_owned(),
+            row! { title: "after restart" },
+            jazz::db::InsertOptions {
+                updated_at_ms: Some(7),
+                ..Default::default()
+            },
+        )
+        .expect("reserve identity after reopen");
+    assert!(
+        second_write.mergeable_tx_id().time > first_tx.time,
+        "the synchronously returned identity must dominate durable history for the reused node",
+    );
+}

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -1,5 +1,7 @@
+use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::task::{Context, Poll};
 
 use futures::executor::block_on;
@@ -430,12 +432,14 @@ fn close_owns_and_drains_cold_failed_and_following_fifo_mutations() {
             Default::default(),
         )
         .expect("reserve failing head");
-    db.enqueue_insert(
-        "todos".to_owned(),
-        row! { title: "second" },
-        Default::default(),
-    )
-    .expect("reserve second");
+    let second = db
+        .enqueue_insert(
+            "todos".to_owned(),
+            row! { title: "second" },
+            Default::default(),
+        )
+        .expect("reserve second");
+    let second_tx = second.mergeable_tx_id();
     db.enqueue_insert(
         "todos".to_owned(),
         row! { title: "third" },
@@ -443,10 +447,50 @@ fn close_owns_and_drains_cold_failed_and_following_fifo_mutations() {
     )
     .expect("reserve third");
 
+    let local_waits = Rc::new(RefCell::new(Vec::new()));
+    let local_wait_results = Rc::clone(&local_waits);
+    db.wait_for_transaction_with(second_tx, DurabilityTier::Local, move |result| {
+        local_wait_results.borrow_mut().push(result);
+    });
+    let edge_waits = Rc::new(RefCell::new(Vec::new()));
+    let edge_wait_results = Rc::clone(&edge_waits);
+    db.wait_for_transaction_with(second_tx, DurabilityTier::Edge, move |result| {
+        edge_wait_results.borrow_mut().push(result);
+    });
+
     let waker = noop_waker();
     let mut context = Context::from_waker(&waker);
     let mut close = Box::pin(db.close());
     assert!(matches!(close.as_mut().poll(&mut context), Poll::Pending));
+
+    let after_closing = match db.enqueue_insert(
+        "todos".to_owned(),
+        row! { title: "must not be accepted after close starts" },
+        Default::default(),
+    ) {
+        Ok(_) => panic!("close must synchronously close shared mutation admission"),
+        Err(error) => error,
+    };
+    assert_eq!(after_closing.code, ErrorCode::WriteRejected);
+    let late_open_tx = OpenTransactionId::new();
+    assert_eq!(
+        db.enqueue_begin_mergeable(late_open_tx, None, None)
+            .expect_err("transaction entry after close starts must be rejected")
+            .code,
+        ErrorCode::WriteRejected,
+    );
+    assert_eq!(
+        db.enqueue_transaction_insert(
+            late_open_tx,
+            false,
+            "todos".to_owned(),
+            row! { title: "must not stage after close starts" },
+            Default::default(),
+        )
+        .expect_err("transaction staging after close starts must be rejected")
+        .code,
+        ErrorCode::WriteRejected,
+    );
     control.resume();
     let close_result = loop {
         if let Poll::Ready(result) = close.as_mut().poll(&mut context) {
@@ -454,6 +498,13 @@ fn close_owns_and_drains_cold_failed_and_following_fifo_mutations() {
         }
     };
     close_result.expect("close drains every accepted operation before storage retirement");
+    assert_eq!(local_waits.borrow().len(), 1);
+    assert_eq!(local_waits.borrow()[0].as_ref().unwrap(), &second_tx);
+    assert_eq!(edge_waits.borrow().len(), 1);
+    assert_eq!(
+        edge_waits.borrow()[0].as_ref().unwrap_err().code,
+        ErrorCode::NotObserved,
+    );
     assert_eq!(
         block_on(failed.write_state())
             .expect_err("failed queued operation remains terminally observable")
@@ -637,7 +688,7 @@ fn queued_exclusive_commit_retains_cold_serializability_and_exact_identity() {
     storage_control.evict_all();
     control.pause_on(TestStorageOperation::Get);
     control.pause_on(TestStorageOperation::ScanOpen);
-    db.enqueue_begin_exclusive(open_tx, None);
+    db.enqueue_begin_exclusive(open_tx, None).unwrap();
     db.enqueue_transaction_update(
         open_tx,
         true,
@@ -645,7 +696,8 @@ fn queued_exclusive_commit_retains_cold_serializability_and_exact_identity() {
         seed.row_uuid(),
         row! { title: "after" },
         Default::default(),
-    );
+    )
+    .unwrap();
     let queued = db
         .enqueue_commit_exclusive_handle(open_tx)
         .expect("reserve final transaction identity");
@@ -719,14 +771,16 @@ fn queued_transaction_stage_failure_poison_prevents_partial_commit() {
         "missing_table".to_owned(),
         row! { title: "invalid" },
         Default::default(),
-    );
+    )
+    .unwrap();
     db.enqueue_transaction_insert(
         open_tx,
         false,
         "todos".to_owned(),
         row! { title: "must not commit" },
         Default::default(),
-    );
+    )
+    .unwrap();
     let commit = db
         .enqueue_commit_mergeable_handle(open_tx)
         .expect("reserve final identity");

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -411,8 +411,8 @@ fn close_owns_and_drains_cold_failed_and_following_fifo_mutations() {
     let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
     let (storage, control) = TestStorage::controlled(&family_refs);
     let reopen_handle = storage.clone();
-    let db = block_on(Db::open(DbConfig::new(
-        schema.clone(),
+    let owner = block_on(Db::open_history_complete(DbConfig::new(
+        empty_schema(),
         storage,
         DbIdentity {
             node: NodeUuid::from_bytes([0x59; 16]),
@@ -420,6 +420,9 @@ fn close_owns_and_drains_cold_failed_and_following_fifo_mutations() {
         },
     )))
     .expect("open yielding database");
+    let db = Rc::new(
+        block_on(owner.register_schema_view(schema.clone())).expect("register sibling schema view"),
+    );
 
     reopen_handle.evict_all();
     control.pause_on(TestStorageOperation::Get);
@@ -449,8 +452,14 @@ fn close_owns_and_drains_cold_failed_and_following_fifo_mutations() {
 
     let local_waits = Rc::new(RefCell::new(Vec::new()));
     let local_wait_results = Rc::clone(&local_waits);
+    let reentrant_waits = Rc::new(RefCell::new(Vec::new()));
+    let reentrant_wait_results = Rc::clone(&reentrant_waits);
+    let reentrant_db = Rc::clone(&db);
     db.wait_for_transaction_with(second_tx, DurabilityTier::Local, move |result| {
         local_wait_results.borrow_mut().push(result);
+        reentrant_db.wait_for_transaction_with(second_tx, DurabilityTier::Edge, move |result| {
+            reentrant_wait_results.borrow_mut().push(result)
+        });
     });
     let edge_waits = Rc::new(RefCell::new(Vec::new()));
     let edge_wait_results = Rc::clone(&edge_waits);
@@ -460,7 +469,7 @@ fn close_owns_and_drains_cold_failed_and_following_fifo_mutations() {
 
     let waker = noop_waker();
     let mut context = Context::from_waker(&waker);
-    let mut close = Box::pin(db.close());
+    let mut close = Box::pin(owner.close());
     assert!(matches!(close.as_mut().poll(&mut context), Poll::Pending));
 
     let after_closing = match db.enqueue_insert(
@@ -472,12 +481,36 @@ fn close_owns_and_drains_cold_failed_and_following_fifo_mutations() {
         Err(error) => error,
     };
     assert_eq!(after_closing.code, ErrorCode::WriteRejected);
+    let direct_after_closing = block_on(db.insert(
+        "todos",
+        row! { title: "direct Rust mutation must share the owner gate" },
+        Default::default(),
+    ))
+    .err()
+    .expect("direct mutation through a sibling schema view must be rejected");
+    assert_eq!(direct_after_closing.code, ErrorCode::WriteRejected);
     let late_open_tx = OpenTransactionId::new();
     assert_eq!(
         db.enqueue_begin_mergeable(late_open_tx, None, None)
             .expect_err("transaction entry after close starts must be rejected")
             .code,
         ErrorCode::WriteRejected,
+    );
+    assert_eq!(
+        block_on(db.begin_exclusive(OpenTransactionId::new()))
+            .expect_err("direct transaction entry through a sibling view must be rejected")
+            .code,
+        ErrorCode::WriteRejected,
+    );
+    let late_waits = Rc::new(RefCell::new(Vec::new()));
+    let late_wait_results = Rc::clone(&late_waits);
+    db.wait_for_transaction_with(second_tx, DurabilityTier::Global, move |result| {
+        late_wait_results.borrow_mut().push(result);
+    });
+    assert_eq!(late_waits.borrow().len(), 1);
+    assert_eq!(
+        late_waits.borrow()[0].as_ref().unwrap_err().code,
+        ErrorCode::NotObserved,
     );
     assert_eq!(
         db.enqueue_transaction_insert(
@@ -505,6 +538,11 @@ fn close_owns_and_drains_cold_failed_and_following_fifo_mutations() {
         edge_waits.borrow()[0].as_ref().unwrap_err().code,
         ErrorCode::NotObserved,
     );
+    assert_eq!(reentrant_waits.borrow().len(), 1);
+    assert_eq!(
+        reentrant_waits.borrow()[0].as_ref().unwrap_err().code,
+        ErrorCode::NotObserved,
+    );
     assert_eq!(
         block_on(failed.write_state())
             .expect_err("failed queued operation remains terminally observable")
@@ -513,6 +551,7 @@ fn close_owns_and_drains_cold_failed_and_following_fifo_mutations() {
     );
     drop(close);
     drop(db);
+    drop(owner);
 
     let reopened_storage = block_on(reopen_handle.reopen(families)).expect("reopen drained store");
     let reopened = block_on(Db::open(DbConfig::new(

--- a/dev/artifacts/build.mjs
+++ b/dev/artifacts/build.mjs
@@ -420,6 +420,23 @@ export function validateNapiStage(
     );
 }
 
+/// Add package-wrapper APIs which deliberately do not exist in the raw native
+/// declaration surface. The raw `__closePollable` ABI is hidden from generated
+/// TypeScript; `index.cjs` owns it and exposes this Promise contract instead.
+export function applyNapiPackageDeclarationOverlay(stagePath) {
+  const declarationsPath = join(stagePath, "index.d.ts");
+  const declarations = readFileSync(declarationsPath, "utf8");
+  const lines = declarations.split("\n");
+  const classStart = lines.indexOf("export declare class NapiDb {");
+  if (classStart === -1) throw new Error("generated NAPI declarations are missing NapiDb");
+  const classEnd = lines.findIndex((line, index) => index > classStart && line === "}");
+  if (classEnd === -1) throw new Error("generated NAPI declarations have an unterminated NapiDb");
+  if (lines.slice(classStart, classEnd).some((line) => /\bclose\s*\(/.test(line)))
+    throw new Error("raw NAPI declarations unexpectedly expose close; wrapper overlay refused");
+  lines.splice(classEnd, 0, "  close(): Promise<undefined>");
+  writeFileSync(declarationsPath, lines.join("\n"));
+}
+
 /**
  * Runtime methods used by jazz-tools before a staged NAPI generation can
  * become the active package binding. Keep this separate from declaration
@@ -500,6 +517,7 @@ export function buildArtifact(kind, profile = "release", extraArgs = []) {
       if (process.env.JAZZ_NAPI_BUILD_FAULT === "missing") rmSync(napiPath, { force: true });
       if (process.env.JAZZ_NAPI_BUILD_FAULT === "unloadable")
         writeFileSync(napiPath, "not a native module");
+      applyNapiPackageDeclarationOverlay(napiStage);
       validateNapiStage(napiStage, expectedNapiBinding, fingerprint, resolvedNapiTarget);
       // Seal a manifest inside the generation before it can become active.
       if (process.env.JAZZ_NAPI_BUILD_FAULT === "manifest-write")

--- a/dev/artifacts/napi-build-contract.test.mjs
+++ b/dev/artifacts/napi-build-contract.test.mjs
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
+  applyNapiPackageDeclarationOverlay,
   publishExpectedFingerprint,
   publishNapiGeneration,
   validateNapiBindingRuntimeSurface,
@@ -28,6 +29,7 @@ const packageRoot = new URL("../../crates/jazz-napi/", import.meta.url);
 const indexCjs = readFileSync(new URL("index.cjs", packageRoot), "utf8");
 const indexMjs = readFileSync(new URL("index.mjs", packageRoot), "utf8");
 const bootstrap = readFileSync(new URL("native-binding.cjs", packageRoot), "utf8");
+const closePollable = readFileSync(new URL("close-pollable.cjs", packageRoot), "utf8");
 
 function fixture() {
   const root = join(tmpdir(), `jazz-napi-artifact-${process.pid}-${Date.now()}-${Math.random()}`);
@@ -36,6 +38,7 @@ function fixture() {
   writeFileSync(join(root, "index.cjs"), indexCjs);
   writeFileSync(join(root, "index.mjs"), indexMjs);
   writeFileSync(join(root, "native-binding.cjs"), bootstrap);
+  writeFileSync(join(root, "close-pollable.cjs"), closePollable);
   return root;
 }
 function stage(root, name, fingerprint, { complete = true, actual = fingerprint } = {}) {
@@ -47,7 +50,7 @@ function stage(root, name, fingerprint, { complete = true, actual = fingerprint 
     writeFileSync(join(path, "index.d.ts"), "export declare class NapiDb { tick(): void }\n");
     writeFileSync(
       join(path, "index.js"),
-      `class NapiDb { tick() {} } module.exports={ NapiDb, nativeArtifactFingerprint: () => ${JSON.stringify(actual)} };\n`,
+      `class NapiDb { tick() {} __closePollable() { return new Uint8Array() } } module.exports={ NapiDb, nativeArtifactFingerprint: () => ${JSON.stringify(actual)} };\n`,
     );
   }
   return path;
@@ -367,6 +370,33 @@ test("a newly generated public export absent from the stable package declaration
     assert.match(error.message, /--- checked-in/);
     assert.match(error.message, /\+\s*2 \| export declare function newlyGeneratedExport/);
     assert.equal(existsSync(join(root, "native-binding.pointer.cjs")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the package declaration overlay exposes Promise close without leaking the raw pollable ABI", () => {
+  const root = fixture();
+  try {
+    const staged = stage(root, ".napi-stage-close-overlay", "next");
+    writeFileSync(
+      join(staged, "index.d.ts"),
+      [
+        "export declare class NapiDb {",
+        "  tick(): void",
+        "}",
+        "export declare class PendingNativeRead { poll(): Uint8Array | null }",
+        "",
+      ].join("\n"),
+    );
+    applyNapiPackageDeclarationOverlay(staged);
+    const declarations = readFileSync(join(staged, "index.d.ts"), "utf8");
+    assert.match(declarations, /close\(\): Promise<undefined>/);
+    assert.doesNotMatch(declarations, /__closePollable/);
+    assert.throws(
+      () => applyNapiPackageDeclarationOverlay(staged),
+      /raw NAPI declarations unexpectedly expose close/,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -157,7 +157,7 @@ type NativeDb = {
   // Native runtime adapters may close synchronously or asynchronously and may
   // report whether they transitioned state. The adapter awaits either form and
   // owns idempotence, so callers never observe that implementation detail.
-  close?(): void | boolean | Uint8Array | NativeReadResult | Promise<void | boolean>;
+  close?(): void | boolean | Promise<void | boolean>;
   registerSchema(schema: Uint8Array): NativeDb;
   beginTransaction(openTransactionId: string, kind: TransactionKind, author?: Uint8Array): void;
   beginTransactionAttributed?(openTransactionId: string, attribution: Uint8Array): void;
@@ -1145,9 +1145,7 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     await this.coreTickCompletion?.catch(() => undefined);
     this.closeRuntimeState(true);
-    const close = this.db.close?.();
-    if (isPendingNativeRead(close)) await this.awaitNativeClose(close);
-    else await close;
+    await this.db.close?.();
     // wasm-bindgen futures may retain this receiver after logical closure.
     // Its registered finalizer owns physical release; explicit `free()` here
     // creates a second, unsynchronised lifetime and can corrupt the WASM heap.
@@ -2493,14 +2491,6 @@ export class NativeRuntimeAdapter implements Runtime {
       const bytes = result.poll();
       if (bytes !== null) return bytes;
       await this.pumpServerTransport();
-      await sleep(0);
-    }
-  }
-
-  /** Closing owns already-admitted native work after the public runtime is closed. */
-  private async awaitNativeClose(close: PendingNativeRead): Promise<void> {
-    for (;;) {
-      if (close.poll() !== null) return;
       await sleep(0);
     }
   }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -157,7 +157,7 @@ type NativeDb = {
   // Native runtime adapters may close synchronously or asynchronously and may
   // report whether they transitioned state. The adapter awaits either form and
   // owns idempotence, so callers never observe that implementation detail.
-  close?(): void | boolean | Promise<void | boolean>;
+  close?(): void | boolean | Uint8Array | NativeReadResult | Promise<void | boolean>;
   registerSchema(schema: Uint8Array): NativeDb;
   beginTransaction(openTransactionId: string, kind: TransactionKind, author?: Uint8Array): void;
   beginTransactionAttributed?(openTransactionId: string, attribution: Uint8Array): void;
@@ -1145,7 +1145,9 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     await this.coreTickCompletion?.catch(() => undefined);
     this.closeRuntimeState(true);
-    await this.db.close?.();
+    const close = this.db.close?.();
+    if (isPendingNativeRead(close)) await this.awaitNativeClose(close);
+    else await close;
     // wasm-bindgen futures may retain this receiver after logical closure.
     // Its registered finalizer owns physical release; explicit `free()` here
     // creates a second, unsynchronised lifetime and can corrupt the WASM heap.
@@ -2491,6 +2493,14 @@ export class NativeRuntimeAdapter implements Runtime {
       const bytes = result.poll();
       if (bytes !== null) return bytes;
       await this.pumpServerTransport();
+      await sleep(0);
+    }
+  }
+
+  /** Closing owns already-admitted native work after the public runtime is closed. */
+  private async awaitNativeClose(close: PendingNativeRead): Promise<void> {
+    for (;;) {
+      if (close.poll() !== null) return;
       await sleep(0);
     }
   }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -160,14 +160,8 @@ type NativeDb = {
   close?(): void | boolean | Promise<void | boolean>;
   registerSchema(schema: Uint8Array): NativeDb;
   beginTransaction(openTransactionId: string, kind: TransactionKind, author?: Uint8Array): void;
-  beginTransactionAsync?(
-    openTransactionId: string,
-    kind: TransactionKind,
-    author?: Uint8Array,
-  ): Promise<void>;
   beginTransactionAttributed?(openTransactionId: string, attribution: Uint8Array): void;
   commitTransaction(openTransactionId: string, kind?: TransactionKind): Write;
-  commitExclusiveTransactionAsync?(openTransactionId: string): Promise<Write>;
   rollbackTransaction(openTransactionId: string): void;
   attachMergeableTx(openTransactionId: string): Tx;
   attachExclusiveTx?(openTransactionId: string): Tx;
@@ -216,13 +210,6 @@ type NativeDb = {
     opts: unknown,
   ): ReadableStream<unknown> | Subscription;
   insertEncoded(table: string, cells: Uint8Array, options?: NativeInsertOptions): Write;
-  /** Persistent-host-only mutation ABI. Foreground in-memory runtimes keep the
-   * synchronous entry point so app-visible mutation shapes remain unchanged. */
-  insertEncodedAsync?(
-    table: string,
-    cells: Uint8Array,
-    options?: NativeInsertOptions,
-  ): Promise<Write>;
   insertWithIdEncodedAttributed?(
     table: string,
     rowId: Uint8Array,
@@ -235,12 +222,6 @@ type NativeDb = {
     patch: Uint8Array,
     options?: NativeUpdateOptions,
   ): Write;
-  updateEncodedAsync?(
-    table: string,
-    rowId: Uint8Array,
-    patch: Uint8Array,
-    options?: NativeUpdateOptions,
-  ): Promise<Write>;
   updateEncodedAttributed?(
     table: string,
     rowId: Uint8Array,
@@ -253,12 +234,6 @@ type NativeDb = {
     cells: Uint8Array,
     options?: NativeUpsertOptions,
   ): Write;
-  upsertEncodedAsync?(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    options?: NativeUpsertOptions,
-  ): Promise<Write>;
   upsertEncodedAttributed?(
     table: string,
     rowId: Uint8Array,
@@ -266,11 +241,6 @@ type NativeDb = {
     author: Uint8Array,
   ): Write;
   deleteEncoded(table: string, rowId: Uint8Array, options?: NativeDeleteOptions): Write;
-  deleteEncodedAsync?(
-    table: string,
-    rowId: Uint8Array,
-    options?: NativeDeleteOptions,
-  ): Promise<Write>;
   deleteAttributed?(table: string, rowId: Uint8Array, author: Uint8Array): Write;
   restoreEncoded(
     table: string,
@@ -431,41 +401,19 @@ type Tx = {
   /** Release the native transaction view after its owner batch has completed. */
   close?(): boolean;
   insertEncoded(table: string, cells: Uint8Array, options?: NativeInsertOptions): Uint8Array;
-  insertEncodedAsync?(
-    table: string,
-    cells: Uint8Array,
-    options?: NativeInsertOptions,
-  ): Promise<Uint8Array>;
   updateEncoded(
     table: string,
     rowId: Uint8Array,
     patch: Uint8Array,
     options?: NativeUpdateOptions,
   ): void;
-  updateEncodedAsync?(
-    table: string,
-    rowId: Uint8Array,
-    patch: Uint8Array,
-    options?: NativeUpdateOptions,
-  ): Promise<void>;
   upsertEncoded(
     table: string,
     rowId: Uint8Array,
     cells: Uint8Array,
     options?: NativeUpsertOptions,
   ): void;
-  upsertEncodedAsync?(
-    table: string,
-    rowId: Uint8Array,
-    cells: Uint8Array,
-    options?: NativeUpsertOptions,
-  ): Promise<void>;
   deleteEncoded(table: string, rowId: Uint8Array, options?: NativeDeleteOptions): void;
-  deleteEncodedAsync?(
-    table: string,
-    rowId: Uint8Array,
-    options?: NativeDeleteOptions,
-  ): Promise<void>;
   restoreEncoded(
     table: string,
     rowId: Uint8Array,

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -160,8 +160,14 @@ type NativeDb = {
   close?(): void | boolean | Promise<void | boolean>;
   registerSchema(schema: Uint8Array): NativeDb;
   beginTransaction(openTransactionId: string, kind: TransactionKind, author?: Uint8Array): void;
+  beginTransactionAsync?(
+    openTransactionId: string,
+    kind: TransactionKind,
+    author?: Uint8Array,
+  ): Promise<void>;
   beginTransactionAttributed?(openTransactionId: string, attribution: Uint8Array): void;
   commitTransaction(openTransactionId: string, kind?: TransactionKind): Write;
+  commitExclusiveTransactionAsync?(openTransactionId: string): Promise<Write>;
   rollbackTransaction(openTransactionId: string): void;
   attachMergeableTx(openTransactionId: string): Tx;
   attachExclusiveTx?(openTransactionId: string): Tx;
@@ -425,19 +431,41 @@ type Tx = {
   /** Release the native transaction view after its owner batch has completed. */
   close?(): boolean;
   insertEncoded(table: string, cells: Uint8Array, options?: NativeInsertOptions): Uint8Array;
+  insertEncodedAsync?(
+    table: string,
+    cells: Uint8Array,
+    options?: NativeInsertOptions,
+  ): Promise<Uint8Array>;
   updateEncoded(
     table: string,
     rowId: Uint8Array,
     patch: Uint8Array,
     options?: NativeUpdateOptions,
   ): void;
+  updateEncodedAsync?(
+    table: string,
+    rowId: Uint8Array,
+    patch: Uint8Array,
+    options?: NativeUpdateOptions,
+  ): Promise<void>;
   upsertEncoded(
     table: string,
     rowId: Uint8Array,
     cells: Uint8Array,
     options?: NativeUpsertOptions,
   ): void;
+  upsertEncodedAsync?(
+    table: string,
+    rowId: Uint8Array,
+    cells: Uint8Array,
+    options?: NativeUpsertOptions,
+  ): Promise<void>;
   deleteEncoded(table: string, rowId: Uint8Array, options?: NativeDeleteOptions): void;
+  deleteEncodedAsync?(
+    table: string,
+    rowId: Uint8Array,
+    options?: NativeDeleteOptions,
+  ): Promise<void>;
   restoreEncoded(
     table: string,
     rowId: Uint8Array,

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -210,6 +210,13 @@ type NativeDb = {
     opts: unknown,
   ): ReadableStream<unknown> | Subscription;
   insertEncoded(table: string, cells: Uint8Array, options?: NativeInsertOptions): Write;
+  /** Persistent-host-only mutation ABI. Foreground in-memory runtimes keep the
+   * synchronous entry point so app-visible mutation shapes remain unchanged. */
+  insertEncodedAsync?(
+    table: string,
+    cells: Uint8Array,
+    options?: NativeInsertOptions,
+  ): Promise<Write>;
   insertWithIdEncodedAttributed?(
     table: string,
     rowId: Uint8Array,
@@ -222,6 +229,12 @@ type NativeDb = {
     patch: Uint8Array,
     options?: NativeUpdateOptions,
   ): Write;
+  updateEncodedAsync?(
+    table: string,
+    rowId: Uint8Array,
+    patch: Uint8Array,
+    options?: NativeUpdateOptions,
+  ): Promise<Write>;
   updateEncodedAttributed?(
     table: string,
     rowId: Uint8Array,
@@ -234,6 +247,12 @@ type NativeDb = {
     cells: Uint8Array,
     options?: NativeUpsertOptions,
   ): Write;
+  upsertEncodedAsync?(
+    table: string,
+    rowId: Uint8Array,
+    cells: Uint8Array,
+    options?: NativeUpsertOptions,
+  ): Promise<Write>;
   upsertEncodedAttributed?(
     table: string,
     rowId: Uint8Array,
@@ -241,6 +260,11 @@ type NativeDb = {
     author: Uint8Array,
   ): Write;
   deleteEncoded(table: string, rowId: Uint8Array, options?: NativeDeleteOptions): Write;
+  deleteEncodedAsync?(
+    table: string,
+    rowId: Uint8Array,
+    options?: NativeDeleteOptions,
+  ): Promise<Write>;
   deleteAttributed?(table: string, rowId: Uint8Array, author: Uint8Array): Write;
   restoreEncoded(
     table: string,

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
@@ -383,8 +383,11 @@ it("does not let a concurrent close preempt foreground HLC capture", async () =>
   expect(order).toEqual(["high-water", "close"]);
 });
 
-it("keeps polling an owner-retained native close after the first cold turn", async () => {
-  let polls = 0;
+it("awaits the binding-owned native close promise", async () => {
+  let releaseClose!: () => void;
+  const closeGate = new Promise<void>((resolve) => {
+    releaseClose = resolve;
+  });
   const runtime = new NativeRuntimeAdapter(
     {
       openMemory: () =>
@@ -392,9 +395,7 @@ it("keeps polling an owner-retained native close after the first cold turn", asy
           foregroundTxTimeHighWater: () => 0n,
           prepareQuery: () => ({}),
           tick: () => undefined,
-          close: () => ({
-            poll: () => (++polls < 2 ? null : new Uint8Array()),
-          }),
+          close: () => closeGate,
         }),
       openBrowser: async () => {
         throw new Error("not used");
@@ -407,8 +408,15 @@ it("keeps polling an owner-retained native close after the first cold turn", asy
     true,
   );
 
-  await runtime.close();
-  expect(polls).toBe(2);
+  let settled = false;
+  const close = runtime.close().then(() => {
+    settled = true;
+  });
+  await Promise.resolve();
+  expect(settled).toBe(false);
+  releaseClose();
+  await close;
+  expect(settled).toBe(true);
 });
 
 it("waits for every concurrently admitted stream before foreground handoff", async () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
@@ -383,6 +383,34 @@ it("does not let a concurrent close preempt foreground HLC capture", async () =>
   expect(order).toEqual(["high-water", "close"]);
 });
 
+it("keeps polling an owner-retained native close after the first cold turn", async () => {
+  let polls = 0;
+  const runtime = new NativeRuntimeAdapter(
+    {
+      openMemory: () =>
+        fakeDb({
+          foregroundTxTimeHighWater: () => 0n,
+          prepareQuery: () => ({}),
+          tick: () => undefined,
+          close: () => ({
+            poll: () => (++polls < 2 ? null : new Uint8Array()),
+          }),
+        }),
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    testSchema,
+    new Uint8Array(16),
+    TEST_RUNTIME_AUTHOR,
+    1,
+    true,
+  );
+
+  await runtime.close();
+  expect(polls).toBe(2);
+});
+
 it("waits for every concurrently admitted stream before foreground handoff", async () => {
   let highWater = 7n;
   let releaseFirst!: () => void;


### PR DESCRIPTION
🤖 Fixes #2370.

## Why

Jazz's synchronous client facade polled Core mutation futures with a no-op waker. That worked only when preparation was immediately ready. A genuinely asynchronous storage backend such as IndexedDB can yield while reading parents, staging a transaction, preparing a partial large-value edit, or finalizing a write. Re-polling synchronously could spin forever; dropping a pending future could lose required work.

The public API should remain synchronous and local-first. The asynchronous work belongs to the runtime owner, not to the caller's stack or the lifetime of a returned handle.

## Before

- WASM and NAPI mutation bindings synchronously polled Core futures.
- Cold preparation could block, spin, or be dropped after returning `Pending`.
- Ordinary writes and transaction stages used different ownership paths.
- A returned transaction identity could not safely be reserved before cold parent discovery.
- A reserved identity could incorrectly look resident before publication.
- Dropping a write handle could also drop the only owner of unfinished preparation.

## After

- There remains one synchronous public mutation API.
- A call reserves its definitive row/transaction identity, enqueues one Node-owned operation, and returns the existing write handle.
- One FIFO owns ordinary, attributed, restore, partial-large-value, mergeable, and exclusive transaction operations.
- Memory-backed foreground calls receive one bounded inline owner turn, preserving immediate local read-your-writes behavior without spinning.
- Yielding persistent/WASM operations remain queued and are resumed by scheduler-owned turns.
- Exact reserved IDs survive cold preparation and same-node reopen because every observed/minted transaction time advances a shared high-water clock.
- A failed transaction stage poisons the whole transaction, prevents partial commit, exposes the original terminal error, and queues cleanup of the abandoned Core transaction.
- Dropping a handle cannot cancel queued work.
- `.wait(...)` only observes the requested milestone; reservation alone does not satisfy resident publication.
- Storage and wire formats do not change.

Example: `db.update(...)` returns its normal handle and definitive identity immediately. Internally, preparation may await an IndexedDB parent read, then publish resident state, persist, upload, and settle. `handle.wait("local")` stays pending until publication; dropping the handle does not stop the operation.

For a transaction, `begin`, stages, commit, rollback, and failure cleanup retain FIFO order. If an early stage fails, a later otherwise-valid stage cannot commit a partial transaction.

## Verification

- queued mutation/persistence receipts: 8/8;
- WASM32 and NAPI host checks;
- filtered WASM/NAPI transaction diagnostics;
- plants for dropped first poll, FIFO ownership, exact reserved-ID commit, poisoned-stage partial commit, reopen high-water recovery, and reservation-versus-publication waits;
- no remaining WASM/NAPI synchronous mutation bridges for insert/update/upsert/delete/restore/begin/commit.

## Review boundaries

The independent review should explicitly examine process-crash recovery of pre-admission in-memory operations, close-time queue semantics, preparation-error delivery, transaction poisoning/cleanup, identity dominance across reopen, and Memory versus yielding-storage parity.

Transaction-local query bindings remain synchronous read bridges and are being evaluated as an orthogonal read API concern; this PR does not introduce a second mutation API.

The branch is temporarily based on the integrated alpha.54 stack, so GitHub may show lower-stack changes until the native stack is propagated.
