### PR TITLE
fix(jazz): publish complete deletion result deltas

### DIFF
--- a/crates/jazz-testkit/tests/output_occurrence_id.rs
+++ b/crates/jazz-testkit/tests/output_occurrence_id.rs
@@ -175,6 +175,85 @@ async fn forwarded_flat_join_reset_keeps_contributor_facts_visible_to_one_shot_r
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn forwarded_flat_join_reconciles_joined_source_deletion() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let schema = todos_schema();
+            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let client = TestingClient::builder()
+                .with_server(&server)
+                .with_schema(schema)
+                .with_user_id("00000000-0000-4000-8000-000000000027")
+                .ready_on("todos", Duration::from_secs(30))
+                .connect()
+                .await;
+            let (_root, _, tx) = client
+                .insert(
+                    "todos",
+                    row_input!("title" => "root", "bucket" => "shared", "done" => false),
+                )
+                .expect("insert root");
+            support::wait_for_edge_txs(
+                &client,
+                &[tx.expect("ordinary mutation commits immediately")],
+            )
+            .await;
+            let (joined, _, tx) = client
+                .insert(
+                    "todos",
+                    row_input!("title" => "joined", "bucket" => "shared", "done" => true),
+                )
+                .expect("insert joined source");
+            support::wait_for_edge_txs(
+                &client,
+                &[tx.expect("ordinary mutation commits immediately")],
+            )
+            .await;
+
+            let query = joined_todos(&[("joined", "root.bucket", "joined.bucket")]);
+            let initial = client
+                .query_results_with_read_tier(query.clone(), ReadTier::LocalFirst)
+                .await
+                .expect("query initial joined results");
+            let joined_occurrence = key_for_joined_title(&initial, "joined");
+            let mut stream = client.subscribe(query.clone()).await.expect("subscribe");
+            let reset = next_delta(&mut stream).await;
+            assert!(
+                reset.added.iter().any(|row| row.id == joined_occurrence),
+                "initial reset includes joined-source occurrence"
+            );
+
+            let tx = client.delete(joined).expect("delete joined source");
+            support::wait_for_edge_txs(
+                &client,
+                &[tx.expect("ordinary mutation commits immediately")],
+            )
+            .await;
+            let removal = next_delta_with_removed(&mut stream).await;
+            assert!(
+                removal
+                    .removed
+                    .iter()
+                    .any(|row| row.id == joined_occurrence),
+                "deleting a joined source retracts its forwarded occurrence"
+            );
+            assert!(
+                client
+                    .query_results_with_read_tier(query, ReadTier::LocalFirst)
+                    .await
+                    .expect("query after joined-source deletion")
+                    .iter()
+                    .all(|row| row.key != joined_occurrence),
+                "one-shot and maintained membership agree after deletion"
+            );
+
+            client.shutdown().await.expect("shutdown client");
+            server.shutdown().await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn flat_join_output_occurrence_identity_addresses_additions_removals_and_replacements() {
     tokio::task::LocalSet::new()
         .run_until(async {

--- a/crates/jazz/SPEC/16_maintained_subscription_views.md
+++ b/crates/jazz/SPEC/16_maintained_subscription_views.md
@@ -52,6 +52,14 @@ substitute for this canonical contributor closure: the receiver MUST be able to
 reconstruct the same tuple through its ordinary one-shot path after applying the
 publication, without a same-generation transient remove and re-add.
 
+A deletion-witness transition forces authoritative membership reconciliation
+only when the public result terminals are silent. If the same Groove tick
+already emits a complete result membership or structured-terminal delta, that
+delta is the authoritative incremental consequence and MUST be published
+without reopening the maintained view. Reopening in that case would discard an
+already proven removal and can repeatedly rediscover the same witness instead
+of making subscriber progress.
+
 A maintained peer publication MUST retain the complete semantic read view and
 tier resolved at admission. Initial hydration, suspended retries, incremental
 evaluation, authoritative reconciliation, settlement, and authorization

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -181,9 +181,10 @@ pub(crate) struct ResultTransitions {
     pub(crate) allow_storage_witness_fallback: bool,
     pub(crate) observed_result_delta_batches: usize,
     /// A deletion-register witness changed while its anti-joined result
-    /// terminal may be silent. The caller must replace this tick with an
-    /// authoritative membership reconciliation, even if other terminals
-    /// produced deltas concurrently.
+    /// terminal may be silent. When the public result terminals are silent,
+    /// the caller must replace this tick with an authoritative membership
+    /// reconciliation. A complete public result delta remains authoritative
+    /// and must not be discarded merely because its witness changed too.
     pub(crate) requires_authoritative_membership_reconcile: bool,
 }
 

--- a/crates/jazz/src/peer/publication.rs
+++ b/crates/jazz/src/peer/publication.rs
@@ -581,13 +581,18 @@ impl PeerState {
             .get(&subscription)
             .map(PeerSubscriptionState::member_result_set)
             .unwrap_or_default();
-        if requires_authoritative_membership_reconcile
-            || (observed_result_delta_batches > 0
-                && result_member_adds.is_empty()
-                && result_member_removes.is_empty()
-                && terminal_operations.is_empty()
-                && program_fact_adds.is_empty()
-                && program_fact_removes.is_empty())
+        let public_result_is_silent = result_member_adds.is_empty()
+            && result_member_removes.is_empty()
+            && terminal_operations.is_empty();
+        // Deletion witnesses require a one-shot reconciliation only when the
+        // result terminal itself was silent. When Groove already emitted the
+        // complete public delta, reopening the maintained view would discard
+        // that delta and repeatedly rediscover the same deletion witness.
+        if public_result_is_silent
+            && (requires_authoritative_membership_reconcile
+                || (observed_result_delta_batches > 0
+                    && program_fact_adds.is_empty()
+                    && program_fact_removes.is_empty()))
         {
             let (tier, read_view) = self
                 .publication_states


### PR DESCRIPTION
🤖 Prevents deletion-witness bookkeeping from discarding already-proven public result deltas.

Before:
- A transaction could change a deletion witness and also produce a real public delta.
- Peer publication reopened authoritatively because of the witness change and discarded the proven delta.
- Flat joins, bounded pages, and route subscriptions could then miss removals or time out.

After:
- A complete non-empty public delta is published directly.
- Authoritative reopen remains available only when the collector does not already have a complete delta.

Example: deleting a joined source row now emits the joined-result removal in the same publication instead of timing out while waiting for a reopen.

Verified across flat-join netting/replacement, pagination shift, storage-frontier, and route-smoke receipts. Independent planted review restored the old reopen and reproduced the missing-delta timeout.