### PR TITLE
Preserve flat-join contributors across forwarded resets

### DIFF
--- a/crates/jazz-testkit/tests/output_occurrence_id.rs
+++ b/crates/jazz-testkit/tests/output_occurrence_id.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use jazz::query::{Query, col, eq, lit, table};
 use jazz::row_input;
 use jazz::tools::{
-    ColumnType, DurabilityTier, QueryResult, ResultKey, Schema, SchemaBuilder,
+    ColumnType, DurabilityTier, QueryResult, ReadTier, ResultKey, Schema, SchemaBuilder,
     SubscriptionStreamItem, TableSchema, Value,
 };
 use jazz_server::JazzServer;
@@ -84,6 +84,94 @@ fn joined_todos(sources: &[(&str, &str, &str)]) -> Query {
         Query::from(table("todos").alias("root")).filter(eq(col("root.done"), lit(false))),
         |query, (alias, left, right)| query.flat_join(table("todos").alias(*alias), *left, *right),
     )
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn forwarded_flat_join_reset_keeps_contributor_facts_visible_to_one_shot_reads() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let schema = todos_schema();
+            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let client = TestingClient::builder()
+                .with_server(&server)
+                .with_schema(schema)
+                .with_user_id("00000000-0000-4000-8000-000000000026")
+                .ready_on("todos", Duration::from_secs(30))
+                .connect()
+                .await;
+            let (_root, _, tx) = client
+                .insert(
+                    "todos",
+                    row_input!("title" => "root", "bucket" => "shared", "done" => false),
+                )
+                .expect("insert root");
+            support::wait_for_edge_txs(
+                &client,
+                &[tx.expect("ordinary mutation commits immediately")],
+            )
+            .await;
+            let (_first_joined, _, tx) = client
+                .insert(
+                    "todos",
+                    row_input!("title" => "first", "bucket" => "shared", "done" => true),
+                )
+                .expect("insert first joined source");
+            support::wait_for_edge_txs(
+                &client,
+                &[tx.expect("ordinary mutation commits immediately")],
+            )
+            .await;
+
+            // Both tuple positions deliberately use the same physical table.
+            // The forwarded reset still needs a distinct contributor role for
+            // each source position, even when both positions select one row.
+            let query = joined_todos(&[
+                ("joined", "root.bucket", "joined.bucket"),
+                ("third", "joined.bucket", "third.bucket"),
+            ]);
+            let mut stream = client.subscribe(query.clone()).await.expect("subscribe");
+            let reset = next_delta(&mut stream).await;
+            let root_occurrence = reset.added[0].id.clone();
+
+            let (_joined, _, tx) = client
+                .insert(
+                    "todos",
+                    row_input!("title" => "second", "bucket" => "shared", "done" => true),
+                )
+                .expect("insert joined source");
+            client
+                .wait_for_transaction(
+                    tx.expect("ordinary mutation commits immediately"),
+                    DurabilityTier::Local,
+                )
+                .await
+                .expect("joined source settles locally");
+            let joined_occurrence = key_for_joined_title(
+                &client
+                    .query_results_with_read_tier(query, ReadTier::LocalFirst)
+                    .await
+                    .expect("one-shot flat join remains complete"),
+                "second",
+            );
+            for _ in 0..8 {
+                let delta = next_delta(&mut stream).await;
+                assert!(
+                    delta.removed.iter().all(|row| row.id != root_occurrence),
+                    "one authority generation must not transiently retract its existing occurrence"
+                );
+                assert!(
+                    delta.added.iter().all(|row| row.id != root_occurrence),
+                    "one authority generation must not re-add its existing occurrence"
+                );
+                if delta.added.iter().any(|row| row.id == joined_occurrence) {
+                    client.shutdown().await.expect("shutdown client");
+                    server.shutdown().await;
+                    return;
+                }
+            }
+            panic!("joined occurrence was not published");
+        })
+        .await;
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/jazz/SPEC/16_maintained_subscription_views.md
+++ b/crates/jazz/SPEC/16_maintained_subscription_views.md
@@ -44,6 +44,14 @@ are coverage facts for the maintained subscription view only; they do not become
 complete transaction payload refs. The peer state machine MUST NOT answer a live
 subscription by running an independent semantic scan.
 
+Every reset or incremental publication of flat-tuple membership, including a
+reset forwarded from an already maintained upstream subscription, MUST carry a
+`ContributingMembers` fact for every declared source position. Repeated physical
+source tables still have distinct positional roles. A terminal payload is not a
+substitute for this canonical contributor closure: the receiver MUST be able to
+reconstruct the same tuple through its ordinary one-shot path after applying the
+publication, without a same-generation transient remove and re-add.
+
 A maintained peer publication MUST retain the complete semantic read view and
 tier resolved at admission. Initial hydration, suspended retries, incremental
 evaluation, authoritative reconciliation, settlement, and authorization

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -295,7 +295,7 @@ pub(crate) use query_eval::take_client_physical_row_query_calls_for_test;
 pub(crate) use query_eval::{
     LocalMaintainedViewSubscription, LocalMaintainedViewSubscriptionUpdate,
 };
