### PR TITLE
fix(browser): fence worker retirement during bootstrap

### DIFF
--- a/packages/jazz-tools/src/dev/inspector-overlay/browser-control-registry.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/browser-control-registry.ts
@@ -91,6 +91,11 @@ export async function openAggregatedBrowserInspectorControlPort(
       if (message.type === "terminate-worker") {
         throw new Error("Worker termination is only available on a direct browser control port");
       }
+      if (message.type === "lifecycle-trace") {
+        throw new Error(
+          "Worker lifecycle trace is only available on a direct browser control port",
+        );
+      }
       const route = routes.get(message.contextKey);
       if (!route) throw new Error("Inspector context is no longer available");
       const control = controls.find((candidate) => candidate.port === route.port)!;

--- a/packages/jazz-tools/src/runtime/browser-physical-database-epoch.test.ts
+++ b/packages/jazz-tools/src/runtime/browser-physical-database-epoch.test.ts
@@ -35,11 +35,12 @@ describe("browser physical database epoch", () => {
       BrowserPhysicalDatabaseBusyError,
     );
 
-    first.release();
-    // The Web Locks callback relinquishes after its release continuation.
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    // A caller that needs to reopen immediately must wait for the browser's
+    // lock callback to have actually returned, not merely for the release
+    // request to be queued.
+    await first.release();
     const successor = await acquireBrowserPhysicalDatabaseEpoch("same-root", locks);
     expect(successor.id).not.toBe(first.id);
-    successor.release();
+    await successor.release();
   });
 });

--- a/packages/jazz-tools/src/runtime/browser-physical-database-epoch.ts
+++ b/packages/jazz-tools/src/runtime/browser-physical-database-epoch.ts
@@ -25,7 +25,8 @@ export class BrowserPhysicalDatabaseBusyError extends Error {
 
 export type BrowserPhysicalDatabaseEpoch = {
   readonly id: string;
-  release(): void;
+  /** Resolves only once the browser has actually relinquished the Web Lock. */
+  release(): Promise<void>;
 };
 
 type WebLock = object;
@@ -57,9 +58,14 @@ export async function acquireBrowserPhysicalDatabaseEpoch(
     resolveEpoch = resolve;
     rejectEpoch = reject;
   });
+  let releaseRequested = false;
   let release!: () => void;
   const released = new Promise<void>((resolve) => {
     release = resolve;
+  });
+  let resolveLockReleased!: () => void;
+  const lockReleased = new Promise<void>((resolve) => {
+    resolveLockReleased = resolve;
   });
   const id = crypto.randomUUID();
 
@@ -72,12 +78,25 @@ export async function acquireBrowserPhysicalDatabaseEpoch(
           rejectEpoch(new BrowserPhysicalDatabaseBusyError(databaseName));
           return;
         }
-        resolveEpoch({ id, release });
+        resolveEpoch({
+          id,
+          release: () => {
+            if (!releaseRequested) {
+              releaseRequested = true;
+              release();
+            }
+            return lockReleased;
+          },
+        });
         await released;
       },
     )
