### PR TITLE
fix(runtime): wait for pending remote transport coverage

### DIFF
--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -2067,14 +2067,16 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
 
       const reader = openRuntime("reader", 42, server);
       const queryJson = JSON.stringify({ table: "todos" });
-      const propagatedRow = await waitFor(async () => {
-        const rows = (await reader.query(queryJson, null, "edge")) as Array<{
-          id: string;
-          table: string;
-          values: unknown[];
-        }>;
-        return rows.find((row) => row.id === inserted.id);
-      }, "reader persistent edge query did not receive the propagated row add after server recovery");
+      // A fresh strict-remote read owns its first authority receipt.  It must
+      // not resolve with the reader's empty local state while the restarted
+      // server is still delivering that receipt; callers should receive the
+      // persisted row from this one read.
+      const rows = (await reader.query(queryJson, null, "edge")) as Array<{
+        id: string;
+        table: string;
+        values: unknown[];
+      }>;
+      const propagatedRow = rows.find((row) => row.id === inserted.id);
 
       expect(propagatedRow).toEqual({
         id: inserted.id,

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -2703,7 +2703,33 @@ export class NativeRuntimeAdapter implements Runtime {
     if (this.closed) return;
     if (tier == null || (tier === "local" && !this.nonDurableClient)) return;
     if (!readPropagationIsFull(optionsJson) && !this.nonDurableClient) return;
-    if (!this.hasUpstream()) return;
+    // `connect()` starts its WebSocket handshake before it can admit the
+    // native transport. A strict remote read begun in that interval must
+    // await the in-flight connection instead of falling through to a local
+    // materialization merely because the transport has not been installed yet.
+    while (!this.hasUpstream()) {
+      const pendingConnection = this.serverCarrierPromise;
+      if (!pendingConnection) return;
+      const attempt = this.serverConnectionAttempt;
+      const terminal =
+        attempt?.carrier === this.serverCarrier
+          ? await Promise.race([pendingConnection.then(() => null), attempt.terminal])
+          : null;
+      if (this.closed) return;
+      // Reauthentication/reconnect can retire a stalled carrier while this
+      // query is waiting. Follow the replacement attempt; only surface a
+      // terminal error when this was still the current connection.
+      if (terminal) {
+        if (
+          this.serverCarrierPromise !== null &&
+          this.serverCarrierPromise !== pendingConnection &&
+          this.serverConnectionAttempt?.carrier === this.serverCarrier
+        ) {
+          continue;
+        }
+        throw terminal;
+      }
+    }
     if (!this.db.attachQuery) return;
     // Coverage registration and probes are synchronous node operations. A
     // storage-backed evaluator may hold that node across suspension, so enter

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -242,6 +242,64 @@ describe("NativeRuntimeAdapter server transport", () => {
     ]);
   });
 
+  it("moves a strict remote read from a stalled handshake to its auth-refresh replacement", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+
+      override send(data: Uint8Array | string): void {
+        // Leave the first carrier in its handshake. The second one uses the
+        // normal fake server response after the auth refresh replaces it.
+        if (sockets[0] === this) {
+          this.sent.push(data);
+          return;
+        }
+        super.send(data);
+      }
+    } as unknown as typeof WebSocket;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            all: () => encodeRows([]),
+            connectUpstream: () => new FakeTransport([]),
+            prepareQuery: () => ({}),
+            attachQuery: () => ({}),
+            queryAttachmentIsCovered: () => true,
+            detachQuery: () => undefined,
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    let settled = false;
+    const read = runtime.query(JSON.stringify({ table: "todos" }), null, "edge").then((rows) => {
+      settled = true;
+      return rows;
+    });
+    await waitForFakeWebSocketNegotiation();
+    expect(settled).toBe(false);
+
+    await runtime.updateAuth(JSON.stringify({ jwt_token: "fresh.jwt" }));
+    await waitForFakeWebSocketNegotiation();
+
+    expect(sockets).toHaveLength(2);
+    await vi.waitFor(() => expect(settled).toBe(true));
+    await expect(read).resolves.toEqual([]);
+  });
+
   it("requires native db bindings to expose a tick scheduler", () => {
     expect(
       () =>
@@ -365,6 +423,54 @@ describe("NativeRuntimeAdapter server transport", () => {
     expect(sockets).toHaveLength(2);
     expect(upstreamConnections).toBe(1);
     expect(JSON.parse(sockets[1]!.sent[0] as string).jwt_token).toBe("fresh.jwt");
+  });
+
+  it("rejects a strict remote read when its pre-admission carrier terminates without replacement", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+
+      override send(data: Uint8Array | string): void {
+        // Hold the handshake so the remote read is waiting on this carrier
+        // when the authority sends its terminal pre-admission error.
+        this.sent.push(data);
+      }
+    } as unknown as typeof WebSocket;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            all: () => encodeRows([]),
+            connectUpstream: () => new FakeTransport([]),
+            prepareQuery: () => ({}),
+            attachQuery: () => ({}),
+            queryAttachmentIsCovered: () => true,
+            detachQuery: () => undefined,
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    const read = runtime.query(JSON.stringify({ table: "todos" }), null, "edge");
+    await waitForFakeWebSocketNegotiation();
+
+    sockets[0]!.emitMessage(
+      encodeWebSocketFrameBatch([encodeWireError(3, 1, "pre-admission denied")]),
+    );
+
+    await expect(read).rejects.toThrow("pre-admission denied");
   });
 
   it("does not report non-auth websocket errors as auth failures", async () => {


### PR DESCRIPTION
🤖 Makes strict `Remote` reads wait for the already-started server transport and authoritative query coverage instead of completing from empty local state during connection admission.

Before: `NativeRuntimeAdapter.connect()` could have a WebSocket handshake in flight but no native transport yet. Query attachment treated that transient state as “no upstream,” so a fresh client’s first `Remote` query returned `[]`; the same query returned the server row a second later.

After: strict remote query attachment waits for the current connection attempt, then attaches and awaits exact remote coverage. If auth refresh/reconnect replaces stalled carrier A with carrier B, the read follows B. If A terminates without a real replacement, the read rejects with that terminal error rather than hanging or falling back to local state.

Example: after restarting a persistent CLI core, a fresh memory client’s first `db.all(query, { tier: ReadTier.Remote })` now returns the persisted row in one call. A stalled handshake replaced by `updateAuth()` also settles through the replacement carrier; a malformed pre-hello frame rejects.

Unchanged:
- `LocalFirst` still answers from local knowledge.
- `RemoteIfPossible` still falls back only when the high-level connection state is definitely offline.
- an explicitly offline `Remote` read remains pending until reconnect.
- no timeout was increased and no second query path was introduced.

Verification:
- runtime/read-tier/connection-manager focused suite: 184 passed, 2 skipped
- real NAPI + persistent CLI-core restart receipt passes in one strict read
- independent adversarial review planted both inverse races; each new receipt failed as intended.