-pub(crate) use views::MaintainedViewBundleInputs;
+pub(crate) use views::{FlatTupleSourceTables, MaintainedViewBundleInputs};
 
 type ResultRowMembershipKey = crate::tools::OutputOccurrenceId;
 

--- a/crates/jazz/src/node/tests/view_update_capture.rs
+++ b/crates/jazz/src/node/tests/view_update_capture.rs
@@ -458,7 +458,8 @@ impl MaintainedSubscriptionViewSubscription {
                 complete_exclusive_payloads: false,
                 previous_result_set,
                 previous_program_facts: BTreeSet::new(),
-                flat_tuple_source_tables: Vec::new(),
+                flat_tuple_source_tables:
+                    crate::node::FlatTupleSourceTables::for_query(_shape),
                 result_member_adds: result_member_adds
                     .into_iter()
                     .map(crate::protocol::ResultMemberEntry::from)

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -216,6 +216,35 @@ fn relation_edge_version_rows_for_bundle(
         .collect()
 }
 
+/// Source vocabulary required to turn maintained flat-tuple membership into
+/// canonical contributor facts. Construct this from the validated query rather
+/// than independently from its result rows: an empty vocabulary on a flat join
+/// produces a payload that renders once but cannot be reconstructed afterward.
+pub(crate) struct FlatTupleSourceTables(Vec<String>);
+
+impl FlatTupleSourceTables {
+    pub(crate) fn for_query(shape: &ValidatedQuery) -> Self {
+        Self(
+            shape
+                .query()
+                .flat_join
+                .as_ref()
+                .map(|flat_join| {
+                    flat_join
+                        .sources
+                        .iter()
+                        .map(|source| source.table.clone())
+                        .collect()
+                })
+                .unwrap_or_default(),
+        )
+    }
+
+    pub(crate) fn as_slice(&self) -> &[String] {
+        &self.0
+    }
+}
+
 pub(crate) struct MaintainedViewBundleInputs<'a> {
     pub(crate) subscription: SubscriptionKey,
     /// Peer inventory of transactions whose full row-version payload has
@@ -233,7 +262,7 @@ pub(crate) struct MaintainedViewBundleInputs<'a> {
     /// a durable general-history grant.
     pub(crate) previous_program_facts: BTreeSet<ProgramFactEntry>,
     /// Declared flat-join source table for each contributor position.
-    pub(crate) flat_tuple_source_tables: Vec<String>,
+    pub(crate) flat_tuple_source_tables: FlatTupleSourceTables,
     pub(crate) result_member_adds: Vec<ResultMemberEntry>,
     pub(crate) result_member_removes: Vec<ResultMemberEntry>,
     pub(crate) program_fact_adds: Vec<ProgramFactEntry>,
@@ -681,7 +710,7 @@ where
                 complete_exclusive_payloads: false,
                 previous_result_set,
                 previous_program_facts: BTreeSet::new(),
-                flat_tuple_source_tables: Vec::new(),
+                flat_tuple_source_tables: FlatTupleSourceTables::for_query(shape),
                 identity,
                 tier,
                 maintained_facts: &maintained,
@@ -724,7 +753,7 @@ where
         program_fact_adds.extend(maintained_facts.payload_facts_for_members(&result_member_adds));
         let tuple_source_versions = maintained_facts.tuple_source_versions_for_members(
             &maintained_facts.active_result_members(),
-            &flat_tuple_source_tables,
+            flat_tuple_source_tables.as_slice(),
         );
         let mut desired_tuple_source_facts = BTreeMap::new();
         for (result, source_index, maintained_version) in &tuple_source_versions {

--- a/crates/jazz/src/peer.rs
+++ b/crates/jazz/src/peer.rs
@@ -183,21 +183,6 @@ impl From<MaintainedSubscriptionViewIndexFootprint> for MaintainedSubscriptionVi
     }
 }
 
