### PR TITLE
Queue transaction-local reads on async storage

### DIFF
--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -96,6 +96,14 @@ export declare class NapiDb {
   all(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   /** Read through an open transaction using the identity bound at begin. */
   allInTransaction(query: PreparedQuery, tx: Tx, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
+  /**
+   * Read through an open transaction as its identity bound at begin.
+   *
+   * The core verifies that `author` matches the capability retained by the
+   * transaction; this ABI exists so trusted-serving hosts never fall back
+   * to their ambient/default read identity.
+   */
+  allInTransactionForIdentity(query: PreparedQuery, tx: Tx, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   setIdentityClaims(author: Uint8Array, claims?: Record<string, unknown> | undefined | null): void
   allForIdentity(query: PreparedQuery, author: Uint8Array, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead
   allRelationSnapshot(query: PreparedQuery, opts?: { tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null): Uint8Array | PendingNativeRead

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -2607,6 +2607,110 @@ impl NapiDb {
         }
     }
 
+    /// Read through an open transaction as its identity bound at begin.
+    ///
+    /// The core verifies that `author` matches the capability retained by the
+    /// transaction; this ABI exists so trusted-serving hosts never fall back
+    /// to their ambient/default read identity.
+    #[napi(js_name = "allInTransactionForIdentity")]
+    pub fn all_in_transaction_for_identity(
+        &self,
+        query: &PreparedQuery,
+        tx: &Tx,
+        author: Uint8Array,
+        #[napi(
+            ts_arg_type = "{ tier?: string; local_updates?: string; propagation?: string; include_deleted?: boolean } | undefined | null"
+        )]
+        opts: Option<JsonValue>,
+    ) -> napi::Result<Either<Uint8Array, PendingNativeRead>> {
+        let db = self.inner.borrow();
+        let db = db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("database is closed"))?;
+        let tx_db = tx
+            .db
+            .as_ref()
+            .ok_or_else(|| napi::Error::from_reason("transaction is closed"))?;
+        if !db.shares_runtime_with(tx_db) {
+            return Err(napi::Error::from_reason(
+                "transaction belongs to a different database runtime",
+            ));
+        }
+        let author = core_author_id_from_bytes(&author)?;
+        let opts = core_read_opts_from_json(opts)?;
+        let open_tx = tx.open_tx()?;
+        match (db, tx.kind) {
+            (NapiDbInnerStorage::Memory(db), NapiTxKind::Mergeable) => {
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut rows = db
+                        .mergeable_tx_ref(open_tx)
+                        .all_prepared_for_identity_with_opts(&query, author, opts)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_rows_for_binding(&mut rows)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
+            }
+            (NapiDbInnerStorage::Persistent(db), NapiTxKind::Mergeable) => {
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut rows = db
+                        .mergeable_tx_ref(open_tx)
+                        .all_prepared_for_identity_with_opts(&query, author, opts)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_rows_for_binding(&mut rows)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
+            }
+            (NapiDbInnerStorage::Memory(db), NapiTxKind::Exclusive) => {
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut rows = db
+                        .exclusive_tx_ref(open_tx)
+                        .all_prepared_for_identity_with_opts(&query, author, opts)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_rows_for_binding(&mut rows)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
+            }
+            (NapiDbInnerStorage::Persistent(db), NapiTxKind::Exclusive) => {
+                let db = Rc::clone(db);
+                let query = query.inner.clone();
+                native_read_or_pending(Box::pin(async move {
+                    let mut rows = db
+                        .exclusive_tx_ref(open_tx)
+                        .all_prepared_for_identity_with_opts(&query, author, opts)
+                        .await
+                        .map_err(napi_error)?;
+                    db.hydrate_rows_for_binding(&mut rows)
+                        .await
+                        .map_err(napi_error)?;
+                    encode_core_rows(&rows)
+                        .map(Uint8Array::new)
+                        .map_err(napi_error)
+                }))
+            }
+        }
+    }
+
     #[napi(js_name = "setIdentityClaims")]
     pub fn set_identity_claims(
         &self,

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -10,6 +10,7 @@ use std::task::{Context, Poll, Waker};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use futures_channel::mpsc::{unbounded, UnboundedSender};
+use futures_channel::oneshot;
 use futures_util::future::{AbortHandle, Abortable};
 use futures_util::lock::Mutex as LocalMutex;
 use futures_util::stream;
@@ -18,7 +19,7 @@ use futures_util::{Stream, StreamExt};
 #[cfg(target_arch = "wasm32")]
 use idb_tree::IndexedDbPageStore;
 use jazz::db::{
-    block_on, ConnectionSessionContext, Db, DbConfig, DbIdentity, ExclusiveTxOps,
+    block_on, ConnectionSessionContext, Db, DbConfig, DbIdentity, Error, ErrorCode, ExclusiveTxOps,
     InitialSyncFlushCadence, LargeValueUpdate, LocalUpdates, MergeableTxOps, MutationErrorCallback,
     PeerConnection, PermissionAdvice, PreparedQuery, Propagation, QueryAttachment, ReadOpts,
     RowCells, SeededRowIdSource, StreamingMutationKind, StreamingValueUpload, SubscriptionEvent,
@@ -859,54 +860,30 @@ impl WasmDbInner {
         }
     }
 
-    fn exclusive_all_for_identity(
+    async fn transaction_rows(
         &self,
         tx_id: OpenTransactionId,
-        query: &PreparedQuery,
-        author: AuthorSubject,
+        kind: WasmTxKind,
+        query: PreparedQuery,
+        author: Option<AuthorSubject>,
         opts: ReadOpts,
-    ) -> Result<Vec<jazz::node::CurrentRow>, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.exclusive_tx_ref(tx_id)
-                .all_prepared_for_identity_with_opts(query, author, opts)
-        ))
-    }
-
-    fn exclusive_all(
-        &self,
-        tx_id: OpenTransactionId,
-        query: &PreparedQuery,
-        opts: ReadOpts,
-    ) -> Result<Vec<jazz::node::CurrentRow>, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.exclusive_tx_ref(tx_id)
-                .all_prepared_with_opts(query, opts)
-        ))
-    }
-
-    fn mergeable_all_for_identity(
-        &self,
-        tx_id: OpenTransactionId,
-        query: &PreparedQuery,
-        author: AuthorSubject,
-        opts: ReadOpts,
-    ) -> Result<Vec<jazz::node::CurrentRow>, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.mergeable_tx_ref(tx_id)
-                .all_prepared_for_identity_with_opts(query, author, opts)
-        ))
-    }
-
-    fn mergeable_all(
-        &self,
-        tx_id: OpenTransactionId,
-        query: &PreparedQuery,
-        opts: ReadOpts,
-    ) -> Result<Vec<jazz::node::CurrentRow>, jazz::db::Error> {
-        with_wasm_db!(self, |db| block_on(
-            db.mergeable_tx_ref(tx_id)
-                .all_prepared_with_opts(query, opts)
-        ))
+    ) -> Result<Vec<jazz::node::CurrentRow>, Error> {
+        match self {
+            Self::Memory(db) => {
+                let pending = start_transaction_rows(db, tx_id, kind, query, author, opts);
+                db.drive_queued_mutation_once();
+                pending.await.map_err(transaction_read_cancelled)?
+            }
+            #[cfg(target_arch = "wasm32")]
+            Self::Browser(db) => {
+                let pending = start_transaction_rows(db, tx_id, kind, query, author, opts);
+                pending.await.map_err(transaction_read_cancelled)?
+            }
+            Self::Closed => Err(Error {
+                code: ErrorCode::Protocol,
+                message: "WasmDb is closed".into(),
+            }),
+        }
     }
 
     fn abandon_transaction(&self, tx_id: OpenTransactionId) -> Result<(), jazz::db::Error> {
@@ -1103,6 +1080,55 @@ impl WasmDbInner {
 
     async fn tick(&self) -> Result<(), jazz::db::Error> {
         with_wasm_db!(self, |db| db.tick().await)
+    }
+}
+
+fn start_transaction_rows<S>(
+    db: &Rc<Db<S>>,
+    tx_id: OpenTransactionId,
+    kind: WasmTxKind,
+    query: PreparedQuery,
+    author: Option<AuthorSubject>,
+    opts: ReadOpts,
+) -> oneshot::Receiver<Result<Vec<jazz::node::CurrentRow>, Error>>
+where
+    S: OrderedKvStorage + ReopenableStorage + 'static,
+{
+    let owner = Rc::clone(db);
+    db.enqueue_transaction_read(tx_id, async move {
+        match (kind, author) {
+            (WasmTxKind::Mergeable, Some(author)) => {
+                owner
+                    .mergeable_tx_ref(tx_id)
+                    .all_prepared_for_identity_with_opts(&query, author, opts)
+                    .await
+            }
+            (WasmTxKind::Mergeable, None) => {
+                owner
+                    .mergeable_tx_ref(tx_id)
+                    .all_prepared_with_opts(&query, opts)
+                    .await
+            }
+            (WasmTxKind::Exclusive, Some(author)) => {
+                owner
+                    .exclusive_tx_ref(tx_id)
+                    .all_prepared_for_identity_with_opts(&query, author, opts)
+                    .await
+            }
+            (WasmTxKind::Exclusive, None) => {
+                owner
+                    .exclusive_tx_ref(tx_id)
+                    .all_prepared_with_opts(&query, opts)
+                    .await
+            }
+        }
+    })
+}
+
+fn transaction_read_cancelled(_: oneshot::Canceled) -> Error {
+    Error {
+        code: ErrorCode::Protocol,
+        message: "transaction read owner operation was cancelled".into(),
     }
 }
 
@@ -1814,16 +1840,8 @@ impl WasmDb {
         query: &WasmPreparedQuery,
         tx: &WasmTx,
         opts: JsValue,
-    ) -> Result<Vec<u8>, JsValue> {
-        ensure_transaction_runtime(&self.inner, tx)?;
-        let opts = read_opts_from_js(opts)?;
-        let tx_id = tx.open_tx_for_read()?;
-        let rows = match tx.kind {
-            WasmTxKind::Mergeable => self.inner.mergeable_all(tx_id, &query.inner, opts),
-            WasmTxKind::Exclusive => self.inner.exclusive_all(tx_id, &query.inner, opts),
-        }
-        .map_err(to_js_error)?;
-        encode_synchronous_rows(&rows)
+    ) -> Result<js_sys::Promise, JsValue> {
+        transaction_rows_promise(&self.inner, query, tx, None, opts, false)
     }
 
     #[wasm_bindgen(js_name = allInTransactionForIdentity)]
@@ -1833,23 +1851,9 @@ impl WasmDb {
         tx: &WasmTx,
         author: Vec<u8>,
         opts: JsValue,
-    ) -> Result<Vec<u8>, JsValue> {
-        ensure_transaction_runtime(&self.inner, tx)?;
-        let opts = read_opts_from_js(opts)?;
+    ) -> Result<js_sys::Promise, JsValue> {
         let author = author_id_from_bytes(&author)?;
-        let tx_id = tx.open_tx_for_read()?;
-        let rows = match tx.kind {
-            WasmTxKind::Mergeable => {
-                self.inner
-                    .mergeable_all_for_identity(tx_id, &query.inner, author, opts)
-            }
-            WasmTxKind::Exclusive => {
-                self.inner
-                    .exclusive_all_for_identity(tx_id, &query.inner, author, opts)
-            }
-        }
-        .map_err(to_js_error)?;
-        encode_synchronous_rows(&rows)
+        transaction_rows_promise(&self.inner, query, tx, Some(author), opts, false)
     }
 
     #[wasm_bindgen(js_name = oneInTransaction)]
@@ -1858,10 +1862,8 @@ impl WasmDb {
         query: &WasmPreparedQuery,
         tx: &WasmTx,
         opts: JsValue,
-    ) -> Result<Vec<u8>, JsValue> {
-        let mut rows = read_rows_for_transaction(&self.inner, query, tx, None, opts)?;
-        rows.truncate(1);
-        encode_synchronous_rows(&rows)
+    ) -> Result<js_sys::Promise, JsValue> {
+        transaction_rows_promise(&self.inner, query, tx, None, opts, true)
     }
 
     #[wasm_bindgen(js_name = oneInTransactionForIdentity)]
@@ -1871,11 +1873,9 @@ impl WasmDb {
         tx: &WasmTx,
         author: Vec<u8>,
         opts: JsValue,
-    ) -> Result<Vec<u8>, JsValue> {
+    ) -> Result<js_sys::Promise, JsValue> {
         let author = author_id_from_bytes(&author)?;
-        let mut rows = read_rows_for_transaction(&self.inner, query, tx, Some(author), opts)?;
-        rows.truncate(1);
-        encode_synchronous_rows(&rows)
+        transaction_rows_promise(&self.inner, query, tx, Some(author), opts, true)
     }
 
     #[wasm_bindgen(js_name = setIdentityClaims)]
@@ -3225,30 +3225,35 @@ impl WasmTx {
     }
 }
 
