### PR TITLE
fix(jazz): preserve queued no-op update identity

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -240,11 +240,11 @@ impl NapiDbInnerStorage {
 enum NapiWrite {
     Memory {
         db: Rc<CoreDb<CoreMemoryStorage>>,
-        tx_id: TxId,
+        write: WriteHandle<CoreMemoryStorage>,
     },
     Persistent {
         db: Rc<CoreDb<CoreRocksDbStorage>>,
-        tx_id: TxId,
+        write: WriteHandle<CoreRocksDbStorage>,
     },
 }
 
@@ -878,11 +878,11 @@ impl Write {
             finish_wait_promise(env, deferred, result);
         };
         match write {
-            NapiWrite::Memory { db, tx_id } => {
-                db.wait_for_transaction_with(*tx_id, tier, callback);
+            NapiWrite::Memory { db, write } => {
+                db.wait_for_write_with(write, tier, callback);
             }
-            NapiWrite::Persistent { db, tx_id } => {
-                db.wait_for_transaction_with(*tx_id, tier, callback);
+            NapiWrite::Persistent { db, write } => {
+                db.wait_for_write_with(write, tier, callback);
             }
         }
         Ok(PromiseRaw::new(env, promise))
@@ -912,8 +912,8 @@ impl Write {
             return Err(napi::Error::from_reason("write state is unavailable"));
         };
         let state = match write {
-            NapiWrite::Memory { db, tx_id } => db.write_state(*tx_id),
-            NapiWrite::Persistent { db, tx_id } => db.write_state(*tx_id),
+            NapiWrite::Memory { write, .. } => core_block_on(write.write_state()),
+            NapiWrite::Persistent { write, .. } => core_block_on(write.write_state()),
         }
         .map_err(|error| napi::Error::from_reason(error.to_string()))?;
         Ok(core_write_state_to_json(&state))
@@ -4317,7 +4317,7 @@ fn core_write_memory(
             .map_err(|error| napi::Error::from_reason(error.to_string()))?,
         row_id: result.row_id,
         tx_id: TransactionId::from_committed_tx(tx_id),
-        inner: Some(NapiWrite::Memory { db, tx_id }),
+        inner: Some(NapiWrite::Memory { db, write }),
     })
 }
 
@@ -4335,7 +4335,7 @@ fn core_write_persistent(
             .map_err(|error| napi::Error::from_reason(error.to_string()))?,
         row_id: result.row_id,
         tx_id: TransactionId::from_committed_tx(tx_id),
-        inner: Some(NapiWrite::Persistent { db, tx_id }),
+        inner: Some(NapiWrite::Persistent { db, write }),
     })
 }
 
