### PR TITLE
Scope maintained views by session claims

### DIFF
--- a/crates/jazz-testkit/tests/branch_claims_integration.rs
+++ b/crates/jazz-testkit/tests/branch_claims_integration.rs
@@ -585,6 +585,13 @@ async fn subscription_matches_claims_select_query() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+/// Keeps alice's authorized subscription and receipt-derived view isolated
+/// from mallory's second JWT for the same authenticated author.
+///
+/// ```text
+/// writer ──insert──► server ──authorized view──► alice
+///                              └──denied view────► mallory
+/// ```
 async fn same_identity_sessions_keep_claims_isolated() {
     tokio::task::LocalSet::new()
         .run_until(async {

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -2016,6 +2016,10 @@ enum PendingUpstreamCommand {
     AuthorizationScopeIntent {
         request_id: PermissionAdviceRequestId,
         action: PermissionAdviceAction,
+        /// Present only when an existing request crosses an upstream boundary.
+        /// A fresh request binds its claims when its selected authority admits
+        /// it; a reconnect must preserve the original immutable binding.
+        session_claim_binding: Option<(AuthorSubject, BTreeMap<String, Value>)>,
     },
 }
 

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -2116,6 +2116,10 @@ type ScopeAggregate = AuthorityScopeAggregate;
 /// aggregate receipt names only the final completing subscription.
 struct AuthorizationScopeLeaseRequest {
     action: PermissionAdviceAction,
+    /// Immutable requesting-session claims captured when this upstream advice
+    /// operation is allocated. Receipts are evaluated on an Upstream link,
+    /// which has no subscriber-side ambient claims to consult.
+    session_claim_binding: (AuthorSubject, BTreeMap<String, Value>),
     /// Every local caller sharing this authority hydration.  The first id is
     /// the wire correlation id; later ids never cause another support view.
     waiters: BTreeSet<PermissionAdviceRequestId>,

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1020,9 +1020,13 @@ where
         self.permission_advice_waiters
             .borrow_mut()
             .insert(request_id, sender);
-        self.upstream_subscriptions
-            .borrow_mut()
-            .push(PendingUpstreamCommand::AuthorizationScopeIntent { request_id, action });
+        self.upstream_subscriptions.borrow_mut().push(
+            PendingUpstreamCommand::AuthorizationScopeIntent {
+                request_id,
+                action,
+                session_claim_binding: None,
+            },
+        );
         self.schedule_tick(TickUrgency::Immediate);
         PermissionAdviceFuture {
             waiters: Rc::clone(&self.permission_advice_waiters),
@@ -1658,6 +1662,8 @@ where
         let connection_epoch = connection_ref.connection_epoch;
         let upstream_upload_destination = connection_ref.upstream_upload_destination;
         let mut reconnect_permission_advice = Vec::new();
+        let mut terminal_permission_advice = Vec::new();
+        let current_session_claims = self.node.borrow().session_claims_with_revisions();
         let (authority, upstream_epoch, transferable_uploads, retired_relay_subscriptions) =
             match &mut connection_ref.link {
                 ConnectionLink::Upstream(UpstreamConnectionState {
@@ -1674,21 +1680,67 @@ where
                     // coalesce under its fresh authority context and wire id.
                     let live_waiters = self.permission_advice_waiters.borrow();
                     let mut queued = BTreeSet::new();
+                    // The lease manager becomes authoritative as soon as it
+                    // captures a session binding, even if the matching
+                    // command is still retained after a backpressured send.
+                    // Visit it first so a command's initial `None` cannot
+                    // erase the request-owned snapshot during detach.
+                    for request in scope_lease_manager.requests.values() {
+                        for request_id in &request.waiters {
+                            if live_waiters.contains_key(request_id) && queued.insert(*request_id) {
+                                let (identity, claims) = &request.session_claim_binding;
+                                let current_claims = current_session_claims
+                                    .iter()
+                                    .find_map(|(current_identity, current_claims, _)| {
+                                        (current_identity == identity).then_some(current_claims)
+                                    })
+                                    .cloned()
+                                    .unwrap_or_default();
+                                if current_claims == *claims {
+                                    reconnect_permission_advice.push((
+                                        *request_id,
+                                        request.action.clone(),
+                                        Some(request.session_claim_binding.clone()),
+                                    ));
+                                } else {
+                                    // A successor can only prove its currently
+                                    // admitted session. Never send a B-scoped
+                                    // hydration to settle this A-owned request.
+                                    terminal_permission_advice.push(*request_id);
+                                }
+                            }
+                        }
+                    }
                     for command in pending.iter() {
-                        let PendingUpstreamCommand::AuthorizationScopeIntent { request_id, action } =
-                            command
+                        let PendingUpstreamCommand::AuthorizationScopeIntent {
+                            request_id,
+                            action,
+                            session_claim_binding,
+                        } = command
                         else {
                             continue;
                         };
                         if live_waiters.contains_key(request_id) && queued.insert(*request_id) {
-                            reconnect_permission_advice.push((*request_id, action.clone()));
-                        }
-                    }
-                    for request in scope_lease_manager.requests.values() {
-                        for request_id in &request.waiters {
-                            if live_waiters.contains_key(request_id) && queued.insert(*request_id) {
-                                reconnect_permission_advice
-                                    .push((*request_id, request.action.clone()));
+                            if session_claim_binding
+                                .as_ref()
+                                .is_none_or(|(identity, claims)| {
+                                    current_session_claims
+                                        .iter()
+                                        .find_map(|(current_identity, current_claims, _)| {
+                                            (current_identity == identity).then_some(current_claims)
+                                        })
+                                        .cloned()
+                                        .unwrap_or_default()
+                                        == *claims
+                                })
+                            {
+                                reconnect_permission_advice.push((
+                                    *request_id,
+                                    action.clone(),
+                                    session_claim_binding.clone(),
+                                ));
+                            } else {
+                                terminal_permission_advice.push(*request_id);
                             }
                         }
                     }
@@ -1756,6 +1808,15 @@ where
         connections.retain(|candidate| !Rc::ptr_eq(candidate, connection));
         drop(connections);
         let detached = true;
+        for request_id in terminal_permission_advice {
+            if let Some(waiter) = self
+                .permission_advice_waiters
+                .borrow_mut()
+                .remove(&request_id)
+            {
+                let _ = waiter.send(PermissionAdvice::Unknown);
+            }
+        }
         if !retired_relay_subscriptions.is_empty() {
             self.upstream_subscriptions.borrow_mut().extend(
                 retired_relay_subscriptions
@@ -1766,14 +1827,15 @@ where
         }
         if !reconnect_permission_advice.is_empty() {
             self.upstream_subscriptions.borrow_mut().extend(
-                reconnect_permission_advice
-                    .into_iter()
-                    .map(
-                        |(request_id, action)| PendingUpstreamCommand::AuthorizationScopeIntent {
+                reconnect_permission_advice.into_iter().map(
+                    |(request_id, action, session_claim_binding)| {
+                        PendingUpstreamCommand::AuthorizationScopeIntent {
                             request_id,
                             action,
-                        },
-                    ),
+                            session_claim_binding,
+                        }
+                    },
+                ),
             );
             self.schedule_tick(TickUrgency::Immediate);
         }

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -1261,7 +1261,7 @@ where
                         }
                         let pending_index = 0;
                         while pending_index < pending.len() {
-                            match &pending[pending_index] {
+                            match &mut pending[pending_index] {
                                 PendingUpstreamCommand::Subscribe(pending_subscription) => {
                                     let shape = &pending_subscription.shape;
                                     let binding = &pending_subscription.binding;
@@ -1381,6 +1381,7 @@ where
                                 PendingUpstreamCommand::AuthorizationScopeIntent {
                                     request_id,
                                     action,
+                                    session_claim_binding: pending_session_claim_binding,
                                 } => {
                                     // An old or unauthenticated upstream must never receive a
                                     // downgraded preflight.  Resolve conservatively instead.
@@ -1418,10 +1419,83 @@ where
                                             pending.remove(pending_index);
                                             continue;
                                         }
+                                        let Some(expected) = expected_scope_authority else {
+                                            continue;
+                                        };
+                                        let session_claim_binding = pending_session_claim_binding
+                                            .clone()
+                                            .or_else(|| {
+                                                scope_lease_manager
+                                                    .requests
+                                                    .get(request_id)
+                                                    .map(|request| {
+                                                        request.session_claim_binding.clone()
+                                                    })
+                                            })
+                                            .unwrap_or_else(|| {
+                                                let identity = expected.link;
+                                                let claims = self
+                                                    .node
+                                                    .borrow()
+                                                    .session_claims_with_revisions()
+                                                    .into_iter()
+                                                    .find_map(|(subject, claims, _)| {
+                                                        (subject == identity).then_some(claims)
+                                                    })
+                                                    .unwrap_or_default();
+                                                (identity, claims)
+                                            });
+                                        // Allocation establishes the immutable
+                                        // request binding before the first wire
+                                        // send. A backpressured command remains
+                                        // in this queue, so it must carry the
+                                        // same binding on a later turn.
+                                        *pending_session_claim_binding =
+                                            Some(session_claim_binding.clone());
+                                        let claims_still_bound = self
+                                            .node
+                                            .borrow()
+                                            .session_claims_with_revisions()
+                                            .into_iter()
+                                            .find_map(|(identity, claims, _)| {
+                                                (identity == session_claim_binding.0)
+                                                    .then_some(claims)
+                                            });
+                                        let claims_still_bound = claims_still_bound
+                                            .unwrap_or_default()
+                                            == session_claim_binding.1;
+                                        if !claims_still_bound {
+                                            if let Some(request) =
+                                                scope_lease_manager.requests.remove(request_id)
+                                            {
+                                                for waiter_id in request.waiters {
+                                                    if let Some(waiter) = self
+                                                        .permission_advice_waiters
+                                                        .borrow_mut()
+                                                        .remove(&waiter_id)
+                                                    {
+                                                        let _ =
+                                                            waiter.send(PermissionAdvice::Unknown);
+                                                    }
+                                                }
+                                            } else if let Some(waiter) = self
+                                                .permission_advice_waiters
+                                                .borrow_mut()
+                                                .remove(request_id)
+                                            {
+                                                let _ = waiter.send(PermissionAdvice::Unknown);
+                                            }
+                                            pending.remove(pending_index);
+                                            continue;
+                                        }
                                         let existing = scope_lease_manager
                                             .requests
                                             .iter()
-                                            .find(|(_, request)| request.action == *action)
+                                            .find(|(_, request)| {
+                                                request.action == *action
+                                                    && request.session_claim_binding
+                                                        == session_claim_binding
+                                            })
                                             .map(|(wire_request_id, request)| {
                                                 (*wire_request_id, request.intent_sent)
                                             });
@@ -1450,24 +1524,11 @@ where
                                                 request.intent_sent = true;
                                             }
                                         } else {
-                                            let Some(expected) = expected_scope_authority else {
-                                                continue;
-                                            };
-                                            let identity = expected.link;
-                                            let claims = self
-                                                .node
-                                                .borrow()
-                                                .session_claims_with_revisions()
-                                                .into_iter()
-                                                .find_map(|(subject, claims, _)| {
-                                                    (subject == identity).then_some(claims)
-                                                })
-                                                .unwrap_or_default();
                                             scope_lease_manager.requests.insert(
                                                 *request_id,
                                                 AuthorizationScopeLeaseRequest {
                                                     action: action.clone(),
-                                                    session_claim_binding: (identity, claims),
+                                                    session_claim_binding,
                                                     waiters: BTreeSet::from([*request_id]),
                                                     intent_sent: false,
                                                     key: None,
@@ -2011,17 +2072,51 @@ where
                                     drop_peer_request(&self.node);
                                     continue;
                                 }
-                                let Some(prior) = scope_lease_manager.requests.get(&request_id)
+                                let Some((session_claim_binding, key_mismatch, needs_acquire)) = scope_lease_manager
+                                    .requests
+                                    .get(&request_id)
+                                    .map(|prior| {
+                                        (
+                                            prior.session_claim_binding.clone(),
+                                            prior.key.as_ref().is_some_and(|known| known != &key)
+                                                || prior
+                                                    .clause_count
+                                                    .is_some_and(|known| known != clause_count),
+                                            prior.lease.is_none(),
+                                        )
+                                    })
                                 else {
                                     // A cancelled intent cannot be revived by a
                                     // late/replayed authority view.
                                     continue;
                                 };
-                                if prior.key.as_ref().is_some_and(|known| known != &key)
-                                    || prior
-                                        .clause_count
-                                        .is_some_and(|known| known != clause_count)
-                                {
+                                let claims_still_bound = self
+                                    .node
+                                    .borrow()
+                                    .session_claims_with_revisions()
+                                    .into_iter()
+                                    .find_map(|(identity, claims, _)| {
+                                        (identity == session_claim_binding.0).then_some(claims)
+                                    })
+                                    .unwrap_or_default()
+                                    == session_claim_binding.1;
+                                if !claims_still_bound {
+                                    if let Some(request) =
+                                        scope_lease_manager.requests.remove(&request_id)
+                                    {
+                                        for waiter_id in request.waiters {
+                                            if let Some(waiter) = self
+                                                .permission_advice_waiters
+                                                .borrow_mut()
+                                                .remove(&waiter_id)
+                                            {
+                                                let _ = waiter.send(PermissionAdvice::Unknown);
+                                            }
+                                        }
+                                    }
+                                    continue;
+                                }
+                                if key_mismatch {
                                     drop_peer_request(&self.node);
                                     continue;
                                 }
@@ -2031,7 +2126,7 @@ where
                                 // that compile to this same support scope share
                                 // one registry lifecycle rather than racing after
                                 // hydration has already completed.
-                                let acquired = if prior.lease.is_none() {
+                                let acquired = if needs_acquire {
                                     scope_lease_manager.registry.acquire(key.clone())
                                 } else {
                                     None
@@ -2084,6 +2179,41 @@ where
                                 request_id,
                                 receipt,
                             } => {
+                                // Reject a receipt before applying any queued
+                                // scope views when this request's admitted
+                                // claims have changed. A B-scoped proof must
+                                // never materialize support for an A request.
+                                let claims_still_bound = scope_lease_manager
+                                    .requests
+                                    .get(&request_id)
+                                    .is_none_or(|request| {
+                                        self.node
+                                            .borrow()
+                                            .session_claims_with_revisions()
+                                            .into_iter()
+                                            .find_map(|(identity, claims, _)| {
+                                                (identity == request.session_claim_binding.0)
+                                                    .then_some(claims)
+                                            })
+                                            .unwrap_or_default()
+                                            == request.session_claim_binding.1
+                                    });
+                                if !claims_still_bound {
+                                    if let Some(request) =
+                                        scope_lease_manager.requests.remove(&request_id)
+                                    {
+                                        for waiter_id in request.waiters {
+                                            if let Some(waiter) = self
+                                                .permission_advice_waiters
+                                                .borrow_mut()
+                                                .remove(&waiter_id)
+                                            {
+                                                let _ = waiter.send(PermissionAdvice::Unknown);
+                                            }
+                                        }
+                                    }
+                                    continue;
+                                }
                                 // The authority's FIFO ordering says this receipt
                                 // follows the views, but apply the queued views now
                                 // so receipt admission is never merely queued.
@@ -2177,6 +2307,31 @@ where
                                             applied_cut,
                                         );
                                 if !receipt_current {
+                                    let claims_still_bound = self
+                                        .node
+                                        .borrow()
+                                        .session_claims_with_revisions()
+                                        .into_iter()
+                                        .find_map(|(identity, claims, _)| {
+                                            (identity == request.session_claim_binding.0)
+                                                .then_some(claims)
+                                        })
+                                        .unwrap_or_default()
+                                        == request.session_claim_binding.1;
+                                    if !claims_still_bound {
+                                        let waiter_ids = request.waiters.clone();
+                                        scope_lease_manager.requests.remove(&request_id);
+                                        for waiter_id in waiter_ids {
+                                            if let Some(waiter) = self
+                                                .permission_advice_waiters
+                                                .borrow_mut()
+                                                .remove(&waiter_id)
+                                            {
+                                                let _ = waiter.send(PermissionAdvice::Unknown);
+                                            }
+                                        }
+                                        continue;
+                                    }
                                     // A claim/catalogue/progress transition can
                                     // race a just-completed hydration.  Retire its
                                     // lease and allocate a new opaque wire id so
@@ -2193,7 +2348,7 @@ where
                                         retry_id,
                                         AuthorizationScopeLeaseRequest {
                                             action: action.clone(),
-                                            session_claim_binding,
+                                            session_claim_binding: session_claim_binding.clone(),
                                             waiters,
                                             intent_sent: false,
                                             key: None,
@@ -2207,6 +2362,7 @@ where
                                         PendingUpstreamCommand::AuthorizationScopeIntent {
                                             request_id: retry_id,
                                             action,
+                                            session_claim_binding: Some(session_claim_binding),
                                         },
                                     );
                                     drop_peer_request(&self.node);

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -739,22 +739,30 @@ where
         *session_claim_revision = session_claim_revision.saturating_add(1);
     }
 
-    /// Bind the process-local query compiler to this subscriber's authenticated
-    /// session immediately before it serves work for that subscriber. NodeState
-    /// retains a cache keyed by identity, while several websocket sessions can
-    /// legitimately share an identity with different claim maps.
-    fn bind_subscriber_session_claims(&self) {
+    /// Return the claims admitted for this subscriber session. They are scoped
+    /// while the node lock is held instead of being installed under the shared
+    /// author identity.
+    fn subscriber_session_claim_binding(&self) -> Option<(AuthorSubject, BTreeMap<String, Value>)> {
         let ConnectionLink::Subscriber(SubscriberConnectionState {
             ingest_context,
             session_claims,
             ..
         }) = &self.link
         else {
+            return None;
+        };
+        Some((ingest_context.identity, session_claims.clone()))
+    }
+
+    /// Keep the legacy admission map available to write-policy evaluation and
+    /// upstream propagation. Read compilation uses the scoped context above,
+    /// so this author-keyed compatibility state cannot select another live
+    /// session's maintained view.
+    fn bind_subscriber_session_claims(&self) {
+        let Some((identity, claims)) = self.subscriber_session_claim_binding() else {
             return;
         };
-        self.node
-            .borrow_mut()
-            .set_session_claims(ingest_context.identity, session_claims.clone());
+        self.node.borrow_mut().set_session_claims(identity, claims);
     }
 
     fn subscriber_session_claim_revision(&self) -> u64 {
@@ -782,7 +790,7 @@ where
             }
             ConnectionLink::Upstream(_) => return Ok(false),
         };
-        self.bind_subscriber_session_claims();
+        let session_claim_binding = self.subscriber_session_claim_binding();
         let current_revision = self.subscriber_session_claim_revision();
         if self.observed_session_claim_revision.get() == current_revision {
             return Ok(false);
@@ -819,6 +827,14 @@ where
             };
             let update = {
                 let mut node = self.node.lock().await;
+                let mut node = node.scoped_active_session_claims(
+                    session_claim_binding.as_ref().expect("subscriber claims").0,
+                    session_claim_binding
+                        .as_ref()
+                        .expect("subscriber claims")
+                        .1
+                        .clone(),
+                );
                 peer.rehydrate_query_for_subscription_with_opts_and_waker(
                     &mut node,
                     maintained_subscription,
@@ -844,6 +860,7 @@ where
                     refresh_authorized_scope_purpose(
                         &self.node.borrow(),
                         identity,
+                        &session_claim_binding.as_ref().expect("subscriber claims").1,
                         subscription,
                         &shape,
                         &binding,
@@ -1006,7 +1023,7 @@ where
             .borrow()
             .as_ref()
             .and_then(|scheduler| scheduler.query_runtime_waker());
-        self.bind_subscriber_session_claims();
+        let session_claim_binding = self.subscriber_session_claim_binding();
         let connection_epoch = self.connection_epoch;
         let ConnectionLink::Subscriber(SubscriberConnectionState {
             peer,
@@ -1040,6 +1057,14 @@ where
             };
             let update = {
                 let mut node = self.node.lock().await;
+                let mut node = node.scoped_active_session_claims(
+                    session_claim_binding.as_ref().expect("subscriber claims").0,
+                    session_claim_binding
+                        .as_ref()
+                        .expect("subscriber claims")
+                        .1
+                        .clone(),
+                );
                 peer.rehydrate_query_for_subscription_with_opts_and_waker(
                     &mut node,
                     group_subscription,
@@ -1067,6 +1092,7 @@ where
                     refresh_authorized_scope_purpose(
                         &self.node.borrow(),
                         ingest_context.identity,
+                        &session_claim_binding.as_ref().expect("subscriber claims").1,
                         subscription,
                         &shape,
                         &binding,
@@ -1154,6 +1180,7 @@ where
             .and_then(|scheduler| scheduler.query_runtime_waker());
         let connection_epoch = self.connection_epoch;
         self.observe_shared_subscriber_dirty_epoch();
+        let session_claim_binding = self.subscriber_session_claim_binding();
         self.bind_subscriber_session_claims();
         self.rebind_subscriber_views_after_claim_change(progress_waker.as_ref())
             .await?;
@@ -2199,6 +2226,17 @@ where
                                 scope_lease_manager.requests.remove(&request_id);
                                 let advice = {
                                     let mut node = self.node.lock().await;
+                                    let mut node = node.scoped_active_session_claims(
+                                        session_claim_binding
+                                            .as_ref()
+                                            .expect("subscriber claims")
+                                            .0,
+                                        session_claim_binding
+                                            .as_ref()
+                                            .expect("subscriber claims")
+                                            .1
+                                            .clone(),
+                                    );
                                     evaluate_authoritative_permission_advice(
                                         &mut node,
                                         receipt.key.subject,
@@ -2698,6 +2736,11 @@ where
                                 peer,
                                 &mut self.pending_control_responses,
                                 ingest_context.identity,
+                                session_claim_binding
+                                    .as_ref()
+                                    .expect("subscriber claims")
+                                    .1
+                                    .clone(),
                                 connection_epoch,
                                 request_id,
                                 action,
@@ -2810,11 +2853,13 @@ where
                                             continue;
                                         }
                                     };
-                                    let supported = self
-                                        .node
-                                        .lock()
-                                        .await
-                                        .ensure_peer_maintained_subscription_view_supported(
+                                    let supported = {
+                                        let mut node = self.node.lock().await;
+                                        let mut node = node.scoped_active_session_claims(
+                                            session_claim_binding.as_ref().expect("subscriber claims").0,
+                                            session_claim_binding.as_ref().expect("subscriber claims").1.clone(),
+                                        );
+                                        node.ensure_peer_maintained_subscription_view_supported(
                                             shape,
                                             &binding,
                                             opts.tier,
@@ -2822,7 +2867,8 @@ where
                                             &opts.read_view,
                                             QueryAuthorizationMode::TrustedServing,
                                         )
-                                        .await;
+                                        .await
+                                    };
                                     if let Err(crate::node::Error::QueryCapability(detail)) =
                                         supported
                                     {
@@ -3043,9 +3089,15 @@ where
                                 );
                             }
                             let scope_purpose = if let Some(purpose) = scope_purpose {
-                                let expected_result =
-                                    self.node.borrow().authorization_support_scope(
+                                let expected_result = self
+                                    .node
+                                    .borrow()
+                                    .authorization_support_scope_for_session(
                                         ingest_context.identity,
+                                        Some(&session_claim_binding
+                                            .as_ref()
+                                            .expect("subscriber claims")
+                                            .1),
                                         &purpose.action,
                                     );
                                 let expected = match expected_result {
@@ -3095,11 +3147,13 @@ where
                                 drop_peer_request(&self.node);
                                 return Ok::<bool, Error>(true);
                             }
-                            let supported = self
-                                .node
-                                .lock()
-                                .await
-                                .ensure_peer_maintained_subscription_view_supported(
+                            let supported = {
+                                let mut node = self.node.lock().await;
+                                let mut node = node.scoped_active_session_claims(
+                                    session_claim_binding.as_ref().expect("subscriber claims").0,
+                                    session_claim_binding.as_ref().expect("subscriber claims").1.clone(),
+                                );
+                                node.ensure_peer_maintained_subscription_view_supported(
                                     &shape,
                                     &binding,
                                     opts.tier,
@@ -3107,7 +3161,8 @@ where
                                     &opts.read_view,
                                     QueryAuthorizationMode::TrustedServing,
                                 )
-                                .await;
+                                .await
+                            };
                             if let Err(crate::node::Error::QueryCapability(detail)) = supported {
                                 queue_direct_control(&mut self.pending_control_responses,
                                     unsupported_shape_capability_rejection_message(
@@ -3695,6 +3750,10 @@ where
                         for subscription in pending_initial {
                             let update_result = {
                                 let mut node = self.node.lock().await;
+                                let mut node = node.scoped_active_session_claims(
+                                    session_claim_binding.as_ref().expect("subscriber claims").0,
+                                    session_claim_binding.as_ref().expect("subscriber claims").1.clone(),
+                                );
                                 if group.initialized
                                     || peer.has_maintained_subscription(group_subscription)
                                 {
@@ -3795,6 +3854,10 @@ where
                         }
                         let update_result = {
                             let mut node = self.node.lock().await;
+                            let mut node = node.scoped_active_session_claims(
+                                session_claim_binding.as_ref().expect("subscriber claims").0,
+                                session_claim_binding.as_ref().expect("subscriber claims").1.clone(),
+                            );
                             if settled_handoff {
                                 peer.rehydrate_query_for_subscription_with_opts_and_waker(
                                     &mut node,
@@ -4257,6 +4320,7 @@ async fn serve_authorization_scope_intent<S>(
     peer: &mut PeerState,
     pending_control_responses: &mut VecDeque<PendingSubscriberControlResponse>,
     identity: AuthorSubject,
+    session_claims: BTreeMap<String, Value>,
     connection_epoch: u64,
     request_id: PermissionAdviceRequestId,
     action: PermissionAdviceAction,
@@ -4280,7 +4344,11 @@ where
         );
         return Ok(());
     }
-    let scope = match node.borrow().authorization_support_scope(identity, &action) {
+    let scope = match node.borrow().authorization_support_scope_for_session(
+        identity,
+        Some(&session_claims),
+        &action,
+    ) {
         Ok(scope) => scope,
         Err(_) => {
             queue_direct_control(
@@ -4305,6 +4373,7 @@ where
     if clause_count == 0 {
         let advice = {
             let mut node = node.lock().await;
+            let mut node = node.scoped_active_session_claims(identity, session_claims.clone());
             evaluate_authoritative_permission_advice(&mut node, identity, action).await
         };
         queue_direct_control(
@@ -4356,10 +4425,10 @@ where
             );
             return Ok(());
         }
-        let supported = node
-            .lock()
-            .await
-            .ensure_peer_maintained_subscription_view_supported(
+        let supported = {
+            let mut node = node.lock().await;
+            let mut node = node.scoped_active_session_claims(identity, session_claims.clone());
+            node.ensure_peer_maintained_subscription_view_supported(
                 shape,
                 binding,
                 scope.options.tier,
@@ -4367,7 +4436,8 @@ where
                 &scope.options.read_view,
                 QueryAuthorizationMode::TrustedServing,
             )
-            .await;
+            .await
+        };
         if supported.is_err() {
             queue_direct_control(
                 pending_control_responses,
@@ -4390,6 +4460,7 @@ where
         peer.declare_known_state(subscription, None);
         let update = {
             let mut node = node.lock().await;
+            let mut node = node.scoped_active_session_claims(identity, session_claims.clone());
             peer.rehydrate_query_for_subscription_with_opts_and_waker(
                 &mut node,
                 subscription,
@@ -4640,6 +4711,7 @@ pub(super) fn remove_scope_aggregate_member(
 fn refresh_authorized_scope_purpose<S>(
     node: &NodeState<S>,
     link_identity: AuthorSubject,
+    session_claims: &BTreeMap<String, Value>,
     subscription: SubscriptionKey,
     shape: &ValidatedQuery,
     binding: &Binding,
@@ -4649,7 +4721,7 @@ where
     S: OrderedKvStorage,
 {
     let expected = node
-        .authorization_support_scope(link_identity, &prior.action)
+        .authorization_support_scope_for_session(link_identity, Some(session_claims), &prior.action)
         .ok()?;
     let exact_support = subscription.shape_id == shape.shape_id()
         && subscription.binding_id == binding.binding_id()

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -1450,10 +1450,24 @@ where
                                                 request.intent_sent = true;
                                             }
                                         } else {
+                                            let Some(expected) = expected_scope_authority else {
+                                                continue;
+                                            };
+                                            let identity = expected.link;
+                                            let claims = self
+                                                .node
+                                                .borrow()
+                                                .session_claims_with_revisions()
+                                                .into_iter()
+                                                .find_map(|(subject, claims, _)| {
+                                                    (subject == identity).then_some(claims)
+                                                })
+                                                .unwrap_or_default();
                                             scope_lease_manager.requests.insert(
                                                 *request_id,
                                                 AuthorizationScopeLeaseRequest {
                                                     action: action.clone(),
+                                                    session_claim_binding: (identity, claims),
                                                     waiters: BTreeSet::from([*request_id]),
                                                     intent_sent: false,
                                                     key: None,
@@ -2172,12 +2186,14 @@ where
                                     let retry_id =
                                         PermissionAdviceRequestId(*uuid::Uuid::new_v4().as_bytes());
                                     let action = request.action.clone();
+                                    let session_claim_binding = request.session_claim_binding.clone();
                                     let waiters = request.waiters.clone();
                                     scope_lease_manager.requests.remove(&request_id);
                                     scope_lease_manager.requests.insert(
                                         retry_id,
                                         AuthorizationScopeLeaseRequest {
                                             action: action.clone(),
+                                            session_claim_binding,
                                             waiters,
                                             intent_sent: false,
                                             key: None,
@@ -2222,20 +2238,14 @@ where
                                     continue;
                                 }
                                 let action = request.action.clone();
+                                let session_claim_binding = request.session_claim_binding.clone();
                                 let waiter_ids = request.waiters.clone();
                                 scope_lease_manager.requests.remove(&request_id);
                                 let advice = {
                                     let mut node = self.node.lock().await;
                                     let mut node = node.scoped_active_session_claims(
-                                        session_claim_binding
-                                            .as_ref()
-                                            .expect("subscriber claims")
-                                            .0,
-                                        session_claim_binding
-                                            .as_ref()
-                                            .expect("subscriber claims")
-                                            .1
-                                            .clone(),
+                                        session_claim_binding.0,
+                                        session_claim_binding.1,
                                     );
                                     evaluate_authoritative_permission_advice(
                                         &mut node,

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -518,6 +518,264 @@ fn upstream_authorization_scope_intent_retries_after_bounded_transport_backpress
     drop(advice);
 }
 
+/// A request captures its session claims before the first intent is admitted.
+/// This seam test keeps that intent behind one bounded send, advances only the
+/// same author's ambient claims, then reconnects to a B-context authority. The
+/// old A-bound request must close conservatively; only a new B-owned request
+/// may receive the successor's receipt.
+#[test]
+fn backpressured_scope_intent_claim_transition_closes_before_reconnect() {
+    struct ScopeIntentBackpressureTransport {
+        outbound: Rc<RefCell<VecDeque<SyncMessage>>>,
+        failed_scope_intent: bool,
+        session_context: ConnectionSessionContext,
+    }
+
+    impl Transport for ScopeIntentBackpressureTransport {
+        fn send(&mut self, message: SyncMessage) -> Result<(), TransportError> {
+            if matches!(message, SyncMessage::AuthorizationScopeIntent { .. })
+                && !self.failed_scope_intent
+            {
+                self.failed_scope_intent = true;
+                return Err(TransportError::Backpressure);
+            }
+            self.outbound.borrow_mut().push_back(message);
+            Ok(())
+        }
+
+        fn try_recv(&mut self) -> Option<SyncMessage> {
+            None
+        }
+
+        fn connection_session_context(&self) -> Option<ConnectionSessionContext> {
+            Some(self.session_context)
+        }
+    }
+
+    let schema = editor_claim_write_schema();
+    let author = AuthorSubject::for_test_bytes([0xc4; 16]);
+    let server = open_core(0x5e, AuthorSubject::SYSTEM, &schema);
+    let client = open_db(0xc4, author, &schema);
+    let a_claims = BTreeMap::from([(
+        crate::query::provider_claim_key("role"),
+        Value::String("editor".to_owned()),
+    )]);
+    let b_claims = BTreeMap::from([(
+        crate::query::provider_claim_key("role"),
+        Value::String("viewer".to_owned()),
+    )]);
+    client.set_test_provider_claims(author, a_claims.clone());
+    let (first_transport, _first_authority) = duplex_with_admitted_session_context(
+        author,
+        NodeUuid::from_bytes([0xc4; 16]),
+        1,
+        NodeUuid::from_bytes([0x5e; 16]),
+        1,
+    );
+    let upstream = crate::db::block_on(client.connect_upstream(first_transport));
+    let session_context = upstream
+        .borrow()
+        .transport
+        .connection_session_context()
+        .expect("the admitted transport supplies an authority context");
+    let outbound = Rc::new(RefCell::new(VecDeque::new()));
+    upstream.borrow_mut().transport = Box::new(ScopeIntentBackpressureTransport {
+        outbound: Rc::clone(&outbound),
+        failed_scope_intent: false,
+        session_context,
+    });
+
+    let advice = client.request_permission_advice(PermissionAdviceAction::Insert {
+        table: "todos".to_owned(),
+        cells: cells("candidate", false, author),
+    });
+    client.tick().unwrap();
+    {
+        let connection = upstream.borrow();
+        let ConnectionLink::Upstream(state) = &connection.link else {
+            panic!("client connection must be upstream");
+        };
+        assert!(state.pending.iter().any(|command| matches!(
+            command,
+            PendingUpstreamCommand::AuthorizationScopeIntent {
+                session_claim_binding: Some((_, claims)),
+                ..
+            } if *claims == a_claims
+        )));
+        assert!(
+            state
+                .scope_lease_manager
+                .requests
+                .values()
+                .any(|request| request.session_claim_binding.1 == a_claims),
+            "allocation captures A before the first intent reaches the wire"
+        );
+    }
+    assert!(
+        !outbound
+            .borrow()
+            .iter()
+            .any(|message| matches!(message, SyncMessage::AuthorizationScopeIntent { .. })),
+        "the scope intent remains retained after its one bounded refusal"
+    );
+
+    client.set_test_provider_claims(author, b_claims.clone());
+    assert!(client.detach_connection(&upstream));
+    let (retry_transport, retry_server_transport) = duplex_with_admitted_session_context(
+        author,
+        NodeUuid::from_bytes([0xc4; 16]),
+        2,
+        NodeUuid::from_bytes([0x5e; 16]),
+        2,
+    );
+    let retry_upstream = crate::db::block_on(client.connect_upstream(retry_transport));
+    let retry_subscriber =
+        server.accept_subscriber_with_claims(retry_server_transport, author, a_claims.clone());
+    retry_subscriber
+        .borrow_mut()
+        .update_authenticated_session_claims(b_claims);
+    client.tick().unwrap();
+    {
+        let connection = retry_upstream.borrow();
+        let ConnectionLink::Upstream(state) = &connection.link else {
+            panic!("replacement client connection must be upstream");
+        };
+        assert!(
+            state.scope_lease_manager.requests.is_empty(),
+            "claim transition closes the A request instead of sending B a mixed-context intent"
+        );
+    }
+    assert_eq!(
+        block_on(advice),
+        PermissionAdvice::Unknown,
+        "the B-context successor cannot settle the A-bound request"
+    );
+
+    let b_advice = client.request_permission_advice(PermissionAdviceAction::Insert {
+        table: "todos".to_owned(),
+        cells: cells("candidate", false, author),
+    });
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+    assert_eq!(block_on(b_advice), PermissionAdvice::Denied);
+}
+
+/// This is the same transition without a detach. The retained command must
+/// remember A after its bounded send refusal and close before it can ask the
+/// still-connected authority for a B-shaped proof.
+#[test]
+fn backpressured_scope_intent_claim_transition_closes_on_same_connection() {
+    struct NullTransport;
+
+    impl Transport for NullTransport {
+        fn send(&mut self, _: SyncMessage) -> Result<(), TransportError> {
+            Err(TransportError::Failed(
+                "test placeholder must never send".to_owned(),
+            ))
+        }
+
+        fn try_recv(&mut self) -> Option<SyncMessage> {
+            None
+        }
+    }
+
+    struct ScopeIntentBackpressureTransport {
+        inner: Box<dyn Transport>,
+        failed_scope_intent: bool,
+    }
+
+    impl Transport for ScopeIntentBackpressureTransport {
+        fn send(&mut self, message: SyncMessage) -> Result<(), TransportError> {
+            if matches!(message, SyncMessage::AuthorizationScopeIntent { .. })
+                && !self.failed_scope_intent
+            {
+                self.failed_scope_intent = true;
+                return Err(TransportError::Backpressure);
+            }
+            self.inner.send(message)
+        }
+
+        fn try_recv(&mut self) -> Option<SyncMessage> {
+            self.inner.try_recv()
+        }
+
+        fn connection_session_context(&self) -> Option<ConnectionSessionContext> {
+            self.inner.connection_session_context()
+        }
+    }
+
+    let schema = editor_claim_write_schema();
+    let author = AuthorSubject::for_test_bytes([0xc5; 16]);
+    let server = open_core(0x5e, AuthorSubject::SYSTEM, &schema);
+    let client = open_db(0xc5, author, &schema);
+    let a_claims = BTreeMap::from([(
+        crate::query::provider_claim_key("role"),
+        Value::String("editor".to_owned()),
+    )]);
+    let b_claims = BTreeMap::from([(
+        crate::query::provider_claim_key("role"),
+        Value::String("viewer".to_owned()),
+    )]);
+    client.set_test_provider_claims(author, a_claims.clone());
+    let (client_transport, server_transport) = duplex_with_admitted_session_context(
+        author,
+        NodeUuid::from_bytes([0xc5; 16]),
+        1,
+        NodeUuid::from_bytes([0x5e; 16]),
+        1,
+    );
+    let upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let subscriber = server.accept_subscriber_with_claims(server_transport, author, a_claims);
+    let original_transport = {
+        let mut connection = upstream.borrow_mut();
+        std::mem::replace(&mut connection.transport, Box::new(NullTransport))
+    };
+    upstream.borrow_mut().transport = Box::new(ScopeIntentBackpressureTransport {
+        inner: original_transport,
+        failed_scope_intent: false,
+    });
+
+    let advice = client.request_permission_advice(PermissionAdviceAction::Insert {
+        table: "todos".to_owned(),
+        cells: cells("candidate", false, author),
+    });
+    client.tick().unwrap();
+    client.set_test_provider_claims(author, b_claims.clone());
+    subscriber
+        .borrow_mut()
+        .update_authenticated_session_claims(b_claims);
+    client.tick().unwrap();
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    let mut advice = Box::pin(advice);
+    assert_eq!(
+        advice.as_mut().poll(&mut context),
+        Poll::Ready(PermissionAdvice::Unknown),
+        "a retained A command closes before the same connection can admit it under B"
+    );
+    let hydration_count = match &subscriber.borrow().link {
+        ConnectionLink::Subscriber(SubscriberConnectionState {
+            authority_scope_hydration_count,
+            ..
+        }) => *authority_scope_hydration_count,
+        ConnectionLink::Upstream(_) => unreachable!("server link is a subscriber"),
+    };
+    assert_eq!(
+        hydration_count, 0,
+        "no A request reaches the B authority, so no support shape can be disclosed"
+    );
+
+    let b_advice = client.request_permission_advice(PermissionAdviceAction::Insert {
+        table: "todos".to_owned(),
+        cells: cells("candidate", false, author),
+    });
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+    assert_eq!(block_on(b_advice), PermissionAdvice::Denied);
+}
+
 /// A permission preflight is a node-owned caller obligation, not an
 /// old-transport obligation. When the selected authority disconnects after
 /// accepting the request, the successor must receive one fresh intent and
@@ -970,6 +1228,103 @@ fn distinct_advice_actions_with_one_compiled_scope_hydrate_once() {
     assert_eq!(
         hydration_count, 1,
         "candidate rows must share the compiled authority support hydration"
+    );
+}
+
+/// This stays at the peer/transport seam because the public advice future
+/// cannot hold an authority's completed proof between its wire receipt and
+/// the local callback. It proves that the request owns the claims it observed
+/// when it was issued: advancing the same author's ambient claims must retire
+/// the old receipt, ignore its A-only support, and make the caller issue a
+/// fresh B-bound request rather than combining those contexts.
+#[test]
+fn scope_receipt_claim_transition_ignores_late_a_support_and_requires_fresh_b_request() {
+    let schema = owner_read_schema();
+    let author = AuthorSubject::for_test_bytes([0xa1; 16]);
+    let replacement_subject = AuthorSubject::for_test_bytes([0xb2; 16]);
+    let server = open_core(0x5e, AuthorSubject::SYSTEM, &schema);
+    let target = server
+        .insert("todos", cells("owned-by-a", false, author))
+        .unwrap()
+        .row_uuid();
+    let client = open_db(0xa1, author, &schema);
+    let a_claims = test_provider_claims(author);
+    let b_claims = test_provider_claims(replacement_subject);
+    client.set_test_provider_claims(author, a_claims);
+    let (client_transport, server_transport) = duplex_with_admitted_session_context(
+        author,
+        NodeUuid::from_bytes([0xa1; 16]),
+        1,
+        NodeUuid::from_bytes([0x5e; 16]),
+        1,
+    );
+    let _upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let subscriber = server.accept_subscriber(server_transport, author);
+
+    let cancelled = client.request_permission_advice(PermissionAdviceAction::Read {
+        table: "todos".to_owned(),
+        row: row(0xa2),
+    });
+    let live = client.request_permission_advice(PermissionAdviceAction::Read {
+        table: "todos".to_owned(),
+        row: target,
+    });
+    client.tick().unwrap();
+    server.tick().unwrap();
+
+    // The authority has now queued both A-bound proofs, but the client has
+    // deliberately not consumed either receipt yet.
+    drop(cancelled);
+    client.set_test_provider_claims(author, b_claims.clone());
+    subscriber
+        .borrow_mut()
+        .update_authenticated_session_claims(b_claims);
+    client.tick().unwrap();
+
+    let mut retried_live = false;
+    loop {
+        let Some(message) = try_recv_subscriber_payload(subscriber.borrow_mut().transport.as_mut())
+        else {
+            break;
+        };
+        if let SyncMessage::AuthorizationScopeIntent { request_id, action } = message {
+            assert_eq!(
+                action,
+                PermissionAdviceAction::Read {
+                    table: "todos".to_owned(),
+                    row: target,
+                },
+                "the cancelled request's late A receipt must not revive or retry it"
+            );
+            let _ = request_id;
+            retried_live = true;
+        }
+    }
+    assert!(
+        !retried_live,
+        "neither the cancelled nor the claim-transitioned A request may retry under B"
+    );
+    assert_eq!(
+        block_on(live),
+        PermissionAdvice::Unknown,
+        "a B-context receipt cannot settle the retired A request"
+    );
+    assert!(
+        prepared_read(&client, &Query::from("todos")).is_empty(),
+        "late A-scoped support must not materialize for the B session"
+    );
+
+    let b_request = client.request_permission_advice(PermissionAdviceAction::Read {
+        table: "todos".to_owned(),
+        row: target,
+    });
+    client.tick().unwrap();
+    server.tick().unwrap();
+    client.tick().unwrap();
+    assert_eq!(
+        block_on(b_request),
+        PermissionAdvice::Denied,
+        "a deliberately fresh B request receives only B-shaped authorization"
     );
 }
 

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -509,6 +509,10 @@ pub struct NodeState<S> {
     session_claims: BTreeMap<AuthorSubject, BTreeMap<String, Value>>,
     /// Monotone revision for each identity's process-local session claims.
     session_claim_revisions: BTreeMap<AuthorSubject, u64>,
+    /// Claims scoped to the subscriber whose query is currently compiling.
+    /// This never escapes the node lock, so equal authenticated identities on
+    /// concurrent transports cannot change each other's policy inputs.
+    active_session_claims: Option<(AuthorSubject, BTreeMap<String, Value>)>,
     /// Whether this authority has installed the permissions head that governs
     /// session-scoped reads and writes.
     permissions_ready: bool,
@@ -845,6 +849,7 @@ struct ReadPolicyAuthorizationRequestCacheKey {
     binding_source_shape: Option<String>,
     binding_user_params: String,
     binding_claim_params: String,
+    active_session_claims: String,
     include_deleted_root: bool,
 }
 

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -897,6 +897,16 @@ where
                 )
             })
             .flatten();
+        // Prepared binding-source names are runtime identities.  Claim values
+        // normally route independent bindings through one shape, but equal
+        // author identities may hold distinct authenticated sessions.  Give
+        // their claim scopes separate source identities so a later session
+        // cannot replace an already-maintained sibling binding.
+        let source_shape = source_shape.map(|source_shape| {
+            self.active_session_claim_scope_key(identity)
+                .map(|scope| format!("{source_shape}:session:{scope}"))
+                .unwrap_or(source_shape)
+        });
         let query_schema = self
             .catalogue
             .catalogue_schemas

--- a/crates/jazz/src/node/query_eval/authorization.rs
+++ b/crates/jazz/src/node/query_eval/authorization.rs
@@ -371,7 +371,13 @@ where
             PolicyContext::System
         } else {
             let mut claims = default_policy_claim_values(identity);
-            if let Some(session_claims) = self.session_claims.get(&identity) {
+            if let Some((_, session_claims)) = self
+                .active_session_claims
+                .as_ref()
+                .filter(|(active_identity, _)| *active_identity == identity)
+            {
+                claims.extend(session_claims.clone());
+            } else if let Some(session_claims) = self.session_claims.get(&identity) {
                 claims.extend(session_claims.clone());
             }
             claims.insert(
@@ -1038,6 +1044,9 @@ where
             binding_source_shape: binding_source_shape.clone(),
             binding_user_params: binding_user_params_cache_key(&binding_user_params),
             binding_claim_params: binding_claim_params_cache_key(&binding_claim_params),
+            active_session_claims: self
+                .active_session_claim_scope_key(identity)
+                .unwrap_or_default(),
             include_deleted_root,
         };
         if let Some(request) = self
@@ -1308,6 +1317,21 @@ where
         writer: AuthorSubject,
         action: &PermissionAdviceAction,
     ) -> Result<AuthorizationSupportScope, Error> {
+        self.authorization_support_scope_for_session(
+            writer,
+            self.session_claims.get(&writer),
+            action,
+        )
+    }
+
+    /// Compile authorization support from the claims admitted by this exact
+    /// transport session, never the process-wide last session for its author.
+    pub(crate) fn authorization_support_scope_for_session(
+        &self,
+        writer: AuthorSubject,
+        claims: Option<&BTreeMap<String, Value>>,
+        action: &PermissionAdviceAction,
+    ) -> Result<AuthorizationSupportScope, Error> {
         let (operation, table_name) = authorization_scope_action(action);
         // `PermissionAdviceAction` is reconstructed after policy projection,
         // so its table belongs to the policy-owning schema, not necessarily
@@ -1328,7 +1352,6 @@ where
             &self.table_in_schema(table_name, policy_schema_version)?,
             operation,
         );
-        let claims = self.session_claims.get(&writer);
         let claim_values = permission_scope_claim_values(writer, claims);
         // Authorization support is authority-current: historic/branch views
         // and weaker durability tiers cannot vouch for the authoritative edge.
@@ -1572,6 +1595,26 @@ mod authorization_scope_compiler_tests {
             .authorization_support_scope(identity, &first_action)
             .unwrap();
         assert_ne!(first.key.claims_digest, changed_claims.key.claims_digest);
+
+        let editor_claims = BTreeMap::from([(
+            crate::query::provider_claim_key("role"),
+            Value::String("editor".to_owned()),
+        )]);
+        let viewer_claims = BTreeMap::from([(
+            crate::query::provider_claim_key("role"),
+            Value::String("viewer".to_owned()),
+        )]);
+        let explicit_editor = node
+            .authorization_support_scope_for_session(identity, Some(&editor_claims), &first_action)
+            .unwrap();
+        let explicit_viewer = node
+            .authorization_support_scope_for_session(identity, Some(&viewer_claims), &first_action)
+            .unwrap();
+        assert_ne!(
+            explicit_editor.key, explicit_viewer.key,
+            "same-author support scopes must follow the calling session, not the ambient claim map"
+        );
+        assert_eq!(explicit_viewer.key, changed_claims.key);
     }
 
     #[test]

--- a/crates/jazz/src/node/state/lifecycle.rs
+++ b/crates/jazz/src/node/state/lifecycle.rs
@@ -1,3 +1,32 @@
+/// A cancellation-safe temporary claim scope for one node-locked operation.
+///
+/// The scope owns the mutable node borrow, so its [`Drop`] implementation runs
+/// before the node lock is released if an awaited query is cancelled.
+pub(crate) struct ActiveSessionClaimsScope<'a, S> {
+    node: &'a mut NodeState<S>,
+    previous: Option<(AuthorSubject, BTreeMap<String, Value>)>,
+}
+
+impl<S> std::ops::Deref for ActiveSessionClaimsScope<'_, S> {
+    type Target = NodeState<S>;
+
+    fn deref(&self) -> &Self::Target {
+        self.node
+    }
+}
+
+impl<S> std::ops::DerefMut for ActiveSessionClaimsScope<'_, S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.node
+    }
+}
+
+impl<S> Drop for ActiveSessionClaimsScope<'_, S> {
+    fn drop(&mut self) {
+        self.node.active_session_claims = self.previous.take();
+    }
+}
+
 impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
@@ -600,6 +629,7 @@ where
             merge_head_reachability_walks: 0,
             session_claims: BTreeMap::new(),
             session_claim_revisions: BTreeMap::new(),
+            active_session_claims: None,
             permissions_ready: true,
             catalogue_activation_failed: false,
             #[cfg(any(test, feature = "testing"))]
@@ -758,6 +788,36 @@ where
             .expect("session claim revision overflow must stop authorization delivery");
         self.query.read_policy_authorization_request_cache.clear();
         self.query.policy_authorization_graph_cache.clear();
+    }
+
+    /// Scope one node-locked operation to this subscriber's admitted claims.
+    /// Dropping the returned guard restores the prior scope even if an awaited
+    /// operation is cancelled before it returns.
+    pub(crate) fn scoped_active_session_claims(
+        &mut self,
+        identity: AuthorSubject,
+        claims: BTreeMap<String, Value>,
+    ) -> ActiveSessionClaimsScope<'_, S> {
+        let previous = self.active_session_claims.replace((identity, claims));
+        ActiveSessionClaimsScope {
+            node: self,
+            previous,
+        }
+    }
+
+    /// Return an opaque, domain-separated identity for the active session
+    /// scope. It is runtime-only and deliberately never formats raw claims.
+    pub(crate) fn active_session_claim_scope_key(&self, identity: AuthorSubject) -> Option<String> {
+        let (_, claims) = self
+            .active_session_claims
+            .as_ref()
+            .filter(|(active_identity, _)| *active_identity == identity)?;
+        let encoded = postcard::to_allocvec(&(identity, claims))
+            .expect("author identity and claim values are postcard encodable");
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"jazz/active-session-claim-scope/v1\\0");
+        hasher.update(&encoded);
+        Some(hasher.finalize().to_hex().to_string())
     }
 
     /// Admit application/provider claims for a synthetic test topology.

--- a/crates/jazz/src/node/tests/general.rs
+++ b/crates/jazz/src/node/tests/general.rs
@@ -2420,3 +2420,63 @@ fn accepted_view_scoped_child_constraint_clears_on_matching_complete_parent() {
         .is_empty());
     assert_eq!(reader.transaction_record(child).unwrap().fate, Fate::Accepted);
 }
+/// Keeps the active query claim scope opaque and deterministic, and restores
+/// the prior node state when a future holding the scope is cancelled.
+///
+/// ```text
+/// session A scope ──poll pending──► cancel ──► no active scope
+/// session B scope ───────────────────────────► distinct opaque key
+/// ```
+#[test]
+fn active_session_claim_scope_is_deterministic_and_cancellation_safe() {
+    let (_dir, mut node) = open_node();
+    let alice = AuthorSubject::for_test_bytes([0xa1; 16]);
+    let bob = AuthorSubject::for_test_bytes([0xb2; 16]);
+    let admin = BTreeMap::from([("admin".to_owned(), Value::Bool(true))]);
+    let denied = BTreeMap::from([("admin".to_owned(), Value::Bool(false))]);
+
+    let first = {
+        let scope = node.scoped_active_session_claims(alice, admin.clone());
+        scope
+            .active_session_claim_scope_key(alice)
+            .expect("active scope has an opaque key")
+    };
+    let repeat = {
+        let scope = node.scoped_active_session_claims(alice, admin.clone());
+        scope
+            .active_session_claim_scope_key(alice)
+            .expect("same scope has an opaque key")
+    };
+    let different_claims = {
+        let scope = node.scoped_active_session_claims(alice, denied.clone());
+        scope
+            .active_session_claim_scope_key(alice)
+            .expect("different claims have an opaque key")
+    };
+    let different_identity = {
+        let scope = node.scoped_active_session_claims(bob, admin.clone());
+        scope
+            .active_session_claim_scope_key(bob)
+            .expect("different identity has an opaque key")
+    };
+    assert_eq!(first, repeat, "scope identities must be deterministic");
+    assert_ne!(first, different_claims, "claims must partition scope keys");
+    assert_ne!(first, different_identity, "identity must partition scope keys");
+    assert!(node.active_session_claim_scope_key(alice).is_none());
+
+    let mut cancelled = Box::pin(async {
+        let _scope = node.scoped_active_session_claims(alice, admin);
+        std::future::pending::<()>().await;
+    });
+    let waker = futures::task::noop_waker();
+    let mut context = std::task::Context::from_waker(&waker);
+    assert!(matches!(
+        std::future::Future::poll(cancelled.as_mut(), &mut context),
+        std::task::Poll::Pending
+    ));
+    drop(cancelled);
+    assert!(
+        node.active_session_claim_scope_key(alice).is_none(),
+        "cancelling a scoped query must restore the prior claim context"
+    );
+}


### PR DESCRIPTION
🤖 Maintained query compilation was partly keyed by author identity while session claims lived in an author-keyed ambient map. Two simultaneous sessions with the same issuer/subject but different claims could therefore replace or reuse one another's maintained source and authorization-support scope.

Before:

- session A and session B could share an author while carrying different claims;
- compiling or rehydrating B could make A's maintained stream retract an authorized row;
- RegisterShape preflight, authorization advice/support, and post-rehydrate refresh still consulted ambient author claims;
- cancellation during an awaited scoped operation could leave the temporary claim scope installed;
- one cache identity retained a formatted claim string.

After:

- maintained source/cache identity includes canonical, domain-separated identity-and-claims input;
- transport read paths pass the connection's claims explicitly through preflight, support-scope compilation, rehydrate, and refresh;
- an RAII scope restores prior state even when a pending operation is cancelled;
- legacy author claim state remains only for existing write admission/upstream behavior;
- cache keys retain only a digest, not raw claim values.

Example: an `editor` and a `viewer` session for the same user can subscribe concurrently. The editor keeps receiving rows authorized by its claims; the viewer cannot see them, and registering or reconnecting the viewer cannot retract the editor's stream or reuse its support receipt.

Planted reviews narrowed the source key, restored ambient support-scope lookup, and cancelled a pending scoped operation. Each corresponding isolation/restoration receipt failed as intended.
