### PR TITLE
test(jazz): assert nullable join predicate literal

### DIFF
--- a/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
+++ b/crates/jazz/src/node/query_engine/tests/graph_lowering.rs
@@ -575,7 +575,9 @@ fn current_join_via_lowers_as_left_deep_semijoin() {
                                                 predicate,
                                                 groove::ivm::PredicateExpr::Eq { field, value }
                                                     if field == "user_tag"
-                                                        && value == &groove::ivm::LiteralValue::String("ship".to_owned())
+                                                        && value == &groove::ivm::LiteralValue::Nullable(Some(Box::new(
+                                                            groove::ivm::LiteralValue::String("ship".to_owned()),
+                                                        )))
                                             )
                                     )
                         )


### PR DESCRIPTION
🤖 Aligns the graph-lowering structural receipt with the schema-driven nullable literal representation.

The nullable reference predicate is lowered as `Nullable(Some(String))`, not an unwrapped `String`. Runtime behavior is unchanged; this corrects the exact expected IR shape after nullable-reference normalization.

Independent planted review restored the stale unwrapped expectation and made the receipt fail.