### PR TITLE
test(jazz-tools): await recursive permission setup

### DIFF
--- a/packages/jazz-tools/src/runtime/permissions.repro.test.ts
+++ b/packages/jazz-tools/src/runtime/permissions.repro.test.ts
@@ -574,32 +574,53 @@ describe("runtime permission repros for recursive gather and qualified predicate
     });
 
     const db = context.db(doubleRefReproApp);
-    const { value: userTeam } = db.insert(
-      doubleRefReproApp.teams,
-      { name: "User" },
-      { id: userTeamId },
-    );
-    const { value: directTeam } = db.insert(doubleRefReproApp.teams, { name: "Direct" });
-    const { value: nestedTeam } = db.insert(doubleRefReproApp.teams, { name: "Nested" });
-    const { value: dropdown } = db.insert(doubleRefReproApp.dropdowns, { name: "Visible" });
-    db.insert(doubleRefReproApp.team_entry, {
-      team_id: userTeam.id,
-      target_id: directTeam.id,
-      user_id: reproUser(userTeam.id),
-      administrator: false,
-    });
-    db.insert(doubleRefReproApp.team_entry, {
-      team_id: directTeam.id,
-      target_id: nestedTeam.id,
-      user_id: reproUser("unused"),
-      administrator: false,
-    });
-    db.insert(doubleRefReproApp.dropdowns_access_edges, {
-      resource_id: dropdown.id,
-      team_id: nestedTeam.id,
-      grant_role: "viewer",
-      administrator: false,
-    });
+    const userTeam = await db
+      .insert(doubleRefReproApp.teams, { name: "User" }, { id: userTeamId })
+      .wait({ tier: "local" });
+    const directTeam = await db
+      .insert(doubleRefReproApp.teams, { name: "Direct" })
+      .wait({ tier: "local" });
+    const nestedTeam = await db
+      .insert(doubleRefReproApp.teams, { name: "Nested" })
+      .wait({ tier: "local" });
+    const dropdown = await db
+      .insert(doubleRefReproApp.dropdowns, { name: "Visible" })
+      .wait({ tier: "local" });
+    const sourceOnlyDropdown = await db
+      .insert(doubleRefReproApp.dropdowns, { name: "Not reachable through target_id" })
+      .wait({ tier: "local" });
+    await db
+      .insert(doubleRefReproApp.team_entry, {
+        team_id: userTeam.id,
+        target_id: directTeam.id,
+        user_id: reproUser(userTeam.id),
+        administrator: false,
+      })
+      .wait({ tier: "local" });
+    await db
+      .insert(doubleRefReproApp.team_entry, {
+        team_id: directTeam.id,
+        target_id: nestedTeam.id,
+        user_id: reproUser("unused"),
+        administrator: false,
+      })
+      .wait({ tier: "local" });
+    await db
+      .insert(doubleRefReproApp.dropdowns_access_edges, {
+        resource_id: dropdown.id,
+        team_id: nestedTeam.id,
+        grant_role: "viewer",
+        administrator: false,
+      })
+      .wait({ tier: "local" });
+    await db
+      .insert(doubleRefReproApp.dropdowns_access_edges, {
+        resource_id: sourceOnlyDropdown.id,
+        team_id: userTeam.id,
+        grant_role: "viewer",
+        administrator: false,
+      })
+      .wait({ tier: "local" });
 
     const userDb = context.forSession(
       {


### PR DESCRIPTION
🤖 Repairs the recursive same-table double-reference permission receipt without changing permission lowering.

Before:
- The test enqueued all trusted setup writes and immediately queried from an untrusted session.
- After async mutation persistence, even the trusted setup read could still see an empty database.
- The resulting failure looked like a `team_id` versus `target_id` gather-lowering bug.

After:
- Setup writes await local settlement before the authorization query starts.
- The untrusted query and policy path are unchanged.
- A source-only negative row proves the recursive gather cannot accidentally follow the wrong same-table reference.

Example: the seed projects `team_entry.target_id` for the authenticated user, while recursion follows the `team_id` frontier. The intended target is visible; a row reachable only through the source-side reference remains hidden.

Verified by the full permission repro suite (4 pass, 1 expected failure), exact sealed artifacts, and planted wrong-seed/wrong-frontier regressions.