### PR TITLE
fix(create-jazz): bind previews to immutable commits

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -98,6 +98,13 @@ jobs:
             packages/jazz-tools/bin/native/jazz-tools-linux-arm64 \
             packages/jazz-tools/bin/native/jazz-tools-linux-x64
 
+      - name: Bind create-jazz preview to this immutable commit
+        env:
+          PREVIEW_COMMIT: ${{ github.event.pull_request.head.sha }}
+        run: |
+          CREATE_JAZZ_VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/create-jazz/package.json","utf8")).version')
+          CREATE_JAZZ_VERSION="${CREATE_JAZZ_VERSION}" node -e 'const fs=require("fs");const commit=process.env.PREVIEW_COMMIT;const version=process.env.CREATE_JAZZ_VERSION;if(!/^[a-f0-9]{40}$/.test(commit))throw new Error(`invalid preview commit: ${commit}`);fs.writeFileSync("packages/create-jazz/jazz-source-snapshot.json",`${JSON.stringify({schema:1,packageVersion:version,commit},null,2)}\n`);'
+
       - name: Publish to pkg.pr.new
         run: |
           pnpm exec pkg-pr-new publish \

--- a/packages/create-jazz/package.json
+++ b/packages/create-jazz/package.json
@@ -9,6 +9,7 @@
   "files": [
     "bin/**",
     "dist/**",
+    "jazz-source-snapshot.json",
     "skills/**",
     "README.md"
   ],

--- a/packages/create-jazz/src/release-config.test.ts
+++ b/packages/create-jazz/src/release-config.test.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { parse as parseYaml } from "yaml";
@@ -43,6 +45,50 @@ describe("release config", () => {
     expect(step?.run).toContain("jazz-source-snapshot.json");
     expect(step?.run).toContain("schema:1");
   });
