### PR TITLE
fix(examples): use canonical chat policy identities

### DIFF
--- a/examples/chat-react/tests/permissions/permissions.test.ts
+++ b/examples/chat-react/tests/permissions/permissions.test.ts
@@ -1,9 +1,18 @@
+import { userIdentity } from "jazz-tools";
 import { createPolicyTestApp, type PolicyTestApp } from "jazz-tools/testing";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "../../schema.js";
 import permissions from "../../permissions.js";
 
 let testApp: PolicyTestApp;
+const issuer = "https://chat.example";
+const alice = userIdentity(issuer, "alice");
+const bob = userIdentity(issuer, "bob");
+const carol = userIdentity(issuer, "carol");
+
+function externalSession(user_id: string, claims: Record<string, unknown> = {}) {
+  return { issuer, user_id, claims, authMode: "external" as const };
+}
 
 beforeEach(async () => {
   testApp = await createPolicyTestApp(app, permissions, expect);
@@ -25,17 +34,13 @@ describe("chat permissions", () => {
     await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
-        userId: "alice",
+        userId: alice,
         joinCode: "invite-123",
       }),
     );
 
-    const bobWithoutClaim = testApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
-    const bobWithClaim = testApp.as({
-      user_id: "bob",
-      claims: { join_code: "invite-123" },
-      authMode: "local-first",
-    });
+    const bobWithoutClaim = testApp.as(externalSession("bob"));
+    const bobWithClaim = testApp.as(externalSession("bob", { join_code: "invite-123" }));
 
     await expect(bobWithoutClaim.all(app.chats.where({ id: privateChat.id }))).resolves.toEqual([]);
     await expect(bobWithClaim.all(app.chats.where({ id: privateChat.id }))).resolves.toEqual([
@@ -46,7 +51,7 @@ describe("chat permissions", () => {
   it("allows chat name updates", async () => {
     await testApp.seed((db) =>
       db.insert(app.profiles, {
-        userId: "alice",
+        userId: alice,
         name: "Alice",
       }),
     );
@@ -60,12 +65,12 @@ describe("chat permissions", () => {
     await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
-        userId: "alice",
+        userId: alice,
         joinCode: "invite-456",
       }),
     );
 
-    const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+    const aliceDb = testApp.as(externalSession("alice"));
 
     aliceDb.expectAllowed((db) =>
       db.update(app.chats, privateChat.id, {
@@ -77,7 +82,7 @@ describe("chat permissions", () => {
   it("does not allow isPublic updates", async () => {
     await testApp.seed((db) =>
       db.insert(app.profiles, {
-        userId: "alice",
+        userId: alice,
         name: "Alice",
       }),
     );
@@ -91,12 +96,12 @@ describe("chat permissions", () => {
     await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
-        userId: "alice",
+        userId: alice,
         joinCode: "invite-456",
       }),
     );
 
-    const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+    const aliceDb = testApp.as(externalSession("alice"));
 
     await aliceDb.expectDenied((db) =>
       db.update(app.chats, privateChat.id, {
@@ -105,16 +110,36 @@ describe("chat permissions", () => {
     );
   });
 
+  it("does not treat a raw subject fixture as the authenticated identity", async () => {
+    const privateChat = await testApp.seed((db) =>
+      db.insert(app.chats, {
+        name: "Canonical identities only",
+        isPublic: false,
+        joinCode: "invite-canonical",
+      }),
+    );
+    await testApp.seed((db) =>
+      db.insert(app.chatMembers, {
+        chatId: privateChat.id,
+        userId: "alice",
+        joinCode: "invite-canonical",
+      }),
+    );
+
+    const aliceDb = testApp.as(externalSession("alice"));
+    await expect(aliceDb.all(app.chats.where({ id: privateChat.id }))).resolves.toEqual([]);
+  });
+
   it("allows message inserts only for chat members", async () => {
     const aliceProfile = await testApp.seed((db) =>
       db.insert(app.profiles, {
-        userId: "alice",
+        userId: alice,
         name: "Alice",
       }),
     );
     const bobProfile = await testApp.seed((db) =>
       db.insert(app.profiles, {
-        userId: "bob",
+        userId: bob,
         name: "Bob",
       }),
     );
@@ -128,13 +153,13 @@ describe("chat permissions", () => {
     await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
-        userId: "alice",
+        userId: alice,
         joinCode: "invite-456",
       }),
     );
 
-    const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
-    const bobDb = testApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
+    const aliceDb = testApp.as(externalSession("alice"));
+    const bobDb = testApp.as(externalSession("bob"));
 
     aliceDb.expectAllowed((db) =>
       db.insert(app.messages, {
@@ -155,7 +180,7 @@ describe("chat permissions", () => {
     await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
-        userId: "bob",
+        userId: bob,
         joinCode: "invite-456",
       }),
     );
@@ -172,13 +197,13 @@ describe("chat permissions", () => {
   it("binds message attribution to the authenticated user's profile", async () => {
     const aliceProfile = await testApp.seed((db) =>
       db.insert(app.profiles, {
-        userId: "alice",
+        userId: alice,
         name: "Alice",
       }),
     );
     const bobProfile = await testApp.seed((db) =>
       db.insert(app.profiles, {
-        userId: "bob",
+        userId: bob,
         name: "Bob",
       }),
     );
@@ -192,12 +217,12 @@ describe("chat permissions", () => {
     await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: chat.id,
-        userId: "alice",
+        userId: alice,
         joinCode: "invite-authors",
       }),
     );
 
-    const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+    const aliceDb = testApp.as(externalSession("alice"));
 
     aliceDb.expectAllowed((db) =>
       db.insert(app.messages, {
@@ -218,7 +243,7 @@ describe("chat permissions", () => {
   it("binds reaction attribution to the authenticated user", async () => {
     const aliceProfile = await testApp.seed((db) =>
       db.insert(app.profiles, {
-        userId: "alice",
+        userId: alice,
         name: "Alice",
       }),
     );
@@ -232,7 +257,7 @@ describe("chat permissions", () => {
     await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: chat.id,
-        userId: "alice",
+        userId: alice,
         joinCode: "invite-reactions",
       }),
     );
@@ -244,19 +269,19 @@ describe("chat permissions", () => {
       }),
     );
 
-    const aliceDb = testApp.as({ user_id: "alice", claims: {}, authMode: "local-first" });
+    const aliceDb = testApp.as(externalSession("alice"));
 
     aliceDb.expectAllowed((db) =>
       db.insert(app.reactions, {
         messageId: message.id,
-        userId: "alice",
+        userId: alice,
         emoji: "thumbs-up",
       }),
     );
     await aliceDb.expectDenied((db) =>
       db.insert(app.reactions, {
         messageId: message.id,
-        userId: "bob",
+        userId: bob,
         emoji: "fire",
       }),
     );
@@ -265,7 +290,7 @@ describe("chat permissions", () => {
   it("inherits reaction reads from the parent message/chat chain", async () => {
     const aliceProfile = await testApp.seed((db) =>
       db.insert(app.profiles, {
-        userId: "alice",
+        userId: alice,
         name: "Alice",
       }),
     );
@@ -279,14 +304,14 @@ describe("chat permissions", () => {
     await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
-        userId: "alice",
+        userId: alice,
         joinCode: "invite-789",
       }),
     );
     await testApp.seed((db) =>
       db.insert(app.chatMembers, {
         chatId: privateChat.id,
-        userId: "bob",
+        userId: bob,
         joinCode: "invite-789",
       }),
     );
@@ -300,13 +325,13 @@ describe("chat permissions", () => {
     const reaction = await testApp.seed((db) =>
       db.insert(app.reactions, {
         messageId: message.id,
-        userId: "alice",
+        userId: alice,
         emoji: "fire",
       }),
     );
 
-    const bobDb = testApp.as({ user_id: "bob", claims: {}, authMode: "local-first" });
-    const carolDb = testApp.as({ user_id: "carol", claims: {}, authMode: "local-first" });
+    const bobDb = testApp.as(externalSession("bob"));
+    const carolDb = testApp.as(externalSession("carol"));
 
     await expect(bobDb.all(app.reactions.where({ id: reaction.id }))).resolves.toEqual([
       expect.objectContaining({ id: reaction.id, emoji: "fire" }),


### PR DESCRIPTION
🤖 Updates the Chat example's policy receipts to use Jazz's canonical external
session identity rather than treating a raw JWT subject as a user identity.

Before this change, the documented example constructed test sessions without
an issuer and stored raw values such as `"alice"` in policy membership rows.
Current Jazz identities are canonical `[issuer, sub]` values, so the receipt
failed before reaching its intended permission assertions.

After this change:

- every external test session has an explicit issuer;
- stored policy identities use the public `userIdentity(issuer, subject)` helper;
- the same canonical value is exposed as `session.user`;
- a negative receipt proves raw `"alice"` does not authorize canonical external
  Alice.

Example: Alice authenticated by `https://chat.example` is represented by the
canonical encoding of that issuer plus subject. Alice from another issuer, or
the bare string `"alice"`, is a different identity and receives no membership.

Verification:

- Chat policy unit receipt: 8/8 passed;
- production build passed;
- issuer-substitution and raw/canonical planted mutations failed their intended
  authorization assertions;
- independently reviewed with no production runtime changes found.

This PR changes example tests only.
