### PR TITLE
fix(jazz): retain maintained replacement support

### DIFF
--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -957,9 +957,6 @@ where
             output_request
                 .facts
                 .remove(&ProgramFactKey::VersionWitnesses);
-            output_request
-                .facts
-                .remove(&ProgramFactKey::ReplacementWitnesses);
         }
         Ok(QueryProgramRequest {
             authorization_mode,
@@ -3344,12 +3341,7 @@ where
             .request
             .output
             .facts
-            .contains(&ProgramFactKey::VersionWitnesses)
-            && !program
-                .request
-                .output
-                .facts
-                .contains(&ProgramFactKey::ReplacementWitnesses);
+            .contains(&ProgramFactKey::VersionWitnesses);
         let inline_content_branch_keys = program
             .request
             .reads

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -293,45 +293,6 @@ impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
 {
-    /// Add one exact winner to the per-update bundle cache when the small
-    /// storage-backed maintained subset deliberately omitted its source-wide
-    /// replacement witnesses.  This is a wire-payload fallback only: the
-    /// maintained program still retains no per-binding replacement state.
-    async fn ensure_maintained_view_winner_in_bundle_cache(
-        &mut self,
-        tx_versions_cache: &mut BTreeMap<TxId, Vec<VersionRow>>,
-        winner: &VersionRow,
-        allow_storage_witness_fallback: bool,
-        context: &mut ViewEvaluationContext,
-    ) -> Result<(), Error> {
-        let tx_id = self.version_tx_id(winner)?;
-        if tx_versions_cache
-            .get(&tx_id)
-            .is_some_and(|versions| maintained_view_tx_versions_contain_winner(versions, winner))
-        {
-            return Ok(());
-        }
-        if !allow_storage_witness_fallback {
-            return Ok(());
-        }
-
-        let stored_tx = self
-            .query_transaction_memo(tx_id, context)
-            .await?
-            .ok_or(Error::MissingTransaction(tx_id))?;
-        let wanted_row = BTreeSet::from([(winner.table().to_owned(), winner.row_uuid())]);
-        let stored_versions = self
-            .query_versions_for_tx_rows_by_alias(tx_id, stored_tx.node_alias, &wanted_row)
-            .await?;
-        let cached = tx_versions_cache.entry(tx_id).or_default();
-        for stored in stored_versions {
-            if !cached.iter().any(|existing| existing == &stored) {
-                cached.push(stored);
-            }
-        }
-        Ok(())
-    }
-
     /// Recover the deletion-register winner currently visible at the
     /// subscription tier for an optimized scalar root. Result membership tells
     /// us that the row is visible, but not whether that visibility is due to a
@@ -1090,6 +1051,8 @@ where
                 "add result row missing Stream B content witness",
             ));
         }