-fn read_rows_for_transaction(
+fn transaction_rows_promise(
     db: &WasmDbInner,
     query: &WasmPreparedQuery,
     tx: &WasmTx,
     author: Option<AuthorSubject>,
     opts: JsValue,
-) -> Result<Vec<jazz::node::CurrentRow>, JsValue> {
+    one: bool,
+) -> Result<js_sys::Promise, JsValue> {
     ensure_transaction_runtime(db, tx)?;
     let opts = read_opts_from_js(opts)?;
     let tx_id = tx.open_tx_for_read()?;
-    match (tx.kind, author) {
-        (WasmTxKind::Mergeable, Some(author)) => db
-            .mergeable_all_for_identity(tx_id, &query.inner, author, opts)
-            .map_err(to_js_error),
-        (WasmTxKind::Mergeable, None) => db
-            .mergeable_all(tx_id, &query.inner, opts)
-            .map_err(to_js_error),
-        (WasmTxKind::Exclusive, Some(author)) => db
-            .exclusive_all_for_identity(tx_id, &query.inner, author, opts)
-            .map_err(to_js_error),
-        (WasmTxKind::Exclusive, None) => db
-            .exclusive_all(tx_id, &query.inner, opts)
-            .map_err(to_js_error),
+    if !query.inner.shape().query().array_subqueries.is_empty() {
+        return Err(JsValue::from_str(
+            "transaction-local reads do not support relation array subqueries",
+        ));
     }
+    let db = db.clone();
+    let query = query.inner.clone();
+    let kind = tx.kind;
+    Ok(future_to_promise(async move {
+        let mut rows = db
+            .transaction_rows(tx_id, kind, query, author, opts)
+            .await
+            .map_err(to_js_error)?;
+        if one {
+            rows.truncate(1);
+        }
+        bytes_to_js(encode_rows(&rows).map_err(to_js_error)?)
+    }))
 }
 
 fn ensure_transaction_runtime(db: &WasmDbInner, tx: &WasmTx) -> Result<(), JsValue> {
@@ -4868,9 +4873,14 @@ mod dynamic_schema_view_tests {
         ))
         .unwrap();
         let prepared = view.prepare_query(&view.table("items")).unwrap();
-        let rows = WasmDbInner::Memory(Rc::clone(&view))
-            .mergeable_all(batch, &prepared, ReadOpts::default())
-            .unwrap();
+        let rows = block_on(WasmDbInner::Memory(Rc::clone(&view)).transaction_rows(
+            batch,
+            WasmTxKind::Mergeable,
+            prepared,
+            None,
+            ReadOpts::default(),
+        ))
+        .unwrap();
         assert_eq!(rows.len(), 1, "the attached view reads staged rows");
         block_on(owner.commit_mergeable_handle(batch)).unwrap();
 

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1510,6 +1510,7 @@ type PendingRelaySubscriptionRejections =
     Rc<RefCell<BTreeMap<u64, VecDeque<RelaySubscriptionRejection>>>>;
 type SharedTickScheduler = Rc<RefCell<Option<Rc<dyn TickScheduler>>>>;
 type QueuedMutationFuture = Pin<Box<dyn Future<Output = Result<(), Error>> + 'static>>;
+type QueuedMutationCompletion = Box<dyn FnOnce(Result<(), Error>) + 'static>;
 type TransactionWaitObserver = Pin<Box<dyn Future<Output = ()> + 'static>>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1523,6 +1524,7 @@ struct QueuedMutationOperation {
     open_tx_id: Option<OpenTransactionId>,
     future: QueuedMutationFuture,
     status: Option<Rc<RefCell<QueuedMutationStatus>>>,
+    completion: Option<QueuedMutationCompletion>,
 }
 
 enum QueuedMutationStatus {

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -497,6 +497,18 @@ where
         self.node.poll_queued_mutation_once();
     }
 
+    /// Queue a transaction-local read behind already-admitted transaction
+    /// work. Bindings retain the returned receiver instead of synchronously
+    /// polling cold storage on their host thread.
+    #[doc(hidden)]
+    pub fn enqueue_transaction_read<T: 'static>(
+        &self,
+        tx_id: OpenTransactionId,
+        read: impl Future<Output = Result<T, Error>> + 'static,
+    ) -> futures::channel::oneshot::Receiver<Result<T, Error>> {
+        self.node.enqueue_transaction_read(tx_id, read)
+    }
+
     pub(super) fn clone_for_reserved_transaction(&self, tx_id: TxId) -> Self {
         Self {
             schema: self.schema.clone(),

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -203,6 +203,7 @@ where
                 open_tx_id: None,
                 future,
                 status: Some(Rc::clone(&status)),
+                completion: None,
             });
         self.schedule_tick(TickUrgency::Immediate);
         status
