### PR TITLE
fix(ci): remove preview tool installer action dependency

### DIFF
--- a/.github/actions/install-rust-tool/action.yml
+++ b/.github/actions/install-rust-tool/action.yml
@@ -1,10 +1,14 @@
 name: Install Rust tool
-description: Install a pinned Rust development tool in a job-local action home.
+description: Install an allowlisted, pinned Cargo tool in a job-local action home.
 
 inputs:
   tool:
-    description: Tool name and version accepted by taiki-e/install-action.
+    description: Pinned tool name accepted by dev/ci/install-rust-tool.sh.
     required: true
+  installer-revision:
+    description: Bump to invalidate a broken immutable hosted-tool cache.
+    required: false
+    default: "v1"
 
 runs:
   using: composite
@@ -16,7 +20,7 @@ runs:
         if [[ -f /opt/jazz-ci/toolchains/v1/manifest.json ]]; then
           node dev/ci/validate-tool-bundle.mjs >/dev/null
           case '${{ inputs.tool }}' in
-            sccache|cargo-nextest@0.9.143|wasm-pack@0.13.1)
+            sccache@0.15.0|cargo-nextest@0.9.143|wasm-pack@0.13.1)
               echo "active=true" >> "${GITHUB_OUTPUT}"
               ;;
             *)
@@ -27,14 +31,33 @@ runs:
           echo "active=false" >> "${GITHUB_OUTPUT}"
         fi
 
-    # install-action stages downloads under $HOME/.install-action and can use
-    # $CARGO_HOME/bin for Cargo-crate fallback. Self-hosted runner agents can
-    # share HOME/CARGO_HOME, so isolate both mutable roots to this job. These
-    # step-scoped variables do not change later Cargo registry/cache use.
-    - if: steps.provisioned-tool.outputs.active != 'true'
-      uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+    # Cargo's registry and install state must not leak between concurrent
+    # self-hosted jobs. These step-scoped paths leave later build caches alone.
+    # The key includes every compatibility dimension; do not add restore keys,
+    # because an older tool is not an acceptable fallback.
+    - name: Restore pinned Cargo tool
+      id: tool-cache
+      if: steps.provisioned-tool.outputs.active != 'true'
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
       with:
-        tool: ${{ inputs.tool }}
+        path: ${{ runner.temp }}/jazz-rust-tool
+        key: jazz-rust-tool-${{ inputs.installer-revision }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.tool }}
+
+    - name: Install pinned Cargo tool
+      if: steps.provisioned-tool.outputs.active != 'true'
+      shell: bash
+      run: dev/ci/install-rust-tool.sh
       env:
-        HOME: ${{ runner.temp }}/jazz-install-action
-        CARGO_HOME: ${{ runner.temp }}/jazz-install-action/cargo
+        JAZZ_RUST_TOOL: ${{ inputs.tool }}
+        JAZZ_RUST_TOOL_CACHE_HIT: ${{ steps.tool-cache.outputs.cache-hit }}
+        JAZZ_RUST_TOOL_CACHE_KEY: jazz-rust-tool-${{ inputs.installer-revision }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.tool }}
+        CARGO_HOME: ${{ runner.temp }}/jazz-rust-tool/cargo
+
+    # Only a miss can publish this immutable key. Concurrent cold jobs safely
+    # converge when one save observes the other has already created the key.
+    - name: Save pinned Cargo tool
+      if: steps.provisioned-tool.outputs.active != 'true' && steps.tool-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: ${{ runner.temp }}/jazz-rust-tool
+        key: jazz-rust-tool-${{ inputs.installer-revision }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.tool }}

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -139,7 +139,7 @@ runs:
       if: inputs.sccache == 'true' && runner.os == 'Linux' && steps.provisioned-tools.outputs.active != 'true'
       uses: ./.github/actions/install-rust-tool
       with:
-        tool: sccache
+        tool: sccache@0.15.0
 
     - name: Mount sccache sticky disk
       if: inputs.sccache == 'true' && inputs.sccache-sticky-disk == 'true' && runner.os == 'Linux' && steps.provisioned-tools.outputs.active != 'true'