+
+  it("packs and loads the bundled preview source snapshot as an adopter would", () => {
+    const fixture = fs.mkdtempSync(path.join(tmpdir(), "create-jazz-preview-pack-"));
+    const packageDir = path.join(fixture, "create-jazz");
+    const packed = path.join(fixture, "packed");
+    const extracted = path.join(fixture, "extracted");
+    try {
+      fs.cpSync(path.join(repoRoot, "packages", "create-jazz"), packageDir, {
+        recursive: true,
+        filter: (source) => !source.includes(`${path.sep}node_modules`),
+      });
+      fs.copyFileSync(
+        path.join(repoRoot, "pnpm-workspace.yaml"),
+        path.join(fixture, "pnpm-workspace.yaml"),
+      );
+      const version = JSON.parse(
+        fs.readFileSync(path.join(packageDir, "package.json"), "utf8"),
+      ).version;
+      fs.writeFileSync(
+        path.join(packageDir, "jazz-source-snapshot.json"),
+        `${JSON.stringify({ schema: 1, packageVersion: version, commit: "a".repeat(40) })}\n`,
+      );
+      fs.mkdirSync(packed);
+      fs.mkdirSync(extracted);
+      execFileSync("pnpm", ["pack", "--pack-destination", packed], { cwd: packageDir });
+      const tarball = fs.readdirSync(packed).find((file) => file.endsWith(".tgz"));
+      expect(tarball).toBeDefined();
+      if (!tarball) throw new Error("create-jazz pack did not produce a tarball");
+      execFileSync("tar", ["-xzf", path.join(packed, tarball!), "-C", extracted]);
+      expect(
+        JSON.parse(
+          fs.readFileSync(path.join(extracted, "package/jazz-source-snapshot.json"), "utf8"),
+        ),
+      ).toEqual({ schema: 1, packageVersion: version, commit: "a".repeat(40) });
+      execFileSync("npm", ["install", "--ignore-scripts", "--no-package-lock", "--omit=dev"], {
+        cwd: path.join(extracted, "package"),
+      });
+      execFileSync(process.execPath, ["--input-type=module", "-e", 'import("./dist/index.js")'], {
+        cwd: path.join(extracted, "package"),
+      });
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  }, 30_000);
 
   it("establishes the exact source tag before publishing any package", () => {
     const workflow = parseYaml(

--- a/packages/create-jazz/src/release-config.test.ts
+++ b/packages/create-jazz/src/release-config.test.ts
@@ -15,16 +15,33 @@ describe("release config", () => {
     ) as { initialVersions?: Record<string, string> };
     const createJazzPackage = JSON.parse(
       fs.readFileSync(path.join(repoRoot, "packages", "create-jazz", "package.json"), "utf8"),
-    ) as { version?: string };
+    ) as { version?: string; files?: string[] };
 
     const jazzFixedGroup = ["jazz-tools", "jazz-wasm", "jazz-napi", "jazz-rn", "create-jazz"];
 
     expect(config.fixed).toContainEqual(jazzFixedGroup);
     expect(createJazzPackage.version).toMatch(/^2\.0\.0-alpha\./);
+    expect(createJazzPackage.files).toContain("jazz-source-snapshot.json");
 
     for (const packageName of jazzFixedGroup) {
       expect(preState.initialVersions?.[packageName]).toBe("2.0.0-alpha.6");
     }
+  });
+
+  it("binds pkg.pr.new create-jazz packages to the pull request head commit", () => {
+    const workflow = parseYaml(
+      fs.readFileSync(path.join(repoRoot, ".github", "workflows", "preview-build.yml"), "utf8"),
+    ) as {
+      jobs: {
+        "publish-pkg-pr-new": { steps: Array<{ name?: string; run?: string; env?: unknown }> };
+      };
+    };
+    const step = workflow.jobs["publish-pkg-pr-new"].steps.find(
+      (candidate) => candidate.name === "Bind create-jazz preview to this immutable commit",
+    );
+    expect(step?.env).toEqual({ PREVIEW_COMMIT: "${{ github.event.pull_request.head.sha }}" });
+    expect(step?.run).toContain("jazz-source-snapshot.json");
+    expect(step?.run).toContain("schema:1");
   });
 
   it("establishes the exact source tag before publishing any package", () => {

--- a/packages/create-jazz/src/release-config.test.ts
+++ b/packages/create-jazz/src/release-config.test.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -46,12 +46,13 @@ describe("release config", () => {
     expect(step?.run).toContain("schema:1");
   });
 
-  it("packs and loads the bundled preview source snapshot as an adopter would", () => {
+  it("packs and runs the production CLI fail-closed for invalid preview receipts", () => {
     const fixture = fs.mkdtempSync(path.join(tmpdir(), "create-jazz-preview-pack-"));
     const packageDir = path.join(fixture, "create-jazz");
     const packed = path.join(fixture, "packed");
     const extracted = path.join(fixture, "extracted");
     try {
+      execFileSync("pnpm", ["--filter", "create-jazz", "build"], { cwd: repoRoot });
       fs.cpSync(path.join(repoRoot, "packages", "create-jazz"), packageDir, {
         recursive: true,
         filter: (source) => !source.includes(`${path.sep}node_modules`),
@@ -79,12 +80,54 @@ describe("release config", () => {
           fs.readFileSync(path.join(extracted, "package/jazz-source-snapshot.json"), "utf8"),
         ),
       ).toEqual({ schema: 1, packageVersion: version, commit: "a".repeat(40) });
-      execFileSync("npm", ["install", "--ignore-scripts", "--no-package-lock", "--omit=dev"], {
-        cwd: path.join(extracted, "package"),
-      });
-      execFileSync(process.execPath, ["--input-type=module", "-e", 'import("./dist/index.js")'], {
-        cwd: path.join(extracted, "package"),
-      });
+      const extractedPackage = path.join(extracted, "package");
+      // Keep this receipt hermetic: only the packed CLI's behavior is under
+      // test, so its dependencies are linked from the already-installed repo.
+      fs.symlinkSync(
+        path.join(repoRoot, "packages", "create-jazz", "node_modules"),
+        path.join(extractedPackage, "node_modules"),
+      );
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        JAZZ_STARTER_PATH: path.join(repoRoot, "starters", "next-localfirst"),
+      };
+      delete env.npm_config_user_agent;
+      for (const [name, receipt] of [
+        ["malformed", "not json"],
+        [
+          "version-mismatch",
+          JSON.stringify({
+            schema: 1,
+            packageVersion: "2.0.0-alpha.other",
+            commit: "a".repeat(40),
+          }),
+        ],
+      ]) {
+        fs.writeFileSync(path.join(extractedPackage, "jazz-source-snapshot.json"), receipt);
+        const appName = `invalid-${name}`;
+        const result = spawnSync(
+          process.execPath,
+          [
+            "bin/create-jazz.js",
+            appName,
+            "--starter",
+            "next-localfirst",
+            "--hosting",
+            "selfhosted",
+            "--no-git",
+          ],
+          {
+            cwd: extractedPackage,
+            env,
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+            timeout: 15_000,
+          },
+        );
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
+        expect(result.stdout + result.stderr).toMatch(/invalid bundled preview source snapshot/i);
+        expect(fs.existsSync(path.join(extractedPackage, appName))).toBe(false);
+      }
     } finally {
       fs.rmSync(fixture, { recursive: true, force: true });
     }

--- a/packages/create-jazz/src/scaffold-release.test.ts
+++ b/packages/create-jazz/src/scaffold-release.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { scaffold } from "./scaffold.js";
+import { readSourceSnapshot, scaffold } from "./scaffold.js";
 
 const { tigedMock } = vi.hoisted(() => ({ tigedMock: vi.fn() }));
 
@@ -63,6 +63,57 @@ describe("scaffold() release source snapshots", () => {
     expect(vi.mocked(fetch)).toHaveBeenCalledWith(
       `https://raw.githubusercontent.com/garden-co/jazz/refs/tags/${releaseRef}/pnpm-workspace.yaml`,
       expect.anything(),
+    );
+  });
+
+  it("uses a bundled preview commit for both starter and workspace metadata", async () => {
+    const previewPackage = path.join(tmpRoot, "preview-package");
+    const commit = "a".repeat(40);
+    fs.mkdirSync(previewPackage);
+    fs.writeFileSync(
+      path.join(previewPackage, "package.json"),
+      JSON.stringify({ version: packageVersion }),
+    );
+    fs.writeFileSync(
+      path.join(previewPackage, "jazz-source-snapshot.json"),
+      JSON.stringify({ schema: 1, packageVersion, commit }),
+    );
+
+    await scaffold(
+      {
+        appName: "preview-app",
+        targetDir,
+        pm: null,
+        starter: "next-betterauth",
+        git: false,
+      },
+      readSourceSnapshot(previewPackage),
+    );
+
+    expect(tigedMock).toHaveBeenCalledWith(`garden-co/jazz/starters/next-betterauth#${commit}`, {
+      disableCache: true,
+    });
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      `https://raw.githubusercontent.com/garden-co/jazz/${commit}/pnpm-workspace.yaml`,
+      expect.anything(),
+    );
+  });
+
+  it("rejects absent or mismatched preview receipts without falling back", () => {
+    const previewPackage = path.join(tmpRoot, "invalid-preview-package");
+    fs.mkdirSync(previewPackage);
+    fs.writeFileSync(
+      path.join(previewPackage, "package.json"),
+      JSON.stringify({ version: packageVersion }),
+    );
+    fs.writeFileSync(
+      path.join(previewPackage, "jazz-source-snapshot.json"),
+      JSON.stringify({ schema: 1, packageVersion: "2.0.0-alpha.other", commit: "a".repeat(40) }),
+    );
+    expect(() => readSourceSnapshot(previewPackage)).toThrow(/refusing to fall back/i);
+    fs.writeFileSync(path.join(previewPackage, "jazz-source-snapshot.json"), "not json");
+    expect(() => readSourceSnapshot(previewPackage)).toThrow(
+      /invalid bundled preview source snapshot/i,
     );
   });
 

--- a/packages/create-jazz/src/scaffold.ts
+++ b/packages/create-jazz/src/scaffold.ts
@@ -10,12 +10,14 @@ import {
 import { installJazzSkills } from "./agent-skills.js";
 
 const REPO = "garden-co/jazz";
+const PACKAGE_DIR = path.resolve(import.meta.dirname, "..");
 const CREATE_JAZZ_VERSION = (
-  JSON.parse(fs.readFileSync(path.resolve(import.meta.dirname, "../package.json"), "utf-8")) as {
+  JSON.parse(fs.readFileSync(path.join(PACKAGE_DIR, "package.json"), "utf-8")) as {
     version: string;
   }
 ).version;
 const RELEASE_REF = `v${CREATE_JAZZ_VERSION}`;
+const PREVIEW_SNAPSHOT_FILE = "jazz-source-snapshot.json";
 const DEFAULT_STARTER = "next-betterauth";
 
 export const KNOWN_STARTERS = [
@@ -73,16 +75,58 @@ export interface ScaffoldOptions {
 
 const SCAFFOLD_COPY_SKIP = new Set(["node_modules", ".next", ".jazz", ".turbo", ".env", ".git"]);
 
-function sourceSnapshotError(action: string, cause: unknown): Error {
+export interface SourceSnapshot {
+  ref: string;
+  remoteRef: string;
+  label: string;
+}
+
+/** Resolve the immutable source snapshot bundled with this CLI package. */
+export function readSourceSnapshot(packageDir = PACKAGE_DIR): SourceSnapshot {
+  const snapshotPath = path.join(packageDir, PREVIEW_SNAPSHOT_FILE);
+  if (!fs.existsSync(snapshotPath)) {
+    return {
+      ref: RELEASE_REF,
+      remoteRef: `refs/tags/${RELEASE_REF}`,
+      label: RELEASE_REF,
+    };
+  }
+  let snapshot: { schema?: unknown; packageVersion?: unknown; commit?: unknown };
+  try {
+    snapshot = JSON.parse(fs.readFileSync(snapshotPath, "utf8")) as typeof snapshot;
+  } catch (cause) {
+    throw new Error(`Invalid bundled preview source snapshot: ${String(cause)}`, { cause });
+  }
+  if (
+    snapshot.schema !== 1 ||
+    snapshot.packageVersion !== CREATE_JAZZ_VERSION ||
+    typeof snapshot.commit !== "string" ||
+    !/^[a-f0-9]{40}$/.test(snapshot.commit)
+  )
+    throw new Error(
+      "Invalid bundled preview source snapshot; refusing to fall back to a release tag or main.",
+    );
+  return {
+    ref: snapshot.commit,
+    remoteRef: snapshot.commit,
+    label: `preview commit ${snapshot.commit}`,
+  };
+}
+
+function sourceSnapshotError(action: string, snapshot: SourceSnapshot, cause: unknown): Error {
   return new Error(
-    `Could not ${action} from immutable source snapshot ${RELEASE_REF} for create-jazz@${CREATE_JAZZ_VERSION}. ` +
+    `Could not ${action} from immutable source snapshot ${snapshot.label} for create-jazz@${CREATE_JAZZ_VERSION}. ` +
       "Jazz deliberately does not fall back to main, because that could scaffold code incompatible with the installed CLI. " +
       "This release snapshot may be unavailable; upgrade with `npm create jazz@latest` and try again.",
     { cause },
   );
 }
 
-async function fetchStarter(starter: StarterName, dir: string): Promise<void> {
+async function fetchStarter(
+  starter: StarterName,
+  dir: string,
+  snapshot: SourceSnapshot,
+): Promise<void> {
   const localPath = process.env.JAZZ_STARTER_PATH;
   if (localPath) {
     await fs.promises.cp(localPath, dir, {
@@ -92,16 +136,17 @@ async function fetchStarter(starter: StarterName, dir: string): Promise<void> {
     return;
   }
   const tiged = (await import("tiged")).default;
-  const emitter = tiged(`${REPO}/starters/${starter}#${RELEASE_REF}`, { disableCache: true });
+  const emitter = tiged(`${REPO}/starters/${starter}#${snapshot.ref}`, { disableCache: true });
   try {
     await emitter.clone(dir);
   } catch (cause) {
-    throw sourceSnapshotError(`fetch starter "${starter}"`, cause);
+    throw sourceSnapshotError(`fetch starter "${starter}"`, snapshot, cause);
   }
 }
 
 async function resolveManifest(
   manifest: PackageManifest,
+  snapshot: SourceSnapshot,
   onProgress?: ResolveProgressCallback,
 ): Promise<PackageManifest> {
   const localPath = process.env.JAZZ_STARTER_PATH;
@@ -109,17 +154,16 @@ async function resolveManifest(
     return resolveLocalDeps(manifest, path.resolve(localPath, "../.."), onProgress);
   }
   try {
-    return await resolveRemoteDeps(
-      manifest,
-      { repo: REPO, ref: `refs/tags/${RELEASE_REF}` },
-      onProgress,
-    );
+    return await resolveRemoteDeps(manifest, { repo: REPO, ref: snapshot.remoteRef }, onProgress);
   } catch (cause) {
-    throw sourceSnapshotError("resolve starter dependencies", cause);
+    throw sourceSnapshotError("resolve starter dependencies", snapshot, cause);
   }
 }
 
-export async function scaffold(options: ScaffoldOptions): Promise<void> {
+export async function scaffold(
+  options: ScaffoldOptions,
+  sourceSnapshot = readSourceSnapshot(),
+): Promise<void> {
   validateAppName(options.appName);
 
   const starter = options.starter ?? DEFAULT_STARTER;
@@ -142,12 +186,12 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
   // directory we just created.
   try {
     options.onStep?.("Fetching starter");
-    await fetchStarter(starter, options.targetDir);
+    await fetchStarter(starter, options.targetDir, sourceSnapshot);
 
     options.onStep?.("Resolving dependencies");
     const pkgJsonPath = path.join(options.targetDir, "package.json");
     const rawManifest = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8")) as PackageManifest;
-    const resolved = await resolveManifest(rawManifest, (done, total) => {
+    const resolved = await resolveManifest(rawManifest, sourceSnapshot, (done, total) => {
       options.onStep?.(`Resolving dependencies (${done}/${total})`);
     });
     const finalManifest = { ...resolved, name: options.appName };


### PR DESCRIPTION
🤖 Makes pkg.pr.new `create-jazz` previews scaffold from the exact immutable commit that produced the package, while preserving tag-bound release behavior.

Before: the preview tarball retained the repository package version (currently alpha.53), so `create-jazz@<preview-sha>` tried to fetch `v2.0.0-alpha.53`. If that historical source tag was absent, the CLI correctly refused to fall back to `main`, but no preview scaffold could be created.

After: the same-repository preview workflow stamps the packaged CLI with a strict source receipt containing schema version, matching package version, and the exact 40-hex PR head SHA. Preview starter and raw workspace/dependency fetches use only that SHA. Normal releases without the preview receipt continue to use only their exact version tag.

Example: invoking the f035 preview package now fetches starter sources and workspace dependencies from its producing commit rather than inferring a source tag from alpha.53. A missing, malformed, version-mismatched, or unavailable receipt fails explicitly and never falls back to `main`.

Verification:
- create-jazz tests and typecheck: 85 passed, 1 skipped
- committed production-style build → pack → extract → CLI import receipt confirms the file ships and is executable
- unavailable pinned commit fails closed with the immutable-source diagnostic
- independent adversarial review planted removal of package-version binding; the negative receipt caught it

This changes preview packaging only; normal release source selection remains tag-bound.