@@ -5435,15 +5435,16 @@ mod tests {
 
     use crate::{
         CoreOpenDbConfig, CoreSelfSignedClientProof, InsertOptions, JazzServer, JazzServerInner,
-        NapiDb, NapiDbInnerStorage, NapiTxKind, PendingNativeRead, PendingNativeSubscriptionBatch,
-        PendingSubscriptionBatchOutcome, PendingSubscriptionBatchPoll, PreparedQuery,
-        RestoreOptions, Tx, UpdateOptions, UpsertOptions, authority_epoch_from_bigint,
-        close_after_cleanup, core_author_id_from_bytes, core_block_on, core_claim_value_from_json,
-        core_drive_direct_mutation_once, core_insert_options, core_open_backend_identity,
-        core_open_identity, core_read_opts_from_json, core_read_tier_from_str,
-        core_restore_options, core_subscription_event_to_napi, core_update_options,
-        core_upsert_options, encode_core_subscription_delta, requeue_retryable_subscription_batch,
-        unknown_transaction_kind_message,
+        NapiDb, NapiDbInnerStorage, NapiTxKind, NapiWrite, PendingNativeRead,
+        PendingNativeSubscriptionBatch, PendingSubscriptionBatchOutcome,
+        PendingSubscriptionBatchPoll, PreparedQuery, RestoreOptions, Tx, UpdateOptions,
+        UpsertOptions, authority_epoch_from_bigint, close_after_cleanup, core_author_id_from_bytes,
+        core_block_on, core_claim_value_from_json, core_drive_direct_mutation_once,
+        core_insert_options, core_open_backend_identity, core_open_identity,
+        core_read_opts_from_json, core_read_tier_from_str, core_restore_options,
+        core_subscription_event_to_napi, core_update_options, core_upsert_options,
+        core_write_memory, core_write_state_to_json, encode_core_subscription_delta,
+        requeue_retryable_subscription_batch, unknown_transaction_kind_message,
     };
 
     #[test]
@@ -5921,6 +5922,98 @@ mod tests {
             core_block_on(second.wait(DurabilityTier::Local)).expect("second wait resolves"),
             second.mergeable_tx_id(),
             "the retained FIFO successor eventually completes normally"
+        );
+    }
+
+    /// A public NAPI write owns the bounded completion target for a queued
+    /// no-op. Its request id is intentionally not a durable transaction, so
+    /// resolving `writeState` or `wait` through `Db::write_state(request)`
+    /// would incorrectly report `NotObserved` after admission.
+    #[test]
+    fn napi_write_retains_queued_noop_completion_target() {
+        let source = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("items")
+                    .column("label", ColumnType::Text)
+                    .policies(
+                        TablePolicies::new()
+                            .with_select(PolicyExpr::True)
+                            .with_insert(PolicyExpr::True)
+                            .with_update(Some(PolicyExpr::True), PolicyExpr::True)
+                            .with_delete(PolicyExpr::True),
+                    ),
+            )
+            .build();
+        let schema = jazz::schema::JazzSchema::new(&source)
+            .expect("NAPI no-op write fixture schema compiles");
+        let families = schema.column_families();
+        let families = families.iter().map(String::as_str).collect::<Vec<_>>();
+        let author = CoreAuthorSubject::for_test_bytes([0xc4; 16]);
+        let db = Rc::new(
+            core_block_on(CoreDb::open(CoreDbConfig::new(
+                schema,
+                CoreMemoryStorage::new(&families).expect("valid memory storage families"),
+                CoreDbIdentity {
+                    node: CoreNodeUuid::from_bytes([0x54; 16]),
+                    author: author.clone(),
+                },
+            )))
+            .expect("NAPI no-op write fixture opens"),
+        );
+        let row = CoreRowUuid::from_bytes([0x64; 16]);
+        let existing_tx_id = db
+            .seed_settled_mergeable_for_bootstrap(
+                "items",
+                row,
+                author,
+                BTreeMap::from([("label".to_owned(), CoreValue::String("before".to_owned()))]),
+            )
+            .expect("seed current row");
+        let queued = db
+            .enqueue_update("items".to_owned(), row, BTreeMap::new(), Default::default())
+            .expect("queue empty update");
+        let reserved_tx_id = queued.mergeable_tx_id();
+        let napi_write = core_write_memory(Rc::clone(&db), queued).expect("wrap queued write");
+
+        let waited = Rc::new(RefCell::new(None));
+        let waited_for_callback = Rc::clone(&waited);
+        match napi_write
+            .inner
+            .as_ref()
+            .expect("public write keeps inner handle")
+        {
+            NapiWrite::Memory { db, write } => {
+                db.wait_for_write_with(write, DurabilityTier::Local, move |outcome| {
+                    *waited_for_callback.borrow_mut() = Some(outcome)
+                })
+            }
+            NapiWrite::Persistent { .. } => panic!("memory write retained wrong backend"),
+        }
+        db.drive_queued_mutation_once();
+        core_block_on(db.tick()).expect("the scheduled binding observer receives no-op completion");
+
+        assert_eq!(
+            napi_write
+                .write_state()
+                .expect("NAPI write state follows target"),
+            core_write_state_to_json(
+                &db.write_state(existing_tx_id)
+                    .expect("existing transaction remains observable"),
+            ),
+            "the public write follows its bounded completion target rather than a global alias"
+        );
+        assert_eq!(
+            waited
+                .borrow_mut()
+                .take()
+                .expect("NAPI wait callback resolves")
+                .expect("no-op target is locally durable"),
+            reserved_tx_id,
+            "the public wait retains its synchronous request identity"
+        );
+        assert!(
+            db.write_state(reserved_tx_id).is_err(),
+            "NAPI did not reintroduce a runtime-global no-op alias"
         );
     }
 

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -34,7 +34,7 @@ use jazz::protocol::{BranchSelector, BranchViewBase, PermissionAdviceAction, Rea
 use jazz::query::{Query, RelationExpr, RelationQuery};
 use jazz::schema::JazzSchema;
 use jazz::tools::{OpenTransactionId, TransactionId};
-use jazz::tx::{DurabilityTier, TxId};
+use jazz::tx::DurabilityTier;
 use jazz::wire::{TransportError, WireAuthorityEndpoint, WireTransport};
 use serde::{Deserialize, Serialize};
 
@@ -377,12 +377,12 @@ impl WasmStreamingMutation {
 enum WasmWriteInner {
     MemoryTx {
         db: Rc<Db<MemoryStorage>>,
-        tx_id: TxId,
+        write: WriteHandle<MemoryStorage>,
     },
     #[cfg(target_arch = "wasm32")]
     BrowserTx {
         db: Rc<Db<BrowserStorage>>,
-        tx_id: TxId,
+        write: WriteHandle<BrowserStorage>,
     },
 }
 
@@ -406,12 +406,12 @@ impl WasmWrite {
     #[wasm_bindgen(js_name = writeState)]
     pub fn write_state(&self) -> Result<JsValue, JsValue> {
         match &self.inner {
-            Some(WasmWriteInner::MemoryTx { db, tx_id }) => {
-                write_state_to_js(db.write_state(*tx_id).map_err(to_js_error)?)
+            Some(WasmWriteInner::MemoryTx { write, .. }) => {
+                write_state_to_js(block_on(write.write_state()).map_err(to_js_error)?)
             }
             #[cfg(target_arch = "wasm32")]
-            Some(WasmWriteInner::BrowserTx { db, tx_id }) => {
-                write_state_to_js(db.write_state(*tx_id).map_err(to_js_error)?)
+            Some(WasmWriteInner::BrowserTx { write, .. }) => {
+                write_state_to_js(block_on(write.write_state()).map_err(to_js_error)?)
             }
             None => Err(JsValue::from_str("write state is unavailable")),
         }
@@ -421,12 +421,12 @@ impl WasmWrite {
     pub fn wait(&self, tier: String) -> Result<js_sys::Promise, JsValue> {
         let tier = durability_tier_from_str(&tier)?;
         match &self.inner {
-            Some(WasmWriteInner::MemoryTx { db, tx_id }) => {
-                Ok(wait_promise(db.as_ref(), *tx_id, tier))
+            Some(WasmWriteInner::MemoryTx { db, write }) => {
+                Ok(wait_promise(db.as_ref(), write, tier))
             }
             #[cfg(target_arch = "wasm32")]
-            Some(WasmWriteInner::BrowserTx { db, tx_id }) => {
-                Ok(wait_promise(db.as_ref(), *tx_id, tier))
+            Some(WasmWriteInner::BrowserTx { db, write }) => {
+                Ok(wait_promise(db.as_ref(), write, tier))
             }
             None => Err(JsValue::from_str("write state is unavailable")),
         }
@@ -3731,12 +3731,12 @@ where
     Ok(stats.subscription_events as u32)
 }
 
-fn wait_promise<S>(db: &Db<S>, tx_id: TxId, tier: DurabilityTier) -> js_sys::Promise
+fn wait_promise<S>(db: &Db<S>, write: &WriteHandle<S>, tier: DurabilityTier) -> js_sys::Promise
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
 {
     js_sys::Promise::new(&mut |resolve, reject| {
-        db.wait_for_transaction_with(tx_id, tier, move |result| match result {
+        db.wait_for_write_with(write, tier, move |result| match result {
             Ok(_) => {
                 let _ = resolve.call0(&JsValue::UNDEFINED);
             }
@@ -3879,7 +3879,7 @@ fn wasm_write_memory(
         payload: postcard::to_allocvec(&result).map_err(to_js_error)?,
         row_id: result.row_id,
         tx_id: TransactionId::from_committed_tx(tx_id),
-        inner: Some(WasmWriteInner::MemoryTx { db, tx_id }),
+        inner: Some(WasmWriteInner::MemoryTx { db, write }),
     })
 }
 
@@ -3897,7 +3897,7 @@ fn wasm_write_browser(
         payload: postcard::to_allocvec(&result).map_err(to_js_error)?,
         row_id: result.row_id,
         tx_id: TransactionId::from_committed_tx(tx_id),
-        inner: Some(WasmWriteInner::BrowserTx { db, tx_id }),
+        inner: Some(WasmWriteInner::BrowserTx { db, write }),
     })
 }
 
@@ -4417,6 +4417,97 @@ mod dynamic_schema_view_tests {
                 "invalid updatedAtMs {invalid:?} must fail before a write"
             );
         }
+    }
+
+    /// The WASM object itself, rather than the runtime, owns the completion
+    /// target for a queued empty update. Retaining only the request id would
+    /// make the public `wait`/`writeState` methods lose the existing current
+    /// transaction as soon as the no-op admission completes.
+    #[test]
+    fn wasm_write_retains_queued_noop_completion_target() {
+        let source = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("items")
+                    .column("label", ColumnType::Text)
+                    .policies(
+                        TablePolicies::new()
+                            .with_select(PolicyExpr::True)
+                            .with_insert(PolicyExpr::True)
+                            .with_update(Some(PolicyExpr::True), PolicyExpr::True)
+                            .with_delete(PolicyExpr::True),
+                    ),
+            )
+            .build();
+        let schema = JazzSchema::new(&source).expect("WASM no-op write schema compiles");
+        let families = schema.column_families();
+        let families = families.iter().map(String::as_str).collect::<Vec<_>>();
+        let author = AuthorSubject::for_test_bytes([0xc5; 16]);
+        let db = Rc::new(
+            block_on(Db::open(DbConfig::new(
+                schema,
+                MemoryStorage::new(&families).expect("valid memory storage families"),
+                DbIdentity {
+                    node: NodeUuid::from_bytes([0x55; 16]),
+                    author: author.clone(),
+                },
+            )))
+            .expect("WASM no-op write fixture opens"),
+        );
+        let row = RowUuid::from_bytes([0x65; 16]);
+        let existing_tx_id = db
+            .seed_settled_mergeable_for_bootstrap(
+                "items",
+                row,
+                author,
+                BTreeMap::from([("label".to_owned(), Value::String("before".to_owned()))]),
+            )
+            .expect("seed current row");
+        let queued = db
+            .enqueue_update("items".to_owned(), row, BTreeMap::new(), Default::default())
+            .expect("queue empty update");
+        let reserved_tx_id = queued.mergeable_tx_id();
+        let wasm_write = wasm_write_memory(Rc::clone(&db), queued).expect("wrap queued write");
+
+        let waited = Rc::new(RefCell::new(None));
+        let waited_for_callback = Rc::clone(&waited);
+        match wasm_write
+            .inner
+            .as_ref()
+            .expect("WASM write keeps inner handle")
+        {
+            WasmWriteInner::MemoryTx { db, write } => {
+                db.wait_for_write_with(write, DurabilityTier::Local, move |outcome| {
+                    *waited_for_callback.borrow_mut() = Some(outcome)
+                })
+            }
+            #[cfg(target_arch = "wasm32")]
+            WasmWriteInner::BrowserTx { .. } => panic!("memory write retained wrong backend"),
+        }
+        block_on(db.tick()).expect("scheduled WASM wait receives no-op completion");
+
+        match wasm_write.inner.as_ref().expect("WASM write remains live") {
+            WasmWriteInner::MemoryTx { write, .. } => assert_eq!(
+                block_on(write.write_state()).expect("WASM handle follows target"),
+                db.write_state(existing_tx_id)
+                    .expect("existing transaction remains observable"),
+                "the wrapper retains the handle-local completion target"
+            ),
+            #[cfg(target_arch = "wasm32")]
+            WasmWriteInner::BrowserTx { .. } => unreachable!(),
+        }
+        assert_eq!(
+            waited
+                .borrow_mut()
+                .take()
+                .expect("WASM wait callback resolves")
+                .expect("no-op target is locally durable"),
+            reserved_tx_id,
+            "the binding wait preserves its synchronous request identity"
+        );
+        assert!(
+            db.write_state(reserved_tx_id).is_err(),
+            "WASM did not reintroduce a runtime-global no-op alias"
+        );
     }
 
     /// The JavaScript-facing parsers share the checked timestamp conversion

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1512,6 +1512,7 @@ type SharedTickScheduler = Rc<RefCell<Option<Rc<dyn TickScheduler>>>>;
 type QueuedMutationFuture = Pin<Box<dyn Future<Output = Result<(), Error>> + 'static>>;
 type QueuedMutationCompletion = Box<dyn FnOnce(Result<(), Error>) + 'static>;
 type TransactionWaitObserver = Pin<Box<dyn Future<Output = ()> + 'static>>;
+type QueuedMutationAlias = Rc<RefCell<Option<TxId>>>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MutationOwnerLifecycle {
@@ -3727,6 +3728,7 @@ where
     tx_id: TxId,
     local_tier: DurabilityTier,
     queued_status: Option<Rc<RefCell<QueuedMutationStatus>>>,
+    queued_alias: Option<QueuedMutationAlias>,
 }
 
 impl<S> WriteHandle<S>
@@ -3826,8 +3828,13 @@ where
                 "database handle was dropped",
             ));
         };
+        let resolved_tx_id = self
+            .queued_alias
+            .as_ref()
+            .and_then(|alias| *alias.borrow())
+            .unwrap_or(self.tx_id);
         let Some((fate, global_time, durability)) =
-            node.lock().await.transaction_state(self.tx_id).await
+            node.lock().await.transaction_state(resolved_tx_id).await
         else {
             return Err(Error::new(
                 ErrorCode::NotObserved,

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -456,6 +456,10 @@ where
         // retirement, so the shared Closing state terminalizes them instead
         // of leaving binding promises parked forever.
         self.node.drain_transaction_wait_observers().await;
+        // A drained waiter may have claimed an already-rejected transaction.
+        // Acknowledge that durable rejection before closing storage; there is
+        // no later owner turn after close to flush the bounded acknowledgement.
+        self.node.flush_deferred_rejection_discards().await?;
         // Close finalization admission before the first await. This makes the
         // queued retirement set and durable close one lifecycle transition:
         // a stream dropped while storage is shutting down is either in this
@@ -727,6 +731,24 @@ where
             .wait_for_transaction_with(tx_id, tier, Box::new(callback));
     }
 
+    /// Binding-only callback wait that preserves a queued write handle's
+    /// bounded completion target. Unlike a durable transaction-id lookup, an
+    /// empty queued update may resolve to an existing row transaction.
+    #[doc(hidden)]
+    pub fn wait_for_write_with(
+        &self,
+        write: &WriteHandle<S>,
+        tier: DurabilityTier,
+        callback: impl FnOnce(Result<TxId, Error>) + 'static,
+    ) {
+        self.node.wait_for_write_with(
+            write.tx_id,
+            write.queued_alias.clone(),
+            tier,
+            Box::new(callback),
+        );
+    }
+
     /// Wait until this database observes another state transition for `tx_id`.
     ///
     /// Callers should always check [`Db::write_state`] before and after
@@ -880,6 +902,7 @@ where
     pub async fn tick(&self) -> Result<(), Error> {
         let queued_mutation_pending = self.node.poll_queued_mutation_once();
         self.node.poll_transaction_wait_observers();
+        self.flush_deferred_rejection_discards_after_tick().await?;
         if queued_mutation_pending {
             return Ok(());
         }
@@ -887,6 +910,7 @@ where
         self.node.settle_local_publications().await?;
         self.node.tick().await?;
         self.node.poll_transaction_wait_observers();
+        self.flush_deferred_rejection_discards_after_tick().await?;
         Ok(())
     }
 
@@ -894,6 +918,7 @@ where
     pub async fn tick_stats(&self) -> Result<DbTickStats, Error> {
         let queued_mutation_pending = self.node.poll_queued_mutation_once();
         self.node.poll_transaction_wait_observers();
+        self.flush_deferred_rejection_discards_after_tick().await?;
         if queued_mutation_pending {
             return Ok(DbTickStats::default());
         }
@@ -901,7 +926,15 @@ where
         self.node.settle_local_publications().await?;
         let stats = self.node.tick().await?;
         self.node.poll_transaction_wait_observers();
+        self.flush_deferred_rejection_discards_after_tick().await?;
         Ok(stats)
+    }
+
+    async fn flush_deferred_rejection_discards_after_tick(&self) -> Result<(), Error> {
+        // A durable rejection acknowledgement is part of the owner turn. If
+        // it fails, retain the ID but surface the failure instead of silently
+        // scheduling an unbounded retry loop against a poisoned database.
+        self.node.flush_deferred_rejection_discards().await
     }
 
     #[allow(dead_code)]

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -478,6 +478,7 @@ where
         row: RowUuid,
         tx_id: TxId,
         queued_status: Rc<RefCell<QueuedMutationStatus>>,
+        queued_alias: Option<QueuedMutationAlias>,
     ) -> WriteHandle<S> {
         WriteHandle {
             node: Rc::downgrade(&self.node.node),
@@ -485,6 +486,7 @@ where
             tx_id,
             local_tier: DurabilityTier::None,
             queued_status: Some(queued_status),
+            queued_alias,
         }
     }
 
@@ -513,7 +515,7 @@ where
                 Ok(())
             }),
         );
-        Ok(self.queued_write_handle(row, tx_id, status))
+        Ok(self.queued_write_handle(row, tx_id, status, None))
     }
 
     #[doc(hidden)]
@@ -529,15 +531,27 @@ where
         options.updated_at_ms = Some(now_ms);
         let tx_id = self.reserve_transaction_id_at_ms(now_ms)?;
         let db = self.clone_for_reserved_transaction(tx_id);
+        let empty_patch = patch.is_empty();
+        let alias = Rc::new(RefCell::new(None));
+        let update_alias = Rc::clone(&alias);
         let status = self.node.enqueue_mutation(
             tx_id,
             Box::pin(async move {
                 let write = db.update(&table, row, patch, options).await?;
-                debug_assert_eq!(write.mergeable_tx_id(), tx_id);
+                let actual_tx_id = write.mergeable_tx_id();
+                if empty_patch && actual_tx_id != tx_id {
+                    // Empty root patches deliberately validate visibility and
+                    // reuse the current row transaction. The returned write
+                    // handle retains that existing transaction as its bounded
+                    // completion target once validation succeeds.
+                    *update_alias.borrow_mut() = Some(actual_tx_id);
+                } else {
+                    debug_assert_eq!(actual_tx_id, tx_id);
+                }
                 Ok(())
             }),
         );
-        Ok(self.queued_write_handle(row, tx_id, status))
+        Ok(self.queued_write_handle(row, tx_id, status, Some(alias)))
     }
 
     #[doc(hidden)]
@@ -561,7 +575,7 @@ where
                 Ok(())
             }),
         );
