### PR TITLE
fix(browser): skip terminating worker during lease bootstrap

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.test.ts
@@ -1,15 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createBrowserSharedWorkerBaseName,
+  installWorkerTerminationGenerationHandoff,
   SharedBrowserForegroundNodeLease,
 } from "./browser-shared-worker-connection.js";
 
-type LeaseMessage = {
-  type:
-    | "acquire-foreground-node-lease"
-    | "cancel-foreground-node-lease"
-    | "retire-foreground-node-lease";
-};
+type LeaseMessage =
+  | { type: "probe-foreground-node-lease-worker"; attemptId: string }
+  | {
+      type: "acquire-foreground-node-lease";
+      attemptId?: string;
+      dbName: string;
+      storageOwner: string;
+    }
+  | { type: "cancel-foreground-node-lease" }
+  | { type: "retire-foreground-node-lease" };
 
 class DelayedLeasePort {
   private readonly messageListeners = new Set<(event: MessageEvent) => void>();
@@ -19,6 +24,9 @@ class DelayedLeasePort {
   constructor(
     private readonly readyDelayMs = 1_100,
     private readonly acknowledgeCancellation = true,
+    private readonly acknowledgeProbe = true,
+    private readonly probeDelayMs = 0,
+    private readonly closing = false,
   ) {}
 
   start(): void {}
@@ -37,6 +45,21 @@ class DelayedLeasePort {
 
   postMessage(message: LeaseMessage): void {
     this.sent.push(message);
+    if (message.type === "probe-foreground-node-lease-worker") {
+      if (this.acknowledgeProbe) {
+        setTimeout(
+          () =>
+            this.emit({
+              type: this.closing
+                ? "foreground-node-lease-worker-closing"
+                : "foreground-node-lease-worker-alive",
+              attemptId: message.attemptId,
+            }),
+          this.probeDelayMs,
+        );
+      }
+      return;
+    }
     if (message.type === "acquire-foreground-node-lease") {
       // This is intentionally just beyond the historical one-second budget.
       // Cold IDB admission is allowed to take this long before the foreground
@@ -73,12 +96,61 @@ class DelayedLeasePort {
   }
 }
 
+class InspectorPort {
+  private readonly messageListeners = new Set<(event: MessageEvent) => void>();
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    if (type === "message") this.messageListeners.add(listener);
+  }
+
+  emit(data: unknown): void {
+    for (const listener of this.messageListeners) listener({ data } as MessageEvent);
+  }
+}
+
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
 describe("browser SharedWorker realm identity", () => {
+  it("advances the shared generation when inspector termination is acknowledged", async () => {
+    const values = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    });
+    const dbName = "inspector-terminated-root";
+    const workerName = createBrowserSharedWorkerBaseName(undefined, dbName);
+    const inspector = new InspectorPort();
+    installWorkerTerminationGenerationHandoff(inspector as unknown as MessagePort, workerName, 0);
+
+    // Ordinary inspector results never affect worker selection.
+    inspector.emit({ type: "result", id: 1 });
+    expect(values.size).toBe(0);
+    inspector.emit({ type: "result", id: 2, workerTerminated: true });
+
+    const leasePort = new DelayedLeasePort(0);
+    const workerNames: string[] = [];
+    vi.stubGlobal(
+      "SharedWorker",
+      class {
+        readonly port = leasePort;
+
+        constructor(_url: URL, options: { name: string }) {
+          workerNames.push(options.name);
+        }
+      },
+    );
+    const lease = await SharedBrowserForegroundNodeLease.acquire({
+      dbName,
+      storageOwner: "owner",
+    });
+
+    expect(workerNames).toEqual([expect.stringContaining(":generation-1")]);
+    await lease.retire();
+  });
+
   it("waits through cold durable lease admission rather than treating it as a dead worker", async () => {
     const port = new DelayedLeasePort();
     vi.stubGlobal(
@@ -115,7 +187,12 @@ describe("browser SharedWorker realm identity", () => {
     const rejected = expect(acquire).rejects.toThrow("did not issue a foreground node lease");
     await vi.advanceTimersByTimeAsync(10_000);
     expect(port.sent).toEqual([
-      { type: "acquire-foreground-node-lease", dbName: "timed-out-root", storageOwner: "owner" },
+      expect.objectContaining({ type: "probe-foreground-node-lease-worker" }),
+      expect.objectContaining({
+        type: "acquire-foreground-node-lease",
+        dbName: "timed-out-root",
+        storageOwner: "owner",
+      }),
       { type: "cancel-foreground-node-lease" },
     ]);
     await rejected;
@@ -146,6 +223,84 @@ describe("browser SharedWorker realm identity", () => {
 
     await vi.runAllTimersAsync();
     expect(port.closed).toBe(true);
+  });
+
+  it("skips a closing worker generation before issuing a durable lease request", async () => {
+    vi.useFakeTimers();
+    const closingPort = new DelayedLeasePort(0, true, true, 0, true);
+    const successorPort = new DelayedLeasePort(0, true, true);
+    const workerNames: string[] = [];
+    let workerCount = 0;
+    vi.stubGlobal(
+      "SharedWorker",
+      class {
+        readonly port = ++workerCount === 1 ? closingPort : successorPort;
+
+        constructor(_url: URL, options: { name: string }) {
+          workerNames.push(options.name);
+        }
+      },
+    );
+
+    const acquiring = SharedBrowserForegroundNodeLease.acquire({
+      dbName: "closing-generation-root",
+      storageOwner: "owner",
+    });
+    await vi.runAllTimersAsync();
+    const lease = await acquiring;
+
+    expect(closingPort.sent).toEqual([
+      expect.objectContaining({ type: "probe-foreground-node-lease-worker" }),
+    ]);
+    expect(successorPort.sent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "probe-foreground-node-lease-worker" }),
+        expect.objectContaining({ type: "acquire-foreground-node-lease" }),
+      ]),
+    );
+    expect(workerNames[0]).toContain(":generation-0");
+    expect(workerNames[1]).toContain(":generation-1");
+
+    const retired = lease.retire();
+    await vi.runAllTimersAsync();
+    await retired;
+  });
+
+  it("does not advance generations when a healthy busy worker delays its probe", async () => {
+    vi.useFakeTimers();
+    const delayedHealthyPort = new DelayedLeasePort(0, true, true, 1_100);
+    const workerNames: string[] = [];
+    vi.stubGlobal(
+      "SharedWorker",
+      class {
+        readonly port = delayedHealthyPort;
+
+        constructor(_url: URL, options: { name: string }) {
+          workerNames.push(options.name);
+        }
+      },
+    );
+
+    const acquiring = SharedBrowserForegroundNodeLease.acquire({
+      dbName: "busy-healthy-generation-root",
+      storageOwner: "owner",
+    });
+    await vi.advanceTimersByTimeAsync(1_100);
+    await vi.runAllTimersAsync();
+    const lease = await acquiring;
+
+    expect(workerNames).toHaveLength(1);
+    expect(workerNames[0]).toContain(":generation-0");
+    expect(delayedHealthyPort.sent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "probe-foreground-node-lease-worker" }),
+        expect.objectContaining({ type: "acquire-foreground-node-lease" }),
+      ]),
+    );
+
+    const retired = lease.retire();
+    await vi.runAllTimersAsync();
+    await retired;
   });
 
   it("coalesces repeated opens behind one wedged cancellation cleanup and retries after acknowledgement", async () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -16,6 +16,7 @@ import type {
   BrowserForegroundNodeLeasePortEvent,
   BrowserForegroundNodeLeasePortRequest,
   BrowserFollowerPortRequest,
+  BrowserInspectorControlEvent,
   BrowserWorkerInitOptions,
 } from "./browser-worker-protocol.js";
 import type { NativeRuntimeAdapter } from "./native-runtime-adapter.js";
@@ -28,11 +29,11 @@ export type BrowserForegroundNodeLeaseOptions = Pick<
 // Acquiring a lease is deliberately the first operation on a persistent
 // browser root. On a cold browser profile that means starting the worker,
 // acquiring the Web Lock, opening IndexedDB, checking the durable owner, and
-// committing the lease receipt. This is I/O admission, not a heartbeat: the
-// one-second worker-bootstrap probe used by reconnecting followers is too
-// short for it under a contended CI/browser process. Keep this bounded so a
-// genuinely wedged worker still fails visibly, but give durable admission the
-// same order-of-magnitude budget as the public browser readiness receipts.
+// committing the lease receipt. This is I/O admission, not a heartbeat. Keep
+// the complete probe-and-admission operation bounded so a genuinely wedged
+// worker still fails visibly, but do not guess that a busy realm is dead from
+// a shorter probe timeout. A realm that accepted termination explicitly says
+// it is closing so the client can safely advance to another generation.
 const FOREGROUND_NODE_LEASE_ADMISSION_TIMEOUT_MS = 10_000;
 
 /**
@@ -98,17 +99,38 @@ export class SharedBrowserForegroundNodeLease implements ForegroundNodeLease {
               type: "module",
               name,
             });
-    // Lease acquisition and the schema/runtime connection enter this exact
-    // physical SharedWorker realm. Both generation-qualify the base name so a
-    // realm that has begun closing can be retired without creating a second
-    // durable owner for the same IndexedDB.
-    const worker = createWorker(`${workerName}:generation-${readWorkerGeneration(workerName)}`);
+    // A named SharedWorker constructor can still attach to a realm after that
+    // realm has acknowledged termination but before the browser has finished
+    // destroying it. Probe before sending an allocation request so a realm
+    // that explicitly reports it is closing can be skipped without creating
+    // an orphan-risking durable operation in it.
+    let generation = readWorkerGeneration(workerName);
+    for (let generationAttempt = 0; generationAttempt < 8; generationAttempt += 1) {
+      const worker = createWorker(`${workerName}:generation-${generation}`);
+      const lease = await this.acquireFromWorkerGeneration(
+        worker,
+        options,
+        cleanupKey,
+        crypto.randomUUID(),
+      );
+      if (lease) return lease;
+      generation = advanceWorkerGeneration(workerName, generation);
+    }
+    throw new Error("Shared browser foreground lease worker did not answer after closing");
+  }
+
+  private static acquireFromWorkerGeneration(
+    worker: SharedWorker,
+    options: BrowserForegroundNodeLeaseOptions,
+    cleanupKey: string,
+    attemptId: string,
+  ): Promise<SharedBrowserForegroundNodeLease | null> {
     const port = worker.port;
-    port.start();
-    const lease = await new Promise<SharedBrowserForegroundNodeLease>((resolve, reject) => {
+    return new Promise<SharedBrowserForegroundNodeLease | null>((resolve, reject) => {
       let cancellationRequested = false;
       let publicResultSettled = false;
       let cleanupToken: symbol | null = null;
+      let admissionTimeout: ReturnType<typeof setTimeout> | null = null;
       const timeoutError = new Error(
         "Shared browser runtime did not issue a foreground node lease",
       );
@@ -117,23 +139,25 @@ export class SharedBrowserForegroundNodeLease implements ForegroundNodeLease {
         publicResultSettled = true;
         reject(error);
       };
-      const timeout = setTimeout(() => {
-        // Do not close the port immediately. The worker might be between the
-        // durable allocation and its ready reply; it must observe this cancel
-        // and retire such a lease before this acquire rejects. Otherwise a
-        // merely slow cold open would burn one node identity per timeout.
-        cancellationRequested = true;
-        cleanupToken = Symbol("foreground-lease-cleanup");
-        pendingForegroundLeaseCleanups.set(cleanupKey, cleanupToken);
-        port.postMessage({ type: "cancel-foreground-node-lease" });
-        // Public startup remains bounded. The open port and listeners stay
-        // alive in the background until the worker observes cancellation and
-        // retires any late lease; closing them here would recreate the orphan
-        // race this cancellation protocol exists to prevent.
-        rejectPublic(timeoutError);
-      }, FOREGROUND_NODE_LEASE_ADMISSION_TIMEOUT_MS);
+      const beginAdmissionTimeout = () =>
+        setTimeout(() => {
+          // Do not close the port immediately. The worker might be between the
+          // durable allocation and its ready reply; it must observe this cancel
+          // and retire such a lease before this acquire rejects. Otherwise a
+          // merely slow cold open would burn one node identity per timeout.
+          cancellationRequested = true;
+          cleanupToken = Symbol("foreground-lease-cleanup");
+          pendingForegroundLeaseCleanups.set(cleanupKey, cleanupToken);
+          port.postMessage({ type: "cancel-foreground-node-lease" });
+          // Public startup remains bounded. The open port and listeners stay
+          // alive in the background until the worker observes cancellation and
+          // retires any late lease; closing them here would recreate the orphan
+          // race this cancellation protocol exists to prevent.
+          rejectPublic(timeoutError);
+        }, FOREGROUND_NODE_LEASE_ADMISSION_TIMEOUT_MS);
       const cleanup = () => {
-        clearTimeout(timeout);
+        if (admissionTimeout) clearTimeout(admissionTimeout);
+        admissionTimeout = null;
         // A successful concurrent admission never owned this retained cleanup.
         // Only its timeout owner may clear the shared key; otherwise it could
         // let a third caller accumulate another orphan-risking port.
@@ -148,6 +172,24 @@ export class SharedBrowserForegroundNodeLease implements ForegroundNodeLease {
       };
       const onMessage = (event: MessageEvent<BrowserForegroundNodeLeaseAcquireResponse>) => {
         const message = event.data;
+        if (message?.type === "foreground-node-lease-worker-alive") {
+          if (message.attemptId !== attemptId || admissionTimeout === null) return;
+          port.postMessage({
+            type: "acquire-foreground-node-lease",
+            attemptId,
+            dbName: options.dbName,
+            storageOwner: options.storageOwner,
+          });
+          return;
+        }
+        if (message?.type === "foreground-node-lease-worker-closing") {
+          if (message.attemptId !== attemptId) return;
+          cleanup();
+          port.close();
+          publicResultSettled = true;
+          resolve(null);
+          return;
+        }
         if (message?.type === "foreground-node-lease-error") {
           cleanup();
           port.close();
@@ -189,13 +231,13 @@ export class SharedBrowserForegroundNodeLease implements ForegroundNodeLease {
       };
       port.addEventListener("message", onMessage);
       port.addEventListener("messageerror", onMessageError);
+      port.start();
+      admissionTimeout = beginAdmissionTimeout();
       port.postMessage({
-        type: "acquire-foreground-node-lease",
-        dbName: options.dbName,
-        storageOwner: options.storageOwner,
+        type: "probe-foreground-node-lease-worker",
+        attemptId,
       });
     });
-    return lease;
   }
 
   async returnWithHighWater(highWater: bigint): Promise<void> {
@@ -250,6 +292,8 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
   private readyError: Error | null = null;
   private connection: MessagePortBrowserFollowerConnection | null = null;
   private closed = false;
+  private readonly workerName: string;
+  private connectedGeneration: number | null = null;
 
   constructor(
     runtime: NativeRuntimeAdapter,
@@ -271,6 +315,7 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
     // separate workers and caches while same-scope tabs share one realm.
     const runtimeSources = resolveBrowserWorkerRuntimeSources(options.runtimeSources);
     const workerName = createBrowserSharedWorkerBaseName(runtimeSources, options.dbName);
+    this.workerName = workerName;
     const createWorker =
       runtimeSources?.brokerWorkerUrl || runtimeSources?.baseUrl || runtimeSources?.wasmVersion
         ? (name: string) =>
@@ -323,6 +368,7 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
       );
       if (outcome.error) throw outcome.error;
       if (outcome.connected) {
+        this.connectedGeneration = generation;
         return;
       }
       generation = advanceWorkerGeneration(workerName, generation);
@@ -474,8 +520,25 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
   async openInspectorControlPort(): Promise<MessagePort> {
     await this.ready();
     if (!this.connection) throw new Error("Shared browser runtime is not connected");
-    return this.connection.openInspectorControlPort();
+    const port = await this.connection.openInspectorControlPort();
+    const generation = this.connectedGeneration;
+    if (generation !== null) {
+      installWorkerTerminationGenerationHandoff(port, this.workerName, generation);
+    }
+    return port;
   }
+}
+
+/** @internal Keeps an acknowledged inspector restart out of its closing realm. */
+export function installWorkerTerminationGenerationHandoff(
+  port: MessagePort,
+  workerName: string,
+  generation: number,
+): void {
+  port.addEventListener("message", (event: MessageEvent<BrowserInspectorControlEvent>) => {
+    if (event.data?.type !== "result" || event.data.workerTerminated !== true) return;
+    advanceWorkerGeneration(workerName, generation);
+  });
 }
 
 function readWorkerGeneration(workerName: string): number {

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-protocol.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-protocol.ts
@@ -28,9 +28,21 @@ export interface BrowserSharedWorkerConnectRequest {
   options: BrowserWorkerInitOptions;
 }
 
+/**
+ * Liveness handshake sent before a foreground lease request. The worker must
+ * acknowledge this without touching durable state; only then may the client
+ * send the allocation request on the same port.
+ */
+export interface BrowserForegroundNodeLeaseProbeRequest {
+  type: "probe-foreground-node-lease-worker";
+  attemptId: string;
+}
+
 /** Lease-only bootstrap that runs before the foreground schema is known. */
 export interface BrowserForegroundNodeLeaseAcquireRequest {
   type: "acquire-foreground-node-lease";
+  /** Correlates this durable operation with its preceding liveness probe. */
+  attemptId?: string;
   dbName: string;
   /** Exact durable owner that must admit the physical root before lease issue. */
   storageOwner: string;
@@ -46,6 +58,15 @@ export interface BrowserForegroundNodeLeaseCancelRequest {
 }
 
 export type BrowserForegroundNodeLeaseAcquireResponse =
+  | {
+      type: "foreground-node-lease-worker-alive";
+      attemptId: string;
+    }
+  | {
+      /** The named realm accepted termination and must not admit durable work. */
+      type: "foreground-node-lease-worker-closing";
+      attemptId: string;
+    }
   | {
       type: "foreground-node-lease-ready";
       leaseId: string;
@@ -181,7 +202,13 @@ export type BrowserInspectorControlRequest =
 export type BrowserInspectorControlEvent =
   | { type: "contexts"; id: number; contexts: BrowserInspectorContext[] }
   | { type: "lifecycle-trace"; id: number; entries: BrowserWorkerLifecycleTrace[] }
-  | { type: "result"; id: number; error?: string };
+  | {
+      type: "result";
+      id: number;
+      error?: string;
+      /** The acknowledged realm is closing; future opens must use its successor. */
+      workerTerminated?: true;
+    };
 
 export type BrowserFollowerPortEvent =
   | { type: "frames"; frames: Uint8Array[] }

--- a/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
@@ -14,6 +14,7 @@ import type {
   BrowserForegroundNodeLeaseAcquireRequest,
   BrowserForegroundNodeLeaseAcquireResponse,
   BrowserForegroundNodeLeaseCancelRequest,
+  BrowserForegroundNodeLeaseProbeRequest,
   BrowserForegroundNodeLeasePortEvent,
   BrowserForegroundNodeLeasePortRequest,
   BrowserFollowerPortEvent,
@@ -88,6 +89,7 @@ type ForegroundLeaseOwner = {
   storageOwner: string;
   activeLeaseIds: Set<string>;
   pendingLeaseAllocations: number;
+  pendingLeaseFinalizations: number;
   allocationTail: Promise<void>;
 };
 
@@ -140,6 +142,11 @@ let pendingBootstrapOperations = 0;
 // deferred close needs an invalidatable token rather than an unconditional
 // `finally(() => close())`.
 let pendingWorkerClose: symbol | null = null;
+// Inspector-directed termination acknowledges before calling `close()` in a
+// later task so the reply can cross its MessagePort. Reject new ports in that
+// acknowledgement gap: admitting them into the doomed realm can otherwise
+// strand a foreground lease request with no terminal response.
+let workerTerminationScheduled = false;
 // The inspector-facing trace intentionally does not serialize this key. It
 // is only an in-worker capability boundary that prevents a later auth scope
 // from observing a prior scope's retained diagnostics for the same realm.
@@ -330,26 +337,66 @@ export function installJazzBrokerWorker(options: JazzBrokerWorkerOptions = {}): 
     // first operation or failed it.
     pendingBootstrapOperations += 1;
     let bootstrapFinished = false;
+    let bootstrapPortClosed = false;
+    let probedLeaseAttemptId: string | null = null;
     const finishBootstrap = () => {
       if (bootstrapFinished) return;
       bootstrapFinished = true;
       pendingBootstrapOperations -= 1;
       maybeCloseWorker();
     };
-    const onBootstrapMessage = (
+    const detachBootstrapListeners = () => {
+      port.removeEventListener("message", onBootstrapMessage);
+      port.removeEventListener("messageerror", onBootstrapMessageError);
+    };
+    const closeBootstrapPort = () => {
+      if (bootstrapPortClosed) return;
+      bootstrapPortClosed = true;
+      detachBootstrapListeners();
+      finishBootstrap();
+      port.close();
+    };
+    function onBootstrapMessage(
       messageEvent: MessageEvent<
-        BrowserSharedWorkerConnectRequest | BrowserForegroundNodeLeaseAcquireRequest
+        | BrowserSharedWorkerConnectRequest
+        | BrowserForegroundNodeLeaseProbeRequest
+        | BrowserForegroundNodeLeaseAcquireRequest
+        | BrowserForegroundNodeLeaseCancelRequest
       >,
-    ) => {
+    ) {
       const message = messageEvent.data;
+      if (workerTerminationScheduled) {
+        if (
+          message?.type === "probe-foreground-node-lease-worker" ||
+          message?.type === "acquire-foreground-node-lease"
+        ) {
+          post(port, {
+            type: "foreground-node-lease-worker-closing",
+            attemptId: message.attemptId ?? "",
+          } satisfies BrowserForegroundNodeLeaseAcquireResponse);
+        }
+        closeBootstrapPort();
+        return;
+      }
+      if (message?.type === "probe-foreground-node-lease-worker") {
+        probedLeaseAttemptId = message.attemptId;
+        post(port, {
+          type: "foreground-node-lease-worker-alive",
+          attemptId: message.attemptId,
+        } satisfies BrowserForegroundNodeLeaseAcquireResponse);
+        return;
+      }
+      if (message?.type === "cancel-foreground-node-lease") {
+        closeBootstrapPort();
+        return;
+      }
       if (
         message?.type !== "connect-runtime" &&
         message?.type !== "acquire-foreground-node-lease"
       ) {
         return;
       }
-      port.removeEventListener("message", onBootstrapMessage);
-      port.removeEventListener("messageerror", onBootstrapMessageError);
+      detachBootstrapListeners();
       if (message.type === "connect-runtime") {
         recordWorkerLifecycle(
           "bootstrap-start",
@@ -359,15 +406,22 @@ export function installJazzBrokerWorker(options: JazzBrokerWorkerOptions = {}): 
         post(port, { type: "worker-alive" });
         void connectTab(port, message, finishBootstrap);
       } else {
+        if (probedLeaseAttemptId !== null && message.attemptId !== probedLeaseAttemptId) {
+          finishBootstrap();
+          post(port, {
+            type: "foreground-node-lease-error",
+            message: "Foreground node lease request did not match its worker probe",
+          } satisfies BrowserForegroundNodeLeaseAcquireResponse);
+          closeBootstrapPort();
+          return;
+        }
         recordWorkerLifecycle("lease-request", message.dbName, null);
         void acquireForegroundNodeLease(port, message).finally(finishBootstrap);
       }
-    };
-    const onBootstrapMessageError = () => {
-      port.removeEventListener("message", onBootstrapMessage);
-      finishBootstrap();
-      port.close();
-    };
+    }
+    function onBootstrapMessageError() {
+      closeBootstrapPort();
+    }
     port.addEventListener("message", onBootstrapMessage);
     port.addEventListener("messageerror", onBootstrapMessageError);
     port.start();
@@ -419,9 +473,8 @@ async function acquireForegroundNodeLease(
       return;
     }
     settled = true;
-    owner.activeLeaseIds.delete(lease.leaseId);
     try {
-      await owner.pageStore.retireForegroundNodeLease(lease.leaseId);
+      await retireForegroundNodeLease(owner, lease.leaseId);
       const testLeaseState = testHooks
         ? await testHooks.cancellationRetired(owner.pageStore, lease.node)
         : undefined;
@@ -453,9 +506,7 @@ async function acquireForegroundNodeLease(
   const retire = async (): Promise<void> => {
     if (settled || !lease || !owner) return;
     settled = true;
-    owner.activeLeaseIds.delete(lease.leaseId);
-    await owner.pageStore.retireForegroundNodeLease(lease.leaseId);
-    maybeCloseWorker();
+    await retireForegroundNodeLease(owner, lease.leaseId);
   };
   const onMessage = (
     event: MessageEvent<
@@ -544,6 +595,7 @@ async function acquireForegroundNodeLease(
           storageOwner: request.storageOwner,
           activeLeaseIds: new Set(),
           pendingLeaseAllocations: 0,
+          pendingLeaseFinalizations: 0,
           allocationTail: Promise.resolve(),
         };
         foregroundLeaseOwners.set(request.dbName, owner);
@@ -638,6 +690,28 @@ async function allocateForegroundNodeLease(
     // On success the active ID now retains the worker. On terminal failure no
     // port can finish handoff, so this balanced decrement may release an idle
     // physical owner. Other queued reservations remain counted independently.
+    maybeCloseWorker();
+  }
+}
+
+async function retireForegroundNodeLease(
+  owner: ForegroundLeaseOwner,
+  leaseId: string,
+): Promise<void> {
+  // Finalization becomes worker-owned synchronously, before the active marker
+  // is removed. This closes the gap where explicit worker termination could
+  // otherwise race a durable retirement that had not committed yet.
+  owner.pendingLeaseFinalizations += 1;
+  owner.activeLeaseIds.delete(leaseId);
+  try {
+    await owner.pageStore.retireForegroundNodeLease(leaseId);
+  } catch (error) {
+    // The durable lease remains active when retirement fails. Restore its
+    // in-memory marker so this realm continues to fail closed as well.
+    owner.activeLeaseIds.add(leaseId);
+    throw error;
+  } finally {
+    owner.pendingLeaseFinalizations -= 1;
     maybeCloseWorker();
   }
 }
@@ -1266,7 +1340,28 @@ function attachInspectorControl(authSessionKey: string, port: MessagePort): void
         } satisfies BrowserInspectorControlEvent);
         return;
       }
-      port.postMessage({ type: "result", id: message.id } satisfies BrowserInspectorControlEvent);
+      if (pendingBootstrapOperations > 0) {
+        port.postMessage({
+          type: "result",
+          id: message.id,
+          error: "Worker still has pending bootstrap operations",
+        } satisfies BrowserInspectorControlEvent);
+        return;
+      }
+      if (hasForegroundLeaseWork()) {
+        port.postMessage({
+          type: "result",
+          id: message.id,
+          error: "Worker still has pending or active foreground node leases",
+        } satisfies BrowserInspectorControlEvent);
+        return;
+      }
+      workerTerminationScheduled = true;
+      port.postMessage({
+        type: "result",
+        id: message.id,
+        workerTerminated: true,
+      } satisfies BrowserInspectorControlEvent);
       // Termination happens in a later task so the acknowledgement crosses the
       // MessagePort before this realm disappears. A subsequent connection's
       // bootstrap retry advances to a distinct SharedWorker generation.
@@ -1467,14 +1562,20 @@ function maybeCloseWorker(): void {
 }
 
 function workerHasLiveWork(): boolean {
-  const hasActiveForegroundLease = [...foregroundLeaseOwners.values()].some(
-    (owner) => owner.activeLeaseIds.size > 0 || owner.pendingLeaseAllocations > 0,
-  );
   return (
     contexts.size > 0 ||
     inspectorControlPorts.size > 0 ||
     pendingBootstrapOperations > 0 ||
-    hasActiveForegroundLease
+    hasForegroundLeaseWork()
+  );
+}
+
+function hasForegroundLeaseWork(): boolean {
+  return [...foregroundLeaseOwners.values()].some(
+    (owner) =>
+      owner.activeLeaseIds.size > 0 ||
+      owner.pendingLeaseAllocations > 0 ||
+      owner.pendingLeaseFinalizations > 0,
   );
 }
 

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   BrowserForegroundNodeLeaseAcquireRequest,
   BrowserForegroundNodeLeaseAcquireResponse,
+  BrowserForegroundNodeLeaseCancelRequest,
+  BrowserForegroundNodeLeasePortRequest,
+  BrowserForegroundNodeLeaseProbeRequest,
   BrowserFollowerPortEvent,
   BrowserFollowerPortRequest,
   BrowserInspectorControlEvent,
@@ -170,6 +173,13 @@ type ForegroundLeaseOutcome = Extract<
   { type: "foreground-node-lease-ready" | "foreground-node-lease-error" }
 >;
 
+type ForegroundLeaseProbeOutcome = Extract<
+  BrowserForegroundNodeLeaseAcquireResponse,
+  {
+    type: "foreground-node-lease-worker-alive" | "foreground-node-lease-worker-closing";
+  }
+>;
+
 type WorkerGlobal = typeof globalThis & {
   onconnect: ((event: MessageEvent & { ports: MessagePort[] }) => void) | null;
   close?: Mock;
@@ -183,6 +193,9 @@ class TestPort {
   private readonly outcomeWaiters: Array<(outcome: RuntimeOutcome) => void> = [];
   private readonly leaseOutcomes: ForegroundLeaseOutcome[] = [];
   private readonly leaseOutcomeWaiters: Array<(outcome: ForegroundLeaseOutcome) => void> = [];
+  private readonly leaseProbeOutcomes: ForegroundLeaseProbeOutcome[] = [];
+  private readonly leaseProbeOutcomeWaiters: Array<(outcome: ForegroundLeaseProbeOutcome) => void> =
+    [];
   private readonly events: BrowserFollowerPortEvent[] = [];
   private readonly eventWaiters: Array<{
     predicate: (event: BrowserFollowerPortEvent) => boolean;
@@ -215,6 +228,15 @@ class TestPort {
     // connection outcome; tests only retain the latter two protocol classes.
     if (message.type === "worker-alive") return;
     if (
+      message.type === "foreground-node-lease-worker-alive" ||
+      message.type === "foreground-node-lease-worker-closing"
+    ) {
+      const waiter = this.leaseProbeOutcomeWaiters.shift();
+      if (waiter) waiter(message);
+      else this.leaseProbeOutcomes.push(message);
+      return;
+    }
+    if (
       message.type === "foreground-node-lease-ready" ||
       message.type === "foreground-node-lease-error"
     ) {
@@ -238,7 +260,10 @@ class TestPort {
   emitMessage(
     message:
       | BrowserSharedWorkerConnectRequest
+      | BrowserForegroundNodeLeaseProbeRequest
       | BrowserForegroundNodeLeaseAcquireRequest
+      | BrowserForegroundNodeLeaseCancelRequest
+      | BrowserForegroundNodeLeasePortRequest
       | BrowserFollowerPortRequest,
   ): void {
     for (const listener of this.listeners.get("message") ?? []) {
@@ -260,6 +285,18 @@ class TestPort {
     const waiter = deferred<ForegroundLeaseOutcome>();
     this.leaseOutcomeWaiters.push(waiter.resolve);
     return waiter.promise;
+  }
+
+  waitForLeaseProbeOutcome(): Promise<ForegroundLeaseProbeOutcome> {
+    const outcome = this.leaseProbeOutcomes.shift();
+    if (outcome) return Promise.resolve(outcome);
+    const waiter = deferred<ForegroundLeaseProbeOutcome>();
+    this.leaseProbeOutcomeWaiters.push(waiter.resolve);
+    return waiter.promise;
+  }
+
+  hasLeaseProbeOutcome(): boolean {
+    return this.leaseProbeOutcomes.length > 0;
   }
 
   waitForEvent(
@@ -314,6 +351,16 @@ function connectLease(request: BrowserForegroundNodeLeaseAcquireRequest): {
   const outcome = port.waitForLeaseOutcome();
   port.emitMessage(request);
   return { outcome, port };
+}
+
+function connectLeaseProbe(): { port: TestPort } {
+  const port = new TestPort();
+  const onconnect = (globalThis as WorkerGlobal).onconnect;
+  if (!onconnect) throw new Error("broker worker did not install its connect handler");
+  onconnect({ ports: [port as unknown as MessagePort] } as MessageEvent & {
+    ports: MessagePort[];
+  });
+  return { port };
 }
 
 function enabledTelemetryOptions(dbName: string): BrowserWorkerInitOptions {
@@ -373,6 +420,22 @@ async function readLifecycle(
   });
 }
 
+async function terminateInspector(
+  port: MessagePort,
+  id: number,
+): Promise<Extract<BrowserInspectorControlEvent, { type: "result" }>> {
+  return new Promise((resolve, reject) => {
+    const onMessage = (event: MessageEvent<BrowserInspectorControlEvent>) => {
+      if (event.data.type !== "result" || event.data.id !== id) return;
+      port.removeEventListener("message", onMessage);
+      if (event.data.error) reject(new Error(event.data.error));
+      else resolve(event.data);
+    };
+    port.addEventListener("message", onMessage);
+    port.postMessage({ type: "terminate-worker", id } satisfies BrowserInspectorControlRequest);
+  });
+}
+
 describe("broker worker context initialization", () => {
   beforeEach(async () => {
     mocks.reset();
@@ -404,6 +467,173 @@ describe("broker worker context initialization", () => {
       type: "runtime-ready",
     });
     expect(mocks.loadWasmModule).toHaveBeenCalledTimes(2);
+  });
+
+  it("acknowledges a lease probe before touching its durable root", async () => {
+    const attemptId = "probe-before-durable-admission";
+    const initOptions = options("probe-before-durable-admission");
+    const { port } = connectLeaseProbe();
+    const probeOutcome = port.waitForLeaseProbeOutcome();
+    port.emitMessage({
+      type: "probe-foreground-node-lease-worker",
+      attemptId,
+    });
+
+    await expect(probeOutcome).resolves.toEqual({
+      type: "foreground-node-lease-worker-alive",
+      attemptId,
+    });
+    expect(mocks.openPageStore).not.toHaveBeenCalled();
+
+    const leaseOutcome = port.waitForLeaseOutcome();
+    port.emitMessage({
+      type: "acquire-foreground-node-lease",
+      attemptId,
+      dbName: initOptions.dbName,
+      storageOwner: initOptions.storageOwner,
+    });
+    await expect(leaseOutcome).resolves.toEqual(
+      expect.objectContaining({ type: "foreground-node-lease-ready" }),
+    );
+    expect(mocks.openPageStore).toHaveBeenCalledOnce();
+  });
+
+  it("does not admit a lease probe after worker termination is acknowledged", async () => {
+    const initOptions = options("terminate-before-successor-probe");
+    const first = await connect(initOptions, "first-tab");
+    await initializeFollower(first.port, 1);
+    const inspector = await openInspector(first.port, 2);
+
+    const closed = first.port.waitForEvent((event) => event.type === "result" && event.id === 3);
+    first.port.emitMessage({ type: "close", id: 3, releaseContext: true });
+    await closed;
+    await new Promise<void>((resolve) => setTimeout(resolve, 60));
+    await expect(terminateInspector(inspector, 4)).resolves.toEqual({
+      type: "result",
+      id: 4,
+      workerTerminated: true,
+    });
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect((globalThis as WorkerGlobal).close).toHaveBeenCalledOnce();
+
+    const successor = connectLeaseProbe();
+    const closing = successor.port.waitForLeaseProbeOutcome();
+    successor.port.emitMessage({
+      type: "probe-foreground-node-lease-worker",
+      attemptId: "probe-after-termination-ack",
+    });
+
+    await expect(closing).resolves.toEqual({
+      type: "foreground-node-lease-worker-closing",
+      attemptId: "probe-after-termination-ack",
+    });
+    expect(successor.port.close).toHaveBeenCalledOnce();
+    inspector.close();
+  });
+
+  it("rejects termination while preconnected lease bootstraps remain pending", async () => {
+    const initOptions = options("terminate-preconnected-lease-bootstrap");
+    const first = await connect(initOptions, "first-tab");
+    await initializeFollower(first.port, 1);
+    const inspector = await openInspector(first.port, 2);
+
+    const closed = first.port.waitForEvent((event) => event.type === "result" && event.id === 3);
+    first.port.emitMessage({ type: "close", id: 3, releaseContext: true });
+    await closed;
+    await new Promise<void>((resolve) => setTimeout(resolve, 60));
+
+    // Both ports connect before termination. One has not sent its first
+    // message; the other has received a liveness response but has not yet
+    // requested durable allocation.
+    const firstMessageAfterTermination = connectLeaseProbe();
+    const acquireAfterTermination = connectLeaseProbe();
+    const alive = acquireAfterTermination.port.waitForLeaseProbeOutcome();
+    acquireAfterTermination.port.emitMessage({
+      type: "probe-foreground-node-lease-worker",
+      attemptId: "alive-before-termination",
+    });
+    await expect(alive).resolves.toEqual({
+      type: "foreground-node-lease-worker-alive",
+      attemptId: "alive-before-termination",
+    });
+    const durableOpenCount = mocks.openPageStore.mock.calls.length;
+
+    await expect(terminateInspector(inspector, 4)).rejects.toThrow(
+      "Worker still has pending bootstrap operations",
+    );
+    expect((globalThis as WorkerGlobal).close).not.toHaveBeenCalled();
+
+    firstMessageAfterTermination.port.emitMessage({
+      type: "cancel-foreground-node-lease",
+    });
+    acquireAfterTermination.port.emitMessage({
+      type: "cancel-foreground-node-lease",
+    });
+    expect(firstMessageAfterTermination.port.close).toHaveBeenCalledOnce();
+    expect(acquireAfterTermination.port.close).toHaveBeenCalledOnce();
+    expect(mocks.openPageStore).toHaveBeenCalledTimes(durableOpenCount);
+    expect(
+      mocks.pageStores.some((store) => store.acquireForegroundNodeLease.mock.calls.length > 0),
+    ).toBe(false);
+
+    await terminateInspector(inspector, 5);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect((globalThis as WorkerGlobal).close).toHaveBeenCalledOnce();
+    inspector.close();
+  });
+
+  it("only terminates after in-flight and active foreground leases are retired", async () => {
+    const initOptions = options("terminate-during-lease-admission");
+    const first = await connect(initOptions, "first-tab");
+    await initializeFollower(first.port, 1);
+    const inspector = await openInspector(first.port, 2);
+
+    const closed = first.port.waitForEvent((event) => event.type === "result" && event.id === 3);
+    first.port.emitMessage({ type: "close", id: 3, releaseContext: true });
+    await closed;
+    await new Promise<void>((resolve) => setTimeout(resolve, 60));
+
+    const pageStore = mocks.pageStores[0]!;
+    const physicalOwnerAdmission = deferred<typeof pageStore>();
+    mocks.openPageStore.mockImplementationOnce(() => physicalOwnerAdmission.promise);
+    const leaseDbName = `${initOptions.dbName}-lease-root`;
+    const lease = connectLease({
+      type: "acquire-foreground-node-lease",
+      dbName: leaseDbName,
+      storageOwner: initOptions.storageOwner,
+    });
+    await vi.waitFor(() => expect(mocks.openPageStore).toHaveBeenCalledTimes(2));
+
+    await expect(terminateInspector(inspector, 4)).rejects.toThrow(
+      "Worker still has pending bootstrap operations",
+    );
+    expect((globalThis as WorkerGlobal).close).not.toHaveBeenCalled();
+
+    physicalOwnerAdmission.resolve(pageStore);
+    await expect(lease.outcome).resolves.toEqual(
+      expect.objectContaining({ type: "foreground-node-lease-ready" }),
+    );
+    await expect(terminateInspector(inspector, 5)).rejects.toThrow(
+      "Worker still has pending or active foreground node leases",
+    );
+    expect((globalThis as WorkerGlobal).close).not.toHaveBeenCalled();
+
+    const durableRetirement = deferred<void>();
+    pageStore.retireForegroundNodeLease.mockImplementationOnce(() => durableRetirement.promise);
+    lease.port.emitMessage({ type: "retire-foreground-node-lease" });
+    await vi.waitFor(() => expect(pageStore.retireForegroundNodeLease).toHaveBeenCalledOnce());
+    await expect(terminateInspector(inspector, 6)).rejects.toThrow(
+      "Worker still has pending or active foreground node leases",
+    );
+    expect((globalThis as WorkerGlobal).close).not.toHaveBeenCalled();
+
+    durableRetirement.resolve();
+    await vi.waitFor(() => expect(lease.port.close).toHaveBeenCalledOnce());
+
+    await terminateInspector(inspector, 7);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect((globalThis as WorkerGlobal).close).toHaveBeenCalledOnce();
+    inspector.close();
   });
 
   it("cancels an idle worker close when a successor bootstrap arrives during physical release", async () => {


### PR DESCRIPTION
🤖 Closes the remaining foreground-lease race between SharedWorker termination acknowledgement and successor startup.

Before: inspector termination acknowledged, then closed the named worker in a later task. A new lease port could attach in that gap and wait forever in the doomed realm. Early probe retries also risked mistaking a merely busy healthy worker for dead.

After:
- a terminating realm explicitly returns a correlated closing response, so clients immediately advance to a successor generation
- healthy slow workers retain the single 10-second total probe/admission bound; there is no one-second death heuristic
- every bootstrap message is fenced against scheduled termination, including ports connected before acknowledgement
- termination is idle-only across runtime contexts, pending bootstraps, pending allocations, active leases, and in-flight durable finalization
- failed retirement restores the active lease marker and remains fail closed

Examples:
- a preconnected port probing after termination acknowledgement receives closing and performs no IndexedDB open
- a healthy probe delayed beyond one second remains on generation 0
- termination during a held physical-owner open, active lease, or delayed durable retirement is rejected; it succeeds after retirement drains

Receipts: focused worker/client suite 32/32; original recovered accepted/rejected foreground-write browser receipt repeated; message-boundary, timeout, idle-gate, and finalization plants fail.

Stacked on #2424.