### PR TITLE
Avoid dropped port reservation in replica restart test

### DIFF
--- a/crates/jazz-testkit/tests/replica_settlement.rs
+++ b/crates/jazz-testkit/tests/replica_settlement.rs
@@ -629,11 +629,6 @@ mod client_transport {
             .build()
     }
 
-    fn reserve_local_port() -> u16 {
-        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve local port");
-        listener.local_addr().expect("reserved local addr").port()
-    }
-
     /// Waits for the initial settled reset of a fresh subscription and
     /// asserts it carries `expected_id`.
     async fn assert_initial_settled_row(
@@ -740,17 +735,19 @@ mod client_transport {
             .run_until(async {
                 let schema = document_schema();
                 let app_id = AppId::random();
-                let port = reserve_local_port();
                 let data_dir = TempDir::new().expect("server data dir");
 
+                // Let the first server retain the kernel-selected port rather
+                // than reserving and dropping one before it starts: nextest
+                // runs this topology alongside other server tests.
                 let first_server = JazzServer::builder()
                     .with_app_id(app_id)
-                    .with_port(port)
                     .with_schema(schema.clone())
                     .with_data_dir(data_dir.path())
                     .with_storage_factory(jazz_testkit::persistent_storage_factory())
                     .start()
                     .await;
+                let port = first_server.port();
                 let alice = TestingClient::builder()
                     .with_server(&first_server)
                     .with_schema(schema.clone())


### PR DESCRIPTION
🤖 One replica-restart test reserves a loopback port by binding port 0, reads the assigned number, then drops that listener before starting the server. Under parallel CI another process can acquire the released port, producing an unrelated `AddrInUse` failure.

Before:

- the test guessed a future server port through a dropped reservation;
- ownership was lost between reservation and actual server bind;
- the restart scenario intermittently failed before exercising any Jazz behavior.

After:

- the first server starts directly on port 0 and therefore owns its selected listener;
- the test reads the actual bound port from the running server;
- it awaits shutdown, then restarts the second server on that same port as the scenario requires.

This changes test setup only. The replica settlement/reconnect behavior under test is unchanged.

Independent review ran the exact receipt successfully and repeated it 12 ways concurrently (12/12). The old reserve/drop behavior remains inherently nondeterministic rather than supplying a reliable negative plant; the new ownership sequence removes the TOCTOU structurally.
