### PR TITLE
fix(policy): bypass SYSTEM authorization support

### DIFF
--- a/crates/jazz/src/peer/repair.rs
+++ b/crates/jazz/src/peer/repair.rs
@@ -200,6 +200,13 @@ impl PeerState {
     where
         S: OrderedKvStorage,
     {
+        // SYSTEM is the trusted backend policy subject. Row-policy admission
+        // already bypasses it, so it must not try to hydrate an authorization
+        // support proof: claim and join predicates have no SYSTEM session to
+        // bind and are irrelevant to the bypass decision.
+        if writer == AuthorSubject::SYSTEM {
+            return Ok(());
+        }
         for action in node
             .authorization_actions_for_versions_in_transaction(versions, Some(candidate_tx_id))
             .await?
@@ -306,6 +313,9 @@ impl PeerState {
     where
         S: OrderedKvStorage,
     {
+        if writer == AuthorSubject::SYSTEM {
+            return Ok(None);
+        }
         let mut unsettled = Vec::new();
         for action in node
             .authorization_actions_for_versions_in_transaction(versions, candidate_tx_id)

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -1040,6 +1040,62 @@ fn resource_commit_unit(
 }
 
 #[test]
+fn system_terminal_write_bypasses_claim_and_join_authorization_support() {
+    let schema = session_seed_write_policy_schema();
+    let (_dir, mut node_state) = open_node_with_schema(node(0xa0), schema.clone());
+    let (_, unit) = node_state
+        .commit_mergeable_unit_settled(
+            MergeableCommit::new("resources", row(0xa1), 1)
+                .made_by(AuthorSubject::SYSTEM)
+                .cells(BTreeMap::from([(
+                    "owner".to_owned(),
+                    Value::Uuid(uuid::Uuid::nil()),
+                )])),
+        )
+        .expect("SYSTEM may create a row protected by a claim-and-join policy");
+    let SyncMessage::CommitUnit { tx, versions } = unit else {
+        panic!("mergeable unit must carry a CommitUnit");
+    };
+
+    let mut peer = PeerState::client_link(AuthorSubject::SYSTEM);
+    assert!(
+        peer.unsettled_authority_scope_subscriptions(
+            &mut node_state,
+            AuthorSubject::SYSTEM,
+            BTreeMap::new(),
+            &versions,
+            Some(tx.tx_id),
+            true,
+        )
+        .expect("SYSTEM must not hydrate edge authorization support")
+        .is_none()
+    );
+    peer.prove_terminal_commit_authorization(
+        &mut node_state,
+        AuthorSubject::SYSTEM,
+        BTreeMap::new(),
+        &versions,
+        tx.tx_id,
+    )
+    .expect("SYSTEM must not bind session claims for a bypassed write");
+    assert_eq!(peer.terminal_authority_scope_proof_count(), 0);
+
+    let denied = crate::db::block_on(node_state.dry_run_mergeable_write_allows_in_schema(
+            schema.version_id(),
+            MergeableCommit::new("resources", row(0xa2), 2)
+                .made_by(AuthorSubject::for_test_bytes([0xa3; 16]))
+                .cells(BTreeMap::from([(
+                    "owner".to_owned(),
+                    Value::Uuid(uuid::Uuid::from_bytes([0xa3; 16])),
+                )])),
+        ));
+    assert!(
+        denied.is_err(),
+        "an unseeded session must not inherit SYSTEM bypass: {denied:?}"
+    );
+}
+
+#[test]
 fn edge_support_hydration_uses_writer_claims_and_fails_closed_when_missing() {
     let schema = session_claim_read_policy_schema();
     let writer = AuthorSubject::for_test_bytes([0xa1; 16]);


### PR DESCRIPTION
🤖 **Before:** `asBackend()` writes use the exact SYSTEM permission subject, and INV-RLS-2 requires SYSTEM to bypass read and write policy. Final write evaluation already honored that rule, but terminal-proof and edge-support preparation ran first. A policy containing `session.user`, `claims.*`, or recursive joins could therefore fail while preparing authorization support before the SYSTEM bypass was reached. BigLabel’s intended first-admin backend bootstrap reproduced this.

**After:** Both terminal proof and unsettled edge support return before hydrating claim/join authorization support when—and only when—the transaction writer is exactly `AuthorSubject::SYSTEM`. Non-SYSTEM writers still prepare dependencies and fail closed when required claims are absent.

**Example:** a trusted backend may seed the first organization membership even though its normal user policy asks whether `session.user` is already an admin. A user write with missing claims remains rejected; merely using a trusted connection or backend attribution does not turn a non-SYSTEM writer into SYSTEM.

**Receipts:** recursive claim+join regression, 85 peer tests, BigLabel authority/full package tests, benchmark tests, and typecheck pass. Independently adversarially reviewed.