-        Ok(self.queued_write_handle(row, tx_id, status))
+        Ok(self.queued_write_handle(row, tx_id, status, None))
     }
 
     #[doc(hidden)]
@@ -584,7 +598,7 @@ where
                 Ok(())
             }),
         );
-        Ok(self.queued_write_handle(row, tx_id, status))
+        Ok(self.queued_write_handle(row, tx_id, status, None))
     }
 
     #[doc(hidden)]
@@ -608,7 +622,7 @@ where
                 Ok(())
             }),
         );
-        Ok(self.queued_write_handle(row, tx_id, status))
+        Ok(self.queued_write_handle(row, tx_id, status, None))
     }
 
     #[doc(hidden)]
@@ -634,7 +648,7 @@ where
                 Ok(())
             }),
         );
-        Ok(self.queued_write_handle(row, tx_id, status))
+        Ok(self.queued_write_handle(row, tx_id, status, None))
     }
     /// Read a byte range from an ordinary bytes or string cell without
     /// exposing its physical representation. Inline and indirect cells share
@@ -2880,6 +2894,7 @@ where
             tx_id,
             local_tier,
             queued_status: None,
+            queued_alias: None,
         })
     }
 
@@ -3354,6 +3369,7 @@ where
             tx_id,
             local_tier,
             queued_status: None,
