### PR TITLE
Bound recursive policy decoding

### DIFF
--- a/crates/jazz-server/src/server/catalogue_payload_codec.rs
+++ b/crates/jazz-server/src/server/catalogue_payload_codec.rs
@@ -3130,6 +3130,66 @@ mod tests {
         );
     }
 
+    const BUG_124_POLICY_EXPRESSION_MAX_DEPTH: usize = 64;
+    const BUG_124_POLICY_EXPRESSION_MAX_NODES: usize = 4_096;
+
+    fn nested_policy_expression(nodes: usize) -> PolicyExpr {
+        assert!(nodes > 0);
+        (1..nodes).fold(PolicyExpr::True, |expression, _| {
+            PolicyExpr::Not(Box::new(expression))
+        })
+    }
+
+    fn wide_policy_expression(nodes: usize) -> PolicyExpr {
+        assert!(nodes > 0);
+        PolicyExpr::And((1..nodes).map(|_| PolicyExpr::True).collect())
+    }
+
+    fn permissions_with_policy(expression: PolicyExpr) -> HashMap<TableName, TablePolicies> {
+        HashMap::from([(
+            TableName::new("documents"),
+            TablePolicies::new().with_select(expression),
+        )])
+    }
+
+    #[test]
+    fn permissions_decode_enforces_policy_depth_and_total_node_boundaries() {
+        // This stays internal because the binary catalogue decoder is the
+        // untrusted boundary and public policy builders already own their tree.
+        let at_depth_limit = permissions_with_policy(nested_policy_expression(
+            BUG_124_POLICY_EXPRESSION_MAX_DEPTH,
+        ));
+        assert_eq!(
+            decode_permissions(&encode_permissions(&at_depth_limit))
+                .expect("exact catalogue policy depth boundary remains valid"),
+            at_depth_limit
+        );
+
+        let over_depth_limit = permissions_with_policy(nested_policy_expression(
+            BUG_124_POLICY_EXPRESSION_MAX_DEPTH + 1,
+        ));
+        assert!(
+            decode_permissions(&encode_permissions(&over_depth_limit)).is_err(),
+            "catalogue policy depth must be rejected while parsing"
+        );
+
+        let at_node_limit =
+            permissions_with_policy(wide_policy_expression(BUG_124_POLICY_EXPRESSION_MAX_NODES));
+        assert_eq!(
+            decode_permissions(&encode_permissions(&at_node_limit))
+                .expect("exact catalogue policy node boundary remains valid"),
+            at_node_limit
+        );
+
+        let over_node_limit = permissions_with_policy(wide_policy_expression(
+            BUG_124_POLICY_EXPRESSION_MAX_NODES + 1,
+        ));
+        assert!(
+            decode_permissions(&encode_permissions(&over_node_limit)).is_err(),
+            "catalogue policy node count must be rejected while parsing"
+        );
+    }
+
     #[test]
     fn permissions_bundle_roundtrip_preserves_target_schema() {
         let schema_hash = SchemaHash::compute(

--- a/crates/jazz-server/src/server/catalogue_payload_codec.rs
+++ b/crates/jazz-server/src/server/catalogue_payload_codec.rs
@@ -9,6 +9,9 @@
 
 use std::collections::{BTreeSet, HashMap};
 
+use jazz::protocol_limits::{
+    MAX_POLICY_EXPRESSION_DEPTH, MAX_POLICY_EXPRESSION_NODES, PolicyExpressionLimitError,
+};
 use jazz::tools::ObjectId;
 use jazz::tools::public_schema::{CmpOp, Operation, PolicyExpr, PolicyValue};
 use jazz::tools::public_schema::{
@@ -38,6 +41,8 @@ pub enum CatalogueEncodingError {
     InvalidTypeTag { tag: u8, context: &'static str },
     /// Invalid UTF-8 string.
     InvalidUtf8 { context: &'static str },
+    /// A named recursive-policy protocol boundary was crossed.
+    ProtocolLimit(PolicyExpressionLimitError),
     /// Generic decode error.
     DecodeError { message: String },
 }
@@ -57,6 +62,7 @@ impl std::fmt::Display for CatalogueEncodingError {
             CatalogueEncodingError::InvalidUtf8 { context } => {
                 write!(f, "invalid UTF-8 in {context}")
             }
+            CatalogueEncodingError::ProtocolLimit(error) => std::fmt::Display::fmt(error, f),
             CatalogueEncodingError::DecodeError { message } => {
                 write!(f, "decode error: {message}")
             }
@@ -1907,13 +1913,117 @@ fn decode_policy_expr(
     data: &[u8],
     offset: &mut usize,
 ) -> Result<PolicyExpr, CatalogueEncodingError> {
+    let mut frames = Vec::new();
+    let mut nodes = 0_usize;
+
+    'decode: loop {
+        let depth = frames.len() + 1;
+        if depth > MAX_POLICY_EXPRESSION_DEPTH {
+            return Err(policy_expression_limit(
+                "MAX_POLICY_EXPRESSION_DEPTH",
+                MAX_POLICY_EXPRESSION_DEPTH,
+                depth,
+            ));
+        }
+        if nodes >= MAX_POLICY_EXPRESSION_NODES {
+            return Err(policy_expression_limit(
+                "MAX_POLICY_EXPRESSION_NODES",
+                MAX_POLICY_EXPRESSION_NODES,
+                nodes + 1,
+            ));
+        }
+        nodes += 1;
+
+        let mut expression = match decode_policy_expr_node(data, offset, nodes)? {
+            DecodedPolicyNode::Complete(expression) => expression,
+            DecodedPolicyNode::Children(frame) => {
+                frames.push(frame);
+                continue;
+            }
+        };
+
+        while let Some(frame) = frames.pop() {
+            match frame {
+                PolicyDecodeFrame::Exists { table } => {
+                    expression = PolicyExpr::Exists {
+                        table,
+                        condition: Box::new(expression),
+                    };
+                }
+                PolicyDecodeFrame::Not => {
+                    expression = PolicyExpr::Not(Box::new(expression));
+                }
+                PolicyDecodeFrame::And {
+                    mut remaining,
+                    mut expressions,
+                } => {
+                    expressions.push(expression);
+                    remaining -= 1;
+                    if remaining == 0 {
+                        expression = PolicyExpr::And(expressions);
+                    } else {
+                        frames.push(PolicyDecodeFrame::And {
+                            remaining,
+                            expressions,
+                        });
+                        continue 'decode;
+                    }
+                }
+                PolicyDecodeFrame::Or {
+                    mut remaining,
+                    mut expressions,
+                } => {
+                    expressions.push(expression);
+                    remaining -= 1;
+                    if remaining == 0 {
+                        expression = PolicyExpr::Or(expressions);
+                    } else {
+                        frames.push(PolicyDecodeFrame::Or {
+                            remaining,
+                            expressions,
+                        });
+                        continue 'decode;
+                    }
+                }
+            }
+        }
+        return Ok(expression);
+    }
+}
+
+enum DecodedPolicyNode {
+    Complete(PolicyExpr),
+    Children(PolicyDecodeFrame),
+}
+
+enum PolicyDecodeFrame {
+    Exists {
+        table: String,
+    },
+    And {
+        remaining: usize,
+        expressions: Vec<PolicyExpr>,
+    },
+    Or {
+        remaining: usize,
+        expressions: Vec<PolicyExpr>,
+    },
+    Not,
+}
+
+fn decode_policy_expr_node(
+    data: &[u8],
+    offset: &mut usize,
+    nodes: usize,
+) -> Result<DecodedPolicyNode, CatalogueEncodingError> {
+    let complete = |expression| Ok(DecodedPolicyNode::Complete(expression));
     let tag = read_u8(data, offset)?;
     match tag {
         POLICY_EXPR_CMP => {
             let column = read_string(data, offset, "policy_cmp_column")?;
             let op = decode_cmp_op(data, offset)?;
             let value = decode_policy_value(data, offset)?;
-            Ok(PolicyExpr::Cmp { column, op, value })
+            complete(PolicyExpr::Cmp { column, op, value })
         }
         POLICY_EXPR_SESSION_CMP => {
             let count = read_count(data, offset, "policy_session_cmp_path")?;
@@ -1923,11 +2033,11 @@ fn decode_policy_expr(
             }
             let op = decode_cmp_op(data, offset)?;
             let value = decode_value(data, offset)?;
-            Ok(PolicyExpr::SessionCmp { path, op, value })
+            complete(PolicyExpr::SessionCmp { path, op, value })
         }
         POLICY_EXPR_IS_NULL => {
             let column = read_string(data, offset, "policy_is_null_column")?;
-            Ok(PolicyExpr::IsNull { column })
+            complete(PolicyExpr::IsNull { column })
         }
         POLICY_EXPR_SESSION_IS_NULL => {
             let count = read_count(data, offset, "policy_session_is_null_path")?;
@@ -1935,11 +2045,11 @@ fn decode_policy_expr(
             for _ in 0..count {
                 path.push(read_string(data, offset, "policy_session_is_null_path")?);
             }
-            Ok(PolicyExpr::SessionIsNull { path })
+            complete(PolicyExpr::SessionIsNull { path })
         }
         POLICY_EXPR_IS_NOT_NULL => {
             let column = read_string(data, offset, "policy_is_not_null_column")?;
-            Ok(PolicyExpr::IsNotNull { column })
+            complete(PolicyExpr::IsNotNull { column })
         }
         POLICY_EXPR_SESSION_IS_NOT_NULL => {
             let count = read_count(data, offset, "policy_session_is_not_null_path")?;
@@ -1951,12 +2061,12 @@ fn decode_policy_expr(
                     "policy_session_is_not_null_path",
                 )?);
             }
-            Ok(PolicyExpr::SessionIsNotNull { path })
+            complete(PolicyExpr::SessionIsNotNull { path })
         }
         POLICY_EXPR_CONTAINS => {
             let column = read_string(data, offset, "policy_contains_column")?;
             let value = decode_policy_value(data, offset)?;
-            Ok(PolicyExpr::Contains { column, value })
+            complete(PolicyExpr::Contains { column, value })
         }
         POLICY_EXPR_SESSION_CONTAINS => {
             let count = read_count(data, offset, "policy_session_contains_path")?;
@@ -1965,7 +2075,7 @@ fn decode_policy_expr(
                 path.push(read_string(data, offset, "policy_session_contains_path")?);
             }
             let value = decode_value(data, offset)?;
-            Ok(PolicyExpr::SessionContains { path, value })
+            complete(PolicyExpr::SessionContains { path, value })
         }
         POLICY_EXPR_IN => {
             let column = read_string(data, offset, "policy_in_column")?;
@@ -1974,7 +2084,7 @@ fn decode_policy_expr(
             for _ in 0..count {
                 session_path.push(read_string(data, offset, "policy_in_session_path")?);
             }
-            Ok(PolicyExpr::In {
+            complete(PolicyExpr::In {
                 column,
                 session_path,
             })
@@ -1986,7 +2096,7 @@ fn decode_policy_expr(
             for _ in 0..count {
                 values.push(decode_policy_value(data, offset)?);
             }
-            Ok(PolicyExpr::InList { column, values })
+            complete(PolicyExpr::InList { column, values })
         }
         POLICY_EXPR_SESSION_IN_LIST => {
             let path_count = read_count(data, offset, "policy_session_in_list_path")?;
@@ -1999,24 +2109,22 @@ fn decode_policy_expr(
             for _ in 0..value_count {
                 values.push(decode_value(data, offset)?);
             }
-            Ok(PolicyExpr::SessionInList { path, values })
+            complete(PolicyExpr::SessionInList { path, values })
         }
         POLICY_EXPR_EXISTS => {
             let table = read_string(data, offset, "policy_exists_table")?;
-            let condition = decode_policy_expr(data, offset)?;
-            Ok(PolicyExpr::Exists {
+            Ok(DecodedPolicyNode::Children(PolicyDecodeFrame::Exists {
                 table,
-                condition: Box::new(condition),
-            })
+            }))
         }
         POLICY_EXPR_EXISTS_REL => {
             let rel = decode_canonical_relation_expr(data, offset)?;
-            Ok(PolicyExpr::ExistsRel { rel })
+            complete(PolicyExpr::ExistsRel { rel })
         }
         POLICY_EXPR_INHERITS => {
             let operation = decode_policy_operation(data, offset)?;
             let via_column = read_string(data, offset, "policy_inherits_via_column")?;
-            Ok(PolicyExpr::Inherits {
+            complete(PolicyExpr::Inherits {
                 operation,
                 via_column,
                 max_depth: None,
@@ -2026,7 +2134,7 @@ fn decode_policy_expr(
             let operation = decode_policy_operation(data, offset)?;
             let via_column = read_string(data, offset, "policy_inherits_via_column")?;
             let max_depth = read_u32(data, offset)? as usize;
-            Ok(PolicyExpr::Inherits {
+            complete(PolicyExpr::Inherits {
                 operation,
                 via_column,
                 max_depth: Some(max_depth),
@@ -2042,7 +2150,7 @@ fn decode_policy_expr(
             } else {
                 None
             };
-            Ok(PolicyExpr::InheritsReferencing {
+            complete(PolicyExpr::InheritsReferencing {
                 operation,
                 source_table,
                 via_column,
@@ -2051,31 +2159,56 @@ fn decode_policy_expr(
         }
         POLICY_EXPR_AND => {
             let count = read_count(data, offset, "policy_and")?;
-            let mut exprs = Vec::with_capacity(count);
-            for _ in 0..count {
-                exprs.push(decode_policy_expr(data, offset)?);
+            if count == 0 {
+                return complete(PolicyExpr::And(Vec::new()));
             }
-            Ok(PolicyExpr::And(exprs))
+            validate_policy_child_count(nodes, count)?;
+            Ok(DecodedPolicyNode::Children(PolicyDecodeFrame::And {
+                remaining: count,
+                expressions: Vec::with_capacity(count),
+            }))
         }
         POLICY_EXPR_OR => {
             let count = read_count(data, offset, "policy_or")?;
-            let mut exprs = Vec::with_capacity(count);
-            for _ in 0..count {
-                exprs.push(decode_policy_expr(data, offset)?);
+            if count == 0 {
+                return complete(PolicyExpr::Or(Vec::new()));
             }
-            Ok(PolicyExpr::Or(exprs))
+            validate_policy_child_count(nodes, count)?;
+            Ok(DecodedPolicyNode::Children(PolicyDecodeFrame::Or {
+                remaining: count,
+                expressions: Vec::with_capacity(count),
+            }))
         }
-        POLICY_EXPR_NOT => {
-            let inner = decode_policy_expr(data, offset)?;
-            Ok(PolicyExpr::Not(Box::new(inner)))
-        }
-        POLICY_EXPR_TRUE => Ok(PolicyExpr::True),
-        POLICY_EXPR_FALSE => Ok(PolicyExpr::False),
+        POLICY_EXPR_NOT => Ok(DecodedPolicyNode::Children(PolicyDecodeFrame::Not)),
+        POLICY_EXPR_TRUE => complete(PolicyExpr::True),
+        POLICY_EXPR_FALSE => complete(PolicyExpr::False),
         _ => Err(CatalogueEncodingError::InvalidTypeTag {
             tag,
             context: "policy_expr",
         }),
     }
+}
+
+fn validate_policy_child_count(
+    nodes: usize,
+    children: usize,
+) -> Result<(), CatalogueEncodingError> {
+    if children > MAX_POLICY_EXPRESSION_NODES - nodes {
+        return Err(policy_expression_limit(
+            "MAX_POLICY_EXPRESSION_NODES",
+            MAX_POLICY_EXPRESSION_NODES,
+            nodes.saturating_add(children),
+        ));
+    }
+    Ok(())
+}
+
+fn policy_expression_limit(
+    limit: &'static str,
+    max: usize,
+    actual: usize,
+) -> CatalogueEncodingError {
+    CatalogueEncodingError::ProtocolLimit(PolicyExpressionLimitError { limit, max, actual })
 }
 
 fn encode_policy_value(buf: &mut Vec<u8>, value: &PolicyValue) {
@@ -3130,9 +3263,6 @@ mod tests {
         );
     }
 
-    const BUG_124_POLICY_EXPRESSION_MAX_DEPTH: usize = 64;
-    const BUG_124_POLICY_EXPRESSION_MAX_NODES: usize = 4_096;
-
     fn nested_policy_expression(nodes: usize) -> PolicyExpr {
         assert!(nodes > 0);
         (1..nodes).fold(PolicyExpr::True, |expression, _| {
@@ -3156,37 +3286,44 @@ mod tests {
     fn permissions_decode_enforces_policy_depth_and_total_node_boundaries() {
         // This stays internal because the binary catalogue decoder is the
         // untrusted boundary and public policy builders already own their tree.
-        let at_depth_limit = permissions_with_policy(nested_policy_expression(
-            BUG_124_POLICY_EXPRESSION_MAX_DEPTH,
-        ));
+        let at_depth_limit =
+            permissions_with_policy(nested_policy_expression(MAX_POLICY_EXPRESSION_DEPTH));
         assert_eq!(
             decode_permissions(&encode_permissions(&at_depth_limit))
                 .expect("exact catalogue policy depth boundary remains valid"),
             at_depth_limit
         );
 
-        let over_depth_limit = permissions_with_policy(nested_policy_expression(
-            BUG_124_POLICY_EXPRESSION_MAX_DEPTH + 1,
-        ));
-        assert!(
-            decode_permissions(&encode_permissions(&over_depth_limit)).is_err(),
-            "catalogue policy depth must be rejected while parsing"
+        let over_depth_limit =
+            permissions_with_policy(nested_policy_expression(MAX_POLICY_EXPRESSION_DEPTH + 1));
+        assert_eq!(
+            decode_permissions(&encode_permissions(&over_depth_limit))
+                .expect_err("catalogue policy depth must be rejected while parsing"),
+            CatalogueEncodingError::ProtocolLimit(PolicyExpressionLimitError {
+                limit: "MAX_POLICY_EXPRESSION_DEPTH",
+                max: MAX_POLICY_EXPRESSION_DEPTH,
+                actual: MAX_POLICY_EXPRESSION_DEPTH + 1,
+            })
         );
 
         let at_node_limit =
-            permissions_with_policy(wide_policy_expression(BUG_124_POLICY_EXPRESSION_MAX_NODES));
+            permissions_with_policy(wide_policy_expression(MAX_POLICY_EXPRESSION_NODES));
         assert_eq!(
             decode_permissions(&encode_permissions(&at_node_limit))
                 .expect("exact catalogue policy node boundary remains valid"),
             at_node_limit
         );
 
-        let over_node_limit = permissions_with_policy(wide_policy_expression(
-            BUG_124_POLICY_EXPRESSION_MAX_NODES + 1,
-        ));
-        assert!(
-            decode_permissions(&encode_permissions(&over_node_limit)).is_err(),
-            "catalogue policy node count must be rejected while parsing"
+        let over_node_limit =
+            permissions_with_policy(wide_policy_expression(MAX_POLICY_EXPRESSION_NODES + 1));
+        assert_eq!(
+            decode_permissions(&encode_permissions(&over_node_limit))
+                .expect_err("catalogue policy node count must be rejected while parsing"),
+            CatalogueEncodingError::ProtocolLimit(PolicyExpressionLimitError {
+                limit: "MAX_POLICY_EXPRESSION_NODES",
+                max: MAX_POLICY_EXPRESSION_NODES,
+                actual: MAX_POLICY_EXPRESSION_NODES + 1,
+            })
         );
     }
 

--- a/crates/jazz/src/protocol_limits.rs
+++ b/crates/jazz/src/protocol_limits.rs
@@ -45,6 +45,42 @@ pub const MAX_FRAGMENT_REASSEMBLY_AGE_MS: u64 = 5 * 60 * 1_000;
 /// before constructing registration options.
 pub const MAX_SHAPE_AST_BYTES: usize = 64 * 1024;
 
+/// Maximum recursive policy-predicate nodes on one root-to-leaf path.
+///
+/// Policy predicates are decoded with a bounded seed before a complete
+/// attacker-controlled tree exists. Sixty-four levels leave ample room for
+/// generated policies while keeping parser and cleanup stacks shallow.
+pub const MAX_POLICY_EXPRESSION_DEPTH: usize = 64;
+
+/// Maximum nodes in one recursively encoded policy expression.
+///
+/// This is independent of encoded bytes: compact `All`/`Any` children can
+/// otherwise create large retained trees below the shape byte ceiling.
+pub const MAX_POLICY_EXPRESSION_NODES: usize = 4_096;
+
+/// A named semantic limit crossed while decoding a recursive policy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PolicyExpressionLimitError {
+    /// Stable protocol-limit name.
+    pub limit: &'static str,
+    /// Configured inclusive boundary.
+    pub max: usize,
+    /// First observed value outside the boundary.
+    pub actual: usize,
+}
+
+impl std::fmt::Display for PolicyExpressionLimitError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "{} exceeded: observed {}, maximum {}",
+            self.limit, self.actual, self.max
+        )
+    }
+}
+
+impl std::error::Error for PolicyExpressionLimitError {}
+
 /// Maximum postcard-encoded retained shape registration payload.
 ///
 /// Source: existing wire fixtures use tiny registrations; 64 KiB leaves

--- a/crates/jazz/src/protocol_limits.rs
+++ b/crates/jazz/src/protocol_limits.rs
@@ -48,15 +48,18 @@ pub const MAX_SHAPE_AST_BYTES: usize = 64 * 1024;
 /// Maximum recursive policy-predicate nodes on one root-to-leaf path.
 ///
 /// Policy predicates are decoded with a bounded seed before a complete
-/// attacker-controlled tree exists. Sixty-four levels leave ample room for
-/// generated policies while keeping parser and cleanup stacks shallow.
-pub const MAX_POLICY_EXPRESSION_DEPTH: usize = 64;
+/// attacker-controlled tree exists. Keep this aligned with the executable
+/// `MAX_ROW_SET_NESTING_DEPTH` planning ceiling: valid generated policy shapes
+/// may reach that boundary before lowering.
+pub const MAX_POLICY_EXPRESSION_DEPTH: usize = 256;
 
 /// Maximum nodes in one recursively encoded policy expression.
 ///
 /// This is independent of encoded bytes: compact `All`/`Any` children can
-/// otherwise create large retained trees below the shape byte ceiling.
-pub const MAX_POLICY_EXPRESSION_NODES: usize = 4_096;
+/// otherwise create large retained trees below the shape byte ceiling. Keep
+/// this aligned with the established `MAX_CATALOGUE_COLLECTION_ITEMS` protocol
+/// tier rather than introducing a lower policy-only cardinality class.
+pub const MAX_POLICY_EXPRESSION_NODES: usize = 16_384;
 
 /// A named semantic limit crossed while decoding a recursive policy.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/jazz/src/query/policy_and_request_contracts.rs
+++ b/crates/jazz/src/query/policy_and_request_contracts.rs
@@ -559,7 +559,7 @@ impl RecursionBound {
 }
 
 /// Query predicate.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
 pub enum Predicate {
     /// All child predicates must match.
     All(Vec<Predicate>),
@@ -595,6 +595,408 @@ pub enum Predicate {
     },
     /// Nullable value is null.
     IsNull(Operand),
+}
+
+impl<'de> serde::Deserialize<'de> for Predicate {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut budget = PolicyExpressionDecodeBudget::default();
+        serde::de::DeserializeSeed::deserialize(
+            PredicateSeed {
+                budget: &mut budget,
+                depth: 1,
+            },
+            deserializer,
+        )
+    }
+}
+
+#[derive(Default)]
+struct PolicyExpressionDecodeBudget {
+    nodes: usize,
+}
+
+impl PolicyExpressionDecodeBudget {
+    fn enter<E>(&mut self, depth: usize) -> Result<(), E>
+    where
+        E: serde::de::Error,
+    {
+        use crate::protocol_limits::{
+            MAX_POLICY_EXPRESSION_DEPTH, MAX_POLICY_EXPRESSION_NODES, PolicyExpressionLimitError,
+        };
+
+        if depth > MAX_POLICY_EXPRESSION_DEPTH {
+            return Err(E::custom(PolicyExpressionLimitError {
+                limit: "MAX_POLICY_EXPRESSION_DEPTH",
+                max: MAX_POLICY_EXPRESSION_DEPTH,
+                actual: depth,
+            }));
+        }
+        if self.nodes >= MAX_POLICY_EXPRESSION_NODES {
+            return Err(E::custom(PolicyExpressionLimitError {
+                limit: "MAX_POLICY_EXPRESSION_NODES",
+                max: MAX_POLICY_EXPRESSION_NODES,
+                actual: self.nodes + 1,
+            }));
+        }
+        self.nodes += 1;
+        Ok(())
+    }
+
+    fn reserve_children<E>(&self, children: usize) -> Result<usize, E>
+    where
+        E: serde::de::Error,
+    {
+        use crate::protocol_limits::{
+            MAX_POLICY_EXPRESSION_NODES, PolicyExpressionLimitError,
+        };
+
+        let remaining = MAX_POLICY_EXPRESSION_NODES - self.nodes;
+        if children > remaining {
+            return Err(E::custom(PolicyExpressionLimitError {
+                limit: "MAX_POLICY_EXPRESSION_NODES",
+                max: MAX_POLICY_EXPRESSION_NODES,
+                actual: self.nodes.saturating_add(children),
+            }));
+        }
+        Ok(children)
+    }
+}
+
+struct PredicateSeed<'a> {
+    budget: &'a mut PolicyExpressionDecodeBudget,
+    depth: usize,
+}
+
+impl<'de> serde::de::DeserializeSeed<'de> for PredicateSeed<'_> {
+    type Value = Predicate;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        self.budget.enter::<D::Error>(self.depth)?;
+        deserializer.deserialize_enum(
+            "Predicate",
+            &[
+                "All",
+                "Any",
+                "Not",
+                "Eq",
+                "Ne",
+                "In",
+                "Gt",
+                "Gte",
+                "Lt",
+                "Lte",
+                "Contains",
+                "EnumMatch",
+                "IsNull",
+            ],
+            PredicateVisitor {
+                budget: self.budget,
+                depth: self.depth,
+            },
+        )
+    }
+}
+
+struct PredicateVisitor<'a> {
+    budget: &'a mut PolicyExpressionDecodeBudget,
+    depth: usize,
+}
+
+impl<'de> serde::de::Visitor<'de> for PredicateVisitor<'_> {
+    type Value = Predicate;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a bounded policy predicate")
+    }
+
+    fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::EnumAccess<'de>,
+    {
+        use serde::de::VariantAccess;
+
+        let (variant, access) = data.variant::<PredicateVariant>()?;
+        let child_depth = self.depth + 1;
+        match variant {
+            PredicateVariant::All => access
+                .newtype_variant_seed(PredicateVecSeed {
+                    budget: self.budget,
+                    depth: child_depth,
+                })
+                .map(Predicate::All),
+            PredicateVariant::Any => access
+                .newtype_variant_seed(PredicateVecSeed {
+                    budget: self.budget,
+                    depth: child_depth,
+                })
+                .map(Predicate::Any),
+            PredicateVariant::Not => access
+                .newtype_variant_seed(PredicateSeed {
+                    budget: self.budget,
+                    depth: child_depth,
+                })
+                .map(Box::new)
+                .map(Predicate::Not),
+            PredicateVariant::Eq => {
+                decode_binary_predicate(access, Predicate::Eq)
+            }
+            PredicateVariant::Ne => {
+                decode_binary_predicate(access, Predicate::Ne)
+            }
+            PredicateVariant::In => access.tuple_variant(
+                2,
+                InPredicateVisitor,
+            ),
+            PredicateVariant::Gt => {
+                decode_binary_predicate(access, Predicate::Gt)
+            }
+            PredicateVariant::Gte => {
+                decode_binary_predicate(access, Predicate::Gte)
+            }
+            PredicateVariant::Lt => {
+                decode_binary_predicate(access, Predicate::Lt)
+            }
+            PredicateVariant::Lte => {
+                decode_binary_predicate(access, Predicate::Lte)
+            }
+            PredicateVariant::Contains => {
+                decode_binary_predicate(access, Predicate::Contains)
+            }
+            PredicateVariant::EnumMatch => access.struct_variant(
+                &["column", "case", "payload"],
+                EnumMatchPredicateVisitor {
+                    budget: self.budget,
+                    depth: child_depth,
+                },
+            ),
+            PredicateVariant::IsNull => access
+                .newtype_variant()
+                .map(Predicate::IsNull),
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+#[serde(field_identifier)]
+enum PredicateVariant {
+    All,
+    Any,
+    Not,
+    Eq,
+    Ne,
+    In,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+    Contains,
+    EnumMatch,
+    IsNull,
+}
+
+struct PredicateVecSeed<'a> {
+    budget: &'a mut PolicyExpressionDecodeBudget,
+    depth: usize,
+}
+
+impl<'de> serde::de::DeserializeSeed<'de> for PredicateVecSeed<'_> {
+    type Value = Vec<Predicate>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(PredicateVecVisitor {
+            budget: self.budget,
+            depth: self.depth,
+        })
+    }
+}
+
+struct PredicateVecVisitor<'a> {
+    budget: &'a mut PolicyExpressionDecodeBudget,
+    depth: usize,
+}
+
+impl<'de> serde::de::Visitor<'de> for PredicateVecVisitor<'_> {
+    type Value = Vec<Predicate>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a bounded sequence of policy predicates")
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let capacity = match sequence.size_hint() {
+            Some(children) => self.budget.reserve_children::<A::Error>(children)?,
+            None => 0,
+        };
+        let mut predicates = Vec::with_capacity(capacity);
+        while let Some(predicate) =
+            sequence.next_element_seed(PredicateSeed {
+                budget: self.budget,
+                depth: self.depth,
+            })?
+        {
+            predicates.push(predicate);
+        }
+        Ok(predicates)
+    }
+}
+
+fn decode_binary_predicate<'de, A>(
+    access: A,
+    constructor: fn(Operand, Operand) -> Predicate,
+) -> Result<Predicate, A::Error>
+where
+    A: serde::de::VariantAccess<'de>,
+{
+    serde::de::VariantAccess::tuple_variant(
+        access,
+        2,
+        BinaryPredicateVisitor { constructor },
+    )
+}
+
+struct BinaryPredicateVisitor {
+    constructor: fn(Operand, Operand) -> Predicate,
+}
+
+impl<'de> serde::de::Visitor<'de> for BinaryPredicateVisitor {
+    type Value = Predicate;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("two policy operands")
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let left = sequence
+            .next_element()?
+            .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+        let right = sequence
+            .next_element()?
+            .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+        Ok((self.constructor)(left, right))
+    }
+}
+
+struct InPredicateVisitor;
+
+impl<'de> serde::de::Visitor<'de> for InPredicateVisitor {
+    type Value = Predicate;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a policy operand and operand list")
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let operand = sequence
+            .next_element()?
+            .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+        let values = sequence
+            .next_element()?
+            .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+        Ok(Predicate::In(operand, values))
+    }
+}
+
+struct EnumMatchPredicateVisitor<'a> {
+    budget: &'a mut PolicyExpressionDecodeBudget,
+    depth: usize,
+}
+
+impl<'de> serde::de::Visitor<'de> for EnumMatchPredicateVisitor<'_> {
+    type Value = Predicate;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("an enum-match policy predicate")
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let column = sequence
+            .next_element()?
+            .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+        let case = sequence
+            .next_element()?
+            .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+        let payload = sequence
+            .next_element_seed(PredicateSeed {
+                budget: self.budget,
+                depth: self.depth,
+            })?
+            .ok_or_else(|| serde::de::Error::invalid_length(2, &self))?;
+        Ok(Predicate::EnumMatch {
+            column,
+            case,
+            payload: Box::new(payload),
+        })
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let mut column = None;
+        let mut case = None;
+        let mut payload = None;
+        while let Some(field) = map.next_key::<EnumMatchField>()? {
+            match field {
+                EnumMatchField::Column => {
+                    if column.is_some() {
+                        return Err(serde::de::Error::duplicate_field("column"));
+                    }
+                    column = Some(map.next_value()?);
+                }
+                EnumMatchField::Case => {
+                    if case.is_some() {
+                        return Err(serde::de::Error::duplicate_field("case"));
+                    }
+                    case = Some(map.next_value()?);
+                }
+                EnumMatchField::Payload => {
+                    if payload.is_some() {
+                        return Err(serde::de::Error::duplicate_field("payload"));
+                    }
+                    payload = Some(map.next_value_seed(PredicateSeed {
+                        budget: self.budget,
+                        depth: self.depth,
+                    })?);
+                }
+            }
+        }
+        Ok(Predicate::EnumMatch {
+            column: column.ok_or_else(|| serde::de::Error::missing_field("column"))?,
+            case: case.ok_or_else(|| serde::de::Error::missing_field("case"))?,
+            payload: Box::new(
+                payload.ok_or_else(|| serde::de::Error::missing_field("payload"))?,
+            ),
+        })
+    }
+}
+
+#[derive(serde::Deserialize)]
+#[serde(field_identifier, rename_all = "lowercase")]
+enum EnumMatchField {
+    Column,
+    Case,
+    Payload,
 }
 
 /// Predicate operand.

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -794,7 +794,7 @@ mod tests {
         build_version_bundle_runs_from_singletons, expand_version_carriers,
     };
     use crate::protocol_limits::{MAX_CHUNK_REQUEST_BATCH_ENTRIES, MAX_WIRE_FRAME_BYTES};
-    use crate::query::{BindingId, Query, ShapeId};
+    use crate::query::{BindingId, Operand, Predicate, Query, ShapeId};
     use crate::schema::{ColumnSchema, TableSchema};
     use crate::time::{GlobalTime, TxTime};
     use crate::tx::{DurabilityTier, Fate, RejectionReason, Transaction, TxId, TxKind};
@@ -1092,6 +1092,80 @@ mod tests {
         assert!(
             decode_sync_message(&encoded).is_err(),
             "remote request cardinality must be bounded before storage work"
+        );
+    }
+
+    const BUG_124_POLICY_EXPRESSION_MAX_DEPTH: usize = 64;
+    const BUG_124_POLICY_EXPRESSION_MAX_NODES: usize = 4_096;
+
+    fn nested_policy_predicate(nodes: usize) -> Predicate {
+        assert!(nodes > 0);
+        (1..nodes).fold(
+            Predicate::IsNull(Operand::Column("owner".to_owned())),
+            |predicate, _| Predicate::Not(Box::new(predicate)),
+        )
+    }
+
+    fn wide_policy_predicate(nodes: usize) -> Predicate {
+        assert!(nodes > 0);
+        Predicate::All(
+            (1..nodes)
+                .map(|_| Predicate::IsNull(Operand::Column("owner".to_owned())))
+                .collect(),
+        )
+    }
+
+    fn register_shape_with_policy_predicate(predicate: Predicate) -> SyncMessage {
+        SyncMessage::RegisterShape {
+            shape_id: ShapeId(uuid::Uuid::from_bytes([0x22; 16])),
+            ast: ShapeAst::new(
+                Query::from("documents").filter(predicate),
+                SchemaVersionId::from_bytes([0x33; 16]),
+            ),
+            opts: RegisterShapeOptions::default(),
+        }
+    }
+
+    #[test]
+    fn policy_predicate_wire_decode_enforces_depth_and_total_node_boundaries() {
+        // This stays internal because postcard decode is the untrusted wire
+        // boundary; public query builders only construct already-owned trees.
+        let at_depth_limit = register_shape_with_policy_predicate(nested_policy_predicate(
+            BUG_124_POLICY_EXPRESSION_MAX_DEPTH,
+        ));
+        let encoded = encode_sync_message(&at_depth_limit).expect("encode depth-limit policy");
+        assert_eq!(
+            decode_sync_message(&encoded).expect("exact policy depth boundary remains valid"),
+            at_depth_limit
+        );
+
+        let over_depth_limit = register_shape_with_policy_predicate(nested_policy_predicate(
+            BUG_124_POLICY_EXPRESSION_MAX_DEPTH + 1,
+        ));
+        let encoded =
+            encode_sync_message(&over_depth_limit).expect("encode over-depth policy fixture");
+        assert!(
+            decode_sync_message(&encoded).is_err(),
+            "policy depth must be rejected while postcard is parsing"
+        );
+
+        let at_node_limit = register_shape_with_policy_predicate(wide_policy_predicate(
+            BUG_124_POLICY_EXPRESSION_MAX_NODES,
+        ));
+        let encoded = encode_sync_message(&at_node_limit).expect("encode node-limit policy");
+        assert_eq!(
+            decode_sync_message(&encoded).expect("exact policy node boundary remains valid"),
+            at_node_limit
+        );
+
+        let over_node_limit = register_shape_with_policy_predicate(wide_policy_predicate(
+            BUG_124_POLICY_EXPRESSION_MAX_NODES + 1,
+        ));
+        let encoded =
+            encode_sync_message(&over_node_limit).expect("encode over-node policy fixture");
+        assert!(
+            decode_sync_message(&encoded).is_err(),
+            "policy node count must be rejected while postcard is parsing"
         );
     }
 

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -793,7 +793,10 @@ mod tests {
         VersionBundleRun, VersionBundleRunError, VersionCarrier, VersionRecord,
         build_version_bundle_runs_from_singletons, expand_version_carriers,
     };
-    use crate::protocol_limits::{MAX_CHUNK_REQUEST_BATCH_ENTRIES, MAX_WIRE_FRAME_BYTES};
+    use crate::protocol_limits::{
+        MAX_CHUNK_REQUEST_BATCH_ENTRIES, MAX_POLICY_EXPRESSION_DEPTH, MAX_POLICY_EXPRESSION_NODES,
+        MAX_WIRE_FRAME_BYTES,
+    };
     use crate::query::{BindingId, Operand, Predicate, Query, ShapeId};
     use crate::schema::{ColumnSchema, TableSchema};
     use crate::time::{GlobalTime, TxTime};
@@ -1095,9 +1098,6 @@ mod tests {
         );
     }
 
-    const BUG_124_POLICY_EXPRESSION_MAX_DEPTH: usize = 64;
-    const BUG_124_POLICY_EXPRESSION_MAX_NODES: usize = 4_096;
-
     fn nested_policy_predicate(nodes: usize) -> Predicate {
         assert!(nodes > 0);
         (1..nodes).fold(
@@ -1131,7 +1131,7 @@ mod tests {
         // This stays internal because postcard decode is the untrusted wire
         // boundary; public query builders only construct already-owned trees.
         let at_depth_limit = register_shape_with_policy_predicate(nested_policy_predicate(
-            BUG_124_POLICY_EXPRESSION_MAX_DEPTH,
+            MAX_POLICY_EXPRESSION_DEPTH,
         ));
         let encoded = encode_sync_message(&at_depth_limit).expect("encode depth-limit policy");
         assert_eq!(
@@ -1140,7 +1140,7 @@ mod tests {
         );
 
         let over_depth_limit = register_shape_with_policy_predicate(nested_policy_predicate(
-            BUG_124_POLICY_EXPRESSION_MAX_DEPTH + 1,
+            MAX_POLICY_EXPRESSION_DEPTH + 1,
         ));
         let encoded =
             encode_sync_message(&over_depth_limit).expect("encode over-depth policy fixture");
@@ -1150,7 +1150,7 @@ mod tests {
         );
 
         let at_node_limit = register_shape_with_policy_predicate(wide_policy_predicate(
-            BUG_124_POLICY_EXPRESSION_MAX_NODES,
+            MAX_POLICY_EXPRESSION_NODES,
         ));
         let encoded = encode_sync_message(&at_node_limit).expect("encode node-limit policy");
         assert_eq!(
@@ -1159,13 +1159,56 @@ mod tests {
         );
 
         let over_node_limit = register_shape_with_policy_predicate(wide_policy_predicate(
-            BUG_124_POLICY_EXPRESSION_MAX_NODES + 1,
+            MAX_POLICY_EXPRESSION_NODES + 1,
         ));
         let encoded =
             encode_sync_message(&over_node_limit).expect("encode over-node policy fixture");
         assert!(
             decode_sync_message(&encoded).is_err(),
             "policy node count must be rejected while postcard is parsing"
+        );
+    }
+
+    #[test]
+    fn ordinary_policy_predicate_variants_keep_their_postcard_roundtrip() {
+        let operands = || {
+            (
+                Operand::Column("owner".to_owned()),
+                Operand::Param("subject".to_owned()),
+            )
+        };
+        let (eq_left, eq_right) = operands();
+        let (ne_left, ne_right) = operands();
+        let (gt_left, gt_right) = operands();
+        let (gte_left, gte_right) = operands();
+        let (lt_left, lt_right) = operands();
+        let (lte_left, lte_right) = operands();
+        let (contains_left, contains_right) = operands();
+        let predicate = Predicate::All(vec![
+            Predicate::Any(Vec::new()),
+            Predicate::Eq(eq_left, eq_right),
+            Predicate::Ne(ne_left, ne_right),
+            Predicate::In(
+                Operand::Column("team".to_owned()),
+                vec![Operand::Param("team".to_owned())],
+            ),
+            Predicate::Gt(gt_left, gt_right),
+            Predicate::Gte(gte_left, gte_right),
+            Predicate::Lt(lt_left, lt_right),
+            Predicate::Lte(lte_left, lte_right),
+            Predicate::Contains(contains_left, contains_right),
+            Predicate::EnumMatch {
+                column: "status".to_owned(),
+                case: "active".to_owned(),
+                payload: Box::new(Predicate::IsNull(Operand::Column("deleted_at".to_owned()))),
+            },
+        ]);
+        let message = register_shape_with_policy_predicate(predicate);
+        let encoded = encode_sync_message(&message).expect("encode ordinary policy variants");
+
+        assert_eq!(
+            decode_sync_message(&encoded).expect("decode ordinary policy variants"),
+            message
         );
     }
 


### PR DESCRIPTION
## Summary

- Apply shared depth and total-node limits while decoding recursive policy expressions.
- Limit policy depth to 256 nodes and total expression size to 16,384 nodes, matching existing execution and protocol ceilings.
- Decode catalogue policies with explicit frames so deeply nested input does not consume the call stack.
- Use bounded Serde visitors for Postcard wire predicates so oversized trees are rejected before full allocation.
- Return consistent named protocol-limit errors from both decoding paths.

Before:

```text
A deeply nested or very wide policy could consume stack or memory before its structure was validated.
```

After:

```text
Catalogue and wire decoders reject policies as soon as they exceed the shared depth or node boundary.
```

## Testing

- `cargo test -p jazz-server permissions_decode_enforces_policy_depth_and_total_node_boundaries` — passed
- `cargo test -p jazz policy_predicate_wire_decode_enforces_depth_and_total_node_boundaries` — passed
- `cargo test -p jazz ordinary_policy_predicate_variants_keep_their_postcard_roundtrip` — passed
