### PR TITLE
Preserve legacy catalogue hash migrations

### DIFF
--- a/.changeset/distinct-column-hash-tags.md
+++ b/.changeset/distinct-column-hash-tags.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Give Double and Bytea columns distinct, cross-runtime structural schema hashes. Existing Bytea catalogue identities remain resolvable, and both schema-only and permissions-bearing deploys publish the corrected identity with an explicit durable legacy-to-current migration edge.

--- a/crates/jazz-server/src/server/catalogue.rs
+++ b/crates/jazz-server/src/server/catalogue.rs
@@ -418,6 +418,10 @@ impl CatalogueIndex {
                     // that must remain invisible to rehydration.
                     return Ok(());
                 }
+                // Stored metadata is the durable identity, not a cache of a
+                // hash to recompute during rehydration. Historical Bytea
+                // entries retain their legacy identity until a lens connects
+                // it to the corrected identity.
                 let declared_hash = entry
                     .metadata
                     .get(MetadataKey::SchemaHash.as_str())
@@ -425,15 +429,17 @@ impl CatalogueIndex {
                     .ok_or_else(|| {
                         corrupt_catalogue_entry(entry, "missing or invalid schema_hash metadata")
                     })?;
-                let computed_hash = SchemaHash::compute(&schema);
-                if declared_hash != computed_hash || entry.object_id != computed_hash.to_object_id()
+                let current_hash = SchemaHash::compute(&schema);
+                let legacy_bytea_hash = SchemaHash::compute_legacy_bytea(&schema);
+                if ![current_hash, legacy_bytea_hash].contains(&declared_hash)
+                    || entry.object_id != declared_hash.to_object_id()
                 {
                     return Err(corrupt_catalogue_entry(
                         entry,
                         "schema payload, schema_hash metadata, and object id must agree",
                     ));
                 }
-                self.schemas.entry(computed_hash).or_insert(schema);
+                self.schemas.entry(declared_hash).or_insert(schema);
                 let published_at = entry
                     .metadata
                     .get(MetadataKey::PublishedAt.as_str())
@@ -446,7 +452,7 @@ impl CatalogueIndex {
                         )
                     })?;
                 self.schema_published_at
-                    .entry(computed_hash)
+                    .entry(declared_hash)
                     .and_modify(|existing| *existing = (*existing).max(published_at))
                     .or_insert(published_at);
             }
@@ -840,9 +846,10 @@ mod tests {
     use std::sync::{Arc, Barrier};
     use std::time::Duration;
 
-    use jazz::tools::public_schema::{SchemaBuilder, TablePolicies};
+    use jazz::tools::public_schema::{ColumnType, SchemaBuilder, TablePolicies, TableSchema};
+    use jazz::tools::schema_lens::LensTransform;
 
-    use super::{CatalogueStore, StoredCatalogue};
+    use super::*;
     use crate::server::catalogue_storage::CatalogueMemoryStorage;
 
     #[test]
@@ -898,6 +905,52 @@ mod tests {
                 })
                 .count(),
             PUBLISHERS - 1
+        );
+    }
+
+    // This stays internal because legacy catalogue metadata and the exact
+    // rehydration boundary are not observable through a public client API.
+    #[test]
+    fn legacy_bytea_identity_rehydrates_and_connects_to_current_identity() {
+        let app_id = AppId::from_name("legacy-bytea-catalogue");
+        let schema = SchemaBuilder::new()
+            .table(TableSchema::builder("files").column("payload", ColumnType::Bytea))
+            .build();
+        let legacy_hash = SchemaHash::compute_legacy_bytea(&schema);
+        let current_hash = SchemaHash::compute(&schema);
+        assert_ne!(legacy_hash, current_hash);
+
+        let mut metadata = catalogue_metadata(app_id, ObjectType::CatalogueSchema);
+        metadata.insert(MetadataKey::SchemaHash.to_string(), legacy_hash.to_string());
+        metadata.insert(MetadataKey::PublishedAt.to_string(), "1".to_owned());
+        let legacy_entry = CatalogueEntry {
+            object_id: legacy_hash.to_object_id(),
+            metadata,
+            content: encode_schema(&schema),
+        };
+        let mut storage = CatalogueMemoryStorage::new();
+        storage
+            .upsert_catalogue_entry(&legacy_entry)
+            .expect("seed legacy catalogue entry");
+
+        let store =
+            StoredCatalogue::new(app_id, None, Box::new(storage)).expect("rehydrate catalogue");
+        assert_eq!(
+            store.known_schema(&legacy_hash).unwrap(),
+            Some(schema.clone())
+        );
+        assert_eq!(store.known_schema(&current_hash).unwrap(), None);
+
+        let current_object_id = store.publish_schema(schema.clone()).unwrap();
+        assert_eq!(current_object_id, current_hash.to_object_id());
+        assert_eq!(store.known_schema(&current_hash).unwrap(), Some(schema));
+
+        let migration = Lens::new(legacy_hash, current_hash, LensTransform::new());
+        store.publish_lens(&migration).unwrap();
+        assert!(
+            store
+                .are_schema_hashes_connected(legacy_hash, current_hash)
+                .unwrap()
         );
     }
 }

--- a/crates/jazz/SPEC/2_data_model_identity.md
+++ b/crates/jazz/SPEC/2_data_model_identity.md
@@ -174,6 +174,37 @@ without creating a second physical storage partition. Changing any storage-shape
 input yields a new `SchemaVersionId`. This content-addressing is what lets
 multiple storage schema versions coexist (ch. 10).
 
+The admin/tooling catalogue also carries a BLAKE3 `SchemaHash` for the public
+structural schema exchanged by Rust and TypeScript. This is distinct from the
+core `SchemaVersionId`, but its byte stream is likewise a durable cross-runtime
+contract. Column types use the following named one-byte tags:
+
+| Type                   | Tag | Type            | Tag |
+| ---------------------- | --: | --------------- | --: |
+| `Integer`              |   1 | `BigInt`        |   2 |
+| `Boolean`              |   3 | `Text`          |   4 |
+| `Timestamp`            |   5 | `Uuid`          |   6 |
+| `Array`                |   7 | `Row`           |   8 |
+| `Enum`                 |   9 | `Double`        |  10 |
+| `Json`                 |  11 | `TransactionId` |  12 |
+| `EnumPayload`          |  13 | `ScalarEnum`    |  14 |
+| `CatalogueEnumPayload` |  15 | `Bytea`         |  16 |
+
+`Array`, `Row`, and payload-enum fields recursively use the same tags. Rust and
+TypeScript MUST emit the same bytes for every portable type, defaults, index
+overrides, and branch keys. Tags are append-only once published.
+
+The historical format accidentally assigned `Bytea` tag 10, colliding with
+`Double`. A stored catalogue schema retains that historical hash from its
+durable `schema_hash` metadata and remains addressable by it. It is not an alias
+for the corrected identity: any newly published copy uses tag 16. A deploy that
+encounters the durable historical identity MUST publish the corrected identity
+and connect the historical hash to the corrected hash with an ordinary durable
+migration lens, regardless of whether the deploy also publishes permissions
+(including schema-only CLI deploys). This appends a forward compatibility edge
+rather than rewriting either identity; the transform is empty when the decoded
+schemas are structurally equal.
+
 _Further invariants._ `INV-DATA-7` — `SchemaVersionId` changes when a column's
 merge strategy changes.
 

--- a/crates/jazz/src/tools/public_api/types/branch.rs
+++ b/crates/jazz/src/tools/public_api/types/branch.rs
@@ -8,6 +8,60 @@ use super::*;
 // Schema Hashing - Content-addressed schema identification
 // ============================================================================
 
+#[repr(u8)]
+#[derive(Clone, Copy)]
+enum ColumnTypeHashTag {
+    Integer = 1,
+    BigInt = 2,
+    Boolean = 3,
+    Text = 4,
+    Timestamp = 5,
+    Uuid = 6,
+    Array = 7,
+    Row = 8,
+    Enum = 9,
+    Double = 10,
+    Json = 11,
+    TransactionId = 12,
+    EnumPayload = 13,
+    ScalarEnum = 14,
+    CatalogueEnumPayload = 15,
+    Bytea = 16,
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy)]
+enum ValueHashTag {
+    Integer = 1,
+    BigInt = 2,
+    Boolean = 3,
+    Text = 4,
+    Timestamp = 5,
+    Uuid = 6,
+    Array = 7,
+    Row = 8,
+    Null = 9,
+    Double = 10,
+    Bytea = 11,
+    TransactionId = 12,
+    Enum = 14,
+}
+
+#[derive(Clone, Copy)]
+enum SchemaHashFormat {
+    Current,
+    LegacyByteaCollision,
+}
+
+impl SchemaHashFormat {
+    fn bytea_tag(self) -> u8 {
+        match self {
+            Self::Current => ColumnTypeHashTag::Bytea as u8,
+            Self::LegacyByteaCollision => ColumnTypeHashTag::Double as u8,
+        }
+    }
+}
+
 /// Content-addressed hash of a schema's structural elements.
 /// Uses BLAKE3 over deterministic table ordering while preserving each table's
 /// declared column order.
@@ -73,8 +127,26 @@ impl SchemaHash {
         ))
     }
 
