### PR TITLE
test(band-chat): seed profiles through authenticated sessions

### DIFF
--- a/examples/band-chat/apps/nextjs-betterauth/tests/permissions.test.ts
+++ b/examples/band-chat/apps/nextjs-betterauth/tests/permissions.test.ts
@@ -30,12 +30,12 @@ describe("BandChat room admission and authorship", () => {
       claims: {},
       authMode: "external",
     });
-    const ownerProfile = await testApp.seed((db) =>
-      db.insert(app.profiles, { author: ownerAuthor, displayName: "Owner" }),
-    );
-    const guestProfile = await testApp.seed((db) =>
-      db.insert(app.profiles, { author: guestAuthor, displayName: "Guest" }),
-    );
+    const ownerProfile = await owner
+      .insert(app.profiles, { author: ownerAuthor, displayName: "Owner" })
+      .wait({ tier: "edge" });
+    const guestProfile = await guest
+      .insert(app.profiles, { author: guestAuthor, displayName: "Guest" })
+      .wait({ tier: "edge" });
     const room = await owner
       .insert(app.rooms, { name: "Private rehearsal" })
       .wait({ tier: "edge" });


### PR DESCRIPTION
🤖 **Before:** BandChat’s permission fixture seeded identity-owned profile rows through the SYSTEM/admin database. After identity-policy binding became strict, the first seed write had no identity context and CI surfaced it only as a malformed SyncMessage/server planner error.

**After:** Each profile is inserted through its matching authenticated owner or guest session. This supplies the required issuer-scoped identity context and exercises the real `profiles.allowInsert.where({ author: session.user })` admission path.

**Unchanged security cases:** the suite still rejects cross-issuer self-admission, forged profile/message authorship, guest self-admission, and post-revocation writes. A planted `allowInsert.always()` mutation makes the forged-profile assertion fail.

**Receipts:** focused BandChat permissions tests and package typecheck pass. Independently adversarially reviewed.