### PR TITLE
fix(release): preserve reused RN relay provenance

### DIFF
--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -537,7 +537,7 @@ jobs:
           test -f packages/jazz-tools/dist/permissions/index.js
 
       - name: Verify staged jazz-rn relay artifacts
-        env:
+        env: &release-artifact-source-revision-env
           # `resolve-preview-artifacts` only permits reuse after proving the
           # release source and preview source have equivalent trees. Preserve
           # the latter's commit SHA here: it is the value sealed into its
@@ -641,12 +641,13 @@ jobs:
           tar -xOf "${TARBALL}" package/index.js | node -e 'let s="";process.stdin.on("data",(d)=>s+=d);process.stdin.on("end",()=>{const unscoped=[...s.matchAll(/require\((["\x27])((?!\.\/)jazz-napi-[^"\x27)]+)\1\)/g)].map((m)=>m[2]);if(unscoped.length){throw new Error(`packed index.js still references unscoped native packages: ${[...new Set(unscoped)].join(", ")}`);}if(!s.includes("@garden-co")){throw new Error("packed index.js is missing the @garden-co package scope");}console.log("Packed loader uses scoped native package names");});'
 
       - name: Verify packed jazz-rn relay payload
+        env: *release-artifact-source-revision-env
         run: |
           TEMPORARY_DIRECTORY=$(mktemp -d)
           pnpm --filter jazz-rn pack --pack-destination "${TEMPORARY_DIRECTORY}"
           TARBALL=$(ls "${TEMPORARY_DIRECTORY}"/jazz-rn-*.tgz | head -n 1)
           tar -xzf "${TARBALL}" -C "${TEMPORARY_DIRECTORY}"
-          JAZZ_NATIVE_RELAY_SOURCE_REVISION="$(git rev-parse HEAD)" \
+          JAZZ_NATIVE_RELAY_SOURCE_REVISION="$(node dev/artifacts/release-artifact-source-revision.mjs)" \
             JAZZ_NATIVE_RELAY_CARGO_NDK_VERSION="${JAZZ_RN_CARGO_NDK_VERSION}" \
             node crates/jazz-rn/scripts/verify-relay-artifacts.mjs \
               --package-root "${TEMPORARY_DIRECTORY}/package" android ios

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -445,8 +445,12 @@ test("alpha verification preserves a reusable preview's sealed source commit acr
   // The release workflow has already established that these commits have the
   // same source tree. Their identities intentionally differ: the latter is a
   // merge commit, while the former is what the preview manifest sealed.
-  assert.equal(select(true), previewCommit);
-  assert.equal(select(false), mergeCommit);
+  for (const [reuse, expected] of [
+    [true, previewCommit],
+    [false, mergeCommit],
+  ]) {
+    assert.equal(select(reuse), expected, `reuse=${reuse} selects the sealed source revision`);
+  }
   assert.throws(
     () =>
       execFileSync(process.execPath, [selector.pathname], {
@@ -460,6 +464,45 @@ test("alpha verification preserves a reusable preview's sealed source commit acr
         },
       }),
     (error) => error?.status === 1,
+  );
+});
+
+test("both alpha jazz-rn verifiers use the shared release source-revision contract", async () => {
+  const workflowText = await readFile(
+    new URL("../../../.github/workflows/publish-jazz-tools-alpha.yml", import.meta.url),
+    "utf8",
+  );
+  const workflow = parse(workflowText);
+  const steps = workflow.jobs["publish-npm"].steps;
+  const staged = steps.find((step) => step.name === "Verify staged jazz-rn relay artifacts");
+  const packed = steps.find((step) => step.name === "Verify packed jazz-rn relay payload");
+
+  assert.ok(staged, "the staged relay verifier must remain in the alpha release workflow");
+  assert.ok(packed, "the packed relay verifier must remain in the alpha release workflow");
+  assert.deepEqual(
+    packed.env,
+    staged.env,
+    "the packed verifier must receive the same reuse-aware source selector inputs as staged verification",
+  );
+  for (const [name, step] of [
+    ["staged", staged],
+    ["packed", packed],
+  ]) {
+    assert.match(
+      step.run,
+      /JAZZ_NATIVE_RELAY_SOURCE_REVISION="\$\(node dev\/artifacts\/release-artifact-source-revision\.mjs\)"/,
+      `${name} verification must use the authoritative release source selector`,
+    );
+  }
+  assert.doesNotMatch(
+    packed.run,
+    /git rev-parse HEAD/,
+    "packed verification must not replace a reusable preview's sealed revision with the merge SHA",
+  );
+  assert.match(
+    workflowText,
+    /env: &release-artifact-source-revision-env[\s\S]*env: \*release-artifact-source-revision-env/,
+    "the two verifier sites must share one env definition so their reuse inputs cannot drift",
   );
 });
 


### PR DESCRIPTION
🤖 Fixes a deterministic alpha-release failure when a release reuses React Native relay artifacts from a preview commit.

Before: the staged relay verifier correctly selected the preview PR head SHA, but the later packed-tarball verifier unconditionally compared the manifest with the release merge SHA. Equivalent trees with different commit identities therefore failed immediately before npm publication.

After: both verification sites share one reuse-aware environment and resolve the expected source revision through the same authoritative selector. Non-reused releases still select the current release SHA.

Example: if preview commit P and release merge commit M have the same tree, a reused manifest sealed to P is accepted at both staging and packed verification; a fresh release remains sealed to M.

Receipts:
- reuse=true and reuse=false selector coverage
- staged and packed verifier anti-drift contract
- planted missing-env and inverted-selector mutations fail
- focused packaging tests and formatting pass

Stacked on #2416.