@@ -221,9 +222,47 @@ where
                 open_tx_id: Some(open_tx_id),
                 future,
                 status: None,
+                completion: None,
             });
         self.schedule_tick(TickUrgency::Immediate);
         Ok(())
+    }
+
+    /// Put a transaction-local read behind every already-admitted operation
+    /// for that transaction. The receiver owns the eventual result, while the
+    /// owner queue retains the cold storage future and its wake route.
+    pub(super) fn enqueue_transaction_read<T: 'static>(
+        &self,
+        open_tx_id: OpenTransactionId,
+        read: impl Future<Output = Result<T, Error>> + 'static,
+    ) -> futures::channel::oneshot::Receiver<Result<T, Error>> {
+        let (sender, receiver) = futures::channel::oneshot::channel();
+        let sender = Rc::new(RefCell::new(Some(sender)));
+        let read_sender = Rc::clone(&sender);
+        let completion_sender = Rc::clone(&sender);
+        self.queued_mutations
+            .borrow_mut()
+            .push_back(QueuedMutationOperation {
+                tx_id: None,
+                open_tx_id: Some(open_tx_id),
+                future: Box::pin(async move {
+                    let result = read.await;
+                    if let Some(sender) = read_sender.borrow_mut().take() {
+                        let _ = sender.send(result);
+                    }
+                    Ok(())
+                }),
+                status: None,
+                completion: Some(Box::new(move |outcome| {
+                    if let Err(error) = outcome
+                        && let Some(sender) = completion_sender.borrow_mut().take()
+                    {
+                        let _ = sender.send(Err(error));
+                    }
+                })),
+            });
+        self.schedule_tick(TickUrgency::Immediate);
+        receiver
     }
 
     pub(super) fn enqueue_transaction_commit(
@@ -241,6 +280,7 @@ where
                 open_tx_id: Some(open_tx_id),
                 future,
                 status: Some(Rc::clone(&status)),
+                completion: None,
             });
         self.schedule_tick(TickUrgency::Immediate);
         status