+            queued_alias: None,
         })
     }
 
@@ -3383,6 +3399,7 @@ where
             tx_id,
             local_tier,
             queued_status: None,
+            queued_alias: None,
         })
     }
 

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -26,6 +26,10 @@ where
     queued_mutations: RefCell<VecDeque<QueuedMutationOperation>>,
     transaction_wait_observers: RefCell<Vec<TransactionWaitObserver>>,
     queued_mutation_failures: RefCell<BTreeMap<TxId, Error>>,
+    /// Rejections claimed by a waiter during the current owner turn. They
+    /// stay observable until every waiter that was woken by the same fate has
+    /// had one polling opportunity, then are discarded before the turn ends.
+    deferred_rejection_discards: RefCell<BTreeSet<TxId>>,
     queued_open_transaction_failures: RefCell<BTreeMap<OpenTransactionId, Error>>,
     reserved_mutations: RefCell<BTreeSet<TxId>>,
     pub(super) local_publication_settler: Rc<futures::lock::Mutex<()>>,
@@ -106,6 +110,7 @@ where
             queued_mutations: RefCell::new(VecDeque::new()),
             transaction_wait_observers: RefCell::new(Vec::new()),
             queued_mutation_failures: RefCell::new(BTreeMap::new()),
+            deferred_rejection_discards: RefCell::new(BTreeSet::new()),
             queued_open_transaction_failures: RefCell::new(BTreeMap::new()),
             reserved_mutations: RefCell::new(BTreeSet::new()),
             local_publication_settler: Rc::new(futures::lock::Mutex::new(())),
@@ -864,9 +869,50 @@ where
         let pending = self.mutation_errors.borrow_mut().pending.remove(&tx_id);
         let retained = self.node.borrow().rejected_transaction(tx_id).is_some();
         if retained {
-            self.node.lock().await.discard_rejection(tx_id).await?;
+            self.deferred_rejection_discards.borrow_mut().insert(tx_id);
+            self.schedule_tick(TickUrgency::Immediate);
         }
         Ok(pending.is_some() || retained)
