### PR TITLE
fix(wire): reject unknown structured error tags

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -630,6 +630,14 @@ describe("websocket frame carrier", () => {
     const nonminimalTag = Uint8Array.from([0x82, 0x00, ...encoded.slice(1)]);
     expect(() => isWireError(nonminimalTag)).toThrow("postcard u64 is not minimally encoded");
     expect(() => decodeWireError(nonminimalTag)).toThrow("postcard u64 is not minimally encoded");
+
+    const unknownCode = encodeWireError(7, 3, "future code");
+    expect(() => isWireError(unknownCode)).toThrow("unknown WireErrorCode discriminant 7");
+    expect(() => decodeWireError(unknownCode)).toThrow("unknown WireErrorCode discriminant 7");
+
+    const unknownRetry = encodeWireError(6, 4, "future retry");
+    expect(() => isWireError(unknownRetry)).toThrow("unknown WireRetry discriminant 4");
+    expect(() => decodeWireError(unknownRetry)).toThrow("unknown WireRetry discriminant 4");
   });
 
   it("surfaces structured wire error frames without forwarding them as payload frames", async () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
@@ -544,7 +544,7 @@ function wireErrorCodeName(tag: number): string {
     case 6:
       return "not_ready";
     default:
-      return `unknown_${tag}`;
+      throw new Error(`unknown WireErrorCode discriminant ${tag}`);
   }
 }
 
@@ -559,7 +559,7 @@ function wireRetryName(tag: number): string {
     case 3:
       return "later";
     default:
-      return `unknown_${tag}`;
+      throw new Error(`unknown WireRetry discriminant ${tag}`);
   }
 }
 


### PR DESCRIPTION
🤖 Reject unknown structured wire-error discriminants so TypeScript and Rust have one exact interpretation of wire v1.

Before:

```text
A frame carrying error code 7 or retry tag 4 was rejected by Rust, but TypeScript classified it as a valid structured error named unknown_7 or unknown_4.
```

After:

```text
Both runtimes reject every unassigned code or retry tag. Known NotReady/Later and MalformedFrame errors retain their existing behavior.
```

The focused corpus includes planted unknown-code and unknown-retry cases. Independent adversarial review additionally covered boundary tags, every truncation point, trailing bytes, and non-minimal encodings; the committed test fails when the former permissive fallback is restored.

Verification:

- TypeScript focused wire tests: 27/27
- TypeScript typecheck: passed
- Independent adversarial review: READY

This is intentionally a closed v1 enum. Future error variants require an explicit coordinated Rust/TypeScript wire change.