### PR TITLE
fix(runtime): gate relation queries on remote admission

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1970,6 +1970,8 @@ export class NativeRuntimeAdapter implements Runtime {
     // fresh remote receipt had just removed.
     const opts = readOptions(tier, queryIncludesDeleted(coreQueryJson), optionsJson);
     if (queryUsesNativeRelationApi(coreQueryJson)) {
+      await this.waitForStrictRemoteQueryTransport(tier);
+      if (this.closed) return [];
       if (this.readAuthorizationHost === "trusted-serving") {
         if (!this.db.allRelationQueryForIdentity) {
           throw new Error("Native runtime does not support trusted-serving relation queries");
@@ -2736,33 +2738,7 @@ export class NativeRuntimeAdapter implements Runtime {
     if (this.closed) return;
     if (tier == null || (tier === "local" && !this.nonDurableClient)) return;
     if (!readPropagationIsFull(optionsJson) && !this.nonDurableClient) return;
-    // `connect()` starts its WebSocket handshake before it can admit the
-    // native transport. A strict remote read begun in that interval must
-    // await the in-flight connection instead of falling through to a local
-    // materialization merely because the transport has not been installed yet.
-    while (!this.hasUpstream()) {
-      const pendingConnection = this.serverCarrierPromise;
-      if (!pendingConnection) return;
-      const attempt = this.serverConnectionAttempt;
-      const terminal =
-        attempt?.carrier === this.serverCarrier
-          ? await Promise.race([pendingConnection.then(() => null), attempt.terminal])
-          : null;
-      if (this.closed) return;
-      // Reauthentication/reconnect can retire a stalled carrier while this
-      // query is waiting. Follow the replacement attempt; only surface a
-      // terminal error when this was still the current connection.
-      if (terminal) {
-        if (
-          this.serverCarrierPromise !== null &&
-          this.serverCarrierPromise !== pendingConnection &&
-          this.serverConnectionAttempt?.carrier === this.serverCarrier
-        ) {
-          continue;
-        }
-        throw terminal;
-      }
-    }
+    await this.waitForStrictRemoteQueryTransport(tier);
     if (!this.db.attachQuery) return;
     // Coverage registration and probes are synchronous node operations. A
     // storage-backed evaluator may hold that node across suspension, so enter
@@ -2829,6 +2805,43 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     this.emitQueryCoverageTrace("covered");
     return attachment;
+  }
+
+  /**
+   * A strict remote query cannot materialize its local snapshot before an
+   * in-flight server handshake has either admitted its authority transport or
+   * failed. Relation-IR reads bypass query attachment, so they share this
+   * gate with attached reads instead of acquiring a second coverage path.
+   */
+  private async waitForStrictRemoteQueryTransport(tier: string | null | undefined): Promise<void> {
+    if (tier !== "edge" && tier !== "global") return;
+    // `connect()` starts its WebSocket handshake before it can admit the
+    // native transport. A strict remote read begun in that interval must
+    // await the in-flight connection instead of falling through to a local
+    // materialization merely because the transport has not been installed yet.
+    while (!this.hasUpstream()) {
+      const pendingConnection = this.serverCarrierPromise;
+      if (!pendingConnection) return;
+      const attempt = this.serverConnectionAttempt;
+      const terminal =
+        attempt?.carrier === this.serverCarrier
+          ? await Promise.race([pendingConnection.then(() => null), attempt.terminal])
+          : null;
+      if (this.closed) return;
+      // Reauthentication/reconnect can retire a stalled carrier while this
+      // query is waiting. Follow the replacement attempt; only surface a
+      // terminal error when this was still the current connection.
+      if (terminal) {
+        if (
+          this.serverCarrierPromise !== null &&
+          this.serverCarrierPromise !== pendingConnection &&
+          this.serverConnectionAttempt?.carrier === this.serverCarrier
+        ) {
+          continue;
+        }
+        throw terminal;
+      }
+    }
   }
 
   private attachLocalReadCoverageInBackground(

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -300,6 +300,230 @@ describe("NativeRuntimeAdapter server transport", () => {
     await expect(read).resolves.toEqual([]);
   });
 
+  it("waits for server admission before running a strict relation query", async () => {
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    const calls: unknown[][] = [];
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            allRelationQuery: (...args: unknown[]) => {
+              calls.push(args);
+              return encodeRows([]);
+            },
+            connectUpstream: () => new FakeTransport([]),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    const read = runtime.query(
+      JSON.stringify({ table: "todos", relation_ir: { Gather: {} } }),
+      null,
+      "edge",
+    );
+    await Promise.resolve();
+
+    expect(calls).toEqual([]);
+    await waitForFakeWebSocketNegotiation();
+    await expect(read).resolves.toEqual([]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("runs a strict relation query normally after server admission", async () => {
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    const calls: unknown[][] = [];
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            allRelationQuery: (...args: unknown[]) => {
+              calls.push(args);
+              return encodeRows([]);
+            },
+            connectUpstream: () => new FakeTransport([]),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+
+    await expect(
+      runtime.query(JSON.stringify({ table: "todos", relation_ir: { Gather: {} } }), null, "edge"),
+    ).resolves.toEqual([]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[1]).toEqual({ tier: "edge" });
+  });
+
+  it("moves a strict relation query from a stalled handshake to its auth-refresh replacement", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+
+      override send(data: Uint8Array | string): void {
+        if (sockets[0] === this) {
+          this.sent.push(data);
+          return;
+        }
+        super.send(data);
+      }
+    } as unknown as typeof WebSocket;
+    let relationQueries = 0;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            allRelationQuery: () => {
+              relationQueries += 1;
+              return encodeRows([]);
+            },
+            connectUpstream: () => new FakeTransport([]),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    const read = runtime.query(
+      JSON.stringify({ table: "todos", relation_ir: { Gather: {} } }),
+      null,
+      "edge",
+    );
+    await waitForFakeWebSocketNegotiation();
+    expect(relationQueries).toBe(0);
+
+    await runtime.updateAuth(JSON.stringify({ jwt_token: "fresh.jwt" }));
+    await waitForFakeWebSocketNegotiation();
+
+    expect(sockets).toHaveLength(2);
+    await expect(read).resolves.toEqual([]);
+    expect(relationQueries).toBe(1);
+  });
+
+  it("rejects a strict relation query when its pre-admission carrier terminates", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+
+      override send(data: Uint8Array | string): void {
+        this.sent.push(data);
+      }
+    } as unknown as typeof WebSocket;
+    let relationQueries = 0;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            allRelationQuery: () => {
+              relationQueries += 1;
+              return encodeRows([]);
+            },
+            connectUpstream: () => new FakeTransport([]),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    const read = runtime.query(
+      JSON.stringify({ table: "todos", relation_ir: { Gather: {} } }),
+      null,
+      "edge",
+    );
+    await waitForFakeWebSocketNegotiation();
+    sockets[0]!.emitMessage(
+      encodeWebSocketFrameBatch([encodeWireError(3, 1, "pre-admission denied")]),
+    );
+
+    await expect(read).rejects.toThrow("pre-admission denied");
+    expect(relationQueries).toBe(0);
+  });
+
+  it("returns an empty result when closing during a strict relation query handshake", async () => {
+    globalThis.WebSocket = class extends FakeWebSocket {
+      override send(data: Uint8Array | string): void {
+        this.sent.push(data);
+      }
+    } as unknown as typeof WebSocket;
+    let relationQueries = 0;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            allRelationQuery: () => {
+              relationQueries += 1;
+              return encodeRows([]);
+            },
+            connectUpstream: () => new FakeTransport([]),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    const read = runtime.query(
+      JSON.stringify({ table: "todos", relation_ir: { Gather: {} } }),
+      null,
+      "edge",
+    );
+    await waitForFakeWebSocketNegotiation();
+    expect(relationQueries).toBe(0);
+
+    await runtime.close();
+
+    await expect(read).resolves.toEqual([]);
+    expect(relationQueries).toBe(0);
+  });
+
   it("requires native db bindings to expose a tick scheduler", () => {
     expect(
       () =>


### PR DESCRIPTION
🤖 Makes strict remote relation queries obey the same transport-admission boundary as ordinary queries.

Before: Join/Gather/Union relation IR bypassed query attachment and therefore also bypassed the pending WebSocket handshake fence. A Remote/Edge/Global relation read begun during connection setup could resolve an early local empty result and never register the intended authority coverage.

After: relation reads share the existing strict-remote transport gate. They follow replacement connection attempts, reject terminal admission failures, and stop without native dispatch if the runtime closes while waiting. Local-first and offline remote-if-possible behavior are unchanged.

Examples:
- a relation read during a stalled handshake remains pending, then runs after admission
- an auth-refresh replacement is followed instead of stranding the read on the retired attempt
- a terminal pre-admission error rejects rather than returning []
- close during the wait resolves [] with zero relation dispatches

Receipts: 126 focused tests passed, 1 skipped; planted dropped-await and removed-close-guard mutations failed. Trusted-serving identity routing was independently probed.

Stacked on #2417.