+    }
+
+    /// Finish rejection acknowledgement after all wait observers woken by one
+    /// owner turn have had a chance to inspect the shared terminal state.
+    pub(super) async fn flush_deferred_rejection_discards(&self) -> Result<(), Error> {
+        let tx_ids = std::mem::take(&mut *self.deferred_rejection_discards.borrow_mut());
+        let mut first_error = None;
+        for tx_id in tx_ids {
+            if let Err(error) = self.node.lock().await.discard_rejection(tx_id).await {
+                self.deferred_rejection_discards.borrow_mut().insert(tx_id);
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+            }
+        }
+        if let Some(error) = first_error {
+            // A failed atomic Groove commit poisons this opened database. Do
+            // not convert its retained acknowledgement into an immediate tick
+            // loop: the caller must observe the error and reopen before this
+            // runtime can make durable progress again. Other errors are also
+            // retained, but have no generic retry-safety contract here, so a
+            // host may explicitly service a later owner turn without us
+            // spinning on an unknown storage failure.
+            if matches!(
+                error,
+                crate::node::Error::Groove(groove::db::Error::DatabasePoisoned)
+            ) {
+                tracing::error!(
+                    %error,
+                    "deferred mutation-error acknowledgement requires reopening the database"
+                );
+            } else {
+                tracing::warn!(
+                    %error,
+                    "deferred mutation-error acknowledgement retained for an explicit later retry"
+                );
+            }
+            return Err(error.into());
+        }
+        Ok(())
     }
 
     pub(super) async fn transaction_wait_outcome(
@@ -900,6 +946,34 @@ where
         }
     }
 