@@ -254,6 +294,7 @@ where
                 open_tx_id: None,
                 future,
                 status: None,
+                completion: None,
             });
         self.schedule_tick(TickUrgency::Immediate);
     }
@@ -287,9 +328,12 @@ where
 
     fn finish_queued_mutation(
         &self,
-        operation: QueuedMutationOperation,
+        mut operation: QueuedMutationOperation,
         result: Result<(), Error>,
     ) {
+        if let Some(completion) = operation.completion.take() {
+            completion(result.clone());
+        }
         if let Some(tx_id) = operation.tx_id {
             self.reserved_mutations.borrow_mut().remove(&tx_id);
         }

--- a/crates/jazz/src/db/tests/transactions.rs
+++ b/crates/jazz/src/db/tests/transactions.rs
@@ -1656,9 +1656,10 @@ fn mergeable_session_mutations_observe_visible_rows_in_their_overlay() {
     db.commit_mergeable_handle(hidden_open).unwrap();
 }
 
-/// Mergeable serving reads retain their existing per-call identity semantics.
+/// A mergeable transaction opened for alice is an identity capability: its
+/// serving reads cannot be re-authorized as bob.
 #[test]
-fn mergeable_transaction_identity_reads_are_not_forced_to_begin_author() {
+fn identity_bound_mergeable_transaction_rejects_cross_identity_reads() {
     let schema = owner_read_schema();
     let db = open_db(0xd3, AuthorSubject::SYSTEM, &schema);
     let alice = AuthorSubject::for_test_bytes([0xa3; 16]);
@@ -1708,11 +1709,6 @@ fn mergeable_transaction_identity_reads_are_not_forced_to_begin_author() {
             .all_prepared_for_identity(&prepared, alice),
     )
     .unwrap();
-    let bob_rows = doctest_support::block_on(
-        db.mergeable_tx_ref(open)
-            .all_prepared_for_identity(&prepared, bob),
-    )
-    .unwrap();
     assert_eq!(
         alice_rows
             .iter()
@@ -1720,13 +1716,13 @@ fn mergeable_transaction_identity_reads_are_not_forced_to_begin_author() {
             .collect::<Vec<_>>(),
         vec![alice_row]
     );
-    assert_eq!(
-        bob_rows
-            .iter()
-            .map(CurrentRow::row_uuid)
-            .collect::<Vec<_>>(),
-        vec![bob_row]
-    );
+    assert!(matches!(
+        doctest_support::block_on(
+            db.mergeable_tx_ref(open)
+                .all_prepared_for_identity(&prepared, bob),
+        ),
+        Err(error) if error.code == ErrorCode::Protocol
+    ));
     db.abandon_transaction_handle(open).unwrap();
 }
 

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -2908,7 +2908,24 @@ where
                 bound_identity
             }
             OpenTransactionKind::Exclusive { bound_author: None } => identity,
-            OpenTransactionKind::Mergeable { .. } => identity,
+            OpenTransactionKind::Mergeable {
+                permission_subject: Some(bound_identity),
+                ..
+            } => {
+                if matches!(authorization_mode, QueryAuthorizationMode::TrustedServing)
+                    && identity != bound_identity
+                {
+                    return Err(Error::OpenTransactionIdentityMismatch);
+                }
+                // A serving-side mergeable batch is also an identity
+                // capability. The raw foreign-function argument selects no
+                // authority beyond the subject fixed at begin.
+                bound_identity
+            }
+            OpenTransactionKind::Mergeable {
+                permission_subject: None,
+                ..
+            } => identity,
         };
         let query = shape.query();
         let predicate_len = self.open_tx(tx_id)?.predicate_reads.len();

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -937,7 +937,7 @@ where
                 )
                 .await
                 .map_err(|_| source_resolution_error(request, SourceGap::TransactionReadOverlay))?;
