### PR TITLE
test(band-chat): seal focused browser artifact consumer

### DIFF
--- a/examples/band-chat/apps/nextjs-betterauth/scripts/test-browser-focused.mjs
+++ b/examples/band-chat/apps/nextjs-betterauth/scripts/test-browser-focused.mjs
@@ -2,12 +2,13 @@
 import { spawnSync } from "node:child_process";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 import { realpathSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 function isInsideBrowserRoot(fileRelative) {
   return !isAbsolute(fileRelative) && fileRelative !== ".." && !fileRelative.startsWith(`..${sep}`);
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const positional = argv.filter((arg) => arg !== "--");
   if (positional.length !== 1) throw new Error("expected exactly one browser test file");
   const browserRoot = realpathSync(resolve("tests/browser"));
@@ -26,26 +27,30 @@ function parseArgs(argv) {
   return file;
 }
 
-try {
-  const file = parseArgs(process.argv.slice(2));
-  const result = spawnSync(
+export function run(argv, spawn = spawnSync) {
+  const file = parseArgs(argv);
+  const result = spawn(
     "node",
     [
       "../../../../dev/gates/run-correctness-consumer.mjs",
       "--",
-      "pnpm",
-      "exec",
-      "vitest",
-      "run",
-      "--config",
-      "vitest.config.browser.ts",
+      "bash",
+      "-c",
+      'pnpm --filter jazz-tools build && pnpm exec vitest run --config vitest.config.browser.ts "$1"',
+      "--",
       file,
     ],
     { stdio: "inherit" },
   );
-  process.exitCode = result.status ?? 1;
-} catch (error) {
-  console.error(`Focused browser test: ${error.message}`);
-  console.error("Usage: pnpm test:browser:focused -- tests/browser/file.test.tsx");
-  process.exitCode = 2;
+  return result.status ?? 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    process.exitCode = run(process.argv.slice(2));
+  } catch (error) {
+    console.error(`Focused browser test: ${error.message}`);
+    console.error("Usage: pnpm test:browser:focused -- tests/browser/file.test.tsx");
+    process.exitCode = 2;
+  }
 }

--- a/examples/band-chat/apps/nextjs-betterauth/tests/test-selection.test.mjs
+++ b/examples/band-chat/apps/nextjs-betterauth/tests/test-selection.test.mjs
@@ -4,9 +4,14 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import packageJson from "../package.json" with { type: "json" };
+import { run } from "../scripts/test-browser-focused.mjs";
 
 const cwd = fileURLToPath(new URL("..", import.meta.url));
 const browserConfig = readFileSync(path.join(cwd, "vitest.config.browser.ts"), "utf8");
+const focusedBrowserRunner = readFileSync(
+  path.join(cwd, "scripts/test-browser-focused.mjs"),
+  "utf8",
+);
 
 test("the Node package gate excludes browser-only topology receipts", () => {
   assert.match(packageJson.scripts.test, /test:permissions/);
@@ -25,4 +30,31 @@ test("the topology browser project provides the complete Jazz server command con
   ]) {
     assert.match(browserConfig, new RegExp(`\\b${command}\\s*:`));
   }
+});
+
+test("the focused browser receipt builds and tests in one admitted consumer process tree", () => {
+  const calls = [];
+  const file = path.join(cwd, "tests/browser/topology.e2e.test.tsx");
+  assert.equal(
+    run([file], (command, args) => {
+      calls.push({ command, args });
+      return { status: 0 };
+    }),
+    0,
+  );
+  assert.deepEqual(calls, [
+    {
+      command: "node",
+      args: [
+        "../../../../dev/gates/run-correctness-consumer.mjs",
+        "--",
+        "bash",
+        "-c",
+        'pnpm --filter jazz-tools build && pnpm exec vitest run --config vitest.config.browser.ts "$1"',
+        "--",
+        file,
+      ],
+    },
+  ]);
+  assert.match(focusedBrowserRunner, /run-correctness-consumer\.mjs/);
 });


### PR DESCRIPTION
🤖 Ensures BandChat’s focused browser receipt builds `jazz-tools` and runs Vitest inside one sealed correctness-artifact consumer.

Before: the focused receipt could build against one admitted artifact snapshot and start its tests under another, allowing stale generated expectations in `jazz-tools/dist` to escape the intended provenance boundary.

After: one outer consumer admits a single immutable snapshot, then runs the tools build followed by the focused Vitest target in the same child process tree. Both phases inherit the same private capability, and the outer postflight verifies that snapshot after testing completes.

Example: if the producer receipt changes between the build and test phases, the single outer postflight rejects the run. Splitting the phases into separate consumers, omitting the build, or reversing their order is caught by the executable selection receipt.

Verification:
- BandChat selection receipt: 3/3
- Artifact-store contracts: 14/14, including snapshot mutation rejection
- Real focused BandChat topology: 2/2
- Independent adversarial review planted split, omitted-build, and reordered variants; each failed as intended

This changes test execution only; application/runtime semantics are unchanged.