-    /// Compute hash for a complete schema (HashMap<TableName, TableSchema>).
+    /// Compute the current structural hash for a complete schema.
+    ///
+    /// New catalogue identities always use the current format. Historical
+    /// Bytea identities can be derived explicitly with
+    /// [`SchemaHash::compute_legacy_bytea`] for catalogue resolution and a
+    /// durable migration edge.
     pub fn compute(schema: &Schema) -> Self {
+        Self::compute_with_format(schema, SchemaHashFormat::Current)
+    }
+
+    /// Compute the historical schema identity where `Bytea` shared `Double`'s
+    /// column-type tag.
+    ///
+    /// This is a read/migration compatibility operation only. New catalogue
+    /// entries must use [`SchemaHash::compute`].
+    pub fn compute_legacy_bytea(schema: &Schema) -> Self {
+        Self::compute_with_format(schema, SchemaHashFormat::LegacyByteaCollision)
+    }
+
+    fn compute_with_format(schema: &Schema, format: SchemaHashFormat) -> Self {
         let mut hasher = blake3::Hasher::new();
 
         // Sort tables by name for deterministic ordering
@@ -89,7 +161,7 @@ impl SchemaHash {
             hasher.update(&[0]); // delimiter
 
             // Hash row descriptor in declared column order
-            hash_row_descriptor(&mut hasher, &table_schema.columns);
+            hash_row_descriptor_with_format(&mut hasher, &table_schema.columns, format);
 
             if let Some(indexed_columns) = &table_schema.indexed_columns {
                 // `None` must hash exactly like pre-index-override schemas so
@@ -144,19 +216,31 @@ impl<'de> Deserialize<'de> for SchemaHash {
 
 /// Hash a RowDescriptor into a hasher, preserving declared column order.
 pub(crate) fn hash_row_descriptor(hasher: &mut blake3::Hasher, descriptor: &RowDescriptor) {
+    hash_row_descriptor_with_format(hasher, descriptor, SchemaHashFormat::Current);
+}
+
+fn hash_row_descriptor_with_format(
+    hasher: &mut blake3::Hasher,
+    descriptor: &RowDescriptor,
+    format: SchemaHashFormat,
+) {
     for col in &descriptor.columns {
-        hash_column_descriptor(hasher, col);
+        hash_column_descriptor(hasher, col, format);
     }
 }
 
 /// Hash a single ColumnDescriptor.
-fn hash_column_descriptor(hasher: &mut blake3::Hasher, col: &ColumnDescriptor) {
+fn hash_column_descriptor(
+    hasher: &mut blake3::Hasher,
+    col: &ColumnDescriptor,
+    format: SchemaHashFormat,
+) {
     // Name
     hasher.update(col.name.as_str().as_bytes());
     hasher.update(&[0]);
 
     // Type
-    hash_column_type(hasher, &col.column_type);
+    hash_column_type(hasher, &col.column_type, format);
 
     // Nullable flag
     hasher.update(&[col.nullable as u8]);
@@ -196,58 +280,58 @@ fn hash_column_descriptor(hasher: &mut blake3::Hasher, col: &ColumnDescriptor) {
 fn hash_value(hasher: &mut blake3::Hasher, value: &Value) {
     match value {
         Value::Integer(v) => {
-            hasher.update(&[1]);
+            hasher.update(&[ValueHashTag::Integer as u8]);
             hasher.update(&v.to_le_bytes());
         }
         Value::BigInt(v) => {
-            hasher.update(&[2]);
+            hasher.update(&[ValueHashTag::BigInt as u8]);
             hasher.update(&v.to_le_bytes());
         }
         Value::Double(v) => {
-            hasher.update(&[10]);
+            hasher.update(&[ValueHashTag::Double as u8]);
             hasher.update(&v.to_le_bytes());
         }
         Value::Boolean(v) => {
-            hasher.update(&[3, *v as u8]);
+            hasher.update(&[ValueHashTag::Boolean as u8, *v as u8]);
         }
         Value::Text(v) => {
-            hasher.update(&[4]);
+            hasher.update(&[ValueHashTag::Text as u8]);
             hasher.update(v.as_bytes());
             hasher.update(&[0]);
         }
         Value::Timestamp(v) => {
-            hasher.update(&[5]);
+            hasher.update(&[ValueHashTag::Timestamp as u8]);
             hasher.update(&v.to_le_bytes());
         }
         Value::Uuid(v) => {
-            hasher.update(&[6]);
+            hasher.update(&[ValueHashTag::Uuid as u8]);
             hasher.update(v.uuid().as_bytes());
         }
         Value::TransactionId(v) => {
-            hasher.update(&[12]);
+            hasher.update(&[ValueHashTag::TransactionId as u8]);
             hasher.update(v);
         }
         Value::Bytea(v) => {
-            hasher.update(&[11]);
+            hasher.update(&[ValueHashTag::Bytea as u8]);
             hasher.update(&(v.len() as u64).to_le_bytes());
             hasher.update(v);
         }
         Value::Array(values) => {
-            hasher.update(&[7]);
+            hasher.update(&[ValueHashTag::Array as u8]);
             hasher.update(&(values.len() as u64).to_le_bytes());
             for inner in values {
                 hash_value(hasher, inner);
             }
         }
         Value::Row { values, .. } => {
-            hasher.update(&[8]);
+            hasher.update(&[ValueHashTag::Row as u8]);
             hasher.update(&(values.len() as u64).to_le_bytes());
             for inner in values {
                 hash_value(hasher, inner);
             }
         }
         Value::Enum { case, values } => {
-            hasher.update(&[14]);
+            hasher.update(&[ValueHashTag::Enum as u8]);
             hasher.update(case.as_bytes());
             hasher.update(&[0]);
             hasher.update(&(values.len() as u64).to_le_bytes());
@@ -256,31 +340,31 @@ fn hash_value(hasher: &mut blake3::Hasher, value: &Value) {
             }
         }
         Value::Null => {
-            hasher.update(&[9]);
+            hasher.update(&[ValueHashTag::Null as u8]);
         }
     }
 }
 
 /// Hash a ColumnType recursively (for Array and Row types).
-fn hash_column_type(hasher: &mut blake3::Hasher, col_type: &ColumnType) {
+fn hash_column_type(hasher: &mut blake3::Hasher, col_type: &ColumnType, format: SchemaHashFormat) {
     match col_type {
         ColumnType::Integer => {
-            hasher.update(&[1]);
+            hasher.update(&[ColumnTypeHashTag::Integer as u8]);
         }
         ColumnType::BigInt => {
-            hasher.update(&[2]);
+            hasher.update(&[ColumnTypeHashTag::BigInt as u8]);
         }
         ColumnType::Double => {
-            hasher.update(&[10]);
+            hasher.update(&[ColumnTypeHashTag::Double as u8]);
         }
         ColumnType::Boolean => {
-            hasher.update(&[3]);
+            hasher.update(&[ColumnTypeHashTag::Boolean as u8]);
         }
         ColumnType::Text => {
-            hasher.update(&[4]);
+            hasher.update(&[ColumnTypeHashTag::Text as u8]);
         }
         ColumnType::Enum { variants } => {
-            hasher.update(&[9]);
+            hasher.update(&[ColumnTypeHashTag::Enum as u8]);
             // Scalar enum order assigns durable discriminant tags, so it is
             // structural schema identity rather than presentation metadata.
             hasher.update(&(variants.len() as u64).to_le_bytes());
@@ -290,7 +374,7 @@ fn hash_column_type(hasher: &mut blake3::Hasher, col_type: &ColumnType) {
             }
         }
         ColumnType::ScalarEnum { name, variants } => {
-            hasher.update(&[14]);
+            hasher.update(&[ColumnTypeHashTag::ScalarEnum as u8]);
             hasher.update(name.as_bytes());
             hasher.update(&[0]);
             hasher.update(&(variants.len() as u64).to_le_bytes());
@@ -300,7 +384,7 @@ fn hash_column_type(hasher: &mut blake3::Hasher, col_type: &ColumnType) {
             }
         }
         ColumnType::CatalogueEnumPayload { name, cases } => {
-            hasher.update(&[15]);
+            hasher.update(&[ColumnTypeHashTag::CatalogueEnumPayload as u8]);
             hasher.update(name.as_bytes());
             hasher.update(&[0]);
             hasher.update(&(cases.len() as u64).to_le_bytes());
@@ -311,13 +395,13 @@ fn hash_column_type(hasher: &mut blake3::Hasher, col_type: &ColumnType) {
                 for field in &case.fields {
                     hasher.update(field.name.as_str().as_bytes());
                     hasher.update(&[0]);
-                    hash_column_type(hasher, &field.column_type);
+                    hash_column_type(hasher, &field.column_type, format);
                     hasher.update(&[u8::from(field.nullable)]);
                 }
             }
         }
         ColumnType::EnumPayload { cases } => {
-            hasher.update(&[13]);
+            hasher.update(&[ColumnTypeHashTag::EnumPayload as u8]);
             hasher.update(&(cases.len() as u64).to_le_bytes());
             for case in cases {
                 hasher.update(case.name.as_bytes());
@@ -326,25 +410,25 @@ fn hash_column_type(hasher: &mut blake3::Hasher, col_type: &ColumnType) {
                 for field in &case.fields {
                     hasher.update(field.name.as_str().as_bytes());
                     hasher.update(&[0]);
-                    hash_column_type(hasher, &field.column_type);
+                    hash_column_type(hasher, &field.column_type, format);
                     hasher.update(&[u8::from(field.nullable)]);
                 }
             }
         }
         ColumnType::Timestamp => {
-            hasher.update(&[5]);
+            hasher.update(&[ColumnTypeHashTag::Timestamp as u8]);
         }
         ColumnType::Uuid => {
-            hasher.update(&[6]);
+            hasher.update(&[ColumnTypeHashTag::Uuid as u8]);
         }
         ColumnType::TransactionId => {
-            hasher.update(&[12]);
+            hasher.update(&[ColumnTypeHashTag::TransactionId as u8]);
         }
         ColumnType::Bytea => {
-            hasher.update(&[10]);
+            hasher.update(&[format.bytea_tag()]);
         }
         ColumnType::Json { schema } => {
-            hasher.update(&[11]);
+            hasher.update(&[ColumnTypeHashTag::Json as u8]);
             match schema {
                 Some(schema) => {
                     hasher.update(&[1]);
@@ -361,12 +445,12 @@ fn hash_column_type(hasher: &mut blake3::Hasher, col_type: &ColumnType) {
             }
         }
         ColumnType::Array { element: elem } => {
-            hasher.update(&[7]);
-            hash_column_type(hasher, elem);
+            hasher.update(&[ColumnTypeHashTag::Array as u8]);
+            hash_column_type(hasher, elem, format);
         }
         ColumnType::Row { columns: desc } => {
-            hasher.update(&[8]);
-            hash_row_descriptor(hasher, desc);
+            hasher.update(&[ColumnTypeHashTag::Row as u8]);
+            hash_row_descriptor_with_format(hasher, desc, format);
         }
     }
 }

--- a/crates/jazz/src/tools/public_api/types/tests.rs
+++ b/crates/jazz/src/tools/public_api/types/tests.rs
@@ -216,6 +216,55 @@ fn row_descriptor_hash_changes_when_merge_strategy_changes() {
     );
 }
 
+#[test]
+fn row_descriptor_hash_distinguishes_double_and_bytea() {
+    let double = RowDescriptor::new(vec![ColumnDescriptor::new("value", ColumnType::Double)]);
+    let bytea = RowDescriptor::new(vec![ColumnDescriptor::new("value", ColumnType::Bytea)]);
+
+    assert_ne!(
+        double.content_hash(),
+        bytea.content_hash(),
+        "Double and Bytea require distinct durable schema identities"
+    );
+}
+
+#[test]
+fn row_descriptor_hash_distinguishes_nested_double_and_bytea() {
+    let array_double = RowDescriptor::new(vec![ColumnDescriptor::new(
+        "value",
+        ColumnType::Array {
+            element: Box::new(ColumnType::Double),
+        },
+    )]);
+    let array_bytea = RowDescriptor::new(vec![ColumnDescriptor::new(
+        "value",
+        ColumnType::Array {
+            element: Box::new(ColumnType::Bytea),
+        },
+    )]);
+    assert_ne!(array_double.content_hash(), array_bytea.content_hash());
+
+    let row_double = RowDescriptor::new(vec![ColumnDescriptor::new(
+        "value",
+        ColumnType::Row {
+            columns: Box::new(RowDescriptor::new(vec![ColumnDescriptor::new(
+                "nested",
+                ColumnType::Double,
+            )])),
+        },
+    )]);
+    let row_bytea = RowDescriptor::new(vec![ColumnDescriptor::new(
+        "value",
+        ColumnType::Row {
+            columns: Box::new(RowDescriptor::new(vec![ColumnDescriptor::new(
+                "nested",
+                ColumnType::Bytea,
+            )])),
+        },
+    )]);
+    assert_ne!(row_double.content_hash(), row_bytea.content_hash());
+}
+
 // ========================================================================
 // Schema Hash Tests
 // ========================================================================
@@ -362,6 +411,36 @@ fn schema_hash_matches_ordered_enum_cross_runtime_fixture() {
         hashes[0], hashes[1],
         "reordering variants changes durable tag meaning"
     );
+}
+
+#[test]
+fn schema_hash_matches_all_column_cross_runtime_fixture_and_legacy_format() {
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AllColumnHashFixture {
+        schema_hash_format: u8,
+        legacy_bytea_column_type_tag: u8,
+        current_bytea_column_type_tag: u8,
+        schema: std::collections::BTreeMap<TableName, TableSchema>,
+        current_hash: String,
+        legacy_bytea_hash: String,
+    }
+
+    let fixture: AllColumnHashFixture = serde_json::from_str(include_str!(
+        "../../../../../../packages/jazz-tools/src/testing/fixtures/all-column-schema-hashes.json"
+    ))
+    .expect("all-column hash fixture is valid JSON");
+
+    assert_eq!(fixture.schema_hash_format, 2);
+    assert_eq!(fixture.legacy_bytea_column_type_tag, 10);
+    assert_eq!(fixture.current_bytea_column_type_tag, 16);
+    let schema: Schema = fixture.schema.into_iter().collect();
+    assert_eq!(SchemaHash::compute(&schema).to_hex(), fixture.current_hash);
+    assert_eq!(
+        SchemaHash::compute_legacy_bytea(&schema).to_hex(),
+        fixture.legacy_bytea_hash
+    );
+    assert_ne!(fixture.current_hash, fixture.legacy_bytea_hash);
 }
 
 #[test]

--- a/packages/jazz-tools/src/dev/catalogue-project.ts
+++ b/packages/jazz-tools/src/dev/catalogue-project.ts
@@ -51,6 +51,7 @@ import {
   resolveKnownSchemaHash,
   resolveStoredStructuralSchemaHash,
   resolveStoredStructuralSchemaHashOrThrow,
+  resolveStoredStructuralSchemaIdentity,
   schemaTransitionRequiresRowTransform,
   shortSchemaHash,
 } from "./catalogue.js";
@@ -1696,13 +1697,16 @@ async function resolveProjectDeployMigrationChain(
     return undefined;
   }
 
+  const storedReleaseIdentity = await resolveStoredStructuralSchemaIdentity(
+    options.appId,
+    options.serverUrl,
+    options.adminSecret,
+    compiled.wasmSchema,
+  );
   const toHash =
-    (await resolveStoredStructuralSchemaHash(
-      options.appId,
-      options.serverUrl,
-      options.adminSecret,
-      compiled.wasmSchema,
-    )) ?? (await computeSchemaHash(compiled.wasmSchema));
+    storedReleaseIdentity?.format === "current"
+      ? storedReleaseIdentity.hash
+      : await computeSchemaHash(compiled.wasmSchema);
   if (head.schemaHash === toHash) {
     return undefined;
   }
@@ -1830,12 +1834,14 @@ export async function deploy(options: DeployOptions): Promise<DeployResult> {
     // The catalogue deploy primitive accepts one migration.  Project deploy
     // deliberately owns multi-step replay so each reviewed edge is published
     // in order, and permissions cannot advance until the complete path exists.
-    const existingReleaseSchema = await resolveStoredStructuralSchemaHash(
+    const storedReleaseIdentity = await resolveStoredStructuralSchemaIdentity(
       options.appId,
       options.serverUrl,
       options.adminSecret,
       compiled.wasmSchema,
     );
+    const existingReleaseSchema =
+      storedReleaseIdentity?.format === "current" ? storedReleaseIdentity.hash : null;
     const warnings = collectMissingExplicitPolicyDiagnostics(
       Object.keys(compiled.wasmSchema),
       compiled.permissions,

--- a/packages/jazz-tools/src/dev/catalogue.test.ts
+++ b/packages/jazz-tools/src/dev/catalogue.test.ts
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { schema as s } from "../index.js";
 import { serializeRuntimeSchema } from "../drivers/schema-wire.js";
 import { createNapiNativeRuntimeAdapter } from "../runtime/testing/napi-runtime-test-utils.js";
+import { deploy as deployCatalogue } from "./catalogue.js";
+import { legacyByteaStructuralSchemaHash, structuralSchemaHash } from "./schema-utils.js";
 
 const tempRoots: string[] = [];
 const APP_ID = "test-app";
@@ -104,6 +106,174 @@ describe("dev catalogue runtime schema identity", () => {
     await createNapiNativeRuntimeAdapter(app.wasmSchema);
 
     expect(serializeRuntimeSchema(app.wasmSchema)).toContain("__jazzRuntimeSchema");
+  });
+});
+
+describe("legacy Bytea catalogue identity", () => {
+  it("publishes the corrected identity and connects the legacy identity with a migration", async () => {
+    const schema = s.defineApp({
+      files: s.table({
+        payload: s.bytes(),
+      }),
+    }).wasmSchema;
+    const legacyHash = legacyByteaStructuralSchemaHash(schema);
+    const currentHash = structuralSchemaHash(schema);
+    const previousHead = {
+      schemaHash: legacyHash,
+      version: 1,
+      parentBundleObjectId: null,
+      bundleObjectId: "11111111-1111-1111-1111-111111111111",
+    };
+    const nextHead = {
+      schemaHash: currentHash,
+      version: 2,
+      parentBundleObjectId: previousHead.bundleObjectId,
+      bundleObjectId: "22222222-2222-2222-2222-222222222222",
+    };
+    let migrationBody: Record<string, unknown> | undefined;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith(`/apps/${APP_ID}/schemas`)) {
+          return new Response(JSON.stringify({ hashes: [legacyHash] }), { status: 200 });
+        }
+        if (
+          url.endsWith(`/apps/${APP_ID}/schema/${legacyHash}`) ||
+          url.endsWith(`/apps/${APP_ID}/schema/${currentHash}`)
+        ) {
+          return new Response(JSON.stringify({ schema: { tables: schema }, publishedAt: 1 }), {
+            status: 200,
+          });
+        }
+        if (url.endsWith(`/apps/${APP_ID}/admin/schemas`)) {
+          return new Response(
+            JSON.stringify({
+              objectId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+              hash: currentHash,
+            }),
+            { status: 201 },
+          );
+        }
+        if (url.endsWith(`/apps/${APP_ID}/admin/permissions/head`)) {
+          return new Response(JSON.stringify({ head: previousHead }), { status: 200 });
+        }
+        if (url.includes(`/apps/${APP_ID}/admin/schema-connectivity`)) {
+          return new Response(JSON.stringify({ connected: false }), { status: 200 });
+        }
+        if (url.endsWith(`/apps/${APP_ID}/admin/migrations`)) {
+          migrationBody = JSON.parse(String(init?.body));
+          return new Response(
+            JSON.stringify({
+              objectId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+              fromHash: legacyHash,
+              toHash: currentHash,
+            }),
+            { status: 201 },
+          );
+        }
+        if (url.endsWith(`/apps/${APP_ID}/admin/permissions`)) {
+          return new Response(JSON.stringify({ head: nextHead }), { status: 201 });
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      }),
+    );
+    const result = await deployCatalogue({
+      appId: APP_ID,
+      serverUrl: SERVER_URL,
+      adminSecret: ADMIN_SECRET,
+      schema,
+      permissions: {},
+    });
+
+    expect(legacyHash).not.toBe(currentHash);
+    expect(result.schema).toMatchObject({ hash: currentHash, status: "published" });
+    expect(result.migration).toMatchObject({
+      fromHash: legacyHash,
+      toHash: currentHash,
+      status: "published",
+    });
+    expect(migrationBody).toEqual({
+      fromHash: legacyHash,
+      toHash: currentHash,
+      forward: [],
+    });
+    expect(result.permissions?.schemaHash).toBe(currentHash);
+  });
+
+  it("connects the durable legacy identity when deploying without permissions", async () => {
+    const schema = s.defineApp({
+      files: s.table({
+        payload: s.bytes(),
+      }),
+    }).wasmSchema;
+    const legacyHash = legacyByteaStructuralSchemaHash(schema);
+    const currentHash = structuralSchemaHash(schema);
+    let migrationBody: Record<string, unknown> | undefined;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith(`/apps/${APP_ID}/schemas`)) {
+          return new Response(JSON.stringify({ hashes: [legacyHash] }), { status: 200 });
+        }
+        if (
+          url.endsWith(`/apps/${APP_ID}/schema/${legacyHash}`) ||
+          url.endsWith(`/apps/${APP_ID}/schema/${currentHash}`)
+        ) {
+          return new Response(JSON.stringify({ schema: { tables: schema }, publishedAt: 1 }), {
+            status: 200,
+          });
+        }
+        if (url.endsWith(`/apps/${APP_ID}/admin/schemas`)) {
+          return new Response(
+            JSON.stringify({
+              objectId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+              hash: currentHash,
+            }),
+            { status: 201 },
+          );
+        }
+        if (url.includes(`/apps/${APP_ID}/admin/schema-connectivity`)) {
+          return new Response(JSON.stringify({ connected: false }), { status: 200 });
+        }
+        if (url.endsWith(`/apps/${APP_ID}/admin/migrations`)) {
+          migrationBody = JSON.parse(String(init?.body));
+          return new Response(
+            JSON.stringify({
+              objectId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+              fromHash: legacyHash,
+              toHash: currentHash,
+            }),
+            { status: 201 },
+          );
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      }),
+    );
+
+    const result = await deployCatalogue({
+      appId: APP_ID,
+      serverUrl: SERVER_URL,
+      adminSecret: ADMIN_SECRET,
+      schema,
+    });
+
+    expect(legacyHash).not.toBe(currentHash);
+    expect(result.schema).toMatchObject({ hash: currentHash, status: "published" });
+    expect(result.migration).toMatchObject({
+      fromHash: legacyHash,
+      toHash: currentHash,
+      status: "published",
+    });
+    expect(migrationBody).toEqual({
+      fromHash: legacyHash,
+      toHash: currentHash,
+      forward: [],
+    });
+    expect(result.permissions).toBeUndefined();
   });
 });
 

--- a/packages/jazz-tools/src/dev/catalogue.test.ts
+++ b/packages/jazz-tools/src/dev/catalogue.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { schema as s } from "../index.js";
 import { serializeRuntimeSchema } from "../drivers/schema-wire.js";
 import { createNapiNativeRuntimeAdapter } from "../runtime/testing/napi-runtime-test-utils.js";
-import { deploy as deployCatalogue } from "./catalogue.js";
+import { deploy as deployCatalogue, resolveStoredStructuralSchemaIdentity } from "./catalogue.js";
 import { legacyByteaStructuralSchemaHash, structuralSchemaHash } from "./schema-utils.js";
 
 const tempRoots: string[] = [];
@@ -274,6 +274,151 @@ describe("legacy Bytea catalogue identity", () => {
       forward: [],
     });
     expect(result.permissions).toBeUndefined();
+  });
+  it("connects matching legacy and corrected identities when both are already stored", async () => {
+    const schema = s.defineApp({
+      files: s.table({
+        payload: s.bytes(),
+      }),
+    }).wasmSchema;
+    const legacyHash = legacyByteaStructuralSchemaHash(schema);
+    const currentHash = structuralSchemaHash(schema);
+    let migrationBody: Record<string, unknown> | undefined;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith(`/apps/${APP_ID}/schemas`)) {
+          return new Response(JSON.stringify({ hashes: [currentHash, legacyHash] }), {
+            status: 200,
+          });
+        }
+        if (
+          url.endsWith(`/apps/${APP_ID}/schema/${currentHash}`) ||
+          url.endsWith(`/apps/${APP_ID}/schema/${legacyHash}`)
+        ) {
+          return new Response(JSON.stringify({ schema: { tables: schema }, publishedAt: 1 }), {
+            status: 200,
+          });
+        }
+        if (url.includes(`/apps/${APP_ID}/admin/schema-connectivity`)) {
+          return new Response(JSON.stringify({ connected: false }), { status: 200 });
+        }
+        if (url.endsWith(`/apps/${APP_ID}/admin/migrations`)) {
+          migrationBody = JSON.parse(String(init?.body));
+          return new Response(
+            JSON.stringify({
+              objectId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+              fromHash: legacyHash,
+              toHash: currentHash,
+            }),
+            { status: 201 },
+          );
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      }),
+    );
+
+    const result = await deployCatalogue({
+      appId: APP_ID,
+      serverUrl: SERVER_URL,
+      adminSecret: ADMIN_SECRET,
+      schema,
+    });
+
+    expect(result.schema).toEqual({ hash: currentHash, status: "already-stored" });
+    expect(result.migration).toEqual({
+      fromHash: legacyHash,
+      toHash: currentHash,
+      status: "published",
+      objectId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    });
+    expect(migrationBody).toEqual({
+      fromHash: legacyHash,
+      toHash: currentHash,
+      forward: [],
+    });
+  });
+});
+
+describe("stored schema identity lookup", () => {
+  it("checks historical candidates in bounded concurrent batches", async () => {
+    const schema = s.defineApp({
+      todos: s.table({
+        title: s.string(),
+      }),
+    }).wasmSchema;
+    const historicalHashes = Array.from({ length: 10 }, (_, index) =>
+      index.toString(16).padStart(64, "0"),
+    );
+    const matchingHash = historicalHashes.at(-1)!;
+    let activeLookups = 0;
+    let maximumActiveLookups = 0;
+    let startedLookups = 0;
+    let releaseFirstBatch!: () => void;
+    const firstBatchGate = new Promise<void>((resolve) => {
+      releaseFirstBatch = resolve;
+    });
+    let reportFirstBatchStarted!: () => void;
+    const firstBatchStarted = new Promise<void>((resolve) => {
+      reportFirstBatchStarted = resolve;
+    });
+    let reportSecondBatchStarted!: () => void;
+    const secondBatchStarted = new Promise<void>((resolve) => {
+      reportSecondBatchStarted = resolve;
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string) => {
+        const url = String(input);
+        if (url.endsWith(`/apps/${APP_ID}/schemas`)) {
+          return new Response(JSON.stringify({ hashes: historicalHashes }), { status: 200 });
+        }
+
+        const hash = historicalHashes.find((candidate) =>
+          url.endsWith(`/apps/${APP_ID}/schema/${candidate}`),
+        );
+        if (!hash) throw new Error(`Unexpected fetch: ${url}`);
+
+        activeLookups += 1;
+        startedLookups += 1;
+        maximumActiveLookups = Math.max(maximumActiveLookups, activeLookups);
+        if (startedLookups === 8) reportFirstBatchStarted();
+        if (startedLookups === historicalHashes.length) reportSecondBatchStarted();
+        if (startedLookups <= 8) await firstBatchGate;
+        activeLookups -= 1;
+
+        return new Response(
+          JSON.stringify({
+            schema: { tables: hash === matchingHash ? schema : {} },
+            publishedAt: 1,
+          }),
+          { status: 200 },
+        );
+      }),
+    );
+
+    const resolving = resolveStoredStructuralSchemaIdentity(
+      APP_ID,
+      SERVER_URL,
+      ADMIN_SECRET,
+      schema,
+    );
+    await firstBatchStarted;
+
+    expect(startedLookups).toBe(8);
+    expect(activeLookups).toBe(8);
+    releaseFirstBatch();
+    await secondBatchStarted;
+
+    await expect(resolving).resolves.toEqual({
+      hash: matchingHash,
+      format: "historical",
+    });
+    expect(startedLookups).toBe(historicalHashes.length);
+    expect(maximumActiveLookups).toBe(8);
   });
 });
 