-            let (graph, descriptor) = if include_deleted {
+            let (base, descriptor) = if include_deleted {
                 let rows = rows
                     .into_iter()
                     .map(|row| {
@@ -958,6 +958,79 @@ where
                     })?,
                     current_row_descriptor(&table),
                 )
+            };
+            // An open transaction is a snapshot plus its staged overlay, not
+            // an authorization result. Filter the effective rows through the
+            // same identity-bound read policy as an ordinary trusted-serving
+            // source. The matching policy dependency is compiled against this
+            // overlay below, so staged rows are subject to the opening
+            // transaction identity as well.
+            let graph = match &authorization {
+                SourceAuthorizationRequest::System => base,
+                SourceAuthorizationRequest::PolicyFiltered {
+                    permission_subject,
+                    plan,
+                }
+                | SourceAuthorizationRequest::PolicyProof {
+                    permission_subject,
+                    plan,
+                } => {
+                    if plan.protected_source.table != table.name
+                        || plan.role != PolicyDecisionRole::Read
+                        || plan.protected_row_field != "row_uuid"
+                    {
+                        return Err(source_resolution_error(request, SourceGap::Coverage));
+                    }
+                    let policy_request = if include_deleted {
+                        self.node
+                            .table_read_policy_authorization_request_for_include_deleted(
+                                self.read_view.policy_schema,
+                                &table.name,
+                                *permission_subject,
+                                DurabilityTier::Global,
+                                plan.binding_source_shape.clone(),
+                                plan.binding_user_params.clone(),
+                                plan.binding_claim_params.clone(),
+                            )
+                    } else {
+                        let param_binding_mode = if plan.binding_source_shape.is_some() {
+                            ParamBindingMode::RetainAllParams
+                        } else {
+                            ParamBindingMode::InlineAllReachableSeeds
+                        };
+                        self.node.table_read_policy_authorization_request(
+                            self.read_view.policy_schema,
+                            &table.name,
+                            *permission_subject,
+                            param_binding_mode,
+                            DurabilityTier::Global,
+                            plan.binding_source_shape.clone(),
+                            plan.binding_user_params.clone(),
+                            plan.binding_claim_params.clone(),
+                        )
+                    };
+                    let policy_request = policy_request.map(|mut request| {
+                        request.reads.primary = policy_read_view_projected_through(
+                            &request.reads.primary,
+                            self.read_view,
+                        );
+                        request
+                    });
+                    let mut output_fields = descriptor_field_names(&descriptor).map_err(|_| {
+                        source_resolution_error(request, SourceGap::TransactionReadOverlay)
+                    })?;
+                    if include_deleted {
+                        output_fields.push("__jazz_deleted".to_owned());
+                    }
+                    self.node
+                        .compose_policy_filtered_current_source_graph(
+                            policy_request,
+                            base,
+                            &output_fields,
+                        )
+                        .map_err(|error| source_resolution_error_from_policy_proof(request, error))?
+                        .graph
+                }
             };
             (graph, descriptor, BTreeMap::new(), BTreeSet::new())
         } else if request.visibility == RowVisibility::Visible
@@ -1650,7 +1723,8 @@ where
             ),
             SourceExpr::VisibleCurrent { .. }
             | SourceExpr::BranchView { .. }
-            | SourceExpr::SettledBindingView { .. } => {
+            | SourceExpr::SettledBindingView { .. }
+            | SourceExpr::WithOverlays { .. } => {
                 let tier = source.current_tier().unwrap_or(DurabilityTier::Global);
                 if request.visibility == RowVisibility::IncludeDeleted {
                     self.node
@@ -1681,9 +1755,6 @@ where
                     )
                 }
             }