+    /// Read a transaction's wait predicate without claiming its rejection.
+    ///
+    /// A queued empty update may use an existing transaction as its bounded
+    /// completion target. That public request must observe the target's state,
+    /// but it is not an additional owner of the target's mutation-error
+    /// delivery: the target's own waiter or mutation-error callback retains
+    /// that responsibility.
+    async fn completion_target_wait_outcome(
+        &self,
+        public_tx_id: TxId,
+        target_tx_id: TxId,
+        tier: DurabilityTier,
+    ) -> Option<Result<TxId, Error>> {
+        let state = self.node.lock().await.transaction_state(target_tx_id).await;
+        let Some((fate, global_time, durability)) = state else {
+            return Some(Err(Error::new(
+                ErrorCode::NotObserved,
+                format!("completion target for transaction {public_tx_id:?} is not known locally"),
+            )));
+        };
+        let satisfied = transaction_satisfies_wait(&fate, global_time, durability, tier);
+        match fate {
+            Fate::Rejected(reason) => Some(Err(write_rejected(public_tx_id, reason))),
+            Fate::Pending | Fate::Accepted if satisfied => Some(Ok(public_tx_id)),
+            Fate::Pending | Fate::Accepted => None,
+        }
+    }
+
     pub(super) fn queued_mutation_write_state(
         &self,
         tx_id: TxId,
@@ -927,6 +1001,21 @@ where
         tier: DurabilityTier,
         callback: Box<dyn FnOnce(Result<TxId, Error>)>,
     ) {
+        self.wait_for_write_with(tx_id, None, tier, callback);
+    }
+
+    /// Callback wait for a binding-owned write handle. A queued empty update
+    /// reserves a request id before it can asynchronously discover that the
+    /// update is a no-op; its handle-local alias then points at the existing
+    /// transaction whose state satisfies this wait. The alias is retained by
+    /// the caller, never by this runtime.
+    pub(super) fn wait_for_write_with(
+        self: &Rc<Self>,
+        tx_id: TxId,
+        alias: Option<QueuedMutationAlias>,
+        tier: DurabilityTier,
+        callback: Box<dyn FnOnce(Result<TxId, Error>)>,
+    ) {
         if self.mutation_owner_lifecycle.get() == MutationOwnerLifecycle::Closing {
             callback(Err(Error::new(
                 ErrorCode::NotObserved,
@@ -938,9 +1027,77 @@ where
         self.transaction_wait_observers
             .borrow_mut()
             .push(Box::pin(async move {
-                callback(node.wait_for_transaction(tx_id, tier).await);
+                callback(node.wait_for_write(tx_id, alias, tier).await);
             }));
         self.schedule_tick(TickUrgency::Immediate);
+    }
+
+    async fn wait_for_write(
+        &self,
+        tx_id: TxId,
+        alias: Option<QueuedMutationAlias>,
+        tier: DurabilityTier,
+    ) -> Result<TxId, Error> {
+        let Some(alias) = alias else {
+            return self.wait_for_transaction(tx_id, tier).await;
+        };
+        loop {
+            let target_tx_id = { *alias.borrow() };
+            if let Some(target_tx_id) = target_tx_id {
+                return self
+                    .wait_for_completion_target(tx_id, target_tx_id, tier)
+                    .await;
+            }
+            if let Some(outcome) = self.transaction_wait_outcome(tx_id, tier).await {
+                return outcome;
+            }
+            if self.mutation_owner_lifecycle.get() == MutationOwnerLifecycle::Closing
+                && !self.reserved_mutations.borrow().contains(&tx_id)
+            {
+                return Err(Error::new(
+                    ErrorCode::NotObserved,
+                    format!("database closed before transaction {tx_id:?} reached {tier:?}"),
+                ));
+            }
+            let state_change = self.register_write_state_waiter(tx_id);
+            let target_tx_id = { *alias.borrow() };
+            if let Some(target_tx_id) = target_tx_id {
+                drop(state_change);
+                return self
+                    .wait_for_completion_target(tx_id, target_tx_id, tier)
+                    .await;
+            }
+            if let Some(outcome) = self.transaction_wait_outcome(tx_id, tier).await {
+                drop(state_change);
+                return outcome;
+            }
+            state_change.await;
+        }
+    }
+
+    async fn wait_for_completion_target(
+        &self,
+        public_tx_id: TxId,
+        target_tx_id: TxId,
+        tier: DurabilityTier,
+    ) -> Result<TxId, Error> {
+        loop {
+            if let Some(outcome) = self
+                .completion_target_wait_outcome(public_tx_id, target_tx_id, tier)
+                .await
+            {
+                return outcome;
+            }
+            let state_change = self.register_write_state_waiter(target_tx_id);
+            if let Some(outcome) = self
+                .completion_target_wait_outcome(public_tx_id, target_tx_id, tier)
+                .await
+            {
+                drop(state_change);
+                return outcome;
+            }
+            state_change.await;
+        }
     }
 
     pub(super) async fn wait_for_transaction(

--- a/crates/jazz/src/db/tests/mutations.rs
+++ b/crates/jazz/src/db/tests/mutations.rs
@@ -1597,6 +1597,210 @@ fn unhandled_rejection_is_delivered_as_mutation_error() {
     assert_eq!(events[0].transaction.kind, TransactionKind::Mergeable);
 }
 
+/// A queued empty root update validates its target asynchronously, but still
+/// exposes one stable reservation to the synchronous caller. Once validation
+/// completes, that reservation aliases the already-current row transaction;
+/// it must never manufacture a second row version or become unobservable.
+#[test]
+fn queued_empty_update_aliases_current_transaction_without_publishing() {
+    let schema = schema();
+    let author = AuthorSubject::for_test_bytes([0xc0; 16]);
+    let db = open_db(0xc0, author, &schema);
+    let row = row(0xc1);
+    crate::db::block_on(db.insert(
+        "todos",
+        cells("existing", false, author),
+        InsertOptions {
+            row_id: Some(row),
+            ..Default::default()
+        },
+    ))
+    .expect("seed current row");
+
+    let preceding = db
+        .enqueue_update(
+            "todos".to_owned(),
+            row,
+            cells("first queued update", false, author),
+            Default::default(),
+        )
+        .expect("queue a predecessor before the no-op");
+
+    let queued = db
+        .enqueue_update("todos".to_owned(), row, BTreeMap::new(), Default::default())
+        .expect("synchronous facade reserves an empty update");
+    let alias_weak = Rc::downgrade(
+        queued
+            .queued_alias
+            .as_ref()
+            .expect("empty queued update owns a handle-local completion alias"),
+    );
+    let reserved_tx_id = queued.mergeable_tx_id();
+    assert_ne!(
+        reserved_tx_id,
+        preceding.mergeable_tx_id(),
+        "reservation is a fresh request identity"
+    );
+    assert_eq!(
+        crate::db::block_on(queued.write_state())
+            .expect("pending queued write state")
+            .fate,
+        Fate::Pending
+    );
+    let waited = Rc::new(RefCell::new(None));
+    let waited_for_callback = Rc::clone(&waited);
+    db.wait_for_write_with(&queued, DurabilityTier::Local, move |outcome| {
+        *waited_for_callback.borrow_mut() = Some(outcome);
+    });
+    assert!(
+        waited.borrow().is_none(),
+        "a binding-owned wait remains pending until its queued update has been admitted"
+    );
+
+    db.drive_queued_mutation_once();
+    assert_eq!(
+        crate::db::block_on(queued.write_state())
+            .expect("no-op remains pending behind its FIFO predecessor")
+            .fate,
+        Fate::Pending,
+        "the no-op cannot observe or alias a row version before earlier queued work completes"
+    );
+
+    db.tick()
+        .expect("queued no-op validates its current target");
+    db.tick()
+        .expect("binding-owned wait observes the completed no-op target");
+
+    assert_eq!(
+        waited
+            .borrow_mut()
+            .take()
+            .expect("binding-owned wait resolves after the no-op target is known")
+            .expect("current transaction satisfies local durability"),
+        reserved_tx_id,
+        "binding wait preserves the queued request identity while observing its current target"
+    );
+
+    assert_eq!(
+        crate::db::block_on(queued.wait(DurabilityTier::Local))
+            .expect("the reservation resolves through the current transaction"),
+        reserved_tx_id,
+        "queued callers retain the request identity they were synchronously given"
+    );
+    assert_eq!(
+        crate::db::block_on(queued.write_state())
+            .expect("write handle follows the completed no-op alias"),
+        db.write_state(preceding.mergeable_tx_id())
+            .expect("current row transaction remains observable")
+    );
+    assert!(
+        db.write_state(reserved_tx_id).is_err(),
+        "a no-op reservation is not a durable node transaction; only its returned handle owns the completion alias"
+    );
+    let current_row = prepared_read(&db, &Query::from("todos"))
+        .into_iter()
+        .next()
+        .expect("one seeded row");
+    assert_eq!(
+        crate::db::block_on(db.node.node().borrow_mut().current_row_tx_id(&current_row))
+            .expect("current-row transaction lookup"),
+        preceding.mergeable_tx_id(),
+        "the empty update must not publish a new row version"
+    );
+    drop(queued);
+    assert!(
+        alias_weak.upgrade().is_none(),
+        "successful no-op aliases are retained only by their write handles"
+    );
+}
+
+/// A queued no-op can observe the still-pending current transaction at a
+/// stricter tier. Its synthetic request must report that rejection as its own,
+/// without consuming the current transaction's independently registered
+/// mutation-error ownership.
+#[test]
+fn queued_empty_update_rejection_does_not_consume_its_target_error() {
+    let schema = schema();
+    let author = AuthorSubject::for_test_bytes([0xc2; 16]);
+    let client = open_db(0xc2, author, &schema);
+    let (client_transport, mut authority_transport) = duplex();
+    let _upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let current = client
+        .insert(
+            "todos",
+            cells("pending current row", false, author),
+            Default::default(),
+        )
+        .expect("create the pending current transaction");
+    let target_tx_id = current.mergeable_tx_id();
+    let alias = client
+        .enqueue_update(
+            "todos".to_owned(),
+            current.row_uuid(),
+            BTreeMap::new(),
+            Default::default(),
+        )
+        .expect("queue empty update against pending current row");
+    let public_tx_id = alias.mergeable_tx_id();
+    client
+        .tick()
+        .expect("empty update resolves its completion target before the fate arrives");
+
+    let target_outcome = Rc::new(RefCell::new(None));
+    let target_callback = Rc::clone(&target_outcome);
+    client.wait_for_transaction_with(target_tx_id, DurabilityTier::Edge, move |outcome| {
+        *target_callback.borrow_mut() = Some(outcome);
+    });
+    let alias_outcome = Rc::new(RefCell::new(None));
+    let alias_callback = Rc::clone(&alias_outcome);
+    client.wait_for_write_with(&alias, DurabilityTier::Edge, move |outcome| {
+        *alias_callback.borrow_mut() = Some(outcome);
+    });
+    authority_transport
+        .send(SyncMessage::FateUpdate {
+            tx_id: target_tx_id,
+            fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+            global_time: None,
+            durability: Some(DurabilityTier::Edge),
+        })
+        .expect("authority fate reaches client");
+    client.tick().expect("fate settles both active observers");
+
+    let alias_error = alias_outcome
+        .borrow_mut()
+        .take()
+        .expect("aliased write observer resolves")
+        .expect_err("target rejection is surfaced through the alias");
+    assert_eq!(alias_error.code, ErrorCode::WriteRejected);
+    assert!(
+        alias_error.message.contains(&format!("{public_tx_id:?}")),
+        "the alias reports its public request identity"
+    );
+    assert!(
+        !alias_error.message.contains(&format!("{target_tx_id:?}")),
+        "the private completion target does not leak through the alias error"
+    );
+    let target_error = target_outcome
+        .borrow_mut()
+        .take()
+        .expect("target observer resolves independently")
+        .expect_err("target remains responsible for its own rejection");
+    assert_eq!(target_error.code, ErrorCode::WriteRejected);
+    assert!(
+        target_error.message.contains(&format!("{target_tx_id:?}")),
+        "the target observer retains its own transaction identity"
+    );
+    assert!(
+        client
+            .node
+            .node()
+            .borrow()
+            .rejected_transaction(target_tx_id)
+            .is_none(),
+        "the target observer, not the alias, consumed its mutation-error ownership"
+    );
+}
+
 /// A live application waiter consumes an authority rejection and prevents the
 /// fallback mutation-error callback from firing, including when the fate has
 /// no edge-forwarding route and only the ordinary local handler can notify it.
@@ -1797,6 +2001,90 @@ fn undelivered_mutation_error_is_recovered_after_reopen() {
     assert!(replayed_events.borrow().is_empty());
 }
 
+/// Close drains observers while durable storage is still live. A waiter which
+/// claims a rejection during that drain must acknowledge it immediately rather
+/// than leaving it to be replayed as an unhandled error after reopen.
+#[test]
+fn close_acknowledges_rejection_claimed_by_drained_waiter() {
+    let schema = schema();
+    let author = AuthorSubject::for_test_bytes([0xc4; 16]);
+    let identity = DbIdentity {
+        node: NodeUuid::from_bytes([0xc4; 16]),
+        author,
+    };
+    let dir = tempfile::tempdir().unwrap();
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let client = block_on(Db::open(DbConfig {
+        schema: schema.clone(),
+        storage: RocksDbStorage::open(dir.path(), &refs).expect("open durable client storage"),
+        identity,
+        id_source: Some(Box::new(SeededRowIdSource::new(0xc4))),
+    }))
+    .expect("open durable client");
+    let (client_transport, mut authority_transport) = duplex();
+    let upstream = block_on(client.connect_upstream(client_transport));
+    let write = client
+        .insert(
+            "todos",
+            cells("close-drained rejection", false, author),
+            Default::default(),
+        )
+        .expect("create pending write");
+    let tx_id = write.mergeable_tx_id();
+    authority_transport
+        .send(SyncMessage::FateUpdate {
+            tx_id,
+            fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+            global_time: None,
+            durability: Some(DurabilityTier::Edge),
+        })
+        .expect("authority fate reaches durable client");
+    client
+        .tick()
+        .expect("client persists the authority rejection");
+
+    let drained_outcome = Rc::new(RefCell::new(None));
+    let callback_outcome = Rc::clone(&drained_outcome);
+    client.wait_for_transaction_with(tx_id, DurabilityTier::Edge, move |outcome| {
+        *callback_outcome.borrow_mut() = Some(outcome);
+    });
+    drop(write);
+    drop(upstream);
+    drop(authority_transport);
+    block_on(client.close()).expect("close drains and acknowledges the waiter");
+    assert_eq!(
+        drained_outcome
+            .borrow_mut()
+            .take()
+            .expect("close drained the waiting observer")
+            .expect_err("the drained waiter sees the stored rejection")
+            .code,
+        ErrorCode::WriteRejected
+    );
+    drop(client);
+
+    let reopened = block_on(Db::open(DbConfig {
+        schema,
+        storage: RocksDbStorage::open(dir.path(), &refs).expect("reopen durable client storage"),
+        identity,
+        id_source: Some(Box::new(SeededRowIdSource::new(0xc4))),
+    }))
+    .expect("reopen durable client");
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let callback_events = Rc::clone(&events);
+    reopened.on_mutation_error(Rc::new(move |event| {
+        callback_events.borrow_mut().push(event.clone());
+    }));
+    reopened
+        .tick()
+        .expect("reopened client services pending errors");
+    assert!(
+        events.borrow().is_empty(),
+        "the close-drained rejection was acknowledged exactly once before storage closed"
+    );
+}
+
 #[test]
 fn write_fate_and_durability_are_queryable_through_facade() {
     let schema = schema();
@@ -1883,6 +2171,7 @@ fn session_upload_rejects_forged_made_by_without_ingesting_rows() {
         tx_id,
         local_tier: DurabilityTier::Local,
         queued_status: None,
+        queued_alias: None,
     };
     let err = block_on(handle.wait(DurabilityTier::Global)).unwrap_err();
     assert_eq!(err.code, ErrorCode::WriteRejected);

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -77,6 +77,191 @@ fn reopened_wait_observer_yields_instead_of_sync_polling_cold_storage() {
     assert_eq!(observed.borrow_mut().take().unwrap().unwrap(), tx_id);
 }
 
+/// A failed durable acknowledgement remains retained, but a poisoned database
+/// must surface the terminal tick instead of hot-looping a scheduler forever.
+#[test]
+fn deferred_rejection_acknowledgement_failure_requires_explicit_reopen_without_hot_loop() {
+    let schema = schema();
+    let author = AuthorSubject::for_test_bytes([0xca; 16]);
+    let families = schema.column_families();
+    let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = TestStorage::controlled(&refs);
+    let db = block_on(Db::open(DbConfig {
+        schema,
+        storage,
+        identity: DbIdentity {
+            node: NodeUuid::from_bytes([0xca; 16]),
+            author,
+        },
+        id_source: Some(Box::new(SeededRowIdSource::new(0xca))),
+    }))
+    .expect("open controlled rejection fixture");
+    let (client_transport, mut authority_transport) = duplex();
+    let _upstream = block_on(db.connect_upstream(client_transport));
+    let write = db
+        .insert(
+            "todos",
+            cells("retry deferred acknowledgement", false, author),
+            Default::default(),
+        )
+        .expect("create pending write");
+    let tx_id = write.mergeable_tx_id();
+    authority_transport
+        .send(SyncMessage::FateUpdate {
+            tx_id,
+            fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+            global_time: None,
+            durability: Some(DurabilityTier::Edge),
+        })
+        .expect("authority fate reaches fixture");
+    db.tick().expect("persist authority rejection");
+
+    let outcome = Rc::new(RefCell::new(None));
+    let callback = Rc::clone(&outcome);
+    db.wait_for_transaction_with(tx_id, DurabilityTier::Edge, move |result| {
+        *callback.borrow_mut() = Some(result);
+    });
+    let scheduler = Rc::new(RecordingScheduler::default());
+    db.set_tick_scheduler(Some(scheduler.clone()));
+    control.take_observed();
+    scheduler.take();
+    control.fail_next(TestStorageOperation::WriteMany);
+    let error = db
+        .tick()
+        .expect_err("failed acknowledgement surfaces through the owner tick");
+    assert!(
+        error.to_string().contains("injected WriteMany failure"),
+        "the original acknowledgement failure is not hidden"
+    );
+    assert_eq!(
+        outcome
+            .borrow_mut()
+            .take()
+            .expect("waiter observes rejection")
+            .expect_err("rejected write")
+            .code,
+        ErrorCode::WriteRejected
+    );
+    assert!(
+        db.node
+            .node()
+            .borrow()
+            .rejected_transaction(tx_id)
+            .is_some(),
+        "failed acknowledgement remains retained until a reopened database can acknowledge it"
+    );
+
+    let first_attempts = control
+        .take_observed()
+        .iter()
+        .filter(|operation| **operation == TestStorageOperation::WriteMany)
+        .count();
+    assert!(
+        first_attempts > 0,
+        "the first owner turn attempted the durable acknowledgement"
+    );
+    assert_eq!(
+        scheduler.take(),
+        vec![TickUrgency::Immediate],
+        "the only wake is the waiter completion scheduled before its acknowledgement fails"
+    );
+    let error = db
+        .tick()
+        .expect_err("a poisoned database remains terminal until reopened");
+    assert!(
+        error.to_string().contains("poisoned"),
+        "the later explicit tick makes the reopen requirement visible"
+    );
+    assert!(
+        scheduler.take().is_empty(),
+        "a permanently poisoned acknowledgement cannot create an owner-turn hot loop"
+    );
+    assert!(
+        db.node
+            .node()
+            .borrow()
+            .rejected_transaction(tx_id)
+            .is_some(),
+        "an indeterminate atomic-write failure never loses the rejected transaction"
+    );
+}
+
+/// Close must fail before writing its clean-close marker when a drained
+/// waiter cannot durably acknowledge a rejection.
+#[test]
+fn close_fails_before_clean_marker_when_rejection_acknowledgement_fails() {
+    let schema = schema();
+    let author = AuthorSubject::for_test_bytes([0xcb; 16]);
+    let families = schema.column_families();
+    let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = TestStorage::controlled(&refs);
+    let db = block_on(Db::open(DbConfig {
+        schema,
+        storage,
+        identity: DbIdentity {
+            node: NodeUuid::from_bytes([0xcb; 16]),
+            author,
+        },
+        id_source: Some(Box::new(SeededRowIdSource::new(0xcb))),
+    }))
+    .expect("open controlled close fixture");
+    let (client_transport, mut authority_transport) = duplex();
+    let _upstream = block_on(db.connect_upstream(client_transport));
+    let write = db
+        .insert(
+            "todos",
+            cells("close failed acknowledgement", false, author),
+            Default::default(),
+        )
+        .expect("create pending write");
+    let tx_id = write.mergeable_tx_id();
+    authority_transport
+        .send(SyncMessage::FateUpdate {
+            tx_id,
+            fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+            global_time: None,
+            durability: Some(DurabilityTier::Edge),
+        })
+        .expect("authority fate reaches fixture");
+    db.tick().expect("persist authority rejection");
+
+    let outcome = Rc::new(RefCell::new(None));
+    let callback = Rc::clone(&outcome);
+    db.wait_for_transaction_with(tx_id, DurabilityTier::Edge, move |result| {
+        *callback.borrow_mut() = Some(result);
+    });
+    control.take_observed();
+    control.fail_next(TestStorageOperation::WriteMany);
+    let error = block_on(db.close()).expect_err("close propagates acknowledgement failure");
+    assert!(
+        error.to_string().contains("injected WriteMany failure"),
+        "close exposes the durable acknowledgement failure"
+    );
+    assert_eq!(
+        outcome
+            .borrow_mut()
+            .take()
+            .expect("close drains the waiter")
+            .expect_err("drained waiter observes rejection")
+            .code,
+        ErrorCode::WriteRejected
+    );
+    assert!(
+        db.node
+            .node()
+            .borrow()
+            .rejected_transaction(tx_id)
+            .is_some(),
+        "failed close retains the rejection for an explicit retry"
+    );
+    assert!(
+        !control
+            .take_observed()
+            .contains(&TestStorageOperation::Close),
+        "failed acknowledgement prevents storage close and its clean-close marker"
+    );
+}
+
 #[test]
 fn large_write_pushes_staging_before_syncing_its_referencing_row() {
     let schema = schema();

--- a/crates/jazz/src/db/tests/support.rs
+++ b/crates/jazz/src/db/tests/support.rs
@@ -1867,6 +1867,7 @@ impl CoreDb {
             tx_id,
             local_tier: DurabilityTier::Global,
             queued_status: None,
+            queued_alias: None,
         })
     }
 
@@ -1896,6 +1897,7 @@ impl CoreDb {
             tx_id,
             local_tier: DurabilityTier::Global,
             queued_status: None,
+            queued_alias: None,
         })
     }
 
@@ -1950,6 +1952,7 @@ impl CoreDb {
             tx_id,
             local_tier: DurabilityTier::Global,
             queued_status: None,
+            queued_alias: None,
         })
     }
 
@@ -2010,6 +2013,7 @@ impl CoreDb {
             tx_id,
             local_tier: DurabilityTier::Global,
             queued_status: None,
+            queued_alias: None,
         })
     }
 

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -671,7 +671,7 @@ where
                 Ok(())
             }),
         );
