### PR TITLE
fix(edge): use wall clock for client admission

### DIFF
--- a/crates/jazz-sim/benches/s1_saas.rs
+++ b/crates/jazz-sim/benches/s1_saas.rs
@@ -535,6 +535,7 @@ fn edge_acceptance_phase(
         tx,
         versions,
         u64::MAX,
+        u64::MAX,
     ))
     .unwrap();
     let updates = settle_outcome(&mut edge.node, outcome).unwrap();

--- a/crates/jazz-sim/benches/s2_canvas.rs
+++ b/crates/jazz-sim/benches/s2_canvas.rs
@@ -339,6 +339,7 @@ fn run_live(ctx: &mut dyn DriverContext, config: &Config, coalesced: bool) -> Li
                 tx,
                 versions,
                 u64::MAX,
+                u64::MAX,
             ))
             .expect("edge ingest");
             let updates =
@@ -1179,6 +1180,7 @@ fn run_edge_actor(
                     &mut edge_node,
                     tx,
                     versions,
+                    now_ms,
                     now_ms,
                 ))
                 .expect("edge ingest");

--- a/crates/jazz-sim/benches/s3_permissions.rs
+++ b/crates/jazz-sim/benches/s3_permissions.rs
@@ -2505,6 +2505,7 @@ fn edge_acceptance_phase(
         tx.clone(),
         versions,
         u64::MAX,
+        u64::MAX,
     ))
     .unwrap();
     let first = settle_outcome(&mut edge.node, outcome).unwrap();

--- a/crates/jazz-sim/benches/s5_durable_stream.rs
+++ b/crates/jazz-sim/benches/s5_durable_stream.rs
@@ -706,9 +706,14 @@ fn drain_db_route(
             continue;
         };
         let start = Instant::now();
-        let outcome =
-            block_on(edge_peer.ingest_edge_mergeable_commit_unit(edge, tx, versions, u64::MAX))
-                .unwrap();
+        let outcome = block_on(edge_peer.ingest_edge_mergeable_commit_unit(
+            edge,
+            tx,
+            versions,
+            u64::MAX,
+            u64::MAX,
+        ))
+        .unwrap();
         settle_outcome(edge, outcome).unwrap();
         edge_acceptance
             .record(start.elapsed().as_micros() as u64)

--- a/crates/jazz-sim/benches/s7_migrations.rs
+++ b/crates/jazz-sim/benches/s7_migrations.rs
@@ -232,6 +232,7 @@ fn deliver_client_unit(
             tx,
             versions,
             u64::MAX,
+            u64::MAX,
         ))
         .unwrap();
         settle_outcome(&mut client.edge, outcome).unwrap();

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -19,6 +19,25 @@ use super::*;
 const RELAY_UPSTREAM_SUBSCRIPTION_NAMESPACE: uuid::Uuid =
     uuid::uuid!("ae3eb9f7-65cc-528d-8f3e-a772fb6f68fe");
 
+/// Wall-clock time used exclusively for authority admission checks.
+///
+/// This must not use `UploadRetryClock`: that clock is deliberately monotonic
+/// and process-relative so retry backoff is unaffected by wall-clock changes,
+/// whereas transaction HLC physical components are Unix milliseconds.
+fn authority_admission_now_ms() -> Result<u64, Error> {
+    web_time::SystemTime::now()
+        .duration_since(web_time::UNIX_EPOCH)
+        .map_err(|_| Error::new(ErrorCode::Protocol, "authority clock precedes Unix epoch"))?
+        .as_millis()
+        .try_into()
+        .map_err(|_| {
+            Error::new(
+                ErrorCode::Protocol,
+                "authority clock exceeds u64 milliseconds",
+            )
+        })
+}
+
 fn relay_upstream_subscription_key(
     connection_epoch: u64,
     downstream: SubscriptionKey,
@@ -133,7 +152,7 @@ pub(super) fn dispatch_admitted_subscriber_message<'a, S>(
     edge_fate_routes: &'a EdgeFateRoutes,
     local_fate_routes: &'a LocalFateRoutes,
     downstream_fates: &'a PendingDownstreamFates,
-    now_ms: u64,
+    maintenance_now_ms: u64,
     message: SyncMessage,
 ) -> Pin<Box<dyn Future<Output = Result<PublicationOutcome<Vec<SyncMessage>>, Error>> + 'a>>
 where