--- a/packages/jazz-tools/src/dev/catalogue.ts
+++ b/packages/jazz-tools/src/dev/catalogue.ts
@@ -26,6 +26,7 @@ import {
 } from "../runtime/schema-fetch.js";
 import {
   columnTypeSignature,
+  legacyByteaStructuralSchemaHash,
   normalizeSchemaHashInput,
   shortSchemaHash,
   tableSchemasEqual,
@@ -99,13 +100,15 @@ export interface DeployOptions extends CatalogueServerOptions {
    */
   schema: SchemaSourceInput;
   /**
-   * Permissions to publish. Omitting this param restricts `deploy` to only publish the schema.
+   * Permissions to publish. Omitting this param restricts `deploy` to publishing
+   * the schema and any required identity compatibility edge.
    */
   permissions?: CompiledPermissionsMap;
   /**
-   * Migration between the current server schema and the new schema.
+   * Migration between the current permissions head schema and the new schema.
    * Only published if there's no existing migration between these schemas.
-   * In order to publish migrations, provide {@link permissions} as well.
+   * In order to publish this permissions-driven migration, provide
+   * {@link permissions} as well.
    */
   migration?: DefinedMigration;
   /**
@@ -291,23 +294,69 @@ export function schemaTransitionRequiresRowTransform(
   );
 }
 
+export type StoredStructuralSchemaIdentity = {
+  hash: string;
+  format: "current" | "legacy-bytea" | "historical";
+};
+
+/**
+ * Resolves the durable catalogue identity that owns a stored schema payload.
+ *
+ * The current hash is preferred. The historical Bytea/Double-collision hash is
+ * then resolved explicitly, without treating it as an alias for the current
+ * identity. Callers that publish a release must publish the current identity
+ * and connect a legacy result with a normal catalogue migration edge.
+ */
+export async function resolveStoredStructuralSchemaIdentity(
+  appId: string,
+  serverUrl: string,
+  adminSecret: string,
+  wasmSchema: WasmSchema,
+): Promise<StoredStructuralSchemaIdentity | null> {
+  const { hashes } = await fetchSchemaHashes(serverUrl, { appId, adminSecret });
+  const currentHash = await computeSchemaHash(wasmSchema);
+  const legacyByteaHash = legacyByteaStructuralSchemaHash(wasmSchema);
+  const candidates: StoredStructuralSchemaIdentity[] = [];
+
+  if (hashes.includes(currentHash)) {
+    candidates.push({ hash: currentHash, format: "current" });
+  }
+  if (legacyByteaHash !== currentHash && hashes.includes(legacyByteaHash)) {
+    candidates.push({ hash: legacyByteaHash, format: "legacy-bytea" });
+  }
+  for (const hash of hashes) {
+    if (hash !== currentHash && hash !== legacyByteaHash) {
+      candidates.push({ hash, format: "historical" });
+    }
+  }
+
+  for (const candidate of candidates) {
+    const stored = await fetchStoredWasmSchema(serverUrl, {
+      appId,
+      adminSecret,
+      schemaHash: candidate.hash,
+    });
+    if (wasmSchemasEqual(stored.schema, wasmSchema)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
 export async function resolveStoredStructuralSchemaHash(
   appId: string,
   serverUrl: string,
   adminSecret: string,
   wasmSchema: WasmSchema,
 ): Promise<string | null> {
-  const { hashes } = await fetchSchemaHashes(serverUrl, { appId, adminSecret });
-  const storedSchemas = await Promise.all(
-    hashes.map(async (hash) => ({
-      hash,
-      schema: (await fetchStoredWasmSchema(serverUrl, { appId, adminSecret, schemaHash: hash }))
-        .schema,
-    })),
+  const identity = await resolveStoredStructuralSchemaIdentity(
+    appId,
+    serverUrl,
+    adminSecret,
+    wasmSchema,
   );
-
-  const match = storedSchemas.find(({ schema }) => wasmSchemasEqual(schema, wasmSchema));
-  return match?.hash ?? null;
+  return identity?.hash ?? null;
 }
 
 export async function resolveStoredStructuralSchemaHashOrThrow(
@@ -508,12 +557,14 @@ export async function pushMigration(options: PushMigrationOptions): Promise<Push
 }
 
 /**
- * Publishes a schema and optional permissions.
+ * Publishes a schema, required identity compatibility edges, and optional permissions.
  *
- * When updating permissions to target a new schema, also attempts to publish a migration
- * between the old and new schemas. When a required migration is missing, returns
- * `migration.status === "missing"` without publishing permissions. Set `noVerify` to
- * publish permissions anyway.
+ * A durable legacy Bytea identity is connected to the corrected identity even
+ * when permissions are not part of the deploy. When updating permissions to
+ * target a new schema, also attempts to publish a migration between the old and
+ * new schemas. When a required migration is missing, returns
+ * `migration.status === "missing"` without publishing permissions. Set `noVerify`
+ * to publish permissions anyway.
  */
 export async function deploy(options: DeployOptions): Promise<DeployResult> {
   const wasmSchema = resolveSchemaSource(options.schema);
@@ -526,12 +577,14 @@ export async function deploy(options: DeployOptions): Promise<DeployResult> {
     collectWarning(warnings, diagnostic.message);
   }
 
-  const storedSchemaHash = await resolveStoredStructuralSchemaHash(
+  const storedIdentity = await resolveStoredStructuralSchemaIdentity(
     options.appId,
     options.serverUrl,
     options.adminSecret,
     wasmSchema,
   );
+  const storedSchemaHash =
+    storedIdentity && storedIdentity.format !== "legacy-bytea" ? storedIdentity.hash : null;
 
   let schema: DeploySchemaResult;
   if (storedSchemaHash) {
@@ -552,8 +605,32 @@ export async function deploy(options: DeployOptions): Promise<DeployResult> {
     };
   }
 
+  let migration: DeployResult["migration"];
+  if (storedIdentity?.format === "legacy-bytea" && storedIdentity.hash !== schema.hash) {
+    const { connected } = await fetchSchemaConnectivity(options.serverUrl, {
+      appId: options.appId,
+      adminSecret: options.adminSecret,
+      fromHash: storedIdentity.hash,
+      toHash: schema.hash,
+    });
+
+    migration = connected
+      ? {
+          status: "already-connected",
+          fromHash: storedIdentity.hash,
+          toHash: schema.hash,
+        }
+      : await pushMigration({
+          appId: options.appId,
+          serverUrl: options.serverUrl,
+          adminSecret: options.adminSecret,
+          fromHash: storedIdentity.hash,
+          toHash: schema.hash,
+        });
+  }
+
   if (!options.permissions) {
-    return { schema, warnings };
+    return { schema, migration, warnings };
   }
 
   const { head: previousHead } = await fetchPermissionsHead(options.serverUrl, {
@@ -561,8 +638,11 @@ export async function deploy(options: DeployOptions): Promise<DeployResult> {
     adminSecret: options.adminSecret,
   });
 
-  let migration: DeployResult["migration"];
-  if (previousHead && previousHead.schemaHash !== schema.hash) {
+  if (
+    previousHead &&
+    previousHead.schemaHash !== schema.hash &&
+    (migration?.fromHash !== previousHead.schemaHash || migration?.toHash !== schema.hash)
+  ) {
     const { connected } = await fetchSchemaConnectivity(options.serverUrl, {
       appId: options.appId,
       adminSecret: options.adminSecret,

--- a/packages/jazz-tools/src/dev/catalogue.ts
+++ b/packages/jazz-tools/src/dev/catalogue.ts
@@ -294,54 +294,108 @@ export function schemaTransitionRequiresRowTransform(
   );
 }
 
+const STORED_SCHEMA_LOOKUP_BATCH_SIZE = 8;
+
 export type StoredStructuralSchemaIdentity = {
   hash: string;
   format: "current" | "legacy-bytea" | "historical";
 };
 
+type StoredStructuralSchemaResolution = {
+  identity: StoredStructuralSchemaIdentity | null;
+  matchingLegacyByteaHash: string | null;
+};
+
+async function storedSchemaMatches(
+  appId: string,
+  serverUrl: string,
+  adminSecret: string,
+  wasmSchema: WasmSchema,
+  hash: string,
+): Promise<boolean> {
+  const stored = await fetchStoredWasmSchema(serverUrl, {
+    appId,
+    adminSecret,
+    schemaHash: hash,
+  });
+  return wasmSchemasEqual(stored.schema, wasmSchema);
+}
+
 /**
- * Resolves the durable catalogue identity that owns a stored schema payload.
+ * Resolves the stored identity and any distinct matching legacy Bytea identity.
  *
- * The current hash is preferred. The historical Bytea/Double-collision hash is
- * then resolved explicitly, without treating it as an alias for the current
- * identity. Callers that publish a release must publish the current identity
- * and connect a legacy result with a normal catalogue migration edge.
+ * The current and historical Bytea/Double-collision identities are checked
+ * together so deploy can establish the required compatibility edge when both
+ * exist. Remaining historical identities are checked in bounded concurrent
+ * batches, preserving catalogue order without serialising every network read.
  */
+async function resolveStoredStructuralSchema(
+  appId: string,
+  serverUrl: string,
+  adminSecret: string,
+  wasmSchema: WasmSchema,
+): Promise<StoredStructuralSchemaResolution> {
+  const { hashes } = await fetchSchemaHashes(serverUrl, { appId, adminSecret });
+  const currentHash = await computeSchemaHash(wasmSchema);
+  const legacyByteaHash = legacyByteaStructuralSchemaHash(wasmSchema);
+  const hasCurrent = hashes.includes(currentHash);
+  const hasLegacy = legacyByteaHash !== currentHash && hashes.includes(legacyByteaHash);
+  const [currentMatches, legacyMatches] = await Promise.all([
+    hasCurrent
+      ? storedSchemaMatches(appId, serverUrl, adminSecret, wasmSchema, currentHash)
+      : false,
+    hasLegacy
+      ? storedSchemaMatches(appId, serverUrl, adminSecret, wasmSchema, legacyByteaHash)
+      : false,
+  ]);
+
+  if (currentMatches) {
+    return {
+      identity: { hash: currentHash, format: "current" },
+      matchingLegacyByteaHash: legacyMatches ? legacyByteaHash : null,
+    };
+  }
+  if (legacyMatches) {
+    return {
+      identity: { hash: legacyByteaHash, format: "legacy-bytea" },
+      matchingLegacyByteaHash: legacyByteaHash,
+    };
+  }
+
+  let nextHashIndex = 0;
+  while (nextHashIndex < hashes.length) {
+    const batch: string[] = [];
+    while (nextHashIndex < hashes.length && batch.length < STORED_SCHEMA_LOOKUP_BATCH_SIZE) {
+      const hash = hashes[nextHashIndex++]!;
+      if (hash !== currentHash && hash !== legacyByteaHash) {
+        batch.push(hash);
+      }
+    }
+    if (batch.length === 0) continue;
+
+    const matches = await Promise.all(
+      batch.map((hash) => storedSchemaMatches(appId, serverUrl, adminSecret, wasmSchema, hash)),
+    );
+    const matchingIndex = matches.indexOf(true);
+    if (matchingIndex !== -1) {
+      return {
+        identity: { hash: batch[matchingIndex]!, format: "historical" },
+        matchingLegacyByteaHash: null,
+      };
+    }
+  }
+
+  return { identity: null, matchingLegacyByteaHash: null };
+}
+
+/** Resolves the preferred durable catalogue identity for a stored schema payload. */
 export async function resolveStoredStructuralSchemaIdentity(
   appId: string,
   serverUrl: string,
   adminSecret: string,
   wasmSchema: WasmSchema,
 ): Promise<StoredStructuralSchemaIdentity | null> {
-  const { hashes } = await fetchSchemaHashes(serverUrl, { appId, adminSecret });
-  const currentHash = await computeSchemaHash(wasmSchema);
-  const legacyByteaHash = legacyByteaStructuralSchemaHash(wasmSchema);
-  const candidates: StoredStructuralSchemaIdentity[] = [];
-
-  if (hashes.includes(currentHash)) {
-    candidates.push({ hash: currentHash, format: "current" });
-  }
-  if (legacyByteaHash !== currentHash && hashes.includes(legacyByteaHash)) {
-    candidates.push({ hash: legacyByteaHash, format: "legacy-bytea" });
-  }
-  for (const hash of hashes) {
-    if (hash !== currentHash && hash !== legacyByteaHash) {
-      candidates.push({ hash, format: "historical" });
-    }
-  }
-
-  for (const candidate of candidates) {
-    const stored = await fetchStoredWasmSchema(serverUrl, {
-      appId,
-      adminSecret,
-      schemaHash: candidate.hash,
-    });
-    if (wasmSchemasEqual(stored.schema, wasmSchema)) {
-      return candidate;
-    }
-  }
-
-  return null;
+  return (await resolveStoredStructuralSchema(appId, serverUrl, adminSecret, wasmSchema)).identity;
 }
 
 export async function resolveStoredStructuralSchemaHash(
@@ -577,12 +631,13 @@ export async function deploy(options: DeployOptions): Promise<DeployResult> {
     collectWarning(warnings, diagnostic.message);
   }
 
-  const storedIdentity = await resolveStoredStructuralSchemaIdentity(
-    options.appId,
-    options.serverUrl,
-    options.adminSecret,
-    wasmSchema,
-  );
+  const { identity: storedIdentity, matchingLegacyByteaHash: legacySchemaHash } =
+    await resolveStoredStructuralSchema(
+      options.appId,
+      options.serverUrl,
+      options.adminSecret,
+      wasmSchema,
+    );
   const storedSchemaHash =
     storedIdentity && storedIdentity.format !== "legacy-bytea" ? storedIdentity.hash : null;
 
@@ -606,25 +661,25 @@ export async function deploy(options: DeployOptions): Promise<DeployResult> {
   }
 
   let migration: DeployResult["migration"];
-  if (storedIdentity?.format === "legacy-bytea" && storedIdentity.hash !== schema.hash) {
+  if (legacySchemaHash && legacySchemaHash !== schema.hash) {
     const { connected } = await fetchSchemaConnectivity(options.serverUrl, {
       appId: options.appId,
       adminSecret: options.adminSecret,
-      fromHash: storedIdentity.hash,
+      fromHash: legacySchemaHash,
       toHash: schema.hash,
     });
 
     migration = connected
       ? {
           status: "already-connected",
-          fromHash: storedIdentity.hash,
+          fromHash: legacySchemaHash,
           toHash: schema.hash,
         }
       : await pushMigration({
           appId: options.appId,
           serverUrl: options.serverUrl,
           adminSecret: options.adminSecret,
-          fromHash: storedIdentity.hash,
+          fromHash: legacySchemaHash,
           toHash: schema.hash,
         });
   }

--- a/packages/jazz-tools/src/dev/schema-utils.test.ts
+++ b/packages/jazz-tools/src/dev/schema-utils.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import type { ColumnType, WasmSchema } from "../drivers/types.js";
 
-import { structuralSchemaHash } from "./schema-utils.js";
+import { legacyByteaStructuralSchemaHash, structuralSchemaHash } from "./schema-utils.js";
 
 function enumSchema(variants: string[]) {
   return {
@@ -17,6 +18,14 @@ function enumSchema(variants: string[]) {
   };
 }
 
+function schemaWithColumnType(columnType: ColumnType): WasmSchema {
+  return {
+    values: {
+      columns: [{ name: "value", column_type: columnType, nullable: false }],
+    },
+  };
+}
+
 describe("structuralSchemaHash", () => {
   const orderedEnumFixture = JSON.parse(
     readFileSync(
@@ -24,6 +33,19 @@ describe("structuralSchemaHash", () => {
       "utf8",
     ),
   ) as { schemaLayoutVersion: number; cases: Array<{ variants: string[]; hash: string }> };
+  const allColumnFixture = JSON.parse(
+    readFileSync(
+      new URL("../testing/fixtures/all-column-schema-hashes.json", import.meta.url),
+      "utf8",
+    ),
+  ) as {
+    schemaHashFormat: number;
+    legacyByteaColumnTypeTag: number;
+    currentByteaColumnTypeTag: number;
+    schema: WasmSchema;
+    currentHash: string;
+    legacyByteaHash: string;
+  };
 
   it("treats enum declaration order as durable tag meaning", () => {
     expect(structuralSchemaHash(enumSchema(["draft", "active"]))).not.toBe(
@@ -43,5 +65,42 @@ describe("structuralSchemaHash", () => {
     });
 
     expect(hashes[0]).not.toBe(hashes[1]);
+  });
+
+  it("matches Rust for every portable column type and both Bytea hash formats", () => {
+    expect(allColumnFixture.schemaHashFormat).toBe(2);
+    expect(allColumnFixture.legacyByteaColumnTypeTag).toBe(10);
+    expect(allColumnFixture.currentByteaColumnTypeTag).toBe(16);
+    expect(structuralSchemaHash(allColumnFixture.schema)).toBe(allColumnFixture.currentHash);
+    expect(legacyByteaStructuralSchemaHash(allColumnFixture.schema)).toBe(
+      allColumnFixture.legacyByteaHash,
+    );
+    expect(allColumnFixture.currentHash).not.toBe(allColumnFixture.legacyByteaHash);
+  });
+
+  it("distinguishes Double and Bytea at every recursive column-type boundary", () => {
+    expect(structuralSchemaHash(schemaWithColumnType({ type: "Double" }))).not.toBe(
+      structuralSchemaHash(schemaWithColumnType({ type: "Bytea" })),
+    );
+    expect(
+      structuralSchemaHash(schemaWithColumnType({ type: "Array", element: { type: "Double" } })),
+    ).not.toBe(
+      structuralSchemaHash(schemaWithColumnType({ type: "Array", element: { type: "Bytea" } })),
+    );
+    expect(
+      structuralSchemaHash(
+        schemaWithColumnType({
+          type: "Row",
+          columns: [{ name: "nested", column_type: { type: "Double" }, nullable: false }],
+        }),
+      ),
+    ).not.toBe(
+      structuralSchemaHash(
+        schemaWithColumnType({
+          type: "Row",
+          columns: [{ name: "nested", column_type: { type: "Bytea" }, nullable: false }],
+        }),
+      ),
+    );
   });
 });

--- a/packages/jazz-tools/src/dev/schema-utils.ts
+++ b/packages/jazz-tools/src/dev/schema-utils.ts
@@ -9,6 +9,55 @@ import { bytesToHex } from "@noble/hashes/utils.js";
 
 const SHORT_SCHEMA_HASH_LENGTH = 12;
 
+const COLUMN_TYPE_HASH_TAG = {
+  Integer: 1,
+  BigInt: 2,
+  Boolean: 3,
+  Text: 4,
+  Timestamp: 5,
+  Uuid: 6,
+  Array: 7,
+  Row: 8,
+  Enum: 9,
+  Double: 10,
+  Json: 11,
+  TransactionId: 12,
+  EnumPayload: 13,
+  ScalarEnum: 14,
+  CatalogueEnumPayload: 15,
+  Bytea: 16,
+} as const satisfies Record<
+  WasmColumnType["type"] | "TransactionId" | "ScalarEnum" | "CatalogueEnumPayload",
+  number
+>;
+
+const VALUE_HASH_TAG = {
+  Integer: 1,
+  BigInt: 2,
+  Boolean: 3,
+  Text: 4,
+  Timestamp: 5,
+  Uuid: 6,
+  Array: 7,
+  Row: 8,
+  Null: 9,
+  Double: 10,
+  Bytea: 11,
+  Enum: 14,
+} as const satisfies Record<Value["type"], number>;
+
+const CURRENT_STRUCTURAL_HASH_FORMAT = {
+  byteaTag: COLUMN_TYPE_HASH_TAG.Bytea,
+} as const;
+
+const LEGACY_BYTEA_STRUCTURAL_HASH_FORMAT = {
+  byteaTag: COLUMN_TYPE_HASH_TAG.Double,
+} as const;
+
+type StructuralHashFormat = {
+  byteaTag: number;
+};
+
 export function normalizeSchemaHashInput(hash: string, label: string): string {
   const normalized = hash.trim().toLowerCase();
   if (!/^[0-9a-f]{12,64}$/.test(normalized)) {
@@ -22,6 +71,21 @@ export function shortSchemaHash(hash: string): string {
 }
 
 export function structuralSchemaHash(schema: WasmSchema): string {
+  return structuralSchemaHashWithFormat(schema, CURRENT_STRUCTURAL_HASH_FORMAT);
+}
+
+/**
+ * Computes the historical identity where Bytea shared Double's column-type tag.
+ *
+ * Use this only to resolve an existing catalogue identity and connect it to the
+ * current identity with a durable migration edge. New catalogue identities
+ * always use {@link structuralSchemaHash}.
+ */
+export function legacyByteaStructuralSchemaHash(schema: WasmSchema): string {
+  return structuralSchemaHashWithFormat(schema, LEGACY_BYTEA_STRUCTURAL_HASH_FORMAT);
+}
+
+function structuralSchemaHashWithFormat(schema: WasmSchema, format: StructuralHashFormat): string {
   const writer = new StructuralHashWriter();
 
   for (const tableName of Object.keys(schema).sort()) {
@@ -29,7 +93,7 @@ export function structuralSchemaHash(schema: WasmSchema): string {
 
     writer.stringBytes(tableName);
     writer.byte(0);
-    hashColumns(writer, table.columns);
+    hashColumns(writer, table.columns, format);
 
     if (table.indexed_columns) {
       writer.byte(1);
@@ -38,13 +102,20 @@ export function structuralSchemaHash(schema: WasmSchema): string {
         writer.byte(0);
       }
     }
+
+    if (table.branchBy?.length) {
+      writer.stringBytes("branch_by");
+      writer.byte(0);
+      writer.stringBytes(JSON.stringify(table.branchBy));
+      writer.byte(0);
+    }
   }
 
   return bytesToHex(blake3(writer.bytes()));
 }
 
 export function columnTypeSignature(columnType: WasmColumnType): string {
-  return JSON.stringify(columnType);
+  return JSON.stringify(canonicalizeJsonObject(columnType));
 }
 
 class StructuralHashWriter {
@@ -78,6 +149,12 @@ class StructuralHashWriter {
     this.bytes(bytes);
   }
 
+  i32(value: number): void {
+    const bytes = new Uint8Array(4);
+    new DataView(bytes.buffer).setInt32(0, value, true);
+    this.bytes(bytes);
+  }
+
   i64(value: number | bigint): void {
     const bytes = new Uint8Array(8);
     new DataView(bytes.buffer).setBigInt64(0, BigInt(value), true);
@@ -91,11 +168,15 @@ class StructuralHashWriter {
   }
 }
 
-function hashColumns(writer: StructuralHashWriter, columns: ColumnDescriptor[]): void {
+function hashColumns(
+  writer: StructuralHashWriter,
+  columns: ColumnDescriptor[],
+  format: StructuralHashFormat,
+): void {
   for (const column of columns) {
     writer.stringBytes(column.name);
     writer.byte(0);
-    hashColumnType(writer, column.column_type);
+    hashColumnType(writer, column.column_type, format);
     writer.byte(column.nullable ? 1 : 0);
 
     if (column.references) {
@@ -105,11 +186,11 @@ function hashColumns(writer: StructuralHashWriter, columns: ColumnDescriptor[]):
       writer.byte(0);
     }
 
+    // Absence remains untagged for compatibility with schemas authored before
+    // column defaults were included in structural identity.
     if (column.default) {
       writer.byte(1);
       hashValue(writer, column.default);
-    } else {
-      writer.byte(0);
     }
 
     if (column.merge_strategy) {
@@ -118,84 +199,99 @@ function hashColumns(writer: StructuralHashWriter, columns: ColumnDescriptor[]):
     } else {
       writer.byte(0);
     }
+
+    writer.byte(0);
   }
 }
 
 function hashValue(writer: StructuralHashWriter, value: Value): void {
   switch (value.type) {
     case "Integer":
-      writer.byte(1);
-      writer.i64(value.value);
+      writer.byte(VALUE_HASH_TAG.Integer);
+      writer.i32(value.value);
       return;
     case "BigInt":
-      writer.byte(2);
+      writer.byte(VALUE_HASH_TAG.BigInt);
       writer.i64(value.value);
       return;
     case "Double":
-      writer.byte(10);
+      writer.byte(VALUE_HASH_TAG.Double);
       writer.f64(value.value);
       return;
     case "Boolean":
-      writer.byte(3);
+      writer.byte(VALUE_HASH_TAG.Boolean);
       writer.byte(value.value ? 1 : 0);
       return;
     case "Text":
-      writer.byte(4);
+      writer.byte(VALUE_HASH_TAG.Text);
       writer.stringBytes(value.value);
       writer.byte(0);
       return;
     case "Timestamp":
-      writer.byte(5);
+      writer.byte(VALUE_HASH_TAG.Timestamp);
       writer.i64(value.value);
       return;
     case "Uuid":
-      writer.byte(6);
+      writer.byte(VALUE_HASH_TAG.Uuid);
       writer.bytes(uuidBytes(value.value));
       return;
     case "Bytea":
-      writer.byte(11);
+      writer.byte(VALUE_HASH_TAG.Bytea);
       writer.u64(value.value.length);
       writer.bytes(value.value);
       return;
     case "Array":
-      writer.byte(7);
+      writer.byte(VALUE_HASH_TAG.Array);
       writer.u64(value.value.length);
       for (const inner of value.value) {
         hashValue(writer, inner);
       }
       return;
     case "Row":
-      writer.byte(8);
+      writer.byte(VALUE_HASH_TAG.Row);
+      writer.u64(value.value.values.length);
+      for (const inner of value.value.values) {
+        hashValue(writer, inner);
+      }
+      return;
+    case "Enum":
+      writer.byte(VALUE_HASH_TAG.Enum);
+      writer.stringBytes(value.value.case);
+      writer.byte(0);
       writer.u64(value.value.values.length);
       for (const inner of value.value.values) {
         hashValue(writer, inner);
       }
       return;
     case "Null":
-      writer.byte(9);
+      writer.byte(VALUE_HASH_TAG.Null);
       return;
   }
 }
 
-function hashColumnType(writer: StructuralHashWriter, columnType: WasmColumnType): void {
+function hashColumnType(
+  writer: StructuralHashWriter,
+  columnType: WasmColumnType,
+  format: StructuralHashFormat,
+): void {
   switch (columnType.type) {
     case "Integer":
-      writer.byte(1);
+      writer.byte(COLUMN_TYPE_HASH_TAG.Integer);
       return;
     case "BigInt":
-      writer.byte(2);
+      writer.byte(COLUMN_TYPE_HASH_TAG.BigInt);
       return;
     case "Double":
-      writer.byte(10);
+      writer.byte(COLUMN_TYPE_HASH_TAG.Double);
       return;
     case "Boolean":
-      writer.byte(3);
+      writer.byte(COLUMN_TYPE_HASH_TAG.Boolean);
       return;
     case "Text":
-      writer.byte(4);
+      writer.byte(COLUMN_TYPE_HASH_TAG.Text);
       return;
     case "Enum": {
-      writer.byte(9);
+      writer.byte(COLUMN_TYPE_HASH_TAG.Enum);
       writer.u64(columnType.variants.length);
       for (const variant of columnType.variants) {
         writer.stringBytes(variant);
@@ -203,20 +299,37 @@ function hashColumnType(writer: StructuralHashWriter, columnType: WasmColumnType
       }
       return;
     }
+    case "EnumPayload":
+      writer.byte(COLUMN_TYPE_HASH_TAG.EnumPayload);
+      writer.u64(columnType.cases.length);
+      for (const enumCase of columnType.cases) {
+        writer.stringBytes(enumCase.name);
+        writer.byte(0);
+        writer.u64(enumCase.fields.length);
+        for (const field of enumCase.fields) {
+          writer.stringBytes(field.name);
+          writer.byte(0);
+          hashColumnType(writer, field.column_type, format);
+          writer.byte(field.nullable ? 1 : 0);
+        }
+      }
+      return;
     case "Timestamp":
-      writer.byte(5);
+      writer.byte(COLUMN_TYPE_HASH_TAG.Timestamp);
       return;
     case "Uuid":
-      writer.byte(6);
+      writer.byte(COLUMN_TYPE_HASH_TAG.Uuid);
       return;
     case "Bytea":
-      writer.byte(10);
+      writer.byte(format.byteaTag);
       return;
     case "Json":
-      writer.byte(11);
+      writer.byte(COLUMN_TYPE_HASH_TAG.Json);
       if (columnType.schema) {
         writer.byte(1);
-        const encoded = new TextEncoder().encode(JSON.stringify(columnType.schema));
+        const encoded = new TextEncoder().encode(
+          JSON.stringify(canonicalizeJsonObject(columnType.schema)),
+        );
         writer.u64(encoded.length);
         writer.bytes(encoded);
       } else {
@@ -224,14 +337,44 @@ function hashColumnType(writer: StructuralHashWriter, columnType: WasmColumnType
       }
       return;
     case "Array":
-      writer.byte(7);
-      hashColumnType(writer, columnType.element);
+      writer.byte(COLUMN_TYPE_HASH_TAG.Array);
+      hashColumnType(writer, columnType.element, format);
       return;
     case "Row":
-      writer.byte(8);
-      hashColumns(writer, columnType.columns);
+      writer.byte(COLUMN_TYPE_HASH_TAG.Row);
+      hashColumns(writer, columnType.columns, format);
       return;
   }
+}
+
+function canonicalizeJsonObject(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeJsonObject);
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => compareUnicodeScalarOrder(left, right))
+      .map(([key, entry]) => [key, canonicalizeJsonObject(entry)]),
+  );
+}
+
+function compareUnicodeScalarOrder(left: string, right: string): number {
+  let leftIndex = 0;
+  let rightIndex = 0;
+  while (leftIndex < left.length && rightIndex < right.length) {
+    const leftCodePoint = left.codePointAt(leftIndex)!;
+    const rightCodePoint = right.codePointAt(rightIndex)!;
+    if (leftCodePoint !== rightCodePoint) {
+      return leftCodePoint - rightCodePoint;
+    }
+    leftIndex += leftCodePoint > 0xffff ? 2 : 1;
+    rightIndex += rightCodePoint > 0xffff ? 2 : 1;
+  }
+  return left.length - right.length;
 }
 
 function uuidBytes(value: string): Uint8Array {

--- a/packages/jazz-tools/src/testing/fixtures/all-column-schema-hashes.json
+++ b/packages/jazz-tools/src/testing/fixtures/all-column-schema-hashes.json
@@ -1,0 +1,133 @@
+{
+  "schemaHashFormat": 2,
+  "legacyByteaColumnTypeTag": 10,
+  "currentByteaColumnTypeTag": 16,
+  "schema": {
+    "all_types": {
+      "columns": [
+        {
+          "name": "integer",
+          "column_type": { "type": "Integer" },
+          "nullable": false,
+          "default": { "type": "Integer", "value": 42 }
+        },
+        {
+          "name": "bigint",
+          "column_type": { "type": "BigInt" },
+          "nullable": false,
+          "default": { "type": "BigInt", "value": "9007199254740993" }
+        },
+        {
+          "name": "double",
+          "column_type": { "type": "Double" },
+          "nullable": false,
+          "default": { "type": "Double", "value": 1.25 }
+        },
+        {
+          "name": "boolean",
+          "column_type": { "type": "Boolean" },
+          "nullable": false,
+          "default": { "type": "Boolean", "value": true }
+        },
+        {
+          "name": "text",
+          "column_type": { "type": "Text" },
+          "nullable": false,
+          "default": { "type": "Text", "value": "fixture" }
+        },
+        {
+          "name": "enum",
+          "column_type": { "type": "Enum", "variants": ["draft", "active"] },
+          "nullable": false
+        },
+        {
+          "name": "enum_payload",
+          "column_type": {
+            "type": "EnumPayload",
+            "cases": [
+              { "name": "empty", "fields": [] },
+              {
+                "name": "binary",
+                "fields": [
+                  { "name": "score", "column_type": { "type": "Double" }, "nullable": false },
+                  {
+                    "name": "payload",
+                    "column_type": { "type": "Array", "element": { "type": "Bytea" } },
+                    "nullable": true
+                  }
+                ]
+              }
+            ]
+          },
+          "nullable": false,
+          "default": { "type": "Enum", "value": { "case": "empty", "values": [] } }
+        },
+        {
+          "name": "timestamp",
+          "column_type": { "type": "Timestamp" },
+          "nullable": false,
+          "default": { "type": "Timestamp", "value": 1773285322816 }
+        },
+        {
+          "name": "uuid",
+          "column_type": { "type": "Uuid" },
+          "nullable": false,
+          "default": { "type": "Uuid", "value": "00112233-4455-6677-8899-aabbccddeeff" }
+        },
+        {
+          "name": "bytea",
+          "column_type": { "type": "Bytea" },
+          "nullable": false,
+          "default": { "type": "Bytea", "value": [0, 16, 255] }
+        },
+        { "name": "json", "column_type": { "type": "Json" }, "nullable": true },
+        {
+          "name": "json_schema",
+          "column_type": {
+            "type": "Json",
+            "schema": { "type": "object", "properties": { "ok": { "type": "boolean" } } }
+          },
+          "nullable": false
+        },
+        {
+          "name": "array_double",
+          "column_type": { "type": "Array", "element": { "type": "Double" } },
+          "nullable": false
+        },
+        {
+          "name": "array_bytea",
+          "column_type": { "type": "Array", "element": { "type": "Bytea" } },
+          "nullable": false
+        },
+        {
+          "name": "nested_row",
+          "column_type": {
+            "type": "Row",
+            "columns": [
+              { "name": "double", "column_type": { "type": "Double" }, "nullable": false },
+              { "name": "bytea", "column_type": { "type": "Bytea" }, "nullable": false },
+              {
+                "name": "deeper",
+                "column_type": {
+                  "type": "Array",
+                  "element": {
+                    "type": "Row",
+                    "columns": [
+                      { "name": "payload", "column_type": { "type": "Bytea" }, "nullable": true }
+                    ]
+                  }
+                },
+                "nullable": false
+              }
+            ]
+          },
+          "nullable": false
+        }
+      ],
+      "indexed_columns": ["text", "uuid"],
+      "branchBy": ["uuid"]
+    }
+  },
+  "currentHash": "aa8829b07fd733102562d7055a17578f7284c692af07d625095baacffde2b1a9",
+  "legacyByteaHash": "e07f991368f7315cd7e8361586902c27463dac7994cffebe730565a6f2a8879f"
+}


### PR DESCRIPTION
## Summary
- Keep Double and Bytea structural hashes distinct across runtimes.
- Connect matching legacy and corrected Bytea identities even when both already exist, and bound concurrent historical lookups.

## Before
A deploy could select the corrected identity and skip the legacy migration edge, while historical identity probes ran serially.

## After
Deploys preserve legacy-to-current connectivity and scan historical candidates in deterministic batches of up to eight concurrent requests.

## Test plan
- [x] `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/dev/catalogue.test.ts -t 'legacy Bytea catalogue identity|stored schema identity lookup'`