-fn flat_tuple_source_tables(shape: &ValidatedQuery) -> Vec<String> {
-    shape
-        .query()
-        .flat_join
-        .as_ref()
-        .map(|flat_join| {
-            flat_join
-                .sources
-                .iter()
-                .map(|source| source.table.clone())
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
 #[cfg(test)]
 mod tests {
     include!("peer/tests.rs");

--- a/crates/jazz/src/peer/publication.rs
+++ b/crates/jazz/src/peer/publication.rs
@@ -684,7 +684,8 @@ impl PeerState {
                         && self.role == PeerRole::Relay,
                     previous_result_set: previous_result_tx_ids,
                     previous_program_facts,
-                    flat_tuple_source_tables: flat_tuple_source_tables(shape),
+                    flat_tuple_source_tables:
+                        crate::node::FlatTupleSourceTables::for_query(shape),
                     result_member_adds,
                     result_member_removes,
                     program_fact_adds,
@@ -1157,7 +1158,7 @@ impl PeerState {
                 } else {
                     previous_program_facts
                 },
-                flat_tuple_source_tables: flat_tuple_source_tables(shape),
+                flat_tuple_source_tables: crate::node::FlatTupleSourceTables::for_query(shape),
                 result_member_adds,
                 result_member_removes,
                 program_fact_adds,
@@ -1649,7 +1650,15 @@ impl PeerState {
                         && self.role == PeerRole::Relay,
                     previous_result_set: BTreeSet::new(),
                     previous_program_facts: BTreeSet::new(),
-                    flat_tuple_source_tables: Vec::new(),
+                    // Rehydration forwards the canonical membership through a
+                    // new downstream subscription, but its fact vocabulary is
+                    // still the validated query's vocabulary. Flat tuples need
+                    // one contributor role per joined source so the receiver's
+                    // ordinary one-shot path can rebuild the same tuple from
+                    // immutable source versions instead of depending only on
+                    // the reset payload.
+                    flat_tuple_source_tables:
+                        crate::node::FlatTupleSourceTables::for_query(shape),
                     result_member_adds,
                     result_member_removes: target_result_member_removes,
                     program_fact_adds: Vec::new(),

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -13,6 +13,7 @@ use crate::protocol::{
 };
 use crate::query::{
     Aggregate, ArraySubquery, OrderDirection, Query, col, eq, gt, is_null, lit, ne, not, param,
+    table,
 };
 use crate::schema::{JazzSchema, TableSchema};
 use crate::time::{GlobalTime, TxTime};
@@ -39,6 +40,38 @@ fn row_from_u64(value: u64) -> RowUuid {
     let mut bytes = [0; 16];
     bytes[..8].copy_from_slice(&value.to_be_bytes());
     RowUuid::from_bytes(bytes)
+}
+
+#[test]
+fn flat_tuple_source_vocabulary_is_derived_positionally_from_the_validated_query() {
+    let ordinary = Query::from("todos")
+        .validate(&schema())
+        .expect("validate ordinary query");
+    assert!(
+        crate::node::FlatTupleSourceTables::for_query(&ordinary)
+            .as_slice()
+            .is_empty(),
+        "a non-flat query has no tuple-source roles"
+    );
+
+    let shared_source_table = Query::from(table("todos").alias("root"))
+        .flat_join(
+            table("todos").alias("first"),
+            "root.title",
+            "first.title",
+        )
+        .flat_join(
+            table("todos").alias("second"),
+            "first.title",
+            "second.title",
+        )
+        .validate(&schema())
+        .expect("validate two-source flat query");
+    assert_eq!(
+        crate::node::FlatTupleSourceTables::for_query(&shared_source_table).as_slice(),
+        &["todos".to_owned(), "todos".to_owned()],
+        "shared physical tables retain one contributor role per source position"
+    );
 }
 
 fn settled_member(row_uuid: RowUuid, position: u64) -> ResultMemberEntry {


### PR DESCRIPTION
🤖 Forwarded maintained-view resets retained complete result payloads but discarded the validated flat-join source vocabulary. A receiver could render the authoritative payload, then immediately reconstruct the same generation from incomplete contributor facts and transiently retract a valid occurrence.

Before:

- normal publication paths supplied flat-tuple source tables;
- one forwarding/coverage constructor supplied an empty vector;
- no `ContributingMembers` facts were emitted for joined sources;
- an authoritative `root × child` result appeared, disappeared at the same generation, then reappeared through payload recovery.

After:

- flat-tuple source metadata is a private type derived only from `ValidatedQuery`;
- every initial, reset, forwarding, and test-capture constructor receives the same validated positional vocabulary;
- repeated physical tables remain distinct positional join sources;
- non-flat queries retain an empty vocabulary;
- forwarded receivers can reconstruct contributor facts consistently with the authoritative payload.

Example: for a two-source flat join where both positions happen to use the same physical table, the receiver records two positional contributor entries. It no longer collapses them or treats the joined side as absent.

Independent review planted both complete metadata omission and narrowing to the first positional source. Each deterministically reproduced the same-generation occurrence retraction; restoration passed the focused forwarding receipt.

This PR fixes forwarded insertion/update reconstruction. A separately tracked follow-up handles a newly exposed joined-source deletion invalidation timeout rather than folding that distinct lifecycle into this repair.