-        Ok(self.queued_write_handle(RowUuid::from_bytes([0; 16]), tx_id, status))
+        Ok(self.queued_write_handle(RowUuid::from_bytes([0; 16]), tx_id, status, None))
     }
 
     /// Abandon an owned open transaction handle.
@@ -1325,7 +1325,7 @@ where
                 Ok(())
             }),
         );
-        Ok(self.queued_write_handle(RowUuid::from_bytes([0; 16]), tx_id, status))
+        Ok(self.queued_write_handle(RowUuid::from_bytes([0; 16]), tx_id, status, None))
     }
 
     /// Commit an owned exclusive transaction as an explicit policy identity.


### PR DESCRIPTION
🤖 Preserves the public identity and settlement semantics of queued empty updates without publishing a fake row version or retaining unbounded alias state.

Before:
- A synchronous queued update reserves request transaction A.
- If its validated patch is empty, the direct mutation correctly returns the row's existing transaction B.
- The queue asserted A == B and panicked.
- Naive fixes either leaked an A→B map forever, lost the alias at NAPI/WASM boundaries, stole B's rejection, or hot-looped after durable acknowledgement failure.

After:
- The queued `WriteHandle` keeps stable public identity A and a bounded completion target that may resolve to B.
- NAPI/WASM write wrappers retain that handle; `writeState` and `wait` observe B while reporting A.
- No row version is published and direct `Db::write_state(A)` remains `NotObserved`, because A is not a durable transaction.
- Alias lifetime ends with the handle/wrapper; no runtime-global map exists.
- Waiting A observes B's rejection without consuming B's callback/error ownership.
- Durable rejection acknowledgements are flushed before clean close; failures are retained and surfaced.
- A poisoned Groove database requires reopen and does not schedule an infinite owner-turn retry loop.

Example: queue `update(id, {})` behind another write. Its handle is initially pending under A, then settles by observing current row transaction B. The row history remains unchanged. If B is rejected, B's observer sees B and A's observer sees A exactly once.

Verified across core FIFO/history/lifetime, both observer orders, durable close/reopen and injected storage failure, NAPI/WASM wrappers, and planted retention/reschedule regressions. Seven adversarial review cycles completed.