-            // Transaction overlays already carry explicitly captured rows and
-            // do not apply a second read-policy program in source preparation.
-            SourceExpr::WithOverlays { .. } => return Ok(None),
             _ => return Ok(None),
         };
         match dependency {

--- a/crates/jazz/tests/deferred_local_persistence.rs
+++ b/crates/jazz/tests/deferred_local_persistence.rs
@@ -742,6 +742,167 @@ fn reopened_reservation_clock_dominates_durable_local_history() {
 }
 
 #[test]
+fn queued_transaction_read_waits_for_staging_and_cold_storage_without_sync_polling() {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = TestStorage::controlled(&family_refs);
+    let storage_control = storage.clone();
+    let db = Rc::new(
+        block_on(Db::open(DbConfig::new(
+            schema,
+            storage,
+            DbIdentity {
+                node: NodeUuid::from_bytes([0x5a; 16]),
+                author: AuthorSubject::for_test_bytes([0x6a; 16]),
+            },
+        )))
+        .expect("open yielding database"),
+    );
+    let open_tx = OpenTransactionId::new();
+    block_on(db.begin_mergeable(open_tx)).expect("open transaction");
+    let row_id = db
+        .enqueue_transaction_insert(
+            open_tx,
+            false,
+            "todos".to_owned(),
+            row! { title: "staged before read" },
+            Default::default(),
+        )
+        .expect("queue transaction staging before the read");
+    let query = db.prepare_query(&db.table("todos")).expect("prepare query");
+
+    // IndexedDB can yield at all three storage boundaries. The binding must
+    // retain this future on its owner queue instead of no-op-waker polling it.
+    storage_control.evict_all();
+    control.pause_on(TestStorageOperation::Get);
+    control.pause_on(TestStorageOperation::ScanOpen);
+    control.pause_on(TestStorageOperation::ScanBatch);
+    let read_db = Rc::clone(&db);
+    let pending = db.enqueue_transaction_read(open_tx, async move {
+        read_db
+            .mergeable_tx_ref(open_tx)
+            .all_prepared_with_opts(&query, ReadOpts::default())
+            .await
+    });
+
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    let mut pending = Box::pin(pending);
+    for _ in 0..8 {
+        let mut turn = Box::pin(db.tick());
+        let _ = turn.as_mut().poll(&mut context);
+        drop(turn);
+        if control.observed().iter().any(|operation| {
+            matches!(
+                operation,
+                TestStorageOperation::Get
+                    | TestStorageOperation::ScanOpen
+                    | TestStorageOperation::ScanBatch
+            )
+        }) {
+            break;
+        }
+    }
+    assert!(
+        control.observed().iter().any(|operation| matches!(
+            operation,
+            TestStorageOperation::Get
+                | TestStorageOperation::ScanOpen
+                | TestStorageOperation::ScanBatch
+        )),
+        "the owner-queued read reaches a planted cold storage boundary",
+    );
+    assert!(matches!(pending.as_mut().poll(&mut context), Poll::Pending));
+
+    control.resume();
+    let mut settled = None;
+    for _ in 0..4_096 {
+        let mut turn = Box::pin(db.tick());
+        let _ = turn.as_mut().poll(&mut context);
+        drop(turn);
+        if let Poll::Ready(result) = pending.as_mut().poll(&mut context) {
+            settled = Some(
+                result
+                    .expect("queued read owner operation remains retained")
+                    .expect("queued read settles after storage wake"),
+            );
+            break;
+        }
+    }
+    let rows = settled.expect("bounded owner turns settle the queued read after storage wakes");
+    assert!(
+        rows.iter().any(|row| row.row_uuid() == row_id),
+        "the read executes after its staged FIFO predecessor and sees its row",
+    );
+    for operation in [
+        TestStorageOperation::Get,
+        TestStorageOperation::ScanOpen,
+        TestStorageOperation::ScanBatch,
+    ] {
+        assert!(
+            control.observed().contains(&operation),
+            "the transaction read exercises the cold {operation:?} storage boundary",
+        );
+    }
+}
+
+#[test]
+fn queued_transaction_read_reports_prior_staging_failure_without_running_outside_transaction() {
+    let schema = schema();
+    let families = schema.column_families();
+    let family_refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let db = Rc::new(
+        block_on(Db::open(DbConfig::new(
+            schema,
+            TestStorage::new(&family_refs),
+            DbIdentity {
+                node: NodeUuid::from_bytes([0x5b; 16]),
+                author: AuthorSubject::for_test_bytes([0x6b; 16]),
+            },
+        )))
+        .expect("open database"),
+    );
+    let open_tx = OpenTransactionId::new();
+    block_on(db.begin_mergeable(open_tx)).expect("open transaction");
+    db.enqueue_transaction_update(
+        open_tx,
+        false,
+        "missing".to_owned(),
+        jazz::ids::RowUuid::from_bytes([0x9b; 16]),
+        row! { title: "missing" },
+        Default::default(),
+    )
+    .expect("queue intentionally failing staging operation");
+    let query = db.prepare_query(&db.table("todos")).expect("prepare query");
+    let read_db = Rc::clone(&db);
+    let pending = db.enqueue_transaction_read(open_tx, async move {
+        read_db
+            .mergeable_tx_ref(open_tx)
+            .all_prepared_with_opts(&query, ReadOpts::default())
+            .await
+    });
+
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    let mut pending = Box::pin(pending);
+    let mut outcome = None;
+    for _ in 0..64 {
+        let mut turn = Box::pin(db.tick());
+        let _ = turn.as_mut().poll(&mut context);
+        drop(turn);
+        if let Poll::Ready(result) = pending.as_mut().poll(&mut context) {
+            outcome = Some(result.expect("read receiver remains owned by the queue"));
+            break;
+        }
+    }
+    let error = outcome
+        .expect("the poisoned transaction resolves its queued read")
+        .expect_err("a queued read must not bypass a failed staged predecessor");
+    assert_eq!(error.code, ErrorCode::Schema);
+}
+
+#[test]
 fn queued_mergeable_commit_retains_cold_parent_refresh_and_exact_identity() {
     let schema = schema();
     let families = schema.column_families();

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -1503,6 +1503,99 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
     ).resolves.toEqual([]);
   });
 