-    .catch((error: unknown) => {
-      rejectEpoch(error instanceof Error ? error : new Error(String(error)));
-    });
+    .then(
+      () => resolveLockReleased(),
+      (error: unknown) => {
+        resolveLockReleased();
+        rejectEpoch(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
   return await epoch;
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
@@ -36,6 +36,7 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
   private nextRequestId = 1;
   private closed = false;
   private failed: Error | null = null;
+  private readonly disposeQueryCoverageTrace: (() => void) | null;
 
   constructor(
     private readonly runtime: NativeRuntimeAdapter,
@@ -56,6 +57,15 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
     port.addEventListener("message", this.onMessage);
     port.addEventListener("messageerror", this.onMessageError);
     port.start();
+    this.disposeQueryCoverageTrace = traceRelay
+      ? runtime.onQueryCoverageTrace((entry) => {
+          if (this.closed) return;
+          this.port.postMessage({
+            type: "diagnostic-query-coverage",
+            ...entry,
+          } satisfies BrowserFollowerPortRequest);
+        })
+      : null;
 
     // Establish the accepted peer with this tab's claims before any runtime
     // frames can be delivered. MessagePort ordering keeps the handshake ahead
@@ -292,6 +302,7 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
     this.closed = true;
     this.port.removeEventListener("message", this.onMessage);
     this.port.removeEventListener("messageerror", this.onMessageError);
+    this.disposeQueryCoverageTrace?.();
     this.pump.close();
     this.port.close();
     for (const pending of this.pending.values()) pending.reject(error);

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-protocol.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-protocol.ts
@@ -89,6 +89,13 @@ export type BrowserSharedWorkerConnectResponse =
 export type BrowserFollowerPortRequest =
   | { type: "init"; id: number; sessionClaims: Record<string, unknown> }
   | { type: "frames"; frames: Uint8Array[] }
+  /** @internal Trace-only redacted query-coverage progress from a foreground tab. */
+  | {
+      type: "diagnostic-query-coverage";
+      stage: "attach" | "covered";
+      peerActivityEpoch: number;
+      peerProcessedActivityEpoch: number;
+    }
   | { type: "update-auth"; authJson: string; sessionClaims: Record<string, unknown> }
   | { type: "wait-server"; id: number }
   | { type: "disconnect"; id: number }
@@ -116,6 +123,32 @@ export interface BrowserInspectorContext {
 }
 
 /**
+ * Bounded, redacted lifecycle evidence for diagnosing browser-worker stalls.
+ * It deliberately carries no query text, row data, credentials, or wire
+ * frames: ordering and counters are enough to establish handoff progress.
+ */
+export type BrowserWorkerLifecycleTrace = {
+  sequence: number;
+  event:
+    | "bootstrap-start"
+    | "lease-request"
+    | "lease-admitted"
+    | "peer-attached"
+    | "peer-frames"
+    | "query-attach"
+    | "query-covered"
+    | "owner-release-start"
+    | "owner-release-finished";
+  dbName: string;
+  peerCount: number;
+  pendingBootstraps: number;
+  activeLeases: number;
+  frameCount?: number;
+  peerActivityEpoch?: number;
+  peerProcessedActivityEpoch?: number;
+};
+
+/**
  * Redacted flight-recorder entry for a browser chunk relay. Hashes and
  * locators are short fingerprints; no retrieval capability is exposed.
  */
@@ -134,6 +167,7 @@ export type BrowserRelayTrace = {
 
 export type BrowserInspectorControlRequest =
   | { type: "list-contexts"; id: number }
+  | { type: "lifecycle-trace"; id: number }
   | { type: "terminate-worker"; id: number }
   | {
       type: "attach-context";
@@ -146,6 +180,7 @@ export type BrowserInspectorControlRequest =
 
 export type BrowserInspectorControlEvent =
   | { type: "contexts"; id: number; contexts: BrowserInspectorContext[] }
+  | { type: "lifecycle-trace"; id: number; entries: BrowserWorkerLifecycleTrace[] }
   | { type: "result"; id: number; error?: string };
 
 export type BrowserFollowerPortEvent =

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -731,6 +731,13 @@ export class NativeRuntimeAdapter implements Runtime {
   private serverInboundProcessed = false;
   private readonly peerTransportWorkListeners = new Set<(requiresDistinctPass?: boolean) => void>();
   private readonly auxiliaryTraceListeners = new Set<(entries: AuxiliaryRelayTrace[]) => void>();
+  private readonly queryCoverageTraceListeners = new Set<
+    (entry: {
+      stage: "attach" | "covered";
+      peerActivityEpoch: number;
+      peerProcessedActivityEpoch: number;
+    }) => void
+  >();
   private peerTransportActivityEpoch = 0;
   private peerTransportProcessedActivityEpoch = 0;
   // A non-durable follower needs a worker response before trusting native
@@ -899,6 +906,32 @@ export class NativeRuntimeAdapter implements Runtime {
         this.serverTransport?.setAuxiliaryTraceEnabled?.(false);
       }
     };
+  }
+
+  /** @internal Redacted browser-worker lifecycle diagnostics. */
+  onQueryCoverageTrace(
+    listener: (entry: {
+      stage: "attach" | "covered";
+      peerActivityEpoch: number;
+      peerProcessedActivityEpoch: number;
+    }) => void,
+  ): () => void {
+    if (this !== this.ownerRuntime) return this.ownerRuntime.onQueryCoverageTrace(listener);
+    this.queryCoverageTraceListeners.add(listener);
+    return () => this.queryCoverageTraceListeners.delete(listener);
+  }
+
+  private emitQueryCoverageTrace(stage: "attach" | "covered"): void {
+    if (this !== this.ownerRuntime) {
+      this.ownerRuntime.emitQueryCoverageTrace(stage);
+      return;
+    }
+    const entry = {
+      stage,
+      peerActivityEpoch: this.peerTransportActivityEpoch,
+      peerProcessedActivityEpoch: this.peerTransportProcessedActivityEpoch,
+    };
+    for (const listener of this.queryCoverageTraceListeners) listener(entry);
   }
 
   notifyPeerTransportActivity(): void {
@@ -2750,6 +2783,7 @@ export class NativeRuntimeAdapter implements Runtime {
     } else {
       attachment = this.db.attachQuery(query, opts);
     }
+    this.emitQueryCoverageTrace("attach");
     if (!this.db.queryAttachmentIsCovered) return attachment;
     const coverageKey = this.coverageKey(session);
     const confirmedPeerActivityEpoch = this.peerCoveredQueries.get(query)?.get(coverageKey);
@@ -2793,6 +2827,7 @@ export class NativeRuntimeAdapter implements Runtime {
       confirmations.set(coverageKey, this.peerTransportProcessedActivityEpoch);
       this.peerCoveredQueries.set(query, confirmations);
     }
+    this.emitQueryCoverageTrace("covered");
     return attachment;
   }
 

--- a/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
@@ -20,6 +20,7 @@ import type {
   BrowserFollowerPortRequest,
   BrowserInspectorControlEvent,
   BrowserInspectorControlRequest,
+  BrowserWorkerLifecycleTrace,
   BrowserSharedWorkerConnectRequest,
   BrowserSharedWorkerConnectResponse,
   BrowserWorkerInitOptions,
@@ -130,6 +131,72 @@ let wasmModulePromise: Promise<WasmModule> | null = null;
 let wasmModuleSource: string | null = null;
 let contextInitializationTail: Promise<void> = Promise.resolve();
 let nextResetId = 1;
+// A port has joined this worker but has not yet completed its first durable
+// operation.  It is already a liveness claim: closing the realm in this gap
+// can strand a first lease or context connection with no terminal reply.
+let pendingBootstrapOperations = 0;
+// `workerGlobal.close()` is necessarily deferred behind physical-owner
+// release.  A new port may arrive while that release is in flight, so the
+// deferred close needs an invalidatable token rather than an unconditional
+// `finally(() => close())`.
+let pendingWorkerClose: symbol | null = null;
+// The inspector-facing trace intentionally does not serialize this key. It
+// is only an in-worker capability boundary that prevents a later auth scope
+// from observing a prior scope's retained diagnostics for the same realm.
+type WorkerLifecycleLedgerEntry = BrowserWorkerLifecycleTrace & {
+  authSessionKey: string | null;
+};
+const workerLifecycleLedger: WorkerLifecycleLedgerEntry[] = [];
+let nextWorkerLifecycleSequence = 1;
+const MAX_WORKER_LIFECYCLE_ENTRIES = 128;
+
+/**
+ * Lifecycle evidence is retained at worker-realm scope, but inspection is a
+ * session capability. In particular, a physical database name is not itself
+ * an authorization boundary: an auth turnover can retain old entries while
+ * the same root becomes relevant to a later scope. Keep the scope check
+ * separate from the root check, and never serialize the internal scope key.
+ *
+ * @internal Exported from this worker-private module for a deterministic
+ * boundary receipt; it is not part of the Jazz application API.
+ */
+export function filterWorkerLifecycleEntriesForInspector(
+  entries: readonly WorkerLifecycleLedgerEntry[],
+  authSessionKey: string,
+  allowedDbNames: ReadonlySet<string>,
+): BrowserWorkerLifecycleTrace[] {
+  return entries
+    .filter((entry) => entry.authSessionKey === authSessionKey && allowedDbNames.has(entry.dbName))
+    .map(({ authSessionKey: _authSessionKey, ...entry }) => entry);
+}
+
+function recordWorkerLifecycle(
+  event: BrowserWorkerLifecycleTrace["event"],
+  dbName: string,
+  authSessionKey: string | null,
+  details: Pick<
+    BrowserWorkerLifecycleTrace,
+    "frameCount" | "peerActivityEpoch" | "peerProcessedActivityEpoch"
+  > = {},
+): void {
+  const activeLeases = [...foregroundLeaseOwners.values()].reduce(
+    (count, owner) => count + owner.activeLeaseIds.size,
+    0,
+  );
+  workerLifecycleLedger.push({
+    sequence: nextWorkerLifecycleSequence++,
+    event,
+    dbName,
+    authSessionKey,
+    peerCount: [...contexts.values()].reduce((count, context) => count + context.peers.size, 0),
+    pendingBootstraps: pendingBootstrapOperations,
+    activeLeases,
+    ...details,
+  });
+  if (workerLifecycleLedger.length > MAX_WORKER_LIFECYCLE_ENTRIES) {
+    workerLifecycleLedger.splice(0, workerLifecycleLedger.length - MAX_WORKER_LIFECYCLE_ENTRIES);
+  }
+}
 
 /**
  * Open a physical root only after holding its origin-wide liveness fence.
@@ -211,7 +278,7 @@ async function openPhysicalDatabaseOwner(
     return owner;
   } catch (error) {
     pageStore?.close();
-    epoch.release();
+    await epoch.release();
     throw error;
   }
 }
@@ -227,7 +294,7 @@ async function releasePhysicalDatabaseOwner(dbName: string): Promise<void> {
         owner.disposeInvalidation?.();
         owner.disposeInvalidation = null;
         owner.pageStore.close();
-        owner.epoch.release();
+        await owner.epoch.release();
         physicalDatabaseOwners.delete(dbName);
       }
     })();
@@ -254,6 +321,21 @@ export function installJazzBrokerWorker(options: JazzBrokerWorkerOptions = {}): 
   workerGlobal.onconnect = (event) => {
     const port = event.ports[0];
     if (!port) return;
+    // A SharedWorker can accept this port while a previous idle close is
+    // awaiting IndexedDB/Web-Lock release. Treat delivery of the port as a
+    // new liveness claim before any message task can run; otherwise that old
+    // close can terminate this exact admission mid-flight. Do not merely
+    // cancel the old close token here: the bootstrap reservation is the
+    // durable fact that remains true until this port has either completed its
+    // first operation or failed it.
+    pendingBootstrapOperations += 1;
+    let bootstrapFinished = false;
+    const finishBootstrap = () => {
+      if (bootstrapFinished) return;
+      bootstrapFinished = true;
+      pendingBootstrapOperations -= 1;
+      maybeCloseWorker();
+    };
     const onBootstrapMessage = (
       messageEvent: MessageEvent<
         BrowserSharedWorkerConnectRequest | BrowserForegroundNodeLeaseAcquireRequest
@@ -267,14 +349,27 @@ export function installJazzBrokerWorker(options: JazzBrokerWorkerOptions = {}): 
         return;
       }
       port.removeEventListener("message", onBootstrapMessage);
+      port.removeEventListener("messageerror", onBootstrapMessageError);
       if (message.type === "connect-runtime") {
+        recordWorkerLifecycle(
+          "bootstrap-start",
+          message.options.dbName,
+          message.options.authSessionKey,
+        );
         post(port, { type: "worker-alive" });
-        void connectTab(port, message);
+        void connectTab(port, message, finishBootstrap);
       } else {
-        void acquireForegroundNodeLease(port, message);
+        recordWorkerLifecycle("lease-request", message.dbName, null);
+        void acquireForegroundNodeLease(port, message).finally(finishBootstrap);
       }
     };
+    const onBootstrapMessageError = () => {
+      port.removeEventListener("message", onBootstrapMessage);
+      finishBootstrap();
+      port.close();
+    };
     port.addEventListener("message", onBootstrapMessage);
+    port.addEventListener("messageerror", onBootstrapMessageError);
     port.start();
   };
 }
@@ -484,6 +579,7 @@ async function acquireForegroundNodeLease(
       await requestCancellation();
       return;
     }
+    recordWorkerLifecycle("lease-admitted", request.dbName, null);
     post(port, {
       type: "foreground-node-lease-ready",
       leaseId: lease.leaseId,
@@ -549,6 +645,7 @@ async function allocateForegroundNodeLease(
 async function connectTab(
   port: MessagePort,
   message: BrowserSharedWorkerConnectRequest,
+  finishBootstrap: () => void,
 ): Promise<void> {
   try {
     const key = runtimeKey(message.options);
@@ -581,8 +678,16 @@ async function connectTab(
     await context.initialize;
     await enqueueTransportTransition(context, () => configureServer(context, message.options));
     attachTab(context, message.tabId, port);
+    // The peer now owns a durable runtime context.  Drop the bootstrap
+    // reservation before publishing readiness so an immediately closing tab
+    // still sees normal idle cleanup ordering.
+    finishBootstrap();
     post(port, { type: "runtime-ready" });
   } catch (error) {
+    // Failed connection setup has already cleaned any partial context; clear
+    // the bootstrap reservation before surfacing the terminal result so its
+    // physical owner can be released without a follow-on admission race.
+    finishBootstrap();
     post(port, { type: "runtime-error", message: asError(error).message });
     port.close();
   }
@@ -922,6 +1027,14 @@ function attachTab(context: RuntimeContext, tabId: string, port: MessagePort): v
 async function handleTabMessage(peer: TabPeer, message: BrowserFollowerPortRequest): Promise<void> {
   if (peer.context.peers.get(peer.tabId) !== peer) return;
   if (message.type === "frames") {
+    if (peer.context.options.logLevel === "trace") {
+      recordWorkerLifecycle(
+        "peer-frames",
+        peer.context.options.dbName,
+        peer.context.options.authSessionKey,
+        { frameCount: message.frames.length },
+      );
+    }
     peer.flushedLocal = false;
     if (!peer.pump) {
       // The init handler may be awaiting an evaluator pass while MessagePort
@@ -942,6 +1055,18 @@ async function handleTabMessage(peer: TabPeer, message: BrowserFollowerPortReque
     // the client closes both ends after it observes the result.
     closeTab(peer.context, peer.tabId, false);
     if (releaseWhenIdle) scheduleIdleContextRelease(peer.context);
+    return;
+  }
+  if (message.type === "diagnostic-query-coverage") {
+    recordWorkerLifecycle(
+      message.stage === "attach" ? "query-attach" : "query-covered",
+      peer.context.options.dbName,
+      peer.context.options.authSessionKey,
+      {
+        peerActivityEpoch: message.peerActivityEpoch,
+        peerProcessedActivityEpoch: message.peerProcessedActivityEpoch,
+      },
+    );
     return;
   }
   if (message.type === "storage-reset-observed") {
@@ -985,6 +1110,11 @@ async function handleTabMessage(peer: TabPeer, message: BrowserFollowerPortReque
       // this new peer and therefore continues while admission waits.
       const subscriber = await activeRuntime.acceptPeerWhenIdle(message.sessionClaims);
       const pump = attachPeerTransport(peer, activeRuntime, subscriber);
+      recordWorkerLifecycle(
+        "peer-attached",
+        peer.context.options.dbName,
+        peer.context.options.authSessionKey,
+      );
       if (peer.pendingFrames.length > 0) {
         const pending = peer.pendingFrames.splice(0);
         pump.receive(pending);
@@ -1099,6 +1229,31 @@ function attachInspectorControl(authSessionKey: string, port: MessagePort): void
         type: "contexts",
         id: message.id,
         contexts: available,
+      } satisfies BrowserInspectorControlEvent);
+      return;
+    }
+    if (message.type === "lifecycle-trace") {
+      // An inspector is scoped by its authenticated worker session.  Return
+      // only entries for physical roots currently live under that session;
+      // lifecycle diagnostics must not become a cross-account root oracle.
+      const allowedDbNames = new Set(
+        [...contexts.values()]
+          .filter(
+            (context) =>
+              context.options.authSessionKey === authSessionKey &&
+              !context.storageInvalidated &&
+              context.runtime !== null,
+          )
+          .map((context) => context.options.dbName),
+      );
+      port.postMessage({
+        type: "lifecycle-trace",
+        id: message.id,
+        entries: filterWorkerLifecycleEntriesForInspector(
+          workerLifecycleLedger,
+          authSessionKey,
+          allowedDbNames,
+        ),
       } satisfies BrowserInspectorControlEvent);
       return;
     }
@@ -1271,10 +1426,10 @@ function scheduleIdleContextRelease(context: RuntimeContext): void {
 }
 
 function maybeCloseWorker(): void {
-  const hasActiveForegroundLease = [...foregroundLeaseOwners.values()].some(
-    (owner) => owner.activeLeaseIds.size > 0 || owner.pendingLeaseAllocations > 0,
-  );
-  if (contexts.size === 0 && inspectorControlPorts.size === 0 && !hasActiveForegroundLease) {
+  if (!workerHasLiveWork()) {
+    if (pendingWorkerClose) return;
+    const closeToken = Symbol("worker-idle-close");
+    pendingWorkerClose = closeToken;
     const databaseNames = new Set<string>([
       ...foregroundLeaseOwners.keys(),
       ...physicalDatabaseOwners.keys(),
@@ -1282,13 +1437,45 @@ function maybeCloseWorker(): void {
     // The physical owner writes/deletes its epoch before closing the shared
     // page-store handle below. Closing lease aliases first would turn an
     // otherwise clean handoff into a stale durable epoch.
+    for (const dbName of databaseNames) recordWorkerLifecycle("owner-release-start", dbName, null);
     foregroundLeaseOwners.clear();
     void Promise.all([...databaseNames].map((dbName) => releasePhysicalDatabaseOwner(dbName)))
       .catch(() => undefined)
       // Unit harnesses execute the module outside an actual worker global;
       // production SharedWorkerGlobal always supplies `close`.
-      .finally(() => workerGlobal.close?.());
+      .finally(() => {
+        // A new connection may have arrived while IndexedDB/Web Locks were
+        // draining. Its bootstrap reservation is established synchronously
+        // in `onconnect`, before it can perform its first durable operation.
+        // Never close a realm that has acquired that new work.
+        if (pendingWorkerClose !== closeToken) return;
+        // The release completed while a new port was bootstrapping. It owns
+        // the cancellation of this particular close attempt, but not the
+        // worker forever: clear the stale token so a failed bootstrap can
+        // schedule a fresh idle close in `finishBootstrap`.
+        if (workerHasLiveWork()) {
+          pendingWorkerClose = null;
+          return;
+        }
+        for (const dbName of databaseNames) {
+          recordWorkerLifecycle("owner-release-finished", dbName, null);
+        }
+        pendingWorkerClose = null;
+        workerGlobal.close?.();
+      });
   }
+}
+
+function workerHasLiveWork(): boolean {
+  const hasActiveForegroundLease = [...foregroundLeaseOwners.values()].some(
+    (owner) => owner.activeLeaseIds.size > 0 || owner.pendingLeaseAllocations > 0,
+  );
+  return (
+    contexts.size > 0 ||
+    inspectorControlPorts.size > 0 ||
+    pendingBootstrapOperations > 0 ||
+    hasActiveForegroundLease
+  );
 }
 
 function closeContextPeers(context: RuntimeContext): void {

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -1,8 +1,12 @@
 import type { Mock } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  BrowserForegroundNodeLeaseAcquireRequest,
+  BrowserForegroundNodeLeaseAcquireResponse,
   BrowserFollowerPortEvent,
   BrowserFollowerPortRequest,
+  BrowserInspectorControlEvent,
+  BrowserInspectorControlRequest,
   BrowserSharedWorkerConnectRequest,
   BrowserSharedWorkerConnectResponse,
   BrowserWorkerInitOptions,
@@ -23,6 +27,9 @@ const mocks = vi.hoisted(() => {
     claimBrowserWorkerEpoch: Mock;
     releaseBrowserWorkerEpoch: Mock;
     onInvalidated: Mock;
+    acquireForegroundNodeLease: Mock;
+    returnForegroundNodeLease: Mock;
+    retireForegroundNodeLease: Mock;
     canonicalReplicaNode: Uint8Array;
     readonly replicaNode: Uint8Array;
   }> = [];
@@ -77,6 +84,13 @@ const mocks = vi.hoisted(() => {
           claimBrowserWorkerEpoch: vi.fn(async () => undefined),
           releaseBrowserWorkerEpoch: vi.fn(async () => undefined),
           onInvalidated: vi.fn(() => () => undefined),
+          acquireForegroundNodeLease: vi.fn(async () => ({
+            leaseId: `lease-${pageStores.length}`,
+            node: Uint8Array.from(replicaNode),
+            confirmedTxTime: 0n,
+          })),
+          returnForegroundNodeLease: vi.fn(async () => undefined),
+          retireForegroundNodeLease: vi.fn(async () => undefined),
           canonicalReplicaNode: replicaNode,
           get replicaNode() {
             return Uint8Array.from(replicaNode);
@@ -151,8 +165,14 @@ type RuntimeOutcome = Extract<
   { type: "runtime-ready" | "runtime-error" }
 >;
 
+type ForegroundLeaseOutcome = Extract<
+  BrowserForegroundNodeLeaseAcquireResponse,
+  { type: "foreground-node-lease-ready" | "foreground-node-lease-error" }
+>;
+
 type WorkerGlobal = typeof globalThis & {
   onconnect: ((event: MessageEvent & { ports: MessagePort[] }) => void) | null;
+  close?: Mock;
 };
 
 class TestPort {
@@ -161,6 +181,8 @@ class TestPort {
   private readonly listeners = new Map<string, Set<(event: MessageEvent) => void>>();
   private readonly outcomes: RuntimeOutcome[] = [];
   private readonly outcomeWaiters: Array<(outcome: RuntimeOutcome) => void> = [];
+  private readonly leaseOutcomes: ForegroundLeaseOutcome[] = [];
+  private readonly leaseOutcomeWaiters: Array<(outcome: ForegroundLeaseOutcome) => void> = [];
   private readonly events: BrowserFollowerPortEvent[] = [];
   private readonly eventWaiters: Array<{
     predicate: (event: BrowserFollowerPortEvent) => boolean;
@@ -177,7 +199,12 @@ class TestPort {
     this.listeners.get(type)?.delete(listener);
   }
 
-  postMessage(message: BrowserSharedWorkerConnectResponse | BrowserFollowerPortEvent): void {
+  postMessage(
+    message:
+      | BrowserSharedWorkerConnectResponse
+      | BrowserFollowerPortEvent
+      | BrowserForegroundNodeLeaseAcquireResponse,
+  ): void {
     if (message.type === "runtime-ready" || message.type === "runtime-error") {
       const waiter = this.outcomeWaiters.shift();
       if (waiter) waiter(message);
@@ -187,13 +214,27 @@ class TestPort {
     // Bootstrap liveness is intentionally not a follower event or a runtime
     // connection outcome; tests only retain the latter two protocol classes.
     if (message.type === "worker-alive") return;
+    if (
+      message.type === "foreground-node-lease-ready" ||
+      message.type === "foreground-node-lease-error"
+    ) {
+      const waiter = this.leaseOutcomeWaiters.shift();
+      if (waiter) waiter(message);
+      else this.leaseOutcomes.push(message);
+      return;
+    }
     const waiterIndex = this.eventWaiters.findIndex(({ predicate }) => predicate(message));
     if (waiterIndex >= 0) {
       this.eventWaiters.splice(waiterIndex, 1)[0]!.resolve(message);
     } else this.events.push(message);
   }
 
-  emitMessage(message: BrowserSharedWorkerConnectRequest | BrowserFollowerPortRequest): void {
+  emitMessage(
+    message:
+      | BrowserSharedWorkerConnectRequest
+      | BrowserForegroundNodeLeaseAcquireRequest
+      | BrowserFollowerPortRequest,
+  ): void {
     for (const listener of this.listeners.get("message") ?? []) {
       listener({ data: message } as MessageEvent);
     }
@@ -204,6 +245,14 @@ class TestPort {
     if (outcome) return Promise.resolve(outcome);
     const waiter = deferred<RuntimeOutcome>();
     this.outcomeWaiters.push(waiter.resolve);
+    return waiter.promise;
+  }
+
+  waitForLeaseOutcome(): Promise<ForegroundLeaseOutcome> {
+    const outcome = this.leaseOutcomes.shift();
+    if (outcome) return Promise.resolve(outcome);
+    const waiter = deferred<ForegroundLeaseOutcome>();
+    this.leaseOutcomeWaiters.push(waiter.resolve);
     return waiter.promise;
   }
 
@@ -246,6 +295,21 @@ function options(dbName: string): BrowserWorkerInitOptions {
   };
 }
 
+function connectLease(request: BrowserForegroundNodeLeaseAcquireRequest): {
+  outcome: Promise<ForegroundLeaseOutcome>;
+  port: TestPort;
+} {
+  const port = new TestPort();
+  const onconnect = (globalThis as WorkerGlobal).onconnect;
+  if (!onconnect) throw new Error("broker worker did not install its connect handler");
+  onconnect({ ports: [port as unknown as MessagePort] } as MessageEvent & {
+    ports: MessagePort[];
+  });
+  const outcome = port.waitForLeaseOutcome();
+  port.emitMessage(request);
+  return { outcome, port };
+}
+
 function enabledTelemetryOptions(dbName: string): BrowserWorkerInitOptions {
   return {
     ...options(dbName),
@@ -279,9 +343,34 @@ async function initializeFollower(port: TestPort, id: number): Promise<void> {
   await result;
 }
 
+async function openInspector(port: TestPort, id: number): Promise<MessagePort> {
+  const channel = new MessageChannel();
+  const result = port.waitForEvent((event) => event.type === "result" && event.id === id);
+  port.emitMessage({ type: "open-inspector-control", id, port: channel.port2 });
+  await result;
+  channel.port1.start();
+  return channel.port1;
+}
+
+async function readLifecycle(
+  port: MessagePort,
+  id: number,
+): Promise<Extract<BrowserInspectorControlEvent, { type: "lifecycle-trace" }>["entries"]> {
+  return new Promise((resolve) => {
+    const onMessage = (event: MessageEvent<BrowserInspectorControlEvent>) => {
+      if (event.data.type !== "lifecycle-trace" || event.data.id !== id) return;
+      port.removeEventListener("message", onMessage);
+      resolve(event.data.entries);
+    };
+    port.addEventListener("message", onMessage);
+    port.postMessage({ type: "lifecycle-trace", id } satisfies BrowserInspectorControlRequest);
+  });
+}
+
 describe("broker worker context initialization", () => {
   beforeEach(async () => {
     mocks.reset();
+    (globalThis as WorkerGlobal).close = vi.fn();
     vi.resetModules();
     // The worker owns process-global state, so each case must evaluate a fresh module instance.
     await import("./jazz-broker-worker.js");
@@ -309,6 +398,174 @@ describe("broker worker context initialization", () => {
       type: "runtime-ready",
     });
     expect(mocks.loadWasmModule).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels an idle worker close when a successor bootstrap arrives during physical release", async () => {
+    const releasePhysicalOwner = deferred<void>();
+    mocks.openPageStore.mockImplementationOnce(async () => {
+      const replicaNode = new Uint8Array(16);
+      replicaNode.fill(17);
+      const pageStore = {
+        close: vi.fn(),
+        claimBrowserWorkerEpoch: vi.fn(async () => undefined),
+        releaseBrowserWorkerEpoch: vi.fn(() => releasePhysicalOwner.promise),
+        onInvalidated: vi.fn(() => () => undefined),
+        acquireForegroundNodeLease: vi.fn(async () => ({
+          leaseId: "successor-lease",
+          node: Uint8Array.from(replicaNode),
+          confirmedTxTime: 0n,
+        })),
+        returnForegroundNodeLease: vi.fn(async () => undefined),
+        retireForegroundNodeLease: vi.fn(async () => undefined),
+        canonicalReplicaNode: replicaNode,
+        get replicaNode() {
+          return Uint8Array.from(replicaNode);
+        },
+      };
+      mocks.pageStores.push(pageStore);
+      return pageStore;
+    });
+
+    const initOptions = options("successor-during-idle-release");
+    const first = await connect(initOptions, "first-tab");
+    await initializeFollower(first.port, 1);
+    const closed = first.port.waitForEvent((event) => event.type === "result" && event.id === 2);
+    first.port.emitMessage({ type: "close", id: 2, releaseContext: true });
+    await closed;
+
+    // The idle timer has discarded the context and is now blocked on its
+    // physical Web-Lock/epoch release. Start a *lease-only* successor in
+    // this exact window: no RuntimeContext can yet exist, so this is a
+    // direct receipt that the bootstrap reservation (rather than a context
+    // map entry) fences a stale `finally(close)`.
+    await new Promise<void>((resolve) => setTimeout(resolve, 60));
+    await vi.waitFor(() =>
+      expect(mocks.pageStores[0]?.releaseBrowserWorkerEpoch).toHaveBeenCalledOnce(),
+    );
+    const successor = connectLease({
+      type: "acquire-foreground-node-lease",
+      dbName: initOptions.dbName,
+      storageOwner: initOptions.storageOwner,
+    });
+    expect(mocks.runtimes).toHaveLength(1);
+    releasePhysicalOwner.resolve();
+
+    await expect(successor.outcome).resolves.toEqual(
+      expect.objectContaining({
+        type: "foreground-node-lease-ready",
+        confirmedTxTime: "0",
+        node: expect.any(Uint8Array),
+      }),
+    );
+    expect((globalThis as WorkerGlobal).close).not.toHaveBeenCalled();
+  });
+
+  it("does not expose retained lifecycle entries across browser auth scopes", async () => {
+    const firstOptions = {
+      ...options("lifecycle-scope-a"),
+      authSessionKey: "scope-a",
+      storageOwner: "scope-a-owner",
+    };
+    const secondOptions = {
+      ...options("lifecycle-scope-b"),
+      authSessionKey: "scope-b",
+      storageOwner: "scope-b-owner",
+    };
+    const first = await connect(firstOptions, "scope-a-tab");
+    await initializeFollower(first.port, 1);
+    const second = await connect(secondOptions, "scope-b-tab");
+    await initializeFollower(second.port, 2);
+
+    const firstInspector = await openInspector(first.port, 3);
+    const secondInspector = await openInspector(second.port, 4);
+    try {
+      const firstEntries = await readLifecycle(firstInspector, 5);
+      const secondEntries = await readLifecycle(secondInspector, 6);
+
+      // Both sets remain physically retained in the one SharedWorker realm.
+      // A scope-B inspector must nevertheless receive only entries that were
+      // recorded under scope B; this rules out cross-account diagnostics when
+      // a browser turns over to a different authenticated namespace.
+      expect(firstEntries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ event: "bootstrap-start", dbName: firstOptions.dbName }),
+        ]),
+      );
+      expect(secondEntries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ event: "bootstrap-start", dbName: secondOptions.dbName }),
+        ]),
+      );
+      expect(secondEntries).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ dbName: firstOptions.dbName })]),
+      );
+    } finally {
+      firstInspector.postMessage({ type: "close" } satisfies BrowserInspectorControlRequest);
+      secondInspector.postMessage({ type: "close" } satisfies BrowserInspectorControlRequest);
+      firstInspector.close();
+      secondInspector.close();
+    }
+  });
+
+  it("filters same-root turnover evidence by scope and omits unscoped owner events", async () => {
+    const { filterWorkerLifecycleEntriesForInspector } =
+      await import("./jazz-broker-worker-core.js");
+    const dbName = "retained-turnover-root";
+    const entries = [
+      {
+        sequence: 1,
+        event: "bootstrap-start" as const,
+        dbName,
+        authSessionKey: "scope-a",
+        peerCount: 1,
+        pendingBootstraps: 0,
+        activeLeases: 0,
+      },
+      {
+        sequence: 2,
+        event: "bootstrap-start" as const,
+        dbName,
+        authSessionKey: "scope-b",
+        peerCount: 1,
+        pendingBootstraps: 0,
+        activeLeases: 0,
+      },
+      {
+        sequence: 3,
+        event: "lease-admitted" as const,
+        dbName,
+        authSessionKey: null,
+        peerCount: 0,
+        pendingBootstraps: 0,
+        activeLeases: 1,
+      },
+      {
+        sequence: 4,
+        event: "owner-release-finished" as const,
+        dbName,
+        authSessionKey: null,
+        peerCount: 0,
+        pendingBootstraps: 0,
+        activeLeases: 0,
+      },
+    ];
+
+    // `allowedDbNames` intentionally admits the same root for both scopes:
+    // physical-root filtering alone would leak scope A's retained trace to
+    // scope B after an auth turnover. Scope-less lease/owner events are also
+    // deliberately diagnostic-ineligible rather than guessed-attributed.
+    expect(filterWorkerLifecycleEntriesForInspector(entries, "scope-b", new Set([dbName]))).toEqual(
+      [
+        {
+          sequence: 2,
+          event: "bootstrap-start",
+          dbName,
+          peerCount: 1,
+          pendingBootstraps: 0,
+          activeLeases: 0,
+        },
+      ],
+    );
   });
 
   it("does not let a second context repoint the process-wide WASM realm at another origin", async () => {

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -223,6 +223,12 @@ class TestPort {
       else this.leaseOutcomes.push(message);
       return;
     }
+    if (
+      message.type === "foreground-node-lease-test-allocated" ||
+      message.type === "foreground-node-lease-cancelled"
+    ) {
+      throw new Error(`Unexpected lease bootstrap response: ${message.type}`);
+    }
     const waiterIndex = this.eventWaiters.findIndex(({ predicate }) => predicate(message));
     if (waiterIndex >= 0) {
       this.eventWaiters.splice(waiterIndex, 1)[0]!.resolve(message);

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -82,6 +82,21 @@ async function listWorkerContexts(port: MessagePort): Promise<BrowserInspectorCo
   });
 }
 
+async function listWorkerLifecycle(
+  port: MessagePort,
+): Promise<Extract<BrowserInspectorControlEvent, { type: "lifecycle-trace" }>["entries"]> {
+  const id = nextInspectorRequestId++;
+  return new Promise((resolve) => {
+    const onMessage = (event: MessageEvent<BrowserInspectorControlEvent>) => {
+      if (event.data.type !== "lifecycle-trace" || event.data.id !== id) return;
+      port.removeEventListener("message", onMessage);
+      resolve(event.data.entries);
+    };
+    port.addEventListener("message", onMessage);
+    port.postMessage({ type: "lifecycle-trace", id } satisfies BrowserInspectorControlRequest);
+  });
+}
+
 async function waitForWorkerContextRelease(port: MessagePort, dbName: string): Promise<void> {
   await waitForCondition(
     async () => !(await listWorkerContexts(port)).some((context) => context.dbName === dbName),
@@ -845,6 +860,43 @@ describe("SharedWorker bridge with IndexedDB", () => {
     );
     expect(db).toBeDefined();
     expect(db).toBeInstanceOf(Db);
+  });
+
+  it("exposes a bounded redacted worker lifecycle ledger to the owning inspector", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions("worker-lifecycle-ledger");
+    const db = track(
+      await createDb({
+        appId: syncServer.appId,
+        serverUrl: syncServer.serverUrl,
+        secret: generateAuthSecret(),
+        driver: { type: "persistent", dbName: uniqueDbName("worker-lifecycle-ledger") },
+        logLevel: "trace",
+        schema: app,
+      }),
+    );
+    // `createDb` resolves after the foreground runtime is available; the
+    // worker follower is installed on the first public read.
+    await db.all(allTodos, { tier: "local" });
+    const inspector = await db.openInspectorControlPort();
+    inspector.start();
+    try {
+      const entries = await listWorkerLifecycle(inspector);
+      expect(entries.map((entry) => entry.event)).toEqual(
+        expect.arrayContaining(["bootstrap-start", "peer-attached"]),
+      );
+      expect(entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sequence: expect.any(Number),
+            peerCount: expect.any(Number),
+            pendingBootstraps: expect.any(Number),
+            activeLeases: expect.any(Number),
+          }),
+        ]),
+      );
+    } finally {
+      inspector.postMessage({ type: "close" } satisfies BrowserInspectorControlRequest);
+    }
   });
 
   it("registers concurrent local subscriptions before worker admission while withholding openings", async () => {


### PR DESCRIPTION
🤖 Prevents a stale asynchronous SharedWorker retirement from closing over a newly arriving foreground bootstrap, and makes physical-owner release wait for actual Web Lock relinquishment.

Before: idle close ran from an unconditional async `finally`. A new port or lease request could arrive while the old owner release was still in flight, then the stale completion called `close()` over the successor. Separately, `epoch.release()` acknowledged release when it merely queued the Web Lock callback, so an immediate reopen could still observe the old realm as busy. Under full CI concurrency this appeared as foreground-lease, query-coverage, propagation, and teardown timeouts.

After:
- idle close uses an invalidatable retirement token and treats connecting bootstrap operations as live work;
- a lease-only successor reserves liveness before any runtime context exists;
- owner teardown awaits actual Web Lock callback completion before acknowledging release/reopen;
- a bounded internal lifecycle ledger records lease/peer/query/owner epochs for diagnostics, but exposes only entries bound to the exact auth session and live scoped DB root; scope-less lease/owner events and internal auth keys are never serialized.

Example: while old owner release is held, a successor asks only for a foreground-node lease. Releasing the old owner no longer closes the worker; the successor receives its lease. Removing the bootstrap reservation makes this receipt call `worker.close()` and fail.

Security/privacy boundary: after auth-scope turnover reuses the same physical DB name, scope B sees only its own retained trace. Scope A and unscoped lifecycle entries remain invisible.

Verification:
- focused worker/epoch/inspector units: 24/24 implementation, 20/20 final independent review
- real worker-bridge browser suite: 70 passed, 1 expected failure, 2 skipped
- TS check, browser-helper typecheck, runtime build
- independent plants prove the bootstrap fence, actual Web Lock completion, auth-scope filter, and scope-less exclusion are all test-sensitive
- no timeout or end-to-end assertion was weakened.