--- a/.github/workflows/build-jazz-packages.yml
+++ b/.github/workflows/build-jazz-packages.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: ./.github/actions/install-rust-tool
         with:
-          tool: cargo-zigbuild
+          tool: cargo-zigbuild@0.20.1
 
       - name: Build CLI binary
         run: cargo zigbuild -p jazz-cli --bin jazz-tools --features otel --release --target ${{ matrix.target }}

--- a/dev/ci/install-rust-tool.sh
+++ b/dev/ci/install-rust-tool.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Install the small, explicitly allowlisted set of Cargo tools used by package
+# builds. Keeping this in-repository avoids making every Linux build depend on
+# downloading another action before its first build step can start.
+set -euo pipefail
+
+case "${JAZZ_RUST_TOOL:?JAZZ_RUST_TOOL must name a pinned tool}" in
+  sccache@0.15.0)
+    crate=sccache
+    version=0.15.0
+    binary=sccache
+    ;;
+  cargo-nextest@0.9.143)
+    crate=cargo-nextest
+    version=0.9.143
+    binary=cargo-nextest
+    ;;
+  cargo-zigbuild@0.20.1)
+    crate=cargo-zigbuild
+    version=0.20.1
+    binary=cargo-zigbuild
+    ;;
+  wasm-pack@0.13.1)
+    crate=wasm-pack
+    version=0.13.1
+    binary=wasm-pack
+    ;;
+  *)
+    echo "unsupported pinned Rust tool: ${JAZZ_RUST_TOOL}" >&2
+    exit 64
+    ;;
+esac
+
+install_root="${RUNNER_TEMP:?RUNNER_TEMP must be set}/jazz-rust-tool"
+
+verify_installed_tool() {
+  [[ -x "${install_root}/bin/${binary}" ]] &&
+    "${install_root}/bin/${binary}" --version | grep -F "${binary} ${version}" >/dev/null
+}
+
+if [[ "${JAZZ_RUST_TOOL_CACHE_HIT:-}" == "true" ]]; then
+  if verify_installed_tool; then
+    echo "using validated cached ${JAZZ_RUST_TOOL}"
+    echo "${install_root}/bin" >> "${GITHUB_PATH:?GITHUB_PATH must be set}"
+    exit 0
+  fi
+  echo "::error::cached ${JAZZ_RUST_TOOL} failed version validation for ${JAZZ_RUST_TOOL_CACHE_KEY:-unknown cache key}; expected ${binary} ${version}. Bump installer-revision before retrying." >&2
+  exit 65
+fi
+
+mkdir -p "${install_root}"
+cargo install "${crate}" --version "${version}" --locked --root "${install_root}"
+verify_installed_tool
+echo "${install_root}/bin" >> "${GITHUB_PATH:?GITHUB_PATH must be set}"

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -24,6 +24,10 @@ const installRustTool = fs.readFileSync(
   path.join(root, ".github/actions/install-rust-tool/action.yml"),
   "utf8",
 );
+const installRustToolScript = fs.readFileSync(
+  path.join(root, "dev/ci/install-rust-tool.sh"),
+  "utf8",
+);
 const packageBuild = fs.readFileSync(
   path.join(root, ".github/workflows/build-jazz-packages.yml"),
   "utf8",
@@ -402,25 +406,128 @@ test("build setup isolates mutable Rustup toolchains without moving Cargo caches
   );
 });
 