+  it("enforces the opening trusted identity for transaction-local NAPI reads", async () => {
+    const { NapiDb } = await loadNapiModule();
+    const runtime = new NativeRuntimeAdapter(
+      { openMemory: (schema, config) => NapiDb.openMemory(schema, config) as never },
+      OWNED_TODOS_SCHEMA,
+      deterministicBytes("jazz-napi-transaction-read-identity:node"),
+      testAuthorBytes("jazz-napi-transaction-read-identity:author"),
+      23,
+      true,
+      { readAuthorizationHost: "trusted-serving" },
+    );
+    runtimes.push(runtime);
+    const aliceSession = JSON.stringify({ issuer: "https://issuer.example", user_id: ALICE_ID });
+    const bobSession = JSON.stringify({ issuer: "https://issuer.example", user_id: BOB_ID });
+    const aliceTodo = runtime.insert(
+      "todos",
+      {
+        title: { type: "Text", value: "allowed for opening Alice" },
+        done: { type: "Boolean", value: false },
+        owner_id: { type: "Text", value: ALICE_ID },
+      },
+      aliceSession,
+    );
+    const bobTodo = runtime.insert(
+      "todos",
+      {
+        title: { type: "Text", value: "denied to opening Alice" },
+        done: { type: "Boolean", value: false },
+        owner_id: { type: "Text", value: BOB_ID },
+      },
+      bobSession,
+    );
+    await Promise.all([
+      runtime.waitForTransaction(await committedTxId(aliceTodo), "local"),
+      runtime.waitForTransaction(await committedTxId(bobTodo), "local"),
+    ]);
+
+    const transactionId = createOpenTransactionId();
+    runtime.beginTransaction("mergeable", transactionId, aliceSession);
+    const staged = runtime.insert(
+      "todos",
+      {
+        title: { type: "Text", value: "staged for opening Alice" },
+        done: { type: "Boolean", value: false },
+        owner_id: { type: "Text", value: ALICE_ID },
+      },
+      JSON.stringify({ transaction_id: transactionId, session: JSON.parse(aliceSession) }),
+    );
+
+    const rows = (await runtime.query(
+      JSON.stringify({ table: "todos" }),
+      bobSession,
+      "local",
+      JSON.stringify({ transaction_id: transactionId }),
+    )) as Array<{ id: string }>;
+    expect(rows.map((row) => row.id).sort()).toEqual([aliceTodo.id, staged.id].sort());
+    expect(rows.map((row) => row.id)).not.toContain(bobTodo.id);
+
+    // Exercise the real raw NAPI ABI as well as the adapter. The adapter must
+    // retain Alice, but the core is the authority boundary: supplying Bob's
+    // bytes directly cannot re-authorize this Alice-opened mergeable batch.
+    const raw = runtime as unknown as {
+      db: {
+        allInTransactionForIdentity(
+          query: unknown,
+          tx: unknown,
+          author: Uint8Array,
+          opts: unknown,
+        ): Uint8Array | Promise<Uint8Array>;
+      };
+      pendingTxs: Map<OpenTransactionId, { txByView: Map<NativeRuntimeAdapter, unknown> }>;
+      prepareQuery(queryJson: string): unknown;
+    };
+    const tx = raw.pendingTxs.get(transactionId)?.txByView.get(runtime);
+    expect(tx).toBeDefined();
+    const query = raw.prepareQuery(JSON.stringify({ table: "todos" }));
+    const aliceAuthor = new TextEncoder().encode(
+      JSON.stringify(["https://issuer.example", ALICE_ID]),
+    );
+    const bobAuthor = new TextEncoder().encode(JSON.stringify(["https://issuer.example", BOB_ID]));
+    await expect(
+      Promise.resolve().then(() =>
+        raw.db.allInTransactionForIdentity(query, tx, aliceAuthor, undefined),
+      ),
+    ).resolves.toBeInstanceOf(Uint8Array);
+    await expect(
+      Promise.resolve().then(() =>
+        raw.db.allInTransactionForIdentity(query, tx, bobAuthor, undefined),
+      ),
+    ).rejects.toThrow(/open transaction identity.*bound identity/i);
+    await runtime.rollbackTransaction(transactionId);
+  });
+
   it("does not authenticate client-local session identities to an upstream authority", async () => {
     globalThis.WebSocket ??= WebSocket as unknown as typeof globalThis.WebSocket;
 

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -289,7 +289,23 @@ type NativeDb = {
   mergeableTx(openTransactionId: OpenTransactionId): Tx;
   mergeableTxForIdentity?(openTransactionId: OpenTransactionId, author: Uint8Array): Tx;
   exclusiveTx?(openTransactionId: OpenTransactionId): Tx;
-  allInTransaction?(query: PreparedQuery, tx: Tx, opts: unknown): NativeReadResult;
+  /**
+   * Transaction-local reads may wait for the owning runtime to finish queued
+   * staging work or cold storage. Callers must preserve FIFO visibility by
+   * awaiting this result before decoding it.
+   */
+  allInTransaction?(
+    query: PreparedQuery,
+    tx: Tx,
+    opts: unknown,
+  ): NativeReadResult | Promise<NativeReadResult>;
+  /** Trusted-serving transaction reads must retain the identity fixed at begin. */
+  allInTransactionForIdentity?(
+    query: PreparedQuery,
+    tx: Tx,
+    author: Uint8Array,
+    opts: unknown,
+  ): NativeReadResult | Promise<NativeReadResult>;
   setTickScheduler(
     callback:
       | ((urgency: "immediate" | "deferred") => void)
@@ -1875,6 +1891,17 @@ export class NativeRuntimeAdapter implements Runtime {
     this.applySessionClaims(session);
     assertNoUnsupportedPermissionIntrospection(queryJson);
     const coreQueryJson = addNestedOuterColumns(queryJson);
+    const pendingTx = pendingTxFromOptions(optionsJson, this.pendingTxs);
+    // These bindings currently have transaction-aware row reads only. Calling
+    // the relation/snapshot APIs here would evaluate the ordinary owner view
+    // and silently omit staged writes, so reject until the relation evaluator
+    // can be retained behind the same transaction queue.
+    if (
+      pendingTx &&
+      (queryUsesNativeRelationApi(coreQueryJson) || queryHasArraySubqueries(coreQueryJson))
+    ) {
+      throw new Error("Native runtime does not support relation reads inside a transaction");
+    }
     // Browser runtimes still materialize row bodies from their in-memory
     // cache, but an Edge/Global read must keep its requested tier while doing
     // so. The settled membership from the worker is the authorization
@@ -1934,7 +1961,6 @@ export class NativeRuntimeAdapter implements Runtime {
           subscriptionOutputColumns(coreQueryJson, this.schema).rootColumns,
         );
       }
-      const pendingTx = pendingTxFromOptions(optionsJson, this.pendingTxs);
       const projectedColumns = subscriptionOutputColumns(coreQueryJson, this.schema).rootColumns;
       let rows = await this.readPlainRows(query, opts, session ?? undefined, pendingTx);
       let rowStates = rowsFromBatches(readRowBatches(rows), this.schema, projectedColumns);
@@ -2434,6 +2460,19 @@ export class NativeRuntimeAdapter implements Runtime {
     pendingTx: PendingTx | undefined,
   ): Promise<Uint8Array> {
     if (!pendingTx) return this.readRowsForHostAsync(query, opts, session?.identity);
+    if (this.readAuthorizationHost === "trusted-serving" && pendingTx.identity) {
+      if (!this.db.allInTransactionForIdentity) {
+        throw new Error("Native runtime does not support trusted-serving transaction reads");
+      }
+      return this.awaitNativeRead(
+        this.db.allInTransactionForIdentity(
+          query,
+          this.txForRead(pendingTx),
+          pendingTx.identity,
+          opts,
+        ),
+      );
+    }
     if (!this.db.allInTransaction) {
       throw new Error("Native runtime does not support transaction reads");
     }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
@@ -719,8 +719,16 @@ it("uses the opening identity for trusted-serving transaction reads", async () =
         fakeDb({
           all: () => encodeRows([]),
           allForIdentity: () => encodeRows([]),
-          allInTransaction: (_query: object, receivedTx: TxForTest) => {
+          allInTransaction: () => {
+            throw new Error("trusted-serving reads must not use the ambient transaction method");
+          },
+          allInTransactionForIdentity: (
+            _query: object,
+            receivedTx: TxForTest,
+            receivedIdentity: Uint8Array,
+          ) => {
             expect(receivedTx).toBe(tx);
+            expect(new TextDecoder().decode(receivedIdentity)).toBe(`["${issuer}","${alice}"]`);
             return encodeRows([
               {
                 table: "todos",

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -3562,6 +3562,60 @@ describe("NativeRuntimeAdapter server transport", () => {
     expect(calls).toEqual([]);
   });
 
+  it("rejects relation and array reads inside a transaction before ordinary relation APIs", async () => {
+    const calls: string[] = [];
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            allRelationQuery: () => {
+              calls.push("allRelationQuery");
+              return new Uint8Array();
+            },
+            allRelationSnapshot: () => {
+              calls.push("allRelationSnapshot");
+              return new Uint8Array();
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const transactionId = "relation-read-batch" as never;
+    runtime.beginTransaction("mergeable", transactionId);
+    const opts = JSON.stringify({ transaction_id: transactionId });
+
+    for (const query of [
+      {
+        table: "todos",
+        relation_ir: { Gather: {} },
+      },
+      {
+        table: "todos",
+        array_subqueries: [
+          {
+            column_name: "children",
+            table: "todos",
+            inner_column: "id",
+            outer_column: "todos.id",
+          },
+        ],
+      },
+    ]) {
+      await expect(
+        runtime.query(JSON.stringify(query), undefined, undefined, opts),
+      ).rejects.toThrow("does not support relation reads inside a transaction");
+    }
+    expect(calls).toEqual([]);
+  });
+
   it("rejects permission introspection in array subqueries before native snapshot prep", async () => {
     const calls: string[] = [];
     const runtime = new NativeRuntimeAdapter(


### PR DESCRIPTION
🤖
## Before

Transaction-local reads in the WASM and NAPI adapters could synchronously poll genuinely async storage. Trusted-serving reads also lacked an enforced immutable opening identity at the raw mergeable-transaction boundary, so a direct caller could open as Alice and query the same overlay as Bob.

## After

Transaction reads are owned async operations in the per-transaction FIFO. Cold storage suspends and resumes without blocking. Trusted-serving reads evaluate snapshot and staged rows under the identity captured when the transaction opened, and the core rejects mismatched identities for both exclusive and mergeable transactions.

For example, an Alice transaction containing an Alice-only staged row still returns that row if a later query call carries Bob session context; a direct raw request to read that transaction as Bob is rejected rather than changing the policy subject.

Relation and array-subquery shapes that cannot be evaluated transaction-locally remain explicitly rejected instead of silently reading a stale owner view.

## Verification

- Real raw NAPI Alice-allow / Bob-deny receipt
- Cold Get, ScanOpen, and ScanBatch suspension
- FIFO read-your-writes and failed-stage handling
- Rust, WASM, NAPI, and TypeScript focused gates
- Independent adversarial review

Stacked directly on #2371. Closes #2379.