### PR TITLE
fix(jazz): resume structured relay handoffs

### DIFF
--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -4024,7 +4024,36 @@ where
                                 session_claim_binding.as_ref().expect("subscriber claims").0,
                                 session_claim_binding.as_ref().expect("subscriber claims").1.clone(),
                             );
-                            if settled_handoff {
+                            if settled_handoff && peer.has_maintained_subscription(group_subscription) {
+                                // A cold handoff opens the maintained view on
+                                // its first turn. Retrying that full rehydrate
+                                // would discard the just-opened receiver each
+                                // time, so resume the existing view's initial
+                                // delta and turn it into the authority reset.
+                                peer.query_update_for_subscription_with_opts_and_waker(
+                                    &mut node,
+                                    group_subscription,
+                                    &group.shape,
+                                    &group.binding,
+                                    coverage.opts.clone(),
+                                    progress_waker.as_ref(),
+                                )
+                                .await
+                                .map(|update| {
+                                    update.map(|mut update| {
+                                        if let SyncMessage::ViewUpdate(
+                                            crate::protocol::ViewUpdatePayload {
+                                                reset_result_set,
+                                                ..
+                                            },
+                                        ) = &mut update
+                                        {
+                                            *reset_result_set = true;
+                                        }
+                                        update
+                                    })
+                                })
+                            } else if settled_handoff {
                                 peer.rehydrate_query_for_subscription_with_opts_and_waker(
                                     &mut node,
                                     group_subscription,

--- a/crates/jazz/tests/browser_relay_durability.rs
+++ b/crates/jazz/tests/browser_relay_durability.rs
@@ -707,6 +707,96 @@ fn browser_client_hydrates_local_subscription_from_worker_relay() {
     );
 }
 
+/// A Local structured read is served from the persistent worker's resident
+/// state even when that worker owns a separate authority-session identity.
+/// It must not wait for, or select, an upstream authority source.
+#[test]
+fn browser_client_hydrates_local_structured_subscription_without_authority() {
+    let schema = included_relation_schema();
+    let alice = AuthorSubject::for_test_bytes([0xa4; 16]);
+    let worker = open_db(0x25, AuthorSubject::SYSTEM, &schema);
+    worker.set_relay_authority_session_owner();
+    let profile = worker
+        .insert(
+            "profiles",
+            BTreeMap::from([(
+                "name".to_owned(),
+                Value::String("resident local sender".to_owned()),
+            )]),
+            Default::default(),
+        )
+        .expect("seed worker-local profile");
+    let message = worker
+        .insert(
+            "messages",
+            BTreeMap::from([
+                ("author".to_owned(), Value::Uuid(profile.row_uuid().0)),
+                ("body".to_owned(), Value::String("local message".to_owned())),
+                ("created".to_owned(), Value::U64(1)),
+            ]),
+            Default::default(),
+        )
+        .expect("seed worker-local message");
+
+    let main_thread = open_db(0x14, alice, &schema);
+    main_thread.set_non_durable_client();
+    let (main_transport, worker_transport) = duplex();
+    let _main_connection = block_on(main_thread.connect_upstream(main_transport));
+    let _worker_connection = worker.accept_subscriber(worker_transport, alice);
+    let query = main_thread
+        .prepare_query(
+            &Query::from("messages")
+                .array_subquery(ArraySubquery::new("sender", "profiles", "id", "author")),
+        )
+        .expect("prepare Local structured query");
+    let mut subscription = block_on(main_thread.subscribe(
+        &query,
+        ReadOpts {
+            tier: DurabilityTier::Local,
+            ..ReadOpts::default()
+        },
+    ))
+    .expect("subscribe to Local structured worker state");
+    assert_truthful_empty_local_opening(subscription.try_next_event());
+
+    for _ in 0..3 {
+        main_thread
+            .tick()
+            .expect("request Local structured worker view");
+        worker.tick().expect("serve Local structured worker view");
+        main_thread
+            .tick()
+            .expect("apply Local structured worker view");
+    }
+
+    let events = std::iter::from_fn(|| subscription.try_next_event()).collect::<Vec<_>>();
+    let Some(SubscriptionEvent::Delta { added, .. }) = events.iter().find(|event| {
+        matches!(event, SubscriptionEvent::Delta { added, .. }
+            if added.iter().any(|row| row.row.row_uuid() == message.row_uuid()))
+    }) else {
+        panic!("Local structured read must resolve from worker state, got {events:?}");
+    };
+    let root = added
+        .iter()
+        .find(|row| row.row.row_uuid() == message.row_uuid())
+        .expect("Local structured update contains seeded message");
+    let (descriptor, raw) = root.row.encoded_record();
+    let record = BorrowedRecord::new(raw, descriptor);
+    let Value::Array(sender) = record.get("sender").expect("nested sender field") else {
+        panic!("Local structured update must materialize sender")
+    };
+    assert!(matches!(
+        sender.as_slice(),
+        [Value::Record(sender)] if matches!(sender.get("name"), Ok(Value::String(name)) if name == "resident local sender")
+    ));
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, SubscriptionEvent::Rejected { .. })),
+        "Local structured read cannot require an authority receipt: {events:?}"
+    );
+}
+
 /// A main-thread Local subscription and a one-shot Edge read have distinct
 /// downstream serving options, but both canonicalize to the worker's Global
 /// upstream coverage. Retiring the one-shot usage site must not unsubscribe
