### PR TITLE
fix(jazz-tools): observe post-admission write rejections

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -4489,7 +4489,22 @@ function rejectedWaitError(
   message: string;
 } | null {
   const message = errorMessage(error);
-  if (!message.includes("WriteRejected")) return null;
+  if (extractWriteRejectedReason(message) === null) return null;
+  return queuedWriteRejection(transactionId, error);
+}
+
+function queuedWriteRejection(
+  transactionId: TxId,
+  error: unknown,
+): {
+  kind: "rejected";
+  transactionId: TxId;
+  code: string;
+  reason: string;
+  /** An Error-compatible diagnostic for direct native callers. */
+  message: string;
+} {
+  const message = errorMessage(error);
   const rejection: {
     kind: "rejected";
     transactionId: TxId;
@@ -4518,8 +4533,8 @@ function writeOrNormalizeRejection<T>(
     return write();
   } catch (error) {
     const message = errorMessage(error);
-    if (message.includes("WriteRejected")) {
-      const reason = rejectionReason(message);
+    const reason = extractWriteRejectedReason(message);
+    if (reason !== null) {
       throw new Error(`${operation} failed: WriteError("${reason}")`);
     }
     throw error;
@@ -4570,8 +4585,16 @@ function rejectionCode(message: string): string {
 }
 
 function rejectionReason(message: string): string {
-  if (message.includes("AuthorizationDenied")) return "Write rejected by server authorization";
-  return message.replace(/^.*WriteRejected:?\s*/, "") || "Write rejected";
+  const reason = extractWriteRejectedReason(message);
+  if (reason === null) return message;
+  if (reason.includes("AuthorizationDenied")) return "Write rejected by server authorization";
+  return reason || "Write rejected";
+}
+
+/** Parse the exact stable Rust `Error` display prefix without matching quoted diagnostics. */
+function extractWriteRejectedReason(message: string): string | null {
+  const match = /^WriteRejected:\s*(.*)$/s.exec(message);
+  return match ? match[1]! : null;
 }
 
 function encodeQueryJson(queryJson: string, schema: WasmSchema): Uint8Array {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -42,6 +42,116 @@ describe("NativeRuntimeAdapter server transport", () => {
     globalThis.WebSocket = previousWebSocket;
   });
 
+  it.each([
+    [
+      "transport mentioning a nested rejection",
+      new Error("Protocol: upstream reported WriteRejected: quoted peer diagnostic"),
+    ],
+    ["not-observed", new Error("NotObserved: transaction is not resident")],
+    ["schema", new Error("Schema: invalid authored branch value")],
+    ["cancellation", Object.assign(new Error("operation cancelled"), { name: "AbortError" })],
+    ["unknown", new Error("unknown lifecycle failure")],
+  ])("preserves %s lifecycle errors from native write waits", async (_kind, nativeError) => {
+    const write = {
+      ...fakeWrite(),
+      wait: async () => {
+        throw nativeError;
+      },
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () => fakeDb({ insertEncoded: () => write, tick: () => undefined }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const inserted = runtime.insert(
+      "todos",
+      { title: { type: "Text", value: "lifecycle passthrough" } },
+      null,
+      "00000000-0000-0000-0000-000000000010",
+    );
+
+    await expect(runtime.waitForTransaction(await committedTxId(inserted), "local")).rejects.toBe(
+      nativeError,
+    );
+
+    const admissionRuntime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            insertEncoded: () => {
+              throw nativeError;
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    let admissionError: unknown;
+    try {
+      admissionRuntime.insert(
+        "todos",
+        { title: { type: "Text", value: "admission passthrough" } },
+        null,
+        "00000000-0000-0000-0000-000000000012",
+      );
+    } catch (error) {
+      admissionError = error;
+    }
+    expect(admissionError).toBe(nativeError);
+  });
+
+  it("normalizes a terminal native WriteRejected error", async () => {
+    const write = {
+      ...fakeWrite(),
+      wait: async () => {
+        throw new Error("WriteRejected: queued write was denied");
+      },
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () => fakeDb({ insertEncoded: () => write, tick: () => undefined }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const inserted = runtime.insert(
+      "todos",
+      { title: { type: "Text", value: "terminal rejection" } },
+      null,
+      "00000000-0000-0000-0000-000000000011",
+    );
+
+    await expect(
+      runtime.waitForTransaction(await committedTxId(inserted), "local"),
+    ).rejects.toMatchObject({
+      kind: "rejected",
+      transactionId: await committedTxId(inserted),
+      code: "write_rejected",
+      reason: "queued write was denied",
+    });
+  });
+
   it("connects the native upstream transport to the scoped websocket endpoint", async () => {
     const sockets: FakeWebSocket[] = [];
     globalThis.WebSocket = class extends FakeWebSocket {

--- a/packages/jazz-tools/tests/ts-dsl/branch-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/branch-api.test.ts
@@ -83,9 +83,13 @@ describe("branch API", () => {
       { branch: "draft" },
     ).value;
 
-    expect(() =>
-      db!.update(app.documents, document.id, { branch: "published" }, { branch: "draft" }),
-    ).toThrow("branch column does not match exact branch key");
+    await expect(
+      db!
+        .update(app.documents, document.id, { branch: "published" }, { branch: "draft" })
+        .wait({ tier: "local" }),
+    ).rejects.toThrow(
+      "Schema: invalid mergeable commit: branch column does not match exact branch key",
+    );
 
     expect(await db.one(app.documents.where({ id: document.id }), { branch: "draft" })).toEqual(
       document,

--- a/packages/jazz-tools/tests/ts-dsl/delete-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/delete-api.test.ts
@@ -80,12 +80,16 @@ describe("TS Delete API", () => {
     });
   });
 
-  it("trying to delete an already-deleted row fails", async () => {
+  it("reports an already-deleted rejection through the write handle", async () => {
     const project = insertProject(db);
     db.delete(app.projects, project.id);
 
-    expect(() => db.delete(app.projects, project.id)).toThrow(
-      `Delete failed: WriteError("row already deleted: ${project.id}")`,
+    await expect(db.delete(app.projects, project.id).wait({ tier: "local" })).rejects.toMatchObject(
+      {
+        name: "PersistedWriteRejectedError",
+        code: "write_rejected",
+        reason: `row already deleted: ${project.id}`,
+      },
     );
   });
 });

--- a/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
@@ -124,12 +124,18 @@ describe("TS Insert API", () => {
     });
   });
 
-  it("cannot insert two rows with the same id", async () => {
+  it("reports duplicate caller-supplied ids through the write handle", async () => {
     const id = "00000000-0000-0000-0000-000000000000";
     const { value: project } = db.insert(app.projects, { name: "Test Project 1" }, { id });
-    expect(() => db.insert(app.projects, { name: "Test Project 2" }, { id: project.id })).toThrow(
-      `Insert failed: WriteError("encoding error: object already exists: ${project.id}")`,
-    );
+    await expect(
+      db
+        .insert(app.projects, { name: "Test Project 2" }, { id: project.id })
+        .wait({ tier: "local" }),
+    ).rejects.toMatchObject({
+      name: "PersistedWriteRejectedError",
+      code: "write_rejected",
+      reason: `encoding error: object already exists: ${project.id}`,
+    });
   });
 
   it("keeps caller-supplied ids reserved after the row is deleted", async () => {
@@ -137,9 +143,15 @@ describe("TS Insert API", () => {
     const { value: project } = db.insert(app.projects, { name: "Test Project 1" }, { id });
     db.delete(app.projects, project.id);
 
-    expect(() => db.insert(app.projects, { name: "Test Project 2" }, { id: project.id })).toThrow(
-      `Insert failed: WriteError("row already deleted: ${project.id}")`,
-    );
+    await expect(
+      db
+        .insert(app.projects, { name: "Test Project 2" }, { id: project.id })
+        .wait({ tier: "local" }),
+    ).rejects.toMatchObject({
+      name: "PersistedWriteRejectedError",
+      code: "write_rejected",
+      reason: `row already deleted: ${project.id}`,
+    });
   });
 
   it("uses default values missing from the insert data", async () => {

--- a/packages/jazz-tools/tests/ts-dsl/restore-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/restore-api.test.ts
@@ -99,11 +99,15 @@ describe("TS Restore API", () => {
     ).resolves.toEqual(inserted);
   });
 
-  it("fails when the row is not deleted", async () => {
+  it("reports a restore rejection through the write handle", async () => {
     const project = insertProject(db);
 
-    expect(() => db.restore(app.projects, project.id, { name: "Restored Project" })).toThrow(
-      `Restore failed: WriteError("row not deleted: ${project.id}")`,
-    );
+    await expect(
+      db.restore(app.projects, project.id, { name: "Restored Project" }).wait({ tier: "local" }),
+    ).rejects.toMatchObject({
+      name: "PersistedWriteRejectedError",
+      code: "write_rejected",
+      reason: `row not deleted: ${project.id}`,
+    });
   });
 });

--- a/packages/jazz-tools/tests/ts-dsl/update-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/update-api.test.ts
@@ -182,13 +182,17 @@ describe("TS Update API", () => {
     ).toThrow("update replacements and applyDiffs must not both specify the same column.");
   });
 
-  it("trying to update an already-deleted row fails", async () => {
+  it("reports an update rejection through the write handle", async () => {
     const project = insertProject(db);
     db.delete(app.projects, project.id);
 
-    expect(() => db.update(app.projects, project.id, { name: "Restored Project" })).toThrow(
-      `Update failed: WriteError("row already deleted: ${project.id}")`,
-    );
+    await expect(
+      db.update(app.projects, project.id, { name: "Restored Project" }).wait({ tier: "local" }),
+    ).rejects.toMatchObject({
+      name: "PersistedWriteRejectedError",
+      code: "write_rejected",
+      reason: `row already deleted: ${project.id}`,
+    });
   });
 
   it("enforces constraints on JSON schemas", async () => {

--- a/packages/jazz-tools/tests/ts-dsl/upsert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/upsert-api.test.ts
@@ -151,13 +151,17 @@ describe("TS Upsert API", () => {
     });
   });
 
-  it("keeps deleted row ids reserved", async () => {
+  it("reports deleted-row reservation through the write handle", async () => {
     const project = insertProject(db);
     db.delete(app.projects, project.id);
 
-    expect(() => db.upsert(app.projects, project.id, { name: "Restored Project" })).toThrow(
-      `Upsert failed: WriteError("row already deleted: ${project.id}")`,
-    );
+    await expect(
+      db.upsert(app.projects, project.id, { name: "Restored Project" }).wait({ tier: "local" }),
+    ).rejects.toMatchObject({
+      name: "PersistedWriteRejectedError",
+      code: "write_rejected",
+      reason: `row already deleted: ${project.id}`,
+    });
   });
 
   it("can use caller-supplied updatedAt on new-row upsert", async () => {


### PR DESCRIPTION
🤖 Aligns TypeScript mutation receipts with the asynchronous post-admission write lifecycle.

Before:
- `insert`, `update`, `delete`, `restore`, `upsert`, and branch writes reserve/enqueue synchronously.
- Several tests still expected row-state failures to throw from the call itself.
- An over-broad normalization attempt could misclassify transport or `NotObserved` errors as permanent write rejection.

After:
- Post-admission row-state failures are observed through `WriteHandle.wait({ tier: "local" })`.
- Only native errors beginning with the exact Rust display prefix `WriteRejected:` become `PersistedWriteRejectedError` with stable `txId`, `code`, and `reason`.
- Protocol, Schema, `NotObserved`, cancellation, and unknown lifecycle errors pass through unchanged.
- Synchronous pre-admission validation remains synchronous.

Example: updating a deleted row returns a handle immediately; awaiting its local settlement rejects with `{ name: "PersistedWriteRejectedError", code: "write_rejected", reason: "row already deleted: …" }`. A transport error mentioning the words `WriteRejected` elsewhere remains the exact original transport error.

Verified by 74 focused runtime/client receipts, exact API suites, typecheck, and a planted false-positive classifier regression.