@@ -271,9 +290,16 @@ where
                     }]));
                 }
 
+                let authority_now_ms = authority_admission_now_ms()?;
                 let mut node = node.lock().await;
                 let outcome = peer
-                    .ingest_edge_mergeable_commit_unit(&mut node, tx, versions, now_ms)
+                    .ingest_edge_mergeable_commit_unit(
+                        &mut node,
+                        tx,
+                        versions,
+                        maintenance_now_ms,
+                        authority_now_ms,
+                    )
                     .await
                     .map_err(Error::from)?;
                 let (responses, publications, post_settlement_work) = outcome.into_parts();
@@ -3716,7 +3742,7 @@ where
                             // binding), plus the write-upload path: any
                             // responses (e.g. fate updates) flow back to the
                             // subscriber.
-                            let now_ms = self.upload_retry_clock.borrow().now_ms();
+                            let maintenance_now_ms = self.upload_retry_clock.borrow().now_ms();
                             let outcome = dispatch_admitted_subscriber_message(
                                 &self.node,
                                 peer,
@@ -3726,7 +3752,7 @@ where
                                 &self.edge_fate_routes,
                                 &self.local_fate_routes,
                                 &self.downstream_fates,
-                                now_ms,
+                                maintenance_now_ms,
                                 other,
                             )
                             .await?;

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -1038,6 +1038,118 @@ fn edge_later_client_upload_flushes_earlier_upstream_in_same_tick() {
     );
 }
 