@@ -1832,17 +1922,18 @@ fn browser_relay_hydrates_fresh_included_edge_subscription_from_authority() {
 }
 
 /// A cold browser foreground must finish one complete structured authority
-/// reset when the worker already has no local query runtime for the new Edge
+/// reset when the worker already has no local query runtime for the new remote
 /// usage site. Alice's main runtime opens a bounded ordered message relation;
 /// the worker relays Core's one reset, which contains both the root members and
 /// the profile facts required to materialize the nested `sender` records.
 ///
 /// ```text
-/// alice main ──Edge structured subscribe──► worker ──Global──► core
+/// alice main ──remote structured subscribe──► worker ──Global──► core
 /// alice main ◄──complete reset (roots + sender facts)── worker ◄── core
 /// ```
-#[test]
-fn cold_browser_relay_structured_reset_materializes_ordered_sender_facts() {
+fn assert_cold_browser_relay_structured_reset_materializes_ordered_sender_facts(
+    foreground_tier: DurabilityTier,
+) {
     let schema = included_relation_schema();
     let alice = AuthorSubject::for_test_bytes([0xb4; 16]);
     let main_thread = open_db(0x24, alice, &schema);
@@ -1906,11 +1997,11 @@ fn cold_browser_relay_structured_reset_materializes_ordered_sender_facts() {
                 .order_by("created", OrderDirection::Desc)
                 .limit(21),
         )
-        .expect("prepare cold structured Edge query");
+        .expect("prepare cold structured query");
     let mut subscription = block_on(main_thread.subscribe(
         &query,
         ReadOpts {
-            tier: DurabilityTier::Edge,
+            tier: foreground_tier,
             ..ReadOpts::default()
         },
     ))
@@ -1939,7 +2030,7 @@ fn cold_browser_relay_structured_reset_materializes_ordered_sender_facts() {
 
     assert!(
         authority_update_scheduled,
-        "the worker must schedule its post-reset Edge serve pass"
+        "the worker must schedule its post-reset remote serve pass"
     );
     let events = std::iter::from_fn(|| subscription.try_next_event()).collect::<Vec<_>>();
     let resets = events
@@ -2001,6 +2092,20 @@ fn cold_browser_relay_structured_reset_materializes_ordered_sender_facts() {
             Ok(Value::String(name)) if name == *expected_sender
         ));
     }
+}
+
+#[test]
+fn cold_browser_relay_structured_reset_materializes_ordered_sender_facts() {
+    assert_cold_browser_relay_structured_reset_materializes_ordered_sender_facts(
+        DurabilityTier::Edge,
+    );
+}
+
+#[test]
+fn cold_browser_relay_global_structured_reset_materializes_ordered_sender_facts() {
+    assert_cold_browser_relay_structured_reset_materializes_ordered_sender_facts(
+        DurabilityTier::Global,
+    );
 }
 
 /// A reopened browser tab receives a new Edge receipt after the persistent

--- a/packages/jazz-tools/tests/browser/db.include-subscriptions.server.test.ts
+++ b/packages/jazz-tools/tests/browser/db.include-subscriptions.server.test.ts
@@ -184,6 +184,7 @@ describe("websocket include subscriptions", () => {
       10_000,
       "client B subscribe did not produce an initial snapshot",
     );
+    expect(snapshots).toEqual([[]]);
 
     const org = await withTimeout(
       dbA.insert(app.orgs, { name: "Acme" }).wait({ tier: "global" }),
@@ -225,6 +226,13 @@ describe("websocket include subscriptions", () => {
         snapshots.slice(-3),
       )}`,
     );
+    expect(
+      snapshots.filter(
+        (rows) =>
+          includesNote(rows, org.id, todo.id, userCheck.id, note.id) &&
+          hasProjectedTodo(rows, org.id, todo.id, "ship it"),
+      ),
+    ).toHaveLength(1);
 
     await withTimeout(
       dbA.update(app.todos, todo.id, { title: "ship it again" }).wait({ tier: "global" }),
@@ -240,6 +248,9 @@ describe("websocket include subscriptions", () => {
         snapshots.slice(-3),
       )}`,
     );
+    expect(
+      snapshots.filter((rows) => hasProjectedTodo(rows, org.id, todo.id, "ship it again")),
+    ).toHaveLength(1);
 
     unsubscribe();
     expect(


### PR DESCRIPTION
🤖 Restores cold structured relay handoff without introducing a second authorization or source-selection path.

Before:
- A maintained structured include could attach to an already-open receiver after relay handoff but never resume it.
- The subscriber remained stuck at the initial empty snapshot, even though the relay had the nested rows.
- A broader attempted fix introduced source-binding and terminal-forwarding machinery and conflicted with complete transactions.

After:
- Only the cold-handoff branch resumes the existing maintained receiver through the ordinary query-update path.
- Its first complete publication is marked as a reset because nothing from that group has previously been published.
- Edge, Global, and Local semantics continue to use the same authorization and maintained-view machinery.

Example:
1. A browser subscribes to a depth-3 include through a relay.
2. The foreground owner detaches; the persistent relay retains the cold maintained view.
3. A new foreground owner attaches.
4. The relay resumes that receiver and publishes exactly one fully materialized reset, followed by ordinary updates.

Verified:
- Cold Edge, Global, and Local structured receipts.
- Abrupt detach/reconnect and reopened-tab ownership receipts.
- Browser depth-3 include 2/2.
- Independent planted review: disabling the resume branch leaves snapshots stuck at `[[]]`; restoring it passes.

Stacked on #2385.