### PR TITLE
test(browser): retain scoped worker root across restart

### DIFF
--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -1743,14 +1743,17 @@ describe("SharedWorker bridge with IndexedDB", () => {
 
     const inspectorControl = await dbBeforeRestart.openInspectorControlPort();
     inspectorControl.start();
-    const [initialContext] = (await listWorkerContexts(inspectorControl)).filter(
-      (context) => context.dbName === dbName,
-    );
+    const [initialContext] = await listWorkerContexts(inspectorControl);
     expect(initialContext).toBeDefined();
+    // Persistent browser roots are scoped by the auth session. Inspector
+    // contexts deliberately report that physical name, not the caller's raw
+    // driver.dbName; retain it only as an opaque same-root handle across the
+    // worker restart below.
+    const workerDbName = initialContext!.dbName;
     try {
       await dbBeforeRestart.shutdown();
       untrack(dbBeforeRestart);
-      await waitForWorkerContextRelease(inspectorControl, dbName);
+      await waitForWorkerContextRelease(inspectorControl, workerDbName);
       await terminateWorker(inspectorControl);
 
       const dbAfterAcknowledgement = track(await createPersistentDb(undefined));
@@ -1762,7 +1765,7 @@ describe("SharedWorker bridge with IndexedDB", () => {
       const secondInspectorControl = await dbAfterAcknowledgement.openInspectorControlPort();
       secondInspectorControl.start();
       const [secondContext] = (await listWorkerContexts(secondInspectorControl)).filter(
-        (context) => context.dbName === dbName,
+        (context) => context.dbName === workerDbName,
       );
       expect(secondContext?.workerRealmId).not.toBe(initialContext?.workerRealmId);
       // The destroyed worker context rehydrated the settled local view, but the
@@ -1772,7 +1775,7 @@ describe("SharedWorker bridge with IndexedDB", () => {
 
       await dbAfterAcknowledgement.shutdown();
       untrack(dbAfterAcknowledgement);
-      await waitForWorkerContextRelease(secondInspectorControl, dbName);
+      await waitForWorkerContextRelease(secondInspectorControl, workerDbName);
       await terminateWorker(secondInspectorControl);
 
       const dbAfterSecondRestart = track(await createPersistentDb(undefined));
@@ -1782,7 +1785,7 @@ describe("SharedWorker bridge with IndexedDB", () => {
       const thirdInspectorControl = await dbAfterSecondRestart.openInspectorControlPort();
       thirdInspectorControl.start();
       const [thirdContext] = (await listWorkerContexts(thirdInspectorControl)).filter(
-        (context) => context.dbName === dbName,
+        (context) => context.dbName === workerDbName,
       );
       expect(thirdContext?.workerRealmId).not.toBe(secondContext?.workerRealmId);
       thirdInspectorControl.postMessage({
@@ -1822,12 +1825,12 @@ describe("SharedWorker bridge with IndexedDB", () => {
 
     const inspectorBeforeRestart = await dbBeforeRestart.openInspectorControlPort();
     inspectorBeforeRestart.start();
-    const [contextBeforeRestart] = (await listWorkerContexts(inspectorBeforeRestart)).filter(
-      (context) => context.dbName === dbName,
-    );
+    const [contextBeforeRestart] = await listWorkerContexts(inspectorBeforeRestart);
+    expect(contextBeforeRestart).toBeDefined();
+    const workerDbName = contextBeforeRestart!.dbName;
     await dbBeforeRestart.shutdown();
     untrack(dbBeforeRestart);
-    await waitForWorkerContextRelease(inspectorBeforeRestart, dbName);
+    await waitForWorkerContextRelease(inspectorBeforeRestart, workerDbName);
     await terminateWorker(inspectorBeforeRestart);
 
     const dbAfterRestart = track(await createPersistentDb(syncServer.serverUrl));
@@ -1839,7 +1842,7 @@ describe("SharedWorker bridge with IndexedDB", () => {
     const inspectorAfterRestart = await dbAfterRestart.openInspectorControlPort();
     inspectorAfterRestart.start();
     const [contextAfterRestart] = (await listWorkerContexts(inspectorAfterRestart)).filter(
-      (context) => context.dbName === dbName,
+      (context) => context.dbName === workerDbName,
     );
     expect(contextAfterRestart?.workerRealmId).not.toBe(contextBeforeRestart?.workerRealmId);
 
@@ -1860,7 +1863,7 @@ describe("SharedWorker bridge with IndexedDB", () => {
 
     await dbAfterRestart.shutdown();
     untrack(dbAfterRestart);
-    await waitForWorkerContextRelease(inspectorAfterRestart, dbName);
+    await waitForWorkerContextRelease(inspectorAfterRestart, workerDbName);
     await terminateWorker(inspectorAfterRestart);
 
     const dbAfterSecondRestart = track(await createPersistentDb(undefined));
@@ -1869,7 +1872,7 @@ describe("SharedWorker bridge with IndexedDB", () => {
     inspectorAfterSecondRestart.start();
     const [contextAfterSecondRestart] = (
       await listWorkerContexts(inspectorAfterSecondRestart)
-    ).filter((context) => context.dbName === dbName);
+    ).filter((context) => context.dbName === workerDbName);
     expect(contextAfterSecondRestart?.workerRealmId).not.toBe(contextAfterRestart?.workerRealmId);
     inspectorAfterSecondRestart.postMessage({
       type: "close",
@@ -1916,9 +1919,12 @@ describe("SharedWorker bridge with IndexedDB", () => {
 
     const firstInspector = await first.openInspectorControlPort();
     firstInspector.start();
+    const [firstContext] = await listWorkerContexts(firstInspector);
+    expect(firstContext).toBeDefined();
+    const workerDbName = firstContext!.dbName;
     await first.shutdown();
     untrack(first);
-    await waitForWorkerContextRelease(firstInspector, dbName);
+    await waitForWorkerContextRelease(firstInspector, workerDbName);
     await terminateWorker(firstInspector);
 
     const successor = track(await createPersistentDb(syncServer.serverUrl));
@@ -1960,7 +1966,7 @@ describe("SharedWorker bridge with IndexedDB", () => {
 
     await successor.shutdown();
     untrack(successor);
-    await waitForWorkerContextRelease(successorInspector, dbName);
+    await waitForWorkerContextRelease(successorInspector, workerDbName);
     await terminateWorker(successorInspector);
 
     const later = track(await createPersistentDb(undefined));


### PR DESCRIPTION
🤖 Corrects worker rejection/recovery receipts to retain the auth-scoped physical database root across restart.

Before:
- Inspector contexts correctly reported the physical scoped database name.
- The receipts later waited for release or terminated a worker using the raw logical `driver.dbName`.
- Those checks targeted a different root, returned too early, and left live runtime contexts behind.

After:
- Each receipt captures the inspector-provided physical name as an opaque same-root handle.
- Shutdown, restart, release, and termination checks consistently use that handle.
- Runtime rejection delivery and rehydration semantics are unchanged.

The intended behavior remains:
- A runtime attached only after a rejection receives no historical notification.
- A runtime attached while rehydration is active receives the live outcome exactly once.
- Rehydrated state excludes rejected writes.

Focused Chromium receipts pass 3/3. Independent planted regression back to the logical name makes all three fail with live runtime contexts, proving the corrected target is meaningful.