+        let mut replacement_winners_by_tx =
+            BTreeMap::<TxId, Vec<(String, RowUuid, VersionRow, &'static str)>>::new();
         for (entry_table, row_uuid, content_tx_id) in &row_result_adds {
             let deletion_winner = if let Some(winner) =
                 result_add_deletion_winners.get(&(entry_table.as_str().to_owned(), *row_uuid))
@@ -1116,45 +1079,15 @@ where
                 continue;
             };
             let tx_id = self.version_tx_id(version)?;
-            if tx_id == *content_tx_id || !emitted_versions.insert(tx_id) {
+            if tx_id == *content_tx_id || emitted_versions.contains(&tx_id) {
                 continue;
             }
-            if peer_complete_tx_payloads.contains(&tx_id) {
-                peer_payload_inventory_refs.push(tx_id);
-                record_maintained_view_removal_stream_bundle();
-            } else {
-                tx_versions_cache
-                    .entry(tx_id)
-                    .or_insert_with(|| maintained_facts.versions_by_tx(tx_id));
-                self.ensure_maintained_view_winner_in_bundle_cache(
-                    &mut tx_versions_cache,
-                    version,
-                    allow_storage_witness_fallback,
-                    &mut context,
-                )
-                .await?;
-                let tx_versions = tx_versions_cache
-                    .get(&tx_id)
-                    .expect("winner fallback must preserve the transaction cache entry");
-                if maintained_view_tx_versions_contain_winner(tx_versions, version) {
-                    let stored_tx = self
-                        .query_transaction_memo(tx_id, &mut context)
-                        .await?
-                        .ok_or(Error::MissingTransaction(tx_id))?;
-                    version_bundles.push(
-                        self.version_bundle_for_maintained_view_versions_with_tx(
-                            &stored_tx,
-                            tx_versions,
-                        )
-                        .await?,
-                    );
-                    record_maintained_view_removal_stream_bundle();
-                } else {
-                    return Err(Error::MaintainedViewMissingBundleWitness(
-                        "add result row missing deletion replacement witness",
-                    ));
-                }
-            }
+            replacement_winners_by_tx.entry(tx_id).or_default().push((
+                entry_table.to_string(),
+                *row_uuid,
+                version.clone(),
+                "add result row missing deletion replacement witness",
+            ));
         }
         for (entry_table, row_uuid, old_tx_id) in &row_result_removes {
             let (content_winner, retained_deletion_winner) =
@@ -1189,41 +1122,100 @@ where
                 if tx_id == *old_tx_id || emitted_versions.contains(&tx_id) {
                     continue;
                 }
-                if peer_complete_tx_payloads.contains(&tx_id) {
-                    peer_payload_inventory_refs.push(tx_id);
-                    record_maintained_view_removal_stream_bundle();
-                    continue;
-                }
-                tx_versions_cache
-                    .entry(tx_id)
-                    .or_insert_with(|| maintained_facts.versions_by_tx(tx_id));
-                self.ensure_maintained_view_winner_in_bundle_cache(
-                    &mut tx_versions_cache,
-                    version,
-                    allow_storage_witness_fallback,
-                    &mut context,
-                )
-                .await?;
-                let tx_versions = tx_versions_cache
-                    .get(&tx_id)
-                    .expect("winner fallback must preserve the transaction cache entry");
-                if !maintained_view_tx_versions_contain_winner(tx_versions, version) {
+                replacement_winners_by_tx.entry(tx_id).or_default().push((
+                    entry_table.to_string(),
+                    *row_uuid,
+                    version.clone(),
+                    missing_witness,
+                ));
+            }
+        }
+        for (tx_id, winners) in replacement_winners_by_tx {
+            if emitted_versions.contains(&tx_id) {
+                continue;
+            }
+            if peer_complete_tx_payloads.contains(&tx_id) {
+                emitted_versions.insert(tx_id);
+                peer_payload_inventory_refs.push(tx_id);
+                record_maintained_view_removal_stream_bundle();
+                continue;
+            }
+            let wanted_rows = winners
+                .iter()
+                .map(|(table, row_uuid, _, _)| (table.clone(), *row_uuid))
+                .collect::<BTreeSet<_>>();
+            let tx_versions = tx_versions_cache
+                .entry(tx_id)
+                .or_insert_with(|| maintained_facts.versions_by_tx(tx_id));
+            if winners.iter().any(|(_, _, winner, _)| {
+                !maintained_view_tx_versions_contain_winner(tx_versions, winner)
+            }) {
+                if !allow_storage_witness_fallback {
+                    let (_, _, _, missing_witness) = winners
+                        .iter()
+                        .find(|(_, _, winner, _)| {
+                            !maintained_view_tx_versions_contain_winner(tx_versions, winner)
+                        })
+                        .expect("missing maintained witness must be present");
                     return Err(Error::MaintainedViewMissingBundleWitness(missing_witness));
                 }
-                emitted_versions.insert(tx_id);
                 let stored_tx = self
                     .query_transaction_memo(tx_id, &mut context)
                     .await?
                     .ok_or(Error::MissingTransaction(tx_id))?;
-                version_bundles.push(
-                    self.version_bundle_for_maintained_view_versions_with_tx(
-                        &stored_tx,
-                        tx_versions,
-                    )
-                    .await?,
-                );
-                record_maintained_view_removal_stream_bundle();
+                let fallback_versions =
+                    if complete_exclusive_payloads && stored_tx.tx.kind == TxKind::Exclusive {
+                        self.query_versions_for_tx(tx_id).await?
+                    } else {
+                        self.query_versions_for_tx_rows_by_alias(
+                            tx_id,
+                            stored_tx.node_alias,
+                            &wanted_rows,
+                        )
+                        .await?
+                    };
+                tx_versions_cache.insert(tx_id, fallback_versions);
             }
+            let stored_tx = self
+                .query_transaction_memo(tx_id, &mut context)
+                .await?
+                .ok_or(Error::MissingTransaction(tx_id))?;
+            if complete_exclusive_payloads
+                && stored_tx.tx.kind == TxKind::Exclusive
+                && usize::try_from(stored_tx.tx.n_total_writes).ok()
+                    != tx_versions_cache.get(&tx_id).map(Vec::len)
+            {
+                tx_versions_cache.insert(tx_id, self.query_versions_for_tx(tx_id).await?);
+            }
+            let tx_versions = tx_versions_cache
+                .get(&tx_id)
+                .expect("tx versions cache entry must exist after fallback");
+            if let Some((_, _, _, missing_witness)) = winners.iter().find(|(_, _, winner, _)| {
+                !maintained_view_tx_versions_contain_winner(tx_versions, winner)
+            }) {
+                return Err(Error::MaintainedViewMissingBundleWitness(missing_witness));
+            }
+            emitted_versions.insert(tx_id);
+            let bundled_versions =
+                if complete_exclusive_payloads && stored_tx.tx.kind == TxKind::Exclusive {
+                    tx_versions.clone()
+                } else {
+                    tx_versions
+                        .iter()
+                        .filter(|version| {
+                            wanted_rows.contains(&(version.table().to_owned(), version.row_uuid()))
+                        })
+                        .cloned()
+                        .collect()
+                };
+            version_bundles.push(
+                self.version_bundle_for_maintained_view_versions_with_tx(
+                    &stored_tx,
+                    &bundled_versions,
+                )
+                .await?,
+            );
+            record_maintained_view_removal_stream_bundle();
         }
         for bundle in &mut version_bundles {
             if bundle.tx.kind != TxKind::Exclusive {

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -3102,7 +3102,7 @@ fn maintained_subscription_view_hit_metrics_and_footprint_update() {
     // binding.
     assert_eq!(metrics.footprint.version_identities, 0);
     assert_eq!(metrics.footprint.version_tx_entries, 0);
-    assert_eq!(metrics.footprint.replacement_entries, 0);
+    assert_eq!(metrics.footprint.replacement_entries, 1);
 
     // Flat subscriptions release this duplicate collector after the reset, but
     // membership/version witnesses must still publish a later removal and a
@@ -3165,6 +3165,85 @@ fn maintained_subscription_view_hit_metrics_and_footprint_update() {
         peer.query_update(&mut core, &shape, &binding).unwrap(),
         vec![("todos", row(0x51), restored_tx)],
         vec![],
+    );
+}
+
+#[test]
+fn maintained_storage_fallback_batches_multi_row_replacement_removals() {
+    let schema = public_peer_schema(
+        PublicSchemaBuilder::new()
+            .table(PublicTableSchemaBuilder::new("todos").column("title", PublicColumnType::Text))
+            .table(PublicTableSchemaBuilder::new("users").column("name", PublicColumnType::Text)),
+    );
+    let query_schema = schema.clone();
+    let (_dir, mut core) = open_node_with_schema(node(0x99), schema);
+    let first = row(0x9a);
+    let second = row(0x9b);
+    let first_tx = core
+        .commit_mergeable_settled(MergeableCommit::new("todos", first, 1_000).cells(title_cells("match")))
+        .unwrap();
+    accept_global(&mut core, first_tx, 1);
+    let second_tx = core
+        .commit_mergeable_settled(MergeableCommit::new("todos", second, 1_001).cells(title_cells("match")))
+        .unwrap();
+    accept_global(&mut core, second_tx, 2);
+    let shape = Query::from("todos")
+        .filter(eq(col("title"), param("title")))
+        .validate(&query_schema)
+        .unwrap();
+    let binding = shape
+        .bind(BTreeMap::from([(
+            "title".to_owned(),
+            Value::String("match".to_owned()),
+        )]))
+        .unwrap();
+    let mut peer = PeerState::new();
+    peer.set_ship_complete_exclusive_payloads(true);
+    peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
+
+    let tx = OpenTransactionId::new();
+    core.open_exclusive(tx).unwrap();
+    core.tx_write(tx, "todos", first, title_cells("other"), None)
+        .unwrap();
+    core.tx_write(tx, "todos", second, title_cells("other"), None)
+        .unwrap();
+    let unrelated = row(0x9c);
+    core.tx_write(
+        tx,
+        "users",
+        unrelated,
+        BTreeMap::from([("name".to_owned(), Value::String("unrelated".to_owned()))]),
+        None,
+    )
+    .unwrap();
+    let (replacement_tx, _unit) = core.commit_exclusive_settled(tx, AuthorSubject::SYSTEM, 1_002).unwrap();
+    accept_global(&mut core, replacement_tx, 3);
+
+    let update = peer.query_update(&mut core, &shape, &binding).unwrap();
+    assert_view_update_rows(
+        update.clone(),
+        Vec::new(),
+        vec![("todos", first, first_tx), ("todos", second, second_tx)],
+    );
+    let bundles = version_bundles_for_update(&update);
+    assert_eq!(bundles.len(), 1);
+    assert_eq!(bundles[0].tx.tx_id, replacement_tx);
+    assert_eq!(
+        bundles[0].scope,
+        crate::protocol::VersionBundleScope::CompleteTransaction
+    );
+    assert_eq!(bundles[0].versions.len(), 3);
+    assert_eq!(
+        bundles[0]
+            .versions
+            .iter()
+            .map(|version| (version.table().to_owned(), version.row_uuid()))
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([
+            ("todos".to_owned(), first),
+            ("todos".to_owned(), second),
+            ("users".to_owned(), unrelated),
+        ]),
     );
 }
 


### PR DESCRIPTION
🤖 Preserves replacement witnesses while maintaining storage-backed views.

Before:
- The maintained fallback stripped replacement witnesses from an otherwise valid change bundle.
- A row replacement could therefore lose the removal side of the result transition.

After:
- Maintained evaluation retains the complete replacement information.
- Public result collection can emit the correct removal and addition without reopening or reconstructing the update.

Example: replacing two joined source rows in one transaction now yields one coherent maintained bundle containing both removals and replacements.

Verified by focused storage-backed and multi-row replacement receipts. Independent planted review restored the stripping behavior and made the receipt fail.