### PR TITLE
fix(wire): reject noncanonical WebSocket batches

### DIFF
--- a/crates/jazz-native-transport/src/lib.rs
+++ b/crates/jazz-native-transport/src/lib.rs
@@ -636,7 +636,7 @@ async fn receive_server_hello(
         return Err(WebSocketClientError::UnexpectedHandshakeMessage);
     };
     let encoded: Vec<Vec<u8>> =
-        postcard::from_bytes(&bytes).map_err(WebSocketClientError::DecodeBatch)?;
+        jazz::wire::decode_postcard_exact(&bytes).map_err(WebSocketClientError::DecodeBatch)?;
     if encoded.len() != 1 {
         return Err(WebSocketClientError::UnexpectedHandshakeMessage);
     }
@@ -818,7 +818,7 @@ async fn run_ws_pump(
 }
 
 fn decode_inbound_batch(bytes: &[u8], bootstrap_catalogue: bool) -> Result<Vec<Vec<u8>>, String> {
-    let frames = postcard::from_bytes::<Vec<Vec<u8>>>(bytes)
+    let frames = jazz::wire::decode_postcard_exact::<Vec<Vec<u8>>>(bytes)
         .map_err(|_| "websocket peer sent malformed wire batch".to_owned())?;
     if frames.len() > MAX_WIRE_BATCH_FRAMES {
         return Err(format!(
@@ -956,6 +956,27 @@ mod tests {
             decode_inbound_batch(&flood, false)
                 .expect_err("count flood must be rejected before channel staging")
                 .contains("frame-count limit")
+        );
+    }
+
+    #[test]
+    fn inbound_batch_decoder_consumes_the_complete_carrier() {
+        let valid = [0x01, 0x01, 0x42];
+        assert_eq!(
+            postcard::to_allocvec(&vec![vec![0x42_u8]]).expect("encode valid batch"),
+            valid,
+            "frozen WebSocket batch corpus must remain canonical"
+        );
+        assert_eq!(
+            decode_inbound_batch(&valid, false).expect("decode complete valid batch"),
+            vec![vec![0x42]]
+        );
+
+        let mut suffixed = valid.to_vec();
+        suffixed.push(0x00);
+        assert!(
+            decode_inbound_batch(&suffixed, false).is_err(),
+            "a valid batch plus a suffix must not acquire a second interpretation"
         );
     }
 

--- a/crates/jazz-server/src/loopback/websocket.rs
+++ b/crates/jazz-server/src/loopback/websocket.rs
@@ -687,7 +687,7 @@ fn decode_frame_batch(bytes: &[u8]) -> Result<Vec<Vec<u8>>, postcard::Error> {
     if bytes.len() > MAX_WIRE_FRAME_BYTES {
         return Err(postcard::Error::DeserializeUnexpectedEnd);
     }
-    let frames: Vec<Vec<u8>> = postcard::from_bytes(bytes)?;
+    let frames: Vec<Vec<u8>> = jazz::wire::decode_postcard_exact(bytes)?;
     if frames
         .iter()
         .any(|frame| validate_wire_frame_len(frame.len()).is_err())
@@ -700,6 +700,27 @@ fn decode_frame_batch(bytes: &[u8]) -> Result<Vec<Vec<u8>>, postcard::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn frame_batch_decoder_consumes_the_complete_carrier() {
+        let valid = [0x01, 0x01, 0x42];
+        assert_eq!(
+            postcard::to_allocvec(&vec![vec![0x42_u8]]).expect("encode valid batch"),
+            valid,
+            "frozen WebSocket batch corpus must remain canonical"
+        );
+        assert_eq!(
+            decode_frame_batch(&valid).expect("decode complete valid batch"),
+            vec![vec![0x42]]
+        );
+
+        let mut suffixed = valid.to_vec();
+        suffixed.push(0x00);
+        assert!(
+            decode_frame_batch(&suffixed).is_err(),
+            "a valid batch plus a suffix must not acquire a second interpretation"
+        );
+    }
 
     #[test]
     fn first_frame_subject_validation_rejects_blank_and_preserves_exact_subject() {

--- a/crates/jazz-server/src/server/routes/websocket.rs
+++ b/crates/jazz-server/src/server/routes/websocket.rs
@@ -911,7 +911,7 @@ fn decode_ws_encoded_frame_batch(bytes: &[u8]) -> Result<Vec<Vec<u8>>, postcard:
     if bytes.len() > MAX_WIRE_FRAME_BYTES {
         return Err(postcard::Error::DeserializeUnexpectedEnd);
     }
-    let frames = postcard::from_bytes::<Vec<Vec<u8>>>(bytes)?;
+    let frames = jazz::wire::decode_postcard_exact::<Vec<Vec<u8>>>(bytes)?;
     if frames.is_empty()
         || frames.len() > MAX_WIRE_BATCH_FRAMES
         || frames
@@ -1893,6 +1893,27 @@ mod tests {
             .expect("encode count flood below physical byte cap");
         assert!(flood.len() <= MAX_WIRE_FRAME_BYTES);
         assert!(decode_ws_encoded_frame_batch(&flood).is_err());
+    }
+
+    #[test]
+    fn websocket_frame_batch_decoder_consumes_the_complete_carrier() {
+        let valid = [0x01, 0x01, 0x42];
+        assert_eq!(
+            postcard::to_allocvec(&vec![vec![0x42_u8]]).expect("encode valid batch"),
+            valid,
+            "frozen WebSocket batch corpus must remain canonical"
+        );
+        assert_eq!(
+            decode_ws_encoded_frame_batch(&valid).expect("decode complete valid batch"),
+            vec![vec![0x42]]
+        );
+
+        let mut suffixed = valid.to_vec();
+        suffixed.push(0x00);
+        assert!(
+            decode_ws_encoded_frame_batch(&suffixed).is_err(),
+            "a valid batch plus a suffix must not acquire a second interpretation"
+        );
     }
 
     #[test]

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -446,7 +446,11 @@ pub fn decode_sync_message(bytes: &[u8]) -> Result<SyncMessage, postcard::Error>
 /// interpretations at adjacent protocol seams. Postcard itself also accepts
 /// alternate overlong varint spellings, while the frozen wire contract admits
 /// only the encoder's shortest spelling.
-fn decode_postcard_exact<'a, T>(bytes: &'a [u8]) -> Result<T, postcard::Error>
+///
+/// This is the shared ownership boundary for protocol carriers that contain
+/// exactly one postcard value, including WebSocket frame batches. Callers must
+/// apply their carrier-specific size and cardinality limits separately.
+pub fn decode_postcard_exact<'a, T>(bytes: &'a [u8]) -> Result<T, postcard::Error>
 where
     T: Deserialize<'a> + Serialize,
 {


### PR DESCRIPTION
🤖 Enforces one exact canonical spelling for Rust WebSocket frame-batch carriers.

Before: four Rust ingress/transport paths used postcard from_bytes for the outer Vec<Vec<u8>> batch. That decoder accepts a valid value as a prefix, so appending 00 was silently ignored even though TypeScript rejects the same carrier and INV-WIRE-1 requires full consumption.

After: public server ingress, loopback ingress, native handshake, and native inbound pump all use the shared exact postcard decoder. It requires full byte consumption and encoder-canonical bytes. Existing carrier size, frame count, inner-frame, and handshake checks remain unchanged.

Example: canonical 01 01 42 decodes as one one-byte frame; 01 01 42 00 is rejected instead of acquiring a second accepted spelling.

Receipts:
- frozen valid and suffixed corpus at every Rust boundary
- central suffix and overlong-varint canonicality coverage
- valid native/server/loopback and TypeScript parity checks
- planted removal of exactness checks fails the corpus

Stacked on #2418.