-test("Rust tool installation is isolated from shared self-hosted runner state", () => {
-  const installAction = "taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9";
-  assert.match(installRustTool, new RegExp(`uses: ${installAction}`));
-  assert.match(installRustTool, /HOME: \$\{\{ runner\.temp \}\}\/jazz-install-action/);
-  assert.match(installRustTool, /CARGO_HOME: \$\{\{ runner\.temp \}\}\/jazz-install-action\/cargo/);
-  for (const caller of [workflow, setupBuildAction, packageBuild]) {
-    assert.doesNotMatch(caller, new RegExp(installAction));
+test("Rust tool installation is pinned, allowlisted, and action-download independent", () => {
+  const toolCacheKey =
+    "jazz-rust-tool-${{ inputs.installer-revision }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.tool }}";
+  assert.doesNotMatch(installRustTool, /taiki-e\/install-action/);
+  assert.match(installRustTool, /run: dev\/ci\/install-rust-tool\.sh/);
+  assert.match(installRustTool, /CARGO_HOME: \$\{\{ runner\.temp \}\}\/jazz-rust-tool\/cargo/);
+  assert.match(installRustTool, /JAZZ_RUST_TOOL: \$\{\{ inputs\.tool \}\}/);
+  assert.match(
+    installRustTool,
+    /uses: actions\/cache\/restore@caa296126883cff596d87d8935842f9db880ef25/,
+  );
+  assert.match(
+    installRustTool,
+    /uses: actions\/cache\/save@caa296126883cff596d87d8935842f9db880ef25/,
+  );
+  assert.match(
+    installRustTool,
+    new RegExp(toolCacheKey.replaceAll("$", "\\$").replaceAll("{", "\\{").replaceAll("}", "\\}")),
+  );
+  assert.match(installRustTool, /path: \$\{\{ runner\.temp \}\}\/jazz-rust-tool/);
+  assert.match(
+    installRustTool,
+    /JAZZ_RUST_TOOL_CACHE_HIT: \$\{\{ steps\.tool-cache\.outputs\.cache-hit \}\}/,
+  );
+  assert.match(
+    installRustTool,
+    /JAZZ_RUST_TOOL_CACHE_KEY: jazz-rust-tool-\$\{\{ inputs\.installer-revision \}\}-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-\$\{\{ inputs\.tool \}\}/,
+  );
+  assert.match(installRustTool, /installer-revision:[\s\S]*default: "v1"/);
+  assert.match(
+    installRustTool,
+    /steps\.tool-cache\.outputs\.cache-hit != 'true'[\s\S]*uses: actions\/cache\/save@/,
+  );
+  for (const source of [workflow, setupBuildAction, packageBuild])
+    assert.doesNotMatch(source, /taiki-e\/install-action/);
+  for (const [tool, crate, version, provisioned] of [
+    ["sccache@0.15.0", "sccache", "0.15.0", true],
+    ["cargo-nextest@0.9.143", "cargo-nextest", "0.9.143", true],
+    // cargo-zigbuild is needed only for hosted Linux package cross-builds;
+    // the provisioned bundle intentionally does not include Zig.
+    ["cargo-zigbuild@0.20.1", "cargo-zigbuild", "0.20.1", false],
+    ["wasm-pack@0.13.1", "wasm-pack", "0.13.1", true],
+  ]) {
+    if (provisioned)
+      assert.match(
+        installRustTool,
+        new RegExp(`${tool.replaceAll(".", "\\.")}(?:\\||\\))`),
+        `provisioned and hosted paths must both support ${tool}`,
+      );
+    assert.match(
+      installRustToolScript,
+      new RegExp(
+        `${tool.replaceAll(".", "\\.")}[\\s\\S]*crate=${crate}[\\s\\S]*version=${version.replaceAll(".", "\\.")}`,
+      ),
+    );
   }
+  assert.match(
+    installRustToolScript,
+    /cargo install "\$\{crate\}" --version "\$\{version\}" --locked --root "\$\{install_root\}"/,
+  );
+  assert.match(installRustToolScript, /if \[\[ "\$\{JAZZ_RUST_TOOL_CACHE_HIT:-\}" == "true" \]\]/);
+  assert.match(installRustToolScript, /"\$\{install_root\}\/bin\/\$\{binary\}" --version/);
+  assert.match(
+    installRustToolScript,
+    /failed version validation[\s\S]*Bump installer-revision before retrying/,
+  );
+  assert.match(installRustToolScript, /exit 65/);
+  assert.doesNotMatch(installRustToolScript, /rm -rf/);
+  assert.match(installRustToolScript, /echo "\$\{install_root\}\/bin" >> "\$\{GITHUB_PATH/);
+  assert.match(setupBuildAction, /tool: sccache@0\.15\.0/);
+  assert.match(packageBuild, /tool: cargo-zigbuild@0\.20\.1/);
+  assert.throws(
+    () => assert.match(installRustToolScript.replace(" --locked", ""), / --locked/),
+    /--locked/,
+    "contract must reject a planted unlocked install",
+  );
   assert.throws(
     () =>
       assert.match(
         installRustTool.replace(
-          "        CARGO_HOME: ${{ runner.temp }}/jazz-install-action/cargo\n",
+          "        JAZZ_RUST_TOOL_CACHE_HIT: ${{ steps.tool-cache.outputs.cache-hit }}\n",
           "",
         ),
-        /CARGO_HOME: \$\{\{ runner\.temp \}\}\/jazz-install-action\/cargo/,
+        /JAZZ_RUST_TOOL_CACHE_HIT: \$\{\{ steps\.tool-cache\.outputs\.cache-hit \}\}/,
       ),
-    /CARGO_HOME/,
+    /JAZZ_RUST_TOOL_CACHE_HIT/,
+    "contract must reject a cache hit that skips validation",
   );
+  assert.throws(
+    () => assert.match(installRustToolScript.replace("  exit 65", "  exit 0"), /  exit 65/),
+    /exit 65/,
+    "contract must reject a corrupt cache hit that does not fail closed",
+  );
+});
+
+test("a corrupt exact-key Rust tool cache fails closed without installing or deleting it", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-rust-tool-invalid-cache-"));
+  const githubPath = path.join(temp, "github-path");
+  const cachedBinary = path.join(temp, "jazz-rust-tool", "bin", "sccache");
+  try {
+    fs.mkdirSync(path.dirname(cachedBinary), { recursive: true });
+    fs.writeFileSync(cachedBinary, "#!/usr/bin/env bash\necho 'sccache 0.14.0'\n");
+    fs.chmodSync(cachedBinary, 0o755);
+    const result = spawnSync("bash", ["dev/ci/install-rust-tool.sh"], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_PATH: githubPath,
+        JAZZ_RUST_TOOL: "sccache@0.15.0",
+        JAZZ_RUST_TOOL_CACHE_HIT: "true",
+        JAZZ_RUST_TOOL_CACHE_KEY: "jazz-rust-tool-v1-Linux-X64-sccache@0.15.0",
+        RUNNER_TEMP: temp,
+      },
+    });
+    assert.equal(result.status, 65);
+    assert.match(result.stderr, /failed version validation/);
+    assert.match(result.stderr, /Bump installer-revision/);
+    assert.equal(fs.existsSync(cachedBinary), true);
+  } finally {
+    fs.rmSync(temp, { force: true, recursive: true });
+  }
 });
 
 test("trusted runners consume the validated immutable tool bundle", () => {


### PR DESCRIPTION
🤖 Removes the repeatedly failing taiki-e installer-action download from preview package builds while preserving exact Rust tool versions.

Before: every Linux/WASM preview builder had to download the pinned installer action before compilation. GitHub codeload returned HTTP 400 across two attempts, so no Linux artifact could be built.

After: a repository-owned allowlisted installer uses cargo install --locked for exact versions. An exact immutable cache key includes installer revision, OS, architecture, and tool/version. Warm hits verify the executable version before use; corrupt hits fail closed and tell operators to bump the installer revision; misses install, validate, and save. Provisioned runners keep their existing bypass.

Examples:
- a valid cached sccache 0.15.0 is reused without invoking Cargo
- a wrong-version binary under the exact key exits 65 instead of silently running or repeatedly reinstalling
- concurrent cold saves converge on the same immutable cache key

Receipts: 43 focused workflow tests, full workflow-contract suite, YAML parsing, shell syntax, and planted corrupt-cache/action-drift mutations.

Nonblocking cold-install optimization is tracked in #2419.

Stacked on #2420.