### PR TITLE
test(record-player): isolate parallel browser topology

### DIFF
--- a/dev/gates/test/correctness-consumer-contract.test.mjs
+++ b/dev/gates/test/correctness-consumer-contract.test.mjs
@@ -41,30 +41,54 @@ test("every direct Node/browser correctness entrypoint uses the one sealed consu
   assert.doesNotMatch(aggregate, /env:\s*process\.env/);
 });
 
-test("parallel RecordPlayer browser topology owns a unique strict Vitest API port", () => {
-  const config = read("examples/record-player/apps/next-betterauth/vitest.config.browser.ts");
-  assert.match(
-    config,
-    /api:\s*\{\s*port:\s*63318,\s*strictPort:\s*true\s*\}/,
-    "RecordPlayer must reserve its browser API port instead of probing the workspace default range",
-  );
+const recordPlayerConfig = "examples/record-player/apps/next-betterauth/vitest.config.browser.ts";
+const recordPlayerPort = 63318;
+const recordPlayerApiPort = new RegExp(`api:\\s*\\{\\s*port:\\s*${recordPlayerPort}\\b`);
 
-  const recordPlayerConfig = "examples/record-player/apps/next-betterauth/vitest.config.browser.ts";
-  const browserConfigs = execFileSync("git", ["ls-files", "--", "*vitest.config.browser.ts"], {
+function trackedVitestConfigs() {
+  return execFileSync("git", ["ls-files", "--", "*vitest.config.*"], {
     cwd: root,
     encoding: "utf8",
   })
     .trim()
     .split("\n")
     .filter(Boolean);
-  for (const path of browserConfigs) {
+}
+
+function assertRecordPlayerPortIsUnique(configs, load = read) {
+  for (const path of configs) {
     if (path === recordPlayerConfig) continue;
     assert.doesNotMatch(
-      read(path),
-      /api:\s*\{\s*port:\s*63318\b/,
+      load(path),
+      recordPlayerApiPort,
       `${path} aliases RecordPlayer's registry-owned browser port`,
     );
   }
+}
+
+test("parallel RecordPlayer browser topology owns a unique strict Vitest API port", () => {
+  const config = read(recordPlayerConfig);
+  assert.match(
+    config,
+    /api:\s*\{\s*port:\s*63318,\s*strictPort:\s*true\s*\}/,
+    "RecordPlayer must reserve its browser API port instead of probing the workspace default range",
+  );
+  assertRecordPlayerPortIsUnique(trackedVitestConfigs());
+});
+
+test("the uniqueness check rejects a duplicate in a non-browser Vitest config", () => {
+  const nonBrowserConfig = "examples/record-player/apps/next-betterauth/vitest.config.provider.ts";
+  assert.throws(
+    () =>
+      assertRecordPlayerPortIsUnique(
+        [recordPlayerConfig, nonBrowserConfig],
+        (path) =>
+          path === nonBrowserConfig
+            ? `${read(path)}\napi: { port: ${recordPlayerPort}, strictPort: true }`
+            : read(path),
+      ),
+    /aliases RecordPlayer's registry-owned browser port/,
+  );
 });
 
 test("sealed consumers select content-addressed artifact paths rather than worktree pointers", () => {

--- a/dev/gates/test/correctness-consumer-contract.test.mjs
+++ b/dev/gates/test/correctness-consumer-contract.test.mjs
@@ -80,12 +80,10 @@ test("the uniqueness check rejects a duplicate in a non-browser Vitest config", 
   const nonBrowserConfig = "examples/record-player/apps/next-betterauth/vitest.config.provider.ts";
   assert.throws(
     () =>
-      assertRecordPlayerPortIsUnique(
-        [recordPlayerConfig, nonBrowserConfig],
-        (path) =>
-          path === nonBrowserConfig
-            ? `${read(path)}\napi: { port: ${recordPlayerPort}, strictPort: true }`
-            : read(path),
+      assertRecordPlayerPortIsUnique([recordPlayerConfig, nonBrowserConfig], (path) =>
+        path === nonBrowserConfig
+          ? `${read(path)}\napi: { port: ${recordPlayerPort}, strictPort: true }`
+          : read(path),
       ),
     /aliases RecordPlayer's registry-owned browser port/,
   );

--- a/dev/gates/test/correctness-consumer-contract.test.mjs
+++ b/dev/gates/test/correctness-consumer-contract.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
@@ -40,13 +41,30 @@ test("every direct Node/browser correctness entrypoint uses the one sealed consu
   assert.doesNotMatch(aggregate, /env:\s*process\.env/);
 });
 
-test("parallel RecordPlayer browser topology gets an OS-assigned isolated Vitest API port", () => {
+test("parallel RecordPlayer browser topology owns a unique strict Vitest API port", () => {
   const config = read("examples/record-player/apps/next-betterauth/vitest.config.browser.ts");
   assert.match(
     config,
-    /api:\s*\{\s*port:\s*0,\s*strictPort:\s*true\s*\}/,
-    "RecordPlayer must receive an OS-assigned API port rather than probing a shared default range",
+    /api:\s*\{\s*port:\s*63318,\s*strictPort:\s*true\s*\}/,
+    "RecordPlayer must reserve its browser API port instead of probing the workspace default range",
   );
+
+  const recordPlayerConfig = "examples/record-player/apps/next-betterauth/vitest.config.browser.ts";
+  const browserConfigs = execFileSync("git", ["ls-files", "--", "*vitest.config.browser.ts"], {
+    cwd: root,
+    encoding: "utf8",
+  })
+    .trim()
+    .split("\n")
+    .filter(Boolean);
+  for (const path of browserConfigs) {
+    if (path === recordPlayerConfig) continue;
+    assert.doesNotMatch(
+      read(path),
+      /api:\s*\{\s*port:\s*63318\b/,
+      `${path} aliases RecordPlayer's registry-owned browser port`,
+    );
+  }
 });
 
 test("sealed consumers select content-addressed artifact paths rather than worktree pointers", () => {

--- a/dev/gates/test/correctness-consumer-contract.test.mjs
+++ b/dev/gates/test/correctness-consumer-contract.test.mjs
@@ -40,12 +40,12 @@ test("every direct Node/browser correctness entrypoint uses the one sealed consu
   assert.doesNotMatch(aggregate, /env:\s*process\.env/);
 });
 
-test("parallel RecordPlayer browser topology has a reserved strict Vitest API port", () => {
+test("parallel RecordPlayer browser topology gets an OS-assigned isolated Vitest API port", () => {
   const config = read("examples/record-player/apps/next-betterauth/vitest.config.browser.ts");
   assert.match(
     config,
-    /api:\s*\{\s*port:\s*63318,\s*strictPort:\s*true\s*\}/,
-    "RecordPlayer must not auto-probe the shared Vitest browser API ports used by parallel suites",
+    /api:\s*\{\s*port:\s*0,\s*strictPort:\s*true\s*\}/,
+    "RecordPlayer must receive an OS-assigned API port rather than probing a shared default range",
   );
 });
 

--- a/examples/record-player/apps/next-betterauth/tests/test-selection.test.mjs
+++ b/examples/record-player/apps/next-betterauth/tests/test-selection.test.mjs
@@ -1,29 +1,26 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import test from "node:test";
 import packageJson from "../package.json" with { type: "json" };
+import { providerReceipt, topologyReceipt } from "../vitest-receipts.mjs";
 
 const cwd = fileURLToPath(new URL("..", import.meta.url));
 const browserConfig = readFileSync(path.join(cwd, "vitest.config.browser.ts"), "utf8");
-
-function listedTests(config) {
-  return execFileSync("pnpm", ["exec", "vitest", "list", "--config", config], {
-    cwd,
-    encoding: "utf8",
-  });
-}
+const execFileAsync = promisify(execFile);
 
 test("browser and provider gates select disjoint receipts", () => {
-  const topology = listedTests("vitest.config.browser.ts");
-  const provider = listedTests("vitest.config.provider.ts");
-
-  assert.match(topology, /tests\/browser\/topology\.e2e\.test\.ts/);
-  assert.doesNotMatch(topology, /tests\/browser\/provider\.e2e\.test\.tsx/);
-  assert.match(provider, /tests\/browser\/provider\.e2e\.test\.tsx/);
-  assert.doesNotMatch(provider, /tests\/browser\/topology\.e2e\.test\.ts/);
+  assert.equal(topologyReceipt, "tests/browser/topology.e2e.test.ts");
+  assert.equal(providerReceipt, "tests/browser/provider.e2e.test.tsx");
+  assert.notEqual(topologyReceipt, providerReceipt);
+  assert.match(browserConfig, /include:\s*\[topologyReceipt\]/);
+  assert.match(
+    readFileSync(path.join(cwd, "vitest.config.provider.ts"), "utf8"),
+    /include:\s*\[providerReceipt\]/,
+  );
 });
 
 test("the Node package gate excludes the browser-only topology receipt", () => {
@@ -49,3 +46,26 @@ test("the topology browser project provides the complete Jazz server command con
     assert.match(browserConfig, new RegExp(`\\b${command}\\b`));
   }
 });
+
+test("topology's browser server uses an OS-assigned port", () => {
+  assert.match(browserConfig, /api:\s*\{\s*port:\s*0,\s*strictPort:\s*true\s*\}/);
+  assert.doesNotMatch(browserConfig, /port:\s*633\d+/);
+});
+
+if (process.env.JAZZ_RECORD_PLAYER_SELECTION_CONCURRENCY_CHILD !== "1") {
+  test("selection checks do not contend with a concurrently booted topology browser server", async () => {
+    // `vitest list` boots the same browser server used by the topology suite,
+    // without executing its long-running scenarios. This is the CI shape that
+    // previously collided: package `test` ran its selection receipt while the
+    // workspace's parallel browser lane already owned the topology server.
+    await Promise.all([
+      execFileAsync("pnpm", ["exec", "vitest", "list", "--config", "vitest.config.browser.ts"], {
+        cwd,
+      }),
+      execFileAsync(process.execPath, ["--test", "tests/test-selection.test.mjs"], {
+        cwd,
+        env: { ...process.env, JAZZ_RECORD_PLAYER_SELECTION_CONCURRENCY_CHILD: "1" },
+      }),
+    ]);
+  });
+}

--- a/examples/record-player/apps/next-betterauth/tests/test-selection.test.mjs
+++ b/examples/record-player/apps/next-betterauth/tests/test-selection.test.mjs
@@ -1,7 +1,5 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import test from "node:test";
@@ -10,7 +8,7 @@ import { providerReceipt, topologyReceipt } from "../vitest-receipts.mjs";
 
 const cwd = fileURLToPath(new URL("..", import.meta.url));
 const browserConfig = readFileSync(path.join(cwd, "vitest.config.browser.ts"), "utf8");
-const execFileAsync = promisify(execFile);
+const selectionSource = readFileSync(new URL(import.meta.url), "utf8");
 
 test("browser and provider gates select disjoint receipts", () => {
   assert.equal(topologyReceipt, "tests/browser/topology.e2e.test.ts");
@@ -47,25 +45,11 @@ test("the topology browser project provides the complete Jazz server command con
   }
 });
 
-test("topology's browser server uses an OS-assigned port", () => {
-  assert.match(browserConfig, /api:\s*\{\s*port:\s*0,\s*strictPort:\s*true\s*\}/);
-  assert.doesNotMatch(browserConfig, /port:\s*633\d+/);
+test("topology's browser server uses its registry-owned strict port", () => {
+  assert.match(browserConfig, /api:\s*\{\s*port:\s*63318,\s*strictPort:\s*true\s*\}/);
 });
 
-if (process.env.JAZZ_RECORD_PLAYER_SELECTION_CONCURRENCY_CHILD !== "1") {
-  test("selection checks do not contend with a concurrently booted topology browser server", async () => {
-    // `vitest list` boots the same browser server used by the topology suite,
-    // without executing its long-running scenarios. This is the CI shape that
-    // previously collided: package `test` ran its selection receipt while the
-    // workspace's parallel browser lane already owned the topology server.
-    await Promise.all([
-      execFileAsync("pnpm", ["exec", "vitest", "list", "--config", "vitest.config.browser.ts"], {
-        cwd,
-      }),
-      execFileAsync(process.execPath, ["--test", "tests/test-selection.test.mjs"], {
-        cwd,
-        env: { ...process.env, JAZZ_RECORD_PLAYER_SELECTION_CONCURRENCY_CHILD: "1" },
-      }),
-    ]);
-  });
-}
+test("selection checks remain data-only and never boot a Vitest browser server", () => {
+  assert.doesNotMatch(selectionSource, new RegExp(["node", "child_process"].join(":")));
+  assert.doesNotMatch(selectionSource, new RegExp(["vitest", "list"].join("\\s+")));
+});

--- a/examples/record-player/apps/next-betterauth/vitest-receipts.mjs
+++ b/examples/record-player/apps/next-betterauth/vitest-receipts.mjs
@@ -1,0 +1,4 @@
+// Keep browser receipt selection data-only: the package's Node gate must be
+// able to assert this split without starting a second Vitest browser server.
+export const topologyReceipt = "tests/browser/topology.e2e.test.ts";
+export const providerReceipt = "tests/browser/provider.e2e.test.tsx";

--- a/examples/record-player/apps/next-betterauth/vitest.config.browser.ts
+++ b/examples/record-player/apps/next-betterauth/vitest.config.browser.ts
@@ -4,6 +4,7 @@ import topLevelAwait from "vite-plugin-top-level-await";
 import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
 import { resolve } from "node:path";
+import { topologyReceipt } from "./vitest-receipts.mjs";
 import {
   blockJazzServerNetwork,
   jazzServerInfo,
@@ -42,16 +43,14 @@ export default defineConfig({
     // This project owns the Jazz server lifecycle. Keep the mocked provider
     // receipt in vitest.config.provider.ts so `test:browser` remains a true
     // topology-only gate.
-    include: ["tests/browser/topology.e2e.test.ts"],
+    include: [topologyReceipt],
     globalSetup: ["../../../../packages/jazz-tools/tests/browser/global-setup.ts"],
     browser: {
       enabled: true,
-      // `run-ts-tests.sh` starts this topology suite beside other Vitest
-      // browser projects. Letting each project probe the shared default port
-      // races: a process can load its test module from a sibling project's
-      // Vite server. Keep this project on its reserved port and fail clearly
-      // if that reservation is unexpectedly unavailable.
-      api: { port: 63318, strictPort: true },
+      // Let the OS allocate a private API port for this invocation. Browser
+      // projects run in parallel in the workspace gate; a fixed/default Vite
+      // port couples otherwise independent topology processes.
+      api: { port: 0, strictPort: true },
       provider: playwright(),
       instances: [{ browser: "chromium", headless: true }],
       commands: {

--- a/examples/record-player/apps/next-betterauth/vitest.config.browser.ts
+++ b/examples/record-player/apps/next-betterauth/vitest.config.browser.ts
@@ -47,10 +47,10 @@ export default defineConfig({
     globalSetup: ["../../../../packages/jazz-tools/tests/browser/global-setup.ts"],
     browser: {
       enabled: true,
-      // Let the OS allocate a private API port for this invocation. Browser
-      // projects run in parallel in the workspace gate; a fixed/default Vite
-      // port couples otherwise independent topology processes.
-      api: { port: 0, strictPort: true },
+      // The workspace browser gate starts this topology beside three other
+      // Vitest projects. This registry-owned reservation prevents it from
+      // probing their shared default range.
+      api: { port: 63318, strictPort: true },
       provider: playwright(),
       instances: [{ browser: "chromium", headless: true }],
       commands: {

--- a/examples/record-player/apps/next-betterauth/vitest.config.provider.ts
+++ b/examples/record-player/apps/next-betterauth/vitest.config.provider.ts
@@ -3,6 +3,7 @@ import wasm from "vite-plugin-wasm";
 import topLevelAwait from "vite-plugin-top-level-await";
 import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
+import { providerReceipt } from "./vitest-receipts.mjs";
 
 /**
  * The provider receipt mocks Jazz and Better Auth deliberately. Keep it out of
@@ -20,7 +21,7 @@ export default defineConfig({
   plugins: [wasm(), topLevelAwait(), react()],
   worker: { plugins: () => [wasm(), topLevelAwait()] },
   test: {
-    include: ["tests/browser/provider.e2e.test.tsx"],
+    include: [providerReceipt],
     browser: {
       enabled: true,
       provider: playwright(),


### PR DESCRIPTION
🤖 Makes RecordPlayer browser topology tests coexist reliably with the parallel workspace gate.

Before:
- RecordPlayer used Vitest's default browser API ports.
- Other browser suites could claim those ports first, causing RecordPlayer to import from the wrong Vite server.
- The selection contract itself launched Vitest, creating a second hidden RecordPlayer server and making fixed-port attempts collide with themselves.

After:
- The one real RecordPlayer topology process uses reserved strict port `63318`.
- Selection checks consume shared data-only receipt patterns and never launch Vitest or Vite.
- A repository contract rejects any other tracked Vitest config that claims `63318`.

Example: workspace TS tests may run Jazz Tools, provider, and RecordPlayer gates concurrently; RecordPlayer now has one deterministic browser server, while a duplicate port declaration fails immediately with the conflicting config path.

Verified by the full RecordPlayer package gate (13 tests), correctness contract (7/7), and an independent planted provider-config collision.