### PR TITLE
fix(web): isolate Node lease implementation from browser bundles

### DIFF
--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -13,6 +13,9 @@
   ],
   "type": "module",
   "main": "dist/index.js",
+  "browser": {
+    "./dist/runtime/native-runtime/node-foreground-node-lease.js": "./dist/runtime/native-runtime/node-foreground-node-lease.browser.js"
+  },
   "types": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/jazz-tools/src/package-root-public-api.test.ts
+++ b/packages/jazz-tools/src/package-root-public-api.test.ts
@@ -391,6 +391,27 @@ describe("package root public API", () => {
     }
   });
 
+  it("maps the Node-only foreground lease implementation away from browser bundles", () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(packageRootDir, "..", "package.json"), "utf8"),
+    ) as { browser?: Record<string, string> };
+
+    expect(packageJson.browser).toMatchObject({
+      "./dist/runtime/native-runtime/node-foreground-node-lease.js":
+        "./dist/runtime/native-runtime/node-foreground-node-lease.browser.js",
+    });
+    expect(
+      readFileSync(
+        join(
+          packageRootDir,
+          "..",
+          "src/runtime/native-runtime/node-foreground-node-lease.browser.ts",
+        ),
+        "utf8",
+      ),
+    ).not.toMatch(/from\s+["']node:/);
+  });
+
   it("publishes restored React Native and Expo entrypoints", () => {
     const packageJson = JSON.parse(
       readFileSync(join(packageRootDir, "..", "package.json"), "utf8"),

--- a/packages/jazz-tools/src/runtime/native-runtime/node-foreground-node-lease.browser.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/node-foreground-node-lease.browser.ts
@@ -1,0 +1,22 @@
+/**
+ * Browser resolution stub for the Node-only foreground lease implementation.
+ *
+ * `DefaultRuntimeSource` has one public shape on every JavaScript host, but
+ * durable foreground-node leases are a Node filesystem concern.  The package
+ * `browser` map resolves the dynamic Node import to this module before a
+ * browser bundler walks its dependency graph, so a client bundle never even
+ * reaches `node:fs` or `node:crypto`.
+ */
+import type { ForegroundNodeLease } from "../runtime-source.js";
+
+export type NodeForegroundNodeLeaseOptions = {
+  appId: string;
+  env: string;
+  authScope: string;
+};
+
+export async function acquireNodeForegroundNodeLease(
+  _options: NodeForegroundNodeLeaseOptions,
+): Promise<ForegroundNodeLease> {
+  throw new Error("Node foreground node leases are unavailable in browser bundles");
+}


### PR DESCRIPTION
🤖 A clean-room alpha.54 preview install found that a fresh Next app could typecheck but could not produce a browser build: the shared default runtime source made Turbopack walk the Node foreground-lease implementation and reject `node:fs/promises`.

Before:

```text
Client Component import trace
  default-runtime-source
  node-foreground-node-lease
  node:fs/promises  <- browser build error
```

After:

- `DefaultRuntimeSource` remains the single public API on Node and browsers.
- the package's standard `browser` map replaces only the internal Node lease implementation with a type-compatible, fail-loud browser stub before a bundler traverses it;
- Node ESM resolution continues to use the real filesystem-backed implementation;
- an accidental browser call fails explicitly instead of silently inventing an unsafe identity.

Examples:

- A Next Client Component importing the normal Jazz provider now builds without pulling any `node:` module into its graph.
- A Vite browser build resolves the same guarded module to the browser stub.
- A Node process still acquires a foreground node ID, returns it with a high-water mark, reopens the same ID/mark, and retires it through the real implementation.

Verification:

- fresh create-jazz Next/Turbopack production build: passed with packed fixed package
- fresh Vite production build: passed
- `pnpm --filter jazz-tools build`: passed
- `pnpm --filter jazz-tools check`: passed
- focused package-surface and Node lease receipts: 16/16 passed in implementation lane
- planted missing/wrong browser mapping: both browser builds fail on real Node imports
- independent adversarial review: READY

This is the first repair found by exercising the exact pkg.pr.new candidate as an external adopter.