+/// Edge admission compares a client HLC's Unix-millisecond physical component
+/// with the authority wall clock, not with the process-relative retry timer.
+/// This needs the real connection topology: direct NodeState admission never
+/// exercises the served-client edge path where retry timing is also available.
+#[test]
+fn edge_admits_client_write_with_current_unix_timestamp() {
+    let schema = schema();
+    let alice = AuthorSubject::for_test_bytes([0xa4; 16]);
+    let edge = open_core(0xd6, AuthorSubject::SYSTEM, &schema);
+    let client = open_db(0xd7, alice, &schema);
+
+    let (client_transport, edge_client_transport) = duplex();
+    let _client_upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let _edge_client = edge
+        .server
+        .accept_edge_authority_subscriber_with_claims_and_trust(
+            edge_client_transport,
+            alice,
+            test_provider_claims(alice),
+            CommitUnitTrust::Session,
+        );
+
+    let unix_now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("test clock is after Unix epoch")
+        .as_millis()
+        .try_into()
+        .expect("Unix milliseconds fit u64");
+    let write = client
+        .insert(
+            "todos",
+            cells("current timestamp", false, alice),
+            crate::db::InsertOptions {
+                row_id: Some(row(0xd8)),
+                updated_at_ms: Some(unix_now_ms),
+                ..Default::default()
+            },
+        )
+        .expect("client creates a current-time local write");
+
+    client.tick().expect("client uploads the write");
+    for _ in 0..8 {
+        edge.tick().expect("edge services the client write");
+        if matches!(
+            crate::db::block_on(edge.node().borrow_mut().transaction_state(write.tx_id)),
+            Some((Fate::Accepted, None, DurabilityTier::Edge))
+        ) {
+            break;
+        }
+    }
+
+    let edge_state = crate::db::block_on(edge.node().borrow_mut().transaction_state(write.tx_id));
+    assert!(
+        matches!(
+            edge_state,
+            Some((Fate::Accepted, None, DurabilityTier::Edge))
+        ),
+        "a current Unix-time client write becomes Edge durable instead of being compared to the retry timer; observed {edge_state:?}"
+    );
+    assert!(
+        edge.server
+            .outbox
+            .borrow()
+            .iter()
+            .any(|pending| pending.tx_id == write.tx_id),
+        "the admitted Edge write is retained for its upstream authority"
+    );
+
+    let future = client
+        .insert(
+            "todos",
+            cells("future timestamp", false, alice),
+            crate::db::InsertOptions {
+                row_id: Some(row(0xd9)),
+                updated_at_ms: Some(
+                    unix_now_ms
+                        .saturating_add(crate::node::SKEW_TOLERANCE_MS)
+                        .saturating_add(10_000),
+                ),
+                ..Default::default()
+            },
+        )
+        .expect("client creates a far-future local write");
+    client.tick().expect("client uploads the far-future write");
+    for _ in 0..8 {
+        edge.tick().expect("edge services the far-future write");
+        if matches!(
+            crate::db::block_on(edge.node().borrow_mut().transaction_state(future.tx_id)),
+            Some((
+                Fate::Rejected(RejectionReason::ClientClockTooFarAhead),
+                None,
+                DurabilityTier::Local
+            ))
+        ) {
+            break;
+        }
+    }
+    let future_state =
+        crate::db::block_on(edge.node().borrow_mut().transaction_state(future.tx_id));
+    assert!(
+        matches!(
+            future_state,
+            Some((
+                Fate::Rejected(RejectionReason::ClientClockTooFarAhead),
+                None,
+                DurabilityTier::Local
+            ))
+        ),
+        "the same Edge path retains forward-skew rejection; observed {future_state:?}"
+    );
+}
+
 #[test]
 fn pending_global_state_does_not_complete_remote_wait_or_prune_upload() {
     let schema = schema();

--- a/crates/jazz/src/peer/repair.rs
+++ b/crates/jazz/src/peer/repair.rs
@@ -11,12 +11,13 @@ impl PeerState {
         node: &mut NodeState<S>,
         tx: Transaction,
         versions: Vec<VersionRecord>,
-        now_ms: u64,
+        maintenance_now_ms: u64,
+        admission_now_ms: u64,
     ) -> Result<PublicationOutcome<Vec<SyncMessage>>, Error>
     where
         S: OrderedKvStorage + ReopenableStorage,
     {
-        self.evict_idle_edge_scope_subscriptions(node, now_ms);
+        self.evict_idle_edge_scope_subscriptions(node, maintenance_now_ms);
         if tx.kind != TxKind::Mergeable {
             return Err(Error::UnsupportedCommitUnit(
                 "edge fate deferral only supports mergeable commit units",
@@ -55,7 +56,7 @@ impl PeerState {
                     DeferredEdgeFate {
                         tx,
                         versions,
-                        now_ms,
+                        admission_now_ms,
                         permission_identity,
                         scope_subscriptions,
                     },
@@ -66,7 +67,7 @@ impl PeerState {
         node.ingest_edge_authority_mergeable_commit_unit_with_identity(
             tx,
             versions,
-            now_ms,
+            admission_now_ms,
             permission_identity,
         )
         .await
@@ -77,12 +78,12 @@ impl PeerState {
     pub async fn drain_deferred_edge_fates<S>(
         &mut self,
         node: &mut NodeState<S>,
-        now_ms: u64,
+        maintenance_now_ms: u64,
     ) -> Result<PublicationOutcome<Vec<SyncMessage>>, Error>
     where
         S: OrderedKvStorage + ReopenableStorage,
     {
-        self.evict_idle_edge_scope_subscriptions(node, now_ms);
+        self.evict_idle_edge_scope_subscriptions(node, maintenance_now_ms);
         let deferred = self
             .deferred_edge_fates
             .iter()
@@ -105,13 +106,13 @@ impl PeerState {
             }
             self.deferred_edge_fates.remove(&tx_id);
             for subscription in fate.scope_subscriptions {
-                self.release_edge_scope_subscription(node, subscription, now_ms);
+                self.release_edge_scope_subscription(node, subscription, maintenance_now_ms);
             }
             updates.extend(
                 node.ingest_edge_authority_mergeable_commit_unit_with_identity(
                     fate.tx,
                     fate.versions,
-                    fate.now_ms,
+                    fate.admission_now_ms,
                     fate.permission_identity,
                 )
                 .await?,

--- a/crates/jazz/src/peer/subscription_state.rs
+++ b/crates/jazz/src/peer/subscription_state.rs
@@ -249,7 +249,10 @@ impl CachedPeerQueryPlan {
 pub(super) struct DeferredEdgeFate {
     pub(super) tx: Transaction,
     pub(super) versions: Vec<VersionRecord>,
-    pub(super) now_ms: u64,
+    /// Wall-clock authority time captured when the client upload arrived.
+    /// Deferred admission deliberately preserves this security boundary rather
+    /// than treating time spent awaiting permission support as client slack.
+    pub(super) admission_now_ms: u64,
     pub(super) permission_identity: AuthorSubject,
     pub(super) scope_subscriptions: Vec<SubscriptionKey>,
 }

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -911,7 +911,7 @@ fn edge_support_hydration_uses_writer_claims_and_fails_closed_when_missing() {
     let (_missing_dir, mut missing_edge) = open_node_with_schema(node(0xa5), schema.clone());
     let mut missing_peer = PeerState::edge_client(writer);
     let missing_outcome = missing_peer
-        .ingest_edge_mergeable_commit_unit(&mut missing_edge, tx.clone(), versions.clone(), 10)
+        .ingest_edge_mergeable_commit_unit(&mut missing_edge, tx.clone(), versions.clone(), 10, 10)
         .expect("missing policy claim must fail closed, not abort edge ingest");
     let missing_updates = missing_edge
         .persist_and_settle_outcome(missing_outcome)
@@ -994,7 +994,7 @@ fn edge_ingest_turns_missing_prepared_seed_claim_into_deferred_empty_support() {
     let mut peer = PeerState::edge_client(writer);
 
     let outcome = peer
-        .ingest_edge_mergeable_commit_unit(&mut edge, tx.clone(), versions, 10)
+        .ingest_edge_mergeable_commit_unit(&mut edge, tx.clone(), versions, 10, 10)
         .expect("missing prepared seed claim must be a deferred empty support proof");
     let updates = edge.persist_and_settle_outcome(outcome).unwrap();
     assert!(updates.is_empty());
@@ -1016,19 +1016,19 @@ fn deferred_edge_ingest_rejects_a_conflicting_retransmit() {
     let mut peer = PeerState::edge_client(writer);
 
     let _ = peer
-        .ingest_edge_mergeable_commit_unit(&mut edge, tx.clone(), versions.clone(), 10)
+        .ingest_edge_mergeable_commit_unit(&mut edge, tx.clone(), versions.clone(), 10, 10)
         .expect("missing support claim parks the first commit unit");
     assert_eq!(peer.deferred_edge_fate_count(), 1);
 
     let _ = peer
-        .ingest_edge_mergeable_commit_unit(&mut edge, tx.clone(), versions.clone(), 10)
+        .ingest_edge_mergeable_commit_unit(&mut edge, tx.clone(), versions.clone(), 10, 10)
         .expect("an identical deferred retransmit remains idempotent");
     assert_eq!(peer.deferred_edge_fate_count(), 1);
 
     let mut conflicting = tx.clone();
     conflicting.n_total_writes = conflicting.n_total_writes.saturating_add(1);
     assert!(matches!(
-        peer.ingest_edge_mergeable_commit_unit(&mut edge, conflicting, versions, 10)
+        peer.ingest_edge_mergeable_commit_unit(&mut edge, conflicting, versions, 10, 10)
             .resolve(),
         Err(Error::ConflictingCommitUnit(tx_id)) if tx_id == tx.tx_id
     ));
@@ -1090,6 +1090,72 @@ fn open_node_with_schema(
 fn open_node_with_uuid(node_uuid: NodeUuid) -> (tempfile::TempDir, NodeState<RocksDbStorage>) {
     let schema = schema();
     open_node_with_schema(node_uuid, schema)
+}
+
+/// Permission-scope cache retention is maintenance, not authority admission.
+/// The receipt drives the public edge-ingest path because a direct eviction
+/// call would not prove that ingress keeps the two clocks separate.
+#[test]
+fn edge_ingest_uses_monotonic_scope_ttl_and_retains_wall_admission_time() {
+    let schema = session_seed_write_policy_schema();
+    let writer = AuthorSubject::for_test_bytes([0xa7; 16]);
+    let (_writer_dir, mut writer_node) = open_node_with_schema(node(0xa7), schema.clone());
+    let (tx, versions) = resource_commit_unit(&mut writer_node, writer, row(0xa8));
+    let (_edge_dir, mut edge) = open_node_with_schema(node(0xa9), schema);
+    let mut peer = PeerState::edge_client(writer);
+    let subscription = SubscriptionKey {
+        shape_id: crate::query::ShapeId(uuid::Uuid::from_u128(7)),
+        binding_id: crate::query::BindingId(uuid::Uuid::from_u128(8)),
+        read_view: Default::default(),
+    };
+    let ttl_ms = edge_scope_ttl_ms();
+    assert!(ttl_ms > 0, "this receipt requires the normal positive edge-scope TTL");
+
+    peer.retain_edge_scope_subscription(subscription);
+    peer.release_edge_scope_subscription(&mut edge, subscription, 100);
+    assert_eq!(
+        peer.idle_edge_scope_subscriptions.get(&subscription),
+        Some(&100),
+        "release records the monotonic maintenance instant"
+    );
+
+    // The missing support claim intentionally parks this write before HLC
+    // validation. That lets the receipt inject an extreme authority clock and
+    // assert that it is retained only as the deferred admission timestamp.
+    let first_outcome = peer.ingest_edge_mergeable_commit_unit(
+        &mut edge,
+        tx.clone(),
+        versions.clone(),
+        100 + ttl_ms - 1,
+        u64::MAX,
+    )
+    .expect("missing support defers the edge write");
+    let first_updates = edge.persist_and_settle_outcome(first_outcome).unwrap();
+    assert!(first_updates.is_empty(), "a deferred write has no fate yet");
+    assert!(
+        peer.idle_edge_scope_subscriptions.contains_key(&subscription),
+        "an authority wall-clock jump cannot immediately evict a still-fresh scope"
+    );
+    assert_eq!(
+        peer.deferred_edge_fates[&tx.tx_id].admission_now_ms,
+        u64::MAX,
+        "the deferred fate retains the separately supplied HLC admission time"
+    );
+
+    let retry_outcome = peer.ingest_edge_mergeable_commit_unit(
+        &mut edge,
+        tx,
+        versions,
+        100 + ttl_ms,
+        u64::MAX,
+    )
+    .expect("an identical deferred retransmit remains admissible");
+    let retry_updates = edge.persist_and_settle_outcome(retry_outcome).unwrap();
+    assert!(retry_updates.is_empty(), "the retry remains deferred without support");
+    assert!(
+        !peer.idle_edge_scope_subscriptions.contains_key(&subscription),
+        "the monotonic TTL evicts the idle scope at its boundary"
+    );
 }
 
 fn accept_global(core: &mut NodeState<RocksDbStorage>, tx_id: TxId, seq: u64) {

--- a/crates/jazz/tests/four_tier.rs
+++ b/crates/jazz/tests/four_tier.rs
@@ -315,7 +315,7 @@ fn edge_ingest(
     install_uuid_sub_claim(node, peer.identity());
     block_on(async {
         let outcome = peer
-            .ingest_edge_mergeable_commit_unit(node, tx, versions, now_ms)
+            .ingest_edge_mergeable_commit_unit(node, tx, versions, now_ms, now_ms)
             .await
             .unwrap();
         node.persist_and_settle_outcome(outcome).await.unwrap()


### PR DESCRIPTION
🤖 Uses the correct clock domain for edge-side client HLC admission without contaminating monotonic retry or permission-scope maintenance.

Before: served-client edge admission passed a process-relative monotonic retry clock into Unix-millisecond HLC skew validation. Fresh ordinary writes through an edge were therefore rejected as `client_clock_too_far_ahead`, while the same write direct-to-core succeeded.

After: edge ingress samples Unix wall time for client HLC admission. Retry/backoff and idle permission-scope TTL eviction remain on monotonic maintenance time. Deferred fates retain the wall admission time sampled when the upload arrived, while later release/eviction uses the current monotonic maintenance clock.

Example: a current Unix-time client write now reaches Edge durability and queues upstream; a deliberately far-future HLC still rejects. If the wall clock jumps forward while an idle scope is younger than its 5s monotonic TTL, the scope remains; it is evicted exactly when monotonic maintenance reaches the TTL boundary.

Unchanged:
- Core admission already samples Unix wall time.
- retry scheduling remains monotonic;
- deferred writes do not “age into” validity while policy data hydrates;
- the clock-skew security boundary and far-future rejection remain intact.

Verification:
- real edge-client topology covers current-time acceptance and far-future rejection
- strengthened actual-ingress receipt covers `< TTL` retention and exact-boundary eviction
- simulation benches compile with both clock roles explicit
- independent adversarial review planted both wall/maintenance re-conflation and swapped admission arguments; the receipts failed as intended.