### PR TITLE
Observe native transport terminal outcomes

### DIFF
--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -3563,10 +3563,148 @@ mod tests {
     use crate::groove::storage::{Error as StorageError, StorageFactory, StorageFuture};
     use crate::ids::NodeUuid;
     use crate::tools::AppId;
+    use crate::tools::native_transport_connector::{
+        ConnectedNativeTransport, NativeCatalogueBootstrapFuture, NativeTransportError,
+        NativeTransportFuture, NativeTransportTerminal, NativeTransportTerminalFuture,
+    };
     use crate::tools::public_schema::Schema;
     use crate::tools::{ClientStorage, ColumnType, SchemaBuilder, TableSchema};
+    use crate::wire::{TransportError, WireTransport};
     use serde_json::json;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicUsize;
     use tempfile::TempDir;
+
+    struct NoopNativeWireTransport;
+
+    impl WireTransport for NoopNativeWireTransport {
+        fn send_frame(&mut self, _frame: Vec<u8>) -> std::result::Result<(), TransportError> {
+            Ok(())
+        }
+
+        fn try_recv_frame(&mut self) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
+    struct ControlledTerminal {
+        sender: Option<oneshot::Sender<NativeTransportTerminal>>,
+        observed: Arc<AtomicBool>,
+    }
+    impl ControlledTerminal {
+        fn send(&mut self, terminal: NativeTransportTerminal) {
+            let _ = self
+                .sender
+                .take()
+                .expect("controlled terminal sender is used once")
+                .send(terminal);
+        }
+    }
+
+    struct ControlledNativeConnector {
+        connect_count: AtomicUsize,
+        terminals: Mutex<VecDeque<(oneshot::Receiver<NativeTransportTerminal>, Arc<AtomicBool>)>>,
+    }
+
+    impl ControlledNativeConnector {
+        fn new(
+            terminals: Vec<(oneshot::Receiver<NativeTransportTerminal>, Arc<AtomicBool>)>,
+        ) -> Self {
+            Self {
+                connect_count: AtomicUsize::new(0),
+                terminals: Mutex::new(terminals.into()),
+            }
+        }
+
+        fn connect_count(&self) -> usize {
+            self.connect_count.load(Ordering::Acquire)
+        }
+    }
+
+    impl NativeTransportConnector for ControlledNativeConnector {
+        fn connect(&self, _request: NativeTransportRequest) -> NativeTransportFuture {
+            self.connect_count.fetch_add(1, Ordering::AcqRel);
+            let (receiver, observed) = self
+                .terminals
+                .lock()
+                .expect("take controlled terminal")
+                .pop_front()
+                .expect("test connector has a terminal for every connection");
+            let terminal: NativeTransportTerminalFuture = Box::pin(async move {
+                observed.store(true, Ordering::Release);
+                receiver
+                    .await
+                    .expect("controlled terminal sender remains alive")
+            });
+            Box::pin(async move {
+                Ok(ConnectedNativeTransport {
+                    transport: Box::new(NoopNativeWireTransport),
+                    protocol_version: crate::wire::WIRE_PROTOCOL_VERSION,
+                    features: crate::wire::FEATURE_NONE,
+                    session_context: None,
+                    permits_delegated_sessions: false,
+                    terminal,
+                })
+            })
+        }
+
+        fn bootstrap_catalogue(
+            &self,
+            _request: NativeTransportRequest,
+        ) -> NativeCatalogueBootstrapFuture {
+            Box::pin(async {
+                Err(NativeTransportError(
+                    "catalogue bootstrap is not used by client lifecycle tests".to_owned(),
+                ))
+            })
+        }
+    }
+
+    fn controlled_terminal() -> (
+        ControlledTerminal,
+        oneshot::Receiver<NativeTransportTerminal>,
+    ) {
+        let (sender, receiver) = oneshot::channel();
+        let observed = Arc::new(AtomicBool::new(false));
+        (
+            ControlledTerminal {
+                sender: Some(sender),
+                observed,
+            },
+            receiver,
+        )
+    }
+
+    async fn wait_for_connect_count(connector: &ControlledNativeConnector, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while connector.connect_count() < expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("connection replacement must not deadlock");
+    }
+
+    async fn wait_for_terminal_observation(observed: &AtomicBool) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !observed.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("terminal watcher must poll the controlled terminal future");
+    }
+
+    fn make_native_context(name: &str) -> AppContext {
+        let mut context = make_offline_context(
+            AppId::from_name(name),
+            std::path::PathBuf::new(),
+            declared_todo_schema(),
+        );
+        context.server_url = "ws://native-transport.test".to_owned();
+        context
+    }
 
     #[derive(Debug)]
     struct YieldingStorageFactory;
@@ -4479,6 +4617,96 @@ mod tests {
                     .shutdown()
                     .await
                     .expect("close reopened persistent client");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn idle_peer_closed_terminal_reconnects_without_semantic_traffic() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (mut first, first_receiver) = controlled_terminal();
+                let first_observed = Arc::clone(&first.observed);
+                let (_replacement, replacement_receiver) = controlled_terminal();
+                let connector = Arc::new(ControlledNativeConnector::new(vec![
+                    (first_receiver, first_observed.clone()),
+                    (replacement_receiver, Arc::new(AtomicBool::new(false))),
+                ]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("idle-peer-closed-reconnect"),
+                    connector.clone(),
+                )
+                .await
+                .expect("connect native client");
+
+                assert_eq!(connector.connect_count(), 1);
+                first.send(NativeTransportTerminal::PeerClosed(
+                    "idle peer closed".to_owned(),
+                ));
+                wait_for_terminal_observation(&first_observed).await;
+                wait_for_connect_count(&connector, 2).await;
+
+                client.shutdown().await.expect("shutdown native client");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn owner_dropped_terminal_does_not_reconnect() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (mut terminal, receiver) = controlled_terminal();
+                let observed = Arc::clone(&terminal.observed);
+                let connector = Arc::new(ControlledNativeConnector::new(vec![(
+                    receiver,
+                    observed.clone(),
+                )]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("owner-dropped-no-reconnect"),
+                    connector.clone(),
+                )
+                .await
+                .expect("connect native client");
+
+                terminal.send(NativeTransportTerminal::OwnerDropped);
+                wait_for_terminal_observation(&observed).await;
+                tokio::task::yield_now().await;
+                assert_eq!(
+                    connector.connect_count(),
+                    1,
+                    "deliberately dropped transport must not reconnect"
+                );
+
+                client.shutdown().await.expect("shutdown native client");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_does_not_reconnect_after_terminal() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (mut terminal, receiver) = controlled_terminal();
+                let observed = Arc::clone(&terminal.observed);
+                let connector =
+                    Arc::new(ControlledNativeConnector::new(vec![(receiver, observed)]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("shutdown-no-reconnect"),
+                    connector.clone(),
+                )
+                .await
+                .expect("connect native client");
+
+                client.shutdown().await.expect("shutdown native client");
+                terminal.send(NativeTransportTerminal::PeerClosed(
+                    "terminal raced shutdown".to_owned(),
+                ));
+                tokio::task::yield_now().await;
+                assert_eq!(
+                    connector.connect_count(),
+                    1,
+                    "shutdown must prevent terminal-triggered reconnection"
+                );
             })
             .await;
     }

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -33,8 +33,8 @@ use crate::query::{Aggregate as CoreAggregate, AggregateFunction as CoreAggregat
 use crate::storage_codec_profile::epoch_1_storage_codec_profile;
 use crate::tools::OpenTransactionId;
 use crate::tools::native_transport_connector::{
-    NativeTransportConnector, NativeTransportRequest, NativeTransportTerminal,
-    NativeTransportTerminalFuture,
+    ConnectedNativeTransport, NativeTransportConnector, NativeTransportRequest,
+    NativeTransportTerminal, NativeTransportTerminalFuture,
 };
 use crate::tools::public_api::types::{
     OrderedAdded, OrderedRemoved, OrderedUpdated, QueryResultField,
@@ -197,6 +197,8 @@ struct ClientDbInner {
     upstream: Option<BackendConnection>,
     upstream_generation: u64,
     native_terminal_events: VecDeque<(u64, NativeTransportTerminal)>,
+    upstream_recovery_generation: Option<u64>,
+    upstream_state_notify: Arc<tokio::sync::Notify>,
     write_map: HashMap<TransactionId, CoreTxId>,
     row_tables: HashMap<ObjectId, String>,
     transactions: HashMap<OpenTransactionId, ExclusiveTransactionState>,
@@ -207,6 +209,12 @@ struct ClientDbInner {
     next_subscription_forwarder: u64,
     shutdown_state: ShutdownState,
     shutdown_notify: Arc<tokio::sync::Notify>,
+}
+
+impl Drop for ClientDbInner {
+    fn drop(&mut self) {
+        self.upstream_state_notify.notify_waiters();
+    }
 }
 
 /// A public subscription admission or forwarding task owned by the facade.
@@ -323,10 +331,9 @@ fn tick_driver_retry_delay(attempt: u32) -> Duration {
         .min(TICK_DRIVER_RETRY_MAX_DELAY)
 }
 
-async fn recover_tick_driver_error(
+async fn recover_tick_driver_backpressure(
     inner: &Rc<RefCell<ClientDbInner>>,
     scheduler: &TickSchedulerImpl,
-    class: TickDriverErrorClass,
     error: &CoreDbError,
     attempts: &mut u32,
 ) -> bool {
@@ -340,18 +347,41 @@ async fn recover_tick_driver_error(
 
     #[cfg(feature = "sync-autopsy")]
     crate::db::sync_autopsy::record(format!(
-        "client tick driver retrying {class:?} error attempt {attempts}: {error}"
+        "client tick driver retrying backpressure error attempt {attempts}: {error}"
     ));
     tokio::time::sleep(tick_driver_retry_delay(*attempts)).await;
+    scheduler.wake(TickUrgency::Immediate);
+    true
+}
 
-    if class == TickDriverErrorClass::Reconnect {
-        inner.borrow_mut().disconnect_upstream();
-        if let Err(_reconnect_error) = ClientDbInner::reconnect_upstream(inner).await {
-            #[cfg(feature = "sync-autopsy")]
-            crate::db::sync_autopsy::record(format!(
-                "client tick driver reconnect attempt {attempts} failed: {_reconnect_error}"
+#[cfg(test)]
+async fn recover_tick_driver_error(
+    inner: &Rc<RefCell<ClientDbInner>>,
+    scheduler: &TickSchedulerImpl,
+    class: TickDriverErrorClass,
+    error: &CoreDbError,
+    attempts: &mut u32,
+) -> bool {
+    let expected_generation = inner.borrow().upstream_generation;
+    *attempts = attempts.saturating_add(1);
+    if *attempts > MAX_TICK_DRIVER_RECOVERY_ATTEMPTS {
+        let mut inner_state = inner.borrow_mut();
+        if matches!(inner_state.shutdown_state, ShutdownState::Open)
+            && inner_state.upstream_generation == expected_generation
+            && inner_state.upstream.is_none()
+        {
+            inner_state.record_tick_driver_failure(format!(
+                "recovery exhausted after {MAX_TICK_DRIVER_RECOVERY_ATTEMPTS} attempts for {error}"
             ));
         }
+        return false;
+    }
+
+    tokio::time::sleep(tick_driver_retry_delay(*attempts)).await;
+    if class == TickDriverErrorClass::Reconnect
+        && ClientDbInner::is_current_disconnected_generation(inner, expected_generation)
+    {
+        ClientDbInner::start_upstream_recovery(inner, error.to_string());
     }
     scheduler.wake(TickUrgency::Immediate);
     true
@@ -363,6 +393,23 @@ struct ConnectConfig {
     app_id: crate::tools::AppId,
     auth: WsAuthConfig,
     connector: Arc<dyn NativeTransportConnector>,
+}
+struct UpstreamRecoveryOwner {
+    inner: Weak<RefCell<ClientDbInner>>,
+    generation: u64,
+}
+
+impl Drop for UpstreamRecoveryOwner {
+    fn drop(&mut self) {
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        let mut inner_state = inner.borrow_mut();
+        if inner_state.upstream_recovery_generation == Some(self.generation) {
+            inner_state.upstream_recovery_generation = None;
+            inner_state.upstream_state_notify.notify_waiters();
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1344,7 +1391,7 @@ impl ClientDb {
         generation: u64,
         terminal: NativeTransportTerminal,
     ) {
-        let reconnect = {
+        let recovery_error = {
             let mut inner_state = inner.borrow_mut();
             if generation != inner_state.upstream_generation
                 || !matches!(inner_state.shutdown_state, ShutdownState::Open)
@@ -1354,16 +1401,18 @@ impl ClientDb {
             match terminal {
                 NativeTransportTerminal::OwnerDropped => {
                     inner_state.disconnect_upstream();
-                    false
+                    None
                 }
-                NativeTransportTerminal::PeerClosed(_) | NativeTransportTerminal::Failed(_) => {
-                    inner_state.disconnect_upstream();
-                    true
+                NativeTransportTerminal::PeerClosed(reason) => {
+                    Some(format!("native transport peer closed: {reason}"))
+                }
+                NativeTransportTerminal::Failed(error) => {
+                    Some(format!("native transport failed: {error}"))
                 }
             }
         };
-        if reconnect {
-            let _ = ClientDbInner::reconnect_upstream(inner).await;
+        if let Some(error) = recovery_error {
+            ClientDbInner::start_upstream_recovery(inner, error);
         }
     }
 
@@ -1373,19 +1422,25 @@ impl ClientDb {
     ) {
         let state = scheduler.wake_handle();
         tokio::task::spawn_local(async move {
-            let mut recovery_attempts = 0;
+            let mut backpressure_attempts = 0;
             loop {
                 state.notify.notified().await;
                 while let Some(urgency) = scheduler.take() {
                     let Some(inner) = inner.upgrade() else {
                         return;
                     };
+                    if inner.borrow().tick_driver_error.is_some() {
+                        return;
+                    }
                     loop {
                         let event = { inner.borrow_mut().native_terminal_events.pop_front() };
                         let Some((generation, terminal)) = event else {
                             break;
                         };
                         ClientDb::handle_native_terminal(&inner, generation, terminal).await;
+                    }
+                    if inner.borrow().tick_driver_error.is_some() {
+                        return;
                     }
 
                     if urgency == TickUrgency::Deferred {
@@ -1398,24 +1453,37 @@ impl ClientDb {
                         Err(_) => return,
                     };
                     let tick_result = backend.tick().await;
+                    if inner.borrow().tick_driver_error.is_some() {
+                        return;
+                    }
                     match tick_result {
-                        Ok(()) => recovery_attempts = 0,
+                        Ok(()) => backpressure_attempts = 0,
                         Err(error) => {
                             let class = classify_tick_driver_error(&error);
-                            let should_exit = if class == TickDriverErrorClass::Fatal {
-                                inner
-                                    .borrow_mut()
-                                    .record_tick_driver_failure(error.to_string());
-                                true
-                            } else {
-                                !recover_tick_driver_error(
-                                    &inner,
-                                    &scheduler,
-                                    class,
-                                    &error,
-                                    &mut recovery_attempts,
-                                )
-                                .await
+                            let should_exit = match class {
+                                TickDriverErrorClass::Fatal => {
+                                    inner
+                                        .borrow_mut()
+                                        .record_tick_driver_failure(error.to_string());
+                                    true
+                                }
+                                TickDriverErrorClass::Retry => {
+                                    !recover_tick_driver_backpressure(
+                                        &inner,
+                                        &scheduler,
+                                        &error,
+                                        &mut backpressure_attempts,
+                                    )
+                                    .await
+                                }
+                                TickDriverErrorClass::Reconnect => {
+                                    backpressure_attempts = 0;
+                                    ClientDbInner::start_upstream_recovery(
+                                        &inner,
+                                        error.to_string(),
+                                    );
+                                    false
+                                }
                             };
                             if should_exit {
                                 #[cfg(feature = "sync-autopsy")]
@@ -1447,6 +1515,8 @@ impl ClientDbInner {
 
     fn disconnect_upstream(&mut self) -> bool {
         self.upstream_generation = self.upstream_generation.wrapping_add(1);
+        self.upstream_recovery_generation = None;
+        self.upstream_state_notify.notify_waiters();
         let Some(connection) = self.upstream.take() else {
             return false;
         };
@@ -1495,6 +1565,8 @@ impl ClientDbInner {
     }
 
     fn record_tick_driver_failure(&mut self, error: String) {
+        self.upstream_recovery_generation = None;
+        self.upstream_state_notify.notify_waiters();
         self.tick_driver_error = Some(error);
         self.tick_driver_error_notify.notify_waiters();
     }
@@ -1536,6 +1608,8 @@ impl ClientDbInner {
             upstream: None,
             upstream_generation: 0,
             native_terminal_events: VecDeque::new(),
+            upstream_recovery_generation: None,
+            upstream_state_notify: Arc::new(tokio::sync::Notify::new()),
             write_map: HashMap::new(),
             row_tables: HashMap::new(),
             transactions: HashMap::new(),
@@ -1550,17 +1624,143 @@ impl ClientDbInner {
         Ok(inner)
     }
 
-    async fn reconnect_upstream(inner: &Rc<RefCell<Self>>) -> Result<bool> {
-        Self::connect_upstream_transport(inner).await
+    fn is_current_disconnected_generation(inner: &Rc<RefCell<Self>>, generation: u64) -> bool {
+        let inner_state = inner.borrow();
+        matches!(inner_state.shutdown_state, ShutdownState::Open)
+            && inner_state.tick_driver_error.is_none()
+            && inner_state.upstream_generation == generation
+            && inner_state.upstream.is_none()
     }
 
-    async fn connect_upstream_transport(inner: &Rc<RefCell<Self>>) -> Result<bool> {
-        let (db, identity, scheduler, config) = {
+    fn is_current_disconnected_generation_weak(
+        inner: &Weak<RefCell<Self>>,
+        generation: u64,
+    ) -> bool {
+        inner
+            .upgrade()
+            .is_some_and(|inner| Self::is_current_disconnected_generation(&inner, generation))
+    }
+
+    fn is_current_recovery(inner: &Weak<RefCell<Self>>, generation: u64) -> bool {
+        let Some(inner) = inner.upgrade() else {
+            return false;
+        };
+        let inner_state = inner.borrow();
+        matches!(inner_state.shutdown_state, ShutdownState::Open)
+            && inner_state.tick_driver_error.is_none()
+            && inner_state.upstream_generation == generation
+            && inner_state.upstream.is_none()
+            && inner_state.upstream_recovery_generation == Some(generation)
+    }
+
+    fn start_upstream_recovery(inner: &Rc<RefCell<Self>>, initial_error: String) {
+        let (generation, scheduler) = {
+            let mut inner_state = inner.borrow_mut();
+            if !matches!(inner_state.shutdown_state, ShutdownState::Open)
+                || inner_state.tick_driver_error.is_some()
+                || inner_state.connect_config.is_none()
+            {
+                return;
+            }
+            if inner_state.upstream.is_none()
+                && inner_state.upstream_recovery_generation == Some(inner_state.upstream_generation)
+            {
+                return;
+            }
+            inner_state.disconnect_upstream();
+            let generation = inner_state.upstream_generation;
+            inner_state.upstream_recovery_generation = Some(generation);
+            (generation, Rc::clone(&inner_state.scheduler))
+        };
+        scheduler.wake(TickUrgency::Immediate);
+        tokio::task::spawn_local(Self::run_upstream_recovery(
+            Rc::downgrade(inner),
+            generation,
+            initial_error,
+        ));
+    }
+
+    async fn run_upstream_recovery(
+        inner: Weak<RefCell<Self>>,
+        generation: u64,
+        initial_error: String,
+    ) {
+        let _owner = UpstreamRecoveryOwner {
+            inner: inner.clone(),
+            generation,
+        };
+        let mut last_error = initial_error;
+        for attempt in 1..=MAX_TICK_DRIVER_RECOVERY_ATTEMPTS {
+            if attempt > 1 {
+                tokio::time::sleep(tick_driver_retry_delay(attempt - 1)).await;
+                if !Self::is_current_recovery(&inner, generation) {
+                    return;
+                }
+            }
+
+            match Self::connect_upstream_for_generation(&inner, generation).await {
+                Ok(true) | Ok(false) => return,
+                Err(error) => {
+                    last_error = error.to_string();
+                    #[cfg(feature = "sync-autopsy")]
+                    crate::db::sync_autopsy::record(format!(
+                        "client native upstream recovery attempt {attempt} failed: {error}"
+                    ));
+                }
+            }
+        }
+
+        let Some(inner) = inner.upgrade() else {
+            return;
+        };
+        let scheduler = {
+            let mut inner_state = inner.borrow_mut();
+            if !matches!(inner_state.shutdown_state, ShutdownState::Open)
+                || inner_state.upstream_generation != generation
+                || inner_state.upstream.is_some()
+                || inner_state.upstream_recovery_generation != Some(generation)
+            {
+                return;
+            }
+            inner_state.upstream_recovery_generation = None;
+            inner_state.record_tick_driver_failure(format!(
+                "native upstream recovery exhausted after \
+                 {MAX_TICK_DRIVER_RECOVERY_ATTEMPTS} attempts: {last_error}"
+            ));
+            Rc::clone(&inner_state.scheduler)
+        };
+        scheduler.wake(TickUrgency::Immediate);
+    }
+
+    async fn reconnect_upstream(inner: &Rc<RefCell<Self>>) -> Result<bool> {
+        let generation = {
             let inner_state = inner.borrow();
             if !matches!(inner_state.shutdown_state, ShutdownState::Open) {
                 return Err(Self::shutdown_error());
             }
-            if inner_state.upstream.is_some() {
+            inner_state.upstream_generation
+        };
+        Self::connect_upstream_for_generation(&Rc::downgrade(inner), generation).await
+    }
+
+    async fn connect_upstream_transport(inner: &Rc<RefCell<Self>>) -> Result<bool> {
+        Self::reconnect_upstream(inner).await
+    }
+
+    async fn connect_upstream_for_generation(
+        inner: &Weak<RefCell<Self>>,
+        expected_generation: u64,
+    ) -> Result<bool> {
+        let (db, identity, scheduler, config, state_notify) = {
+            let Some(inner) = inner.upgrade() else {
+                return Ok(false);
+            };
+            let inner_state = inner.borrow();
+            if !matches!(inner_state.shutdown_state, ShutdownState::Open)
+                || inner_state.tick_driver_error.is_some()
+                || inner_state.upstream_generation != expected_generation
+                || inner_state.upstream.is_some()
+            {
                 return Ok(false);
             }
             let Some(config) = inner_state.connect_config.clone() else {
@@ -1571,24 +1771,72 @@ impl ClientDbInner {
                 inner_state.identity,
                 Rc::clone(&inner_state.scheduler),
                 config,
+                Arc::clone(&inner_state.upstream_state_notify),
             )
         };
-        let (connection, terminal) =
-            Self::connect_with_config(&db, identity, Rc::clone(&scheduler), config).await?;
+
+        let connected = Self::await_native_admission(
+            inner,
+            expected_generation,
+            identity,
+            Rc::clone(&scheduler),
+            config,
+            state_notify,
+        )
+        .await?;
+        let Some(connected) = connected else {
+            return Ok(false);
+        };
+        if !Self::is_current_disconnected_generation_weak(inner, expected_generation) {
+            return Ok(false);
+        }
+
+        let ConnectedNativeTransport {
+            transport,
+            protocol_version,
+            features,
+            session_context,
+            permits_delegated_sessions,
+            terminal,
+        } = connected;
+        let connection = db
+            .connect_upstream(Box::new(
+                WireTransportAdapter::new_with_session_context_and_delegated_sessions(
+                    transport,
+                    protocol_version,
+                    features,
+                    None,
+                    session_context,
+                    permits_delegated_sessions,
+                ),
+            ))
+            .await;
+
+        let Some(inner) = inner.upgrade() else {
+            db.detach_connection(&connection);
+            return Ok(false);
+        };
         let generation = {
             let mut inner_state = inner.borrow_mut();
             if !matches!(inner_state.shutdown_state, ShutdownState::Open)
+                || inner_state.tick_driver_error.is_some()
+                || inner_state.upstream_generation != expected_generation
                 || inner_state.upstream.is_some()
             {
+                drop(inner_state);
                 db.detach_connection(&connection);
                 return Ok(false);
             }
             inner_state.upstream_generation = inner_state.upstream_generation.wrapping_add(1);
             inner_state.upstream = Some(connection);
+            if inner_state.upstream_recovery_generation == Some(expected_generation) {
+                inner_state.upstream_recovery_generation = None;
+            }
+            inner_state.upstream_state_notify.notify_waiters();
             inner_state.upstream_generation
         };
         ClientDb::spawn_native_terminal_watcher(
-            Rc::downgrade(inner),
+            Rc::downgrade(&inner),
             scheduler,
             generation,
             terminal,
@@ -1596,40 +1844,45 @@ impl ClientDbInner {
         Ok(true)
     }
 
-    async fn connect_with_config(
-        db: &Backend,
+    async fn await_native_admission(
+        inner: &Weak<RefCell<Self>>,
+        expected_generation: u64,
         identity: CoreDbIdentity,
         scheduler: Rc<TickSchedulerImpl>,
         config: ConnectConfig,
-    ) -> Result<(BackendConnection, NativeTransportTerminalFuture)> {
+        state_notify: Arc<tokio::sync::Notify>,
+    ) -> Result<Option<ConnectedNativeTransport>> {
         let wake = scheduler.wake_handle();
-        let connected = config
-            .connector
-            .connect(NativeTransportRequest {
-                server_url: config.server_url,
-                app_id: config.app_id,
-                peer_identity: identity.author,
-                auth: config.auth,
-                wake: Arc::new(move || {
-                    wake.immediate.store(true, Ordering::Release);
-                    wake.notify.notify_one();
-                }),
-            })
-            .await
-            .map_err(|error| JazzError::Connection(error.to_string()))?;
-        let connection = db
-            .connect_upstream(Box::new(
-                WireTransportAdapter::new_with_session_context_and_delegated_sessions(
-                    connected.transport,
-                    connected.protocol_version,
-                    connected.features,
-                    None,
-                    connected.session_context,
-                    connected.permits_delegated_sessions,
-                ),
-            ))
-            .await;
-        Ok((connection, connected.terminal))
+        let admission = config.connector.connect(NativeTransportRequest {
+            server_url: config.server_url,
+            app_id: config.app_id,
+            peer_identity: identity.author,
+            auth: config.auth,
+            wake: Arc::new(move || {
+                wake.immediate.store(true, Ordering::Release);
+                wake.notify.notify_one();
+            }),
+        });
+        tokio::pin!(admission);
+        loop {
+            let state_changed = state_notify.notified();
+            tokio::pin!(state_changed);
+            state_changed.as_mut().enable();
+            if !Self::is_current_disconnected_generation_weak(inner, expected_generation) {
+                return Ok(None);
+            }
+            tokio::select! {
+                result = &mut admission => {
+                    if !Self::is_current_disconnected_generation_weak(inner, expected_generation) {
+                        return Ok(None);
+                    }
+                    return result
+                        .map(Some)
+                        .map_err(|error| JazzError::Connection(error.to_string()));
+                }
+                _ = &mut state_changed => {}
+            }
+        }
     }
 
     fn ensure_transaction_open(&self, transaction_id: OpenTransactionId) -> Result<()> {
@@ -3638,24 +3891,10 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use tempfile::TempDir;
 
-    #[derive(Default)]
-    struct ControlledWireState {
-        fail_sends: AtomicBool,
-        send_count: AtomicUsize,
-    }
-
-    struct ControlledNativeWireTransport {
-        state: Arc<ControlledWireState>,
-    }
+    struct ControlledNativeWireTransport;
 
     impl WireTransport for ControlledNativeWireTransport {
         fn send_frame(&mut self, _frame: Vec<u8>) -> std::result::Result<(), TransportError> {
-            self.state.send_count.fetch_add(1, Ordering::AcqRel);
-            if self.state.fail_sends.load(Ordering::Acquire) {
-                return Err(TransportError::Failed(
-                    "websocket pump is closed".to_owned(),
-                ));
-            }
             Ok(())
         }
 
@@ -3683,7 +3922,6 @@ mod tests {
         Connected {
             terminal: oneshot::Receiver<NativeTransportTerminal>,
             terminal_observed: Arc<AtomicBool>,
-            wire: Arc<ControlledWireState>,
         },
         Refused(String),
     }
@@ -3693,10 +3931,9 @@ mod tests {
     }
 
     impl ControlledAdmission {
-        fn succeed(&mut self) -> (ControlledTerminal, Arc<ControlledWireState>) {
+        fn succeed(&mut self) -> ControlledTerminal {
             let (terminal, terminal_receiver) = controlled_terminal();
             let terminal_observed = Arc::clone(&terminal.observed);
-            let wire = Arc::new(ControlledWireState::default());
             let _ = self
                 .sender
                 .take()
@@ -3704,9 +3941,8 @@ mod tests {
                 .send(ControlledAdmissionResult::Connected {
                     terminal: terminal_receiver,
                     terminal_observed,
-                    wire: Arc::clone(&wire),
                 });
-            (terminal, wire)
+            terminal
         }
 
         fn refuse(&mut self, error: impl Into<String>) {
@@ -3755,7 +3991,6 @@ mod tests {
                     ControlledAdmissionResult::Connected {
                         terminal,
                         terminal_observed,
-                        wire,
                     } => {
                         let terminal: NativeTransportTerminalFuture = Box::pin(async move {
                             terminal_observed.store(true, Ordering::Release);
@@ -3764,7 +3999,7 @@ mod tests {
                                 .expect("controlled terminal sender remains alive")
                         });
                         Ok(ConnectedNativeTransport {
-                            transport: Box::new(ControlledNativeWireTransport { state: wire }),
+                            transport: Box::new(ControlledNativeWireTransport),
                             protocol_version: crate::wire::WIRE_PROTOCOL_VERSION,
                             features: crate::wire::FEATURE_NONE,
                             session_context: None,
@@ -3814,14 +4049,10 @@ mod tests {
         )
     }
 
-    fn successful_controlled_admission() -> (
-        ControlledTerminal,
-        Arc<ControlledWireState>,
-        ControlledAdmissionReceiver,
-    ) {
+    fn successful_controlled_admission() -> (ControlledTerminal, ControlledAdmissionReceiver) {
         let (mut admission, receiver) = controlled_admission();
-        let (terminal, wire) = admission.succeed();
-        (terminal, wire, receiver)
+        let terminal = admission.succeed();
+        (terminal, receiver)
     }
 
     fn refused_controlled_admission(error: impl Into<String>) -> ControlledAdmissionReceiver {
@@ -3852,14 +4083,6 @@ mod tests {
         yield_until(
             || observed.load(Ordering::Acquire),
             "terminal watcher must poll the controlled terminal future",
-        )
-        .await;
-    }
-
-    async fn wait_for_send_count(state: &ControlledWireState, expected: usize) {
-        yield_until(
-            || state.send_count.load(Ordering::Acquire) >= expected,
-            "tick driver must poll the controlled wire transport",
         )
         .await;
     }
@@ -4800,10 +5023,9 @@ mod tests {
     async fn idle_peer_closed_terminal_reconnects_without_semantic_traffic() {
         tokio::task::LocalSet::new()
             .run_until(async {
-                let (mut first, _first_wire, first_admission) = successful_controlled_admission();
+                let (mut first, first_admission) = successful_controlled_admission();
                 let first_observed = Arc::clone(&first.observed);
-                let (_replacement, _replacement_wire, replacement_admission) =
-                    successful_controlled_admission();
+                let (_replacement, replacement_admission) = successful_controlled_admission();
                 let connector = Arc::new(ControlledNativeConnector::new(vec![
                     first_admission,
                     replacement_admission,
@@ -4831,7 +5053,7 @@ mod tests {
     async fn owner_dropped_terminal_does_not_reconnect() {
         tokio::task::LocalSet::new()
             .run_until(async {
-                let (mut terminal, _wire, admission) = successful_controlled_admission();
+                let (mut terminal, admission) = successful_controlled_admission();
                 let observed = Arc::clone(&terminal.observed);
                 let connector = Arc::new(ControlledNativeConnector::new(vec![admission]));
                 let client = JazzClient::connect_with_native_transport(
@@ -4859,7 +5081,7 @@ mod tests {
     async fn shutdown_does_not_reconnect_after_terminal() {
         tokio::task::LocalSet::new()
             .run_until(async {
-                let (mut terminal, _wire, admission) = successful_controlled_admission();
+                let (mut terminal, admission) = successful_controlled_admission();
                 let connector = Arc::new(ControlledNativeConnector::new(vec![admission]));
                 let client = JazzClient::connect_with_native_transport(
                     make_native_context("shutdown-no-reconnect"),
@@ -4896,11 +5118,10 @@ mod tests {
                         NativeTransportTerminal::Failed(NativeTransportError("failed".to_owned())),
                     ),
                 ] {
-                    let (mut first, _wire, first_admission) = successful_controlled_admission();
+                    let (mut first, first_admission) = successful_controlled_admission();
                     let observed = Arc::clone(&first.observed);
                     let refused = refused_controlled_admission("refused");
-                    let (replacement_terminal, _wire, replacement) =
-                        successful_controlled_admission();
+                    let (replacement_terminal, replacement) = successful_controlled_admission();
                     let replacement_observed = Arc::clone(&replacement_terminal.observed);
                     let connector = Arc::new(ControlledNativeConnector::new(vec![
                         first_admission,
@@ -4930,7 +5151,7 @@ mod tests {
     async fn tick_error_and_terminal_coalesce_to_one_recovery_owner() {
         tokio::task::LocalSet::new()
             .run_until(async {
-                let (mut first, _wire, first_admission) = successful_controlled_admission();
+                let (mut first, first_admission) = successful_controlled_admission();
                 let observed = Arc::clone(&first.observed);
                 let (_replacement, replacement) = controlled_admission();
                 let (_duplicate, duplicate) = controlled_admission();
@@ -4981,7 +5202,7 @@ mod tests {
     async fn stale_admission_completion_cannot_install_after_newer_generation() {
         tokio::task::LocalSet::new()
             .run_until(async {
-                let (_first, _wire, first) = successful_controlled_admission();
+                let (_first, first) = successful_controlled_admission();
                 let (mut stale, stale_receiver) = controlled_admission();
                 let (mut newer, newer_receiver) = controlled_admission();
                 let connector = Arc::new(ControlledNativeConnector::new(vec![
@@ -5007,7 +5228,7 @@ mod tests {
                     ClientDbInner::reconnect_upstream(&inner).await
                 });
                 wait_for_connect_count(&connector, 3).await;
-                let (_terminal, _wire) = newer.succeed();
+                let _terminal = newer.succeed();
                 assert!(
                     newer_task.await.expect("task").expect("admission"),
                     "newer generation installs"
@@ -5015,7 +5236,7 @@ mod tests {
                 client.db.inner.borrow_mut().disconnect_upstream();
                 let generation = client.db.inner.borrow().upstream_generation;
 
-                let (_terminal, _wire) = stale.succeed();
+                let _terminal = stale.succeed();
                 assert!(
                     !stale_task.await.expect("task").expect("admission"),
                     "stale completion must not install"
@@ -5032,9 +5253,9 @@ mod tests {
         tokio::task::LocalSet::new()
             .run_until(async {
                 for shutdown in [false, true] {
-                    let (mut first, _wire, first_admission) = successful_controlled_admission();
+                    let (mut first, first_admission) = successful_controlled_admission();
                     let observed = Arc::clone(&first.observed);
-                    let (_replacement, _wire, replacement) = successful_controlled_admission();
+                    let (_replacement, replacement) = successful_controlled_admission();
                     let connector = Arc::new(ControlledNativeConnector::new(vec![
                         first_admission,
                         replacement,
@@ -5091,8 +5312,8 @@ mod tests {
     async fn stale_exhaustion_does_not_poison_current_generation() {
         tokio::task::LocalSet::new()
             .run_until(async {
-                let (_first, _wire, first) = successful_controlled_admission();
-                let (_replacement, _wire, replacement) = successful_controlled_admission();
+                let (_first, first) = successful_controlled_admission();
+                let (_replacement, replacement) = successful_controlled_admission();
                 let stale_reconnect =
                     refused_controlled_admission("stale recovery must not reconnect");
                 let connector = Arc::new(ControlledNativeConnector::new(vec![
@@ -5180,25 +5401,33 @@ mod tests {
     async fn local_tick_work_remains_responsive_during_retry_delay() {
         tokio::task::LocalSet::new()
             .run_until(async {
-                let (_first, wire, first) = successful_controlled_admission();
-                let (_replacement, _wire, replacement) = successful_controlled_admission();
-                let connector = Arc::new(ControlledNativeConnector::new(vec![first, replacement]));
+                let (mut first, first_admission) = successful_controlled_admission();
+                let refused = refused_controlled_admission("replacement refused");
+                let (_replacement, replacement) = successful_controlled_admission();
+                let connector = Arc::new(ControlledNativeConnector::new(vec![
+                    first_admission,
+                    refused,
+                    replacement,
+                ]));
                 let client = JazzClient::connect_with_native_transport(
                     make_native_context("responsive-during-retry"),
-                    connector,
+                    connector.clone(),
                 )
                 .await
                 .expect("connect");
-                wire.fail_sends.store(true, Ordering::Release);
-                let sends = wire.send_count.load(Ordering::Acquire);
-                client
-                    .db
-                    .inner
-                    .borrow()
-                    .scheduler
-                    .wake(TickUrgency::Immediate);
-                wait_for_send_count(&wire, sends + 1).await;
-                wire.fail_sends.store(false, Ordering::Release);
+                let observed = Arc::clone(&first.observed);
+
+                first.send(NativeTransportTerminal::Failed(NativeTransportError(
+                    "controlled terminal failure".to_owned(),
+                )));
+                wait_for_terminal_observation(&observed).await;
+                wait_for_connect_count(&connector, 2).await;
+                tokio::task::yield_now().await;
+                assert_eq!(
+                    connector.connect_count(),
+                    2,
+                    "refused replacement must leave recovery waiting in retry backoff"
+                );
 
                 let (_, _, transaction) = client
                     .insert(
@@ -5222,6 +5451,11 @@ mod tests {
                 assert!(
                     local_wait.is_finished(),
                     "local tick work must not wait for retry delay"
+                );
+                assert_eq!(
+                    connector.connect_count(),
+                    2,
+                    "retry admission must not begin before local durability completes"
                 );
                 local_wait.await.expect("task").expect("local durability");
             })

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -3638,10 +3638,24 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use tempfile::TempDir;
 
-    struct NoopNativeWireTransport;
+    #[derive(Default)]
+    struct ControlledWireState {
+        fail_sends: AtomicBool,
+        send_count: AtomicUsize,
+    }
 
-    impl WireTransport for NoopNativeWireTransport {
+    struct ControlledNativeWireTransport {
+        state: Arc<ControlledWireState>,
+    }
+
+    impl WireTransport for ControlledNativeWireTransport {
         fn send_frame(&mut self, _frame: Vec<u8>) -> std::result::Result<(), TransportError> {
+            self.state.send_count.fetch_add(1, Ordering::AcqRel);
+            if self.state.fail_sends.load(Ordering::Acquire) {
+                return Err(TransportError::Failed(
+                    "websocket pump is closed".to_owned(),
+                ));
+            }
             Ok(())
         }
 
@@ -3654,6 +3668,7 @@ mod tests {
         sender: Option<oneshot::Sender<NativeTransportTerminal>>,
         observed: Arc<AtomicBool>,
     }
+
     impl ControlledTerminal {
         fn send(&mut self, terminal: NativeTransportTerminal) {
             let _ = self
@@ -3664,18 +3679,57 @@ mod tests {
         }
     }
 
+    enum ControlledAdmissionResult {
+        Connected {
+            terminal: oneshot::Receiver<NativeTransportTerminal>,
+            terminal_observed: Arc<AtomicBool>,
+            wire: Arc<ControlledWireState>,
+        },
+        Refused(String),
+    }
+
+    struct ControlledAdmission {
+        sender: Option<oneshot::Sender<ControlledAdmissionResult>>,
+    }
+
+    impl ControlledAdmission {
+        fn succeed(&mut self) -> (ControlledTerminal, Arc<ControlledWireState>) {
+            let (terminal, terminal_receiver) = controlled_terminal();
+            let terminal_observed = Arc::clone(&terminal.observed);
+            let wire = Arc::new(ControlledWireState::default());
+            let _ = self
+                .sender
+                .take()
+                .expect("controlled admission completes once")
+                .send(ControlledAdmissionResult::Connected {
+                    terminal: terminal_receiver,
+                    terminal_observed,
+                    wire: Arc::clone(&wire),
+                });
+            (terminal, wire)
+        }
+
+        fn refuse(&mut self, error: impl Into<String>) {
+            let _ = self
+                .sender
+                .take()
+                .expect("controlled admission completes once")
+                .send(ControlledAdmissionResult::Refused(error.into()));
+        }
+    }
+
+    type ControlledAdmissionReceiver = oneshot::Receiver<ControlledAdmissionResult>;
+
     struct ControlledNativeConnector {
         connect_count: AtomicUsize,
-        terminals: Mutex<VecDeque<(oneshot::Receiver<NativeTransportTerminal>, Arc<AtomicBool>)>>,
+        admissions: Mutex<VecDeque<ControlledAdmissionReceiver>>,
     }
 
     impl ControlledNativeConnector {
-        fn new(
-            terminals: Vec<(oneshot::Receiver<NativeTransportTerminal>, Arc<AtomicBool>)>,
-        ) -> Self {
+        fn new(admissions: Vec<ControlledAdmissionReceiver>) -> Self {
             Self {
                 connect_count: AtomicUsize::new(0),
-                terminals: Mutex::new(terminals.into()),
+                admissions: Mutex::new(admissions.into()),
             }
         }
 
@@ -3687,27 +3741,39 @@ mod tests {
     impl NativeTransportConnector for ControlledNativeConnector {
         fn connect(&self, _request: NativeTransportRequest) -> NativeTransportFuture {
             self.connect_count.fetch_add(1, Ordering::AcqRel);
-            let (receiver, observed) = self
-                .terminals
+            let admission = self
+                .admissions
                 .lock()
-                .expect("take controlled terminal")
+                .expect("take controlled admission")
                 .pop_front()
-                .expect("test connector has a terminal for every connection");
-            let terminal: NativeTransportTerminalFuture = Box::pin(async move {
-                observed.store(true, Ordering::Release);
-                receiver
-                    .await
-                    .expect("controlled terminal sender remains alive")
-            });
+                .expect("test connector has an admission for every connection");
             Box::pin(async move {
-                Ok(ConnectedNativeTransport {
-                    transport: Box::new(NoopNativeWireTransport),
-                    protocol_version: crate::wire::WIRE_PROTOCOL_VERSION,
-                    features: crate::wire::FEATURE_NONE,
-                    session_context: None,
-                    permits_delegated_sessions: false,
-                    terminal,
-                })
+                match admission
+                    .await
+                    .expect("controlled admission sender remains alive")
+                {
+                    ControlledAdmissionResult::Connected {
+                        terminal,
+                        terminal_observed,
+                        wire,
+                    } => {
+                        let terminal: NativeTransportTerminalFuture = Box::pin(async move {
+                            terminal_observed.store(true, Ordering::Release);
+                            terminal
+                                .await
+                                .expect("controlled terminal sender remains alive")
+                        });
+                        Ok(ConnectedNativeTransport {
+                            transport: Box::new(ControlledNativeWireTransport { state: wire }),
+                            protocol_version: crate::wire::WIRE_PROTOCOL_VERSION,
+                            features: crate::wire::FEATURE_NONE,
+                            session_context: None,
+                            permits_delegated_sessions: false,
+                            terminal,
+                        })
+                    }
+                    ControlledAdmissionResult::Refused(error) => Err(NativeTransportError(error)),
+                }
             })
         }
 
@@ -3738,24 +3804,71 @@ mod tests {
         )
     }
 
-    async fn wait_for_connect_count(connector: &ControlledNativeConnector, expected: usize) {
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while connector.connect_count() < expected {
-                tokio::task::yield_now().await;
+    fn controlled_admission() -> (ControlledAdmission, ControlledAdmissionReceiver) {
+        let (sender, receiver) = oneshot::channel();
+        (
+            ControlledAdmission {
+                sender: Some(sender),
+            },
+            receiver,
+        )
+    }
+
+    fn successful_controlled_admission() -> (
+        ControlledTerminal,
+        Arc<ControlledWireState>,
+        ControlledAdmissionReceiver,
+    ) {
+        let (mut admission, receiver) = controlled_admission();
+        let (terminal, wire) = admission.succeed();
+        (terminal, wire, receiver)
+    }
+
+    fn refused_controlled_admission(error: impl Into<String>) -> ControlledAdmissionReceiver {
+        let (mut admission, receiver) = controlled_admission();
+        admission.refuse(error);
+        receiver
+    }
+
+    async fn yield_until(mut predicate: impl FnMut() -> bool, failure: &str) {
+        for _ in 0..256 {
+            if predicate() {
+                return;
             }
-        })
-        .await
-        .expect("connection replacement must not deadlock");
+            tokio::task::yield_now().await;
+        }
+        assert!(predicate(), "{failure}");
+    }
+
+    async fn wait_for_connect_count(connector: &ControlledNativeConnector, expected: usize) {
+        yield_until(
+            || connector.connect_count() >= expected,
+            "connection replacement must not deadlock",
+        )
+        .await;
     }
 
     async fn wait_for_terminal_observation(observed: &AtomicBool) {
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while !observed.load(Ordering::Acquire) {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("terminal watcher must poll the controlled terminal future");
+        yield_until(
+            || observed.load(Ordering::Acquire),
+            "terminal watcher must poll the controlled terminal future",
+        )
+        .await;
+    }
+
+    async fn wait_for_send_count(state: &ControlledWireState, expected: usize) {
+        yield_until(
+            || state.send_count.load(Ordering::Acquire) >= expected,
+            "tick driver must poll the controlled wire transport",
+        )
+        .await;
+    }
+
+    fn tick_reconnect_error() -> CoreDbError {
+        CoreDbError {
+            code: CoreDbErrorCode::Protocol,
+            message: "websocket pump is closed".to_owned(),
+        }
     }
 
     fn make_native_context(name: &str) -> AppContext {
@@ -4687,12 +4800,13 @@ mod tests {
     async fn idle_peer_closed_terminal_reconnects_without_semantic_traffic() {
         tokio::task::LocalSet::new()
             .run_until(async {
-                let (mut first, first_receiver) = controlled_terminal();
+                let (mut first, _first_wire, first_admission) = successful_controlled_admission();
                 let first_observed = Arc::clone(&first.observed);
-                let (_replacement, replacement_receiver) = controlled_terminal();
+                let (_replacement, _replacement_wire, replacement_admission) =
+                    successful_controlled_admission();
                 let connector = Arc::new(ControlledNativeConnector::new(vec![
-                    (first_receiver, first_observed.clone()),
-                    (replacement_receiver, Arc::new(AtomicBool::new(false))),
+                    first_admission,
+                    replacement_admission,
                 ]));
                 let client = JazzClient::connect_with_native_transport(
                     make_native_context("idle-peer-closed-reconnect"),
@@ -4717,12 +4831,9 @@ mod tests {
     async fn owner_dropped_terminal_does_not_reconnect() {
         tokio::task::LocalSet::new()
             .run_until(async {
-                let (mut terminal, receiver) = controlled_terminal();
+                let (mut terminal, _wire, admission) = successful_controlled_admission();
                 let observed = Arc::clone(&terminal.observed);
-                let connector = Arc::new(ControlledNativeConnector::new(vec![(
-                    receiver,
-                    observed.clone(),
-                )]));
+                let connector = Arc::new(ControlledNativeConnector::new(vec![admission]));
                 let client = JazzClient::connect_with_native_transport(
                     make_native_context("owner-dropped-no-reconnect"),
                     connector.clone(),
@@ -4748,10 +4859,8 @@ mod tests {
     async fn shutdown_does_not_reconnect_after_terminal() {
         tokio::task::LocalSet::new()
             .run_until(async {
-                let (mut terminal, receiver) = controlled_terminal();
-                let observed = Arc::clone(&terminal.observed);
-                let connector =
-                    Arc::new(ControlledNativeConnector::new(vec![(receiver, observed)]));
+                let (mut terminal, _wire, admission) = successful_controlled_admission();
+                let connector = Arc::new(ControlledNativeConnector::new(vec![admission]));
                 let client = JazzClient::connect_with_native_transport(
                     make_native_context("shutdown-no-reconnect"),
                     connector.clone(),
@@ -4769,6 +4878,352 @@ mod tests {
                     1,
                     "shutdown must prevent terminal-triggered reconnection"
                 );
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn recoverable_native_terminals_retry_refused_replacement() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                for (name, outcome) in [
+                    (
+                        "peer-closed",
+                        NativeTransportTerminal::PeerClosed("closed".to_owned()),
+                    ),
+                    (
+                        "failed",
+                        NativeTransportTerminal::Failed(NativeTransportError("failed".to_owned())),
+                    ),
+                ] {
+                    let (mut first, _wire, first_admission) = successful_controlled_admission();
+                    let observed = Arc::clone(&first.observed);
+                    let refused = refused_controlled_admission("refused");
+                    let (replacement_terminal, _wire, replacement) =
+                        successful_controlled_admission();
+                    let replacement_observed = Arc::clone(&replacement_terminal.observed);
+                    let connector = Arc::new(ControlledNativeConnector::new(vec![
+                        first_admission,
+                        refused,
+                        replacement,
+                    ]));
+                    let client = JazzClient::connect_with_native_transport(
+                        make_native_context(&format!("{name}-retry")),
+                        connector.clone(),
+                    )
+                    .await
+                    .expect("connect");
+
+                    first.send(outcome);
+                    wait_for_terminal_observation(&observed).await;
+                    wait_for_connect_count(&connector, 2).await;
+                    tokio::time::advance(TICK_DRIVER_RETRY_BASE_DELAY).await;
+                    wait_for_connect_count(&connector, 3).await;
+                    wait_for_terminal_observation(&replacement_observed).await;
+                    client.shutdown().await.expect("shutdown");
+                }
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn tick_error_and_terminal_coalesce_to_one_recovery_owner() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (mut first, _wire, first_admission) = successful_controlled_admission();
+                let observed = Arc::clone(&first.observed);
+                let (_replacement, replacement) = controlled_admission();
+                let (_duplicate, duplicate) = controlled_admission();
+                let connector = Arc::new(ControlledNativeConnector::new(vec![
+                    first_admission,
+                    replacement,
+                    duplicate,
+                ]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("coalesced-recovery"),
+                    connector.clone(),
+                )
+                .await
+                .expect("connect");
+                let inner = Rc::clone(&client.db.inner);
+                let scheduler = Rc::clone(&inner.borrow().scheduler);
+                let recovery = tokio::task::spawn_local(async move {
+                    let mut attempts = 0;
+                    recover_tick_driver_error(
+                        &inner,
+                        &scheduler,
+                        TickDriverErrorClass::Reconnect,
+                        &tick_reconnect_error(),
+                        &mut attempts,
+                    )
+                    .await
+                });
+                tokio::task::yield_now().await;
+
+                first.send(NativeTransportTerminal::PeerClosed("closed".to_owned()));
+                wait_for_terminal_observation(&observed).await;
+                wait_for_connect_count(&connector, 2).await;
+                tokio::time::advance(TICK_DRIVER_RETRY_BASE_DELAY).await;
+                for _ in 0..64 {
+                    tokio::task::yield_now().await;
+                }
+                assert_eq!(
+                    connector.connect_count(),
+                    2,
+                    "one generation may own only one replacement admission"
+                );
+                recovery.abort();
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn stale_admission_completion_cannot_install_after_newer_generation() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (_first, _wire, first) = successful_controlled_admission();
+                let (mut stale, stale_receiver) = controlled_admission();
+                let (mut newer, newer_receiver) = controlled_admission();
+                let connector = Arc::new(ControlledNativeConnector::new(vec![
+                    first,
+                    stale_receiver,
+                    newer_receiver,
+                ]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("stale-admission"),
+                    connector.clone(),
+                )
+                .await
+                .expect("connect");
+                client.db.inner.borrow_mut().disconnect_upstream();
+
+                let inner = Rc::clone(&client.db.inner);
+                let stale_task = tokio::task::spawn_local(async move {
+                    ClientDbInner::reconnect_upstream(&inner).await
+                });
+                wait_for_connect_count(&connector, 2).await;
+                let inner = Rc::clone(&client.db.inner);
+                let newer_task = tokio::task::spawn_local(async move {
+                    ClientDbInner::reconnect_upstream(&inner).await
+                });
+                wait_for_connect_count(&connector, 3).await;
+                let (_terminal, _wire) = newer.succeed();
+                assert!(
+                    newer_task.await.expect("task").expect("admission"),
+                    "newer generation installs"
+                );
+                client.db.inner.borrow_mut().disconnect_upstream();
+                let generation = client.db.inner.borrow().upstream_generation;
+
+                let (_terminal, _wire) = stale.succeed();
+                assert!(
+                    !stale_task.await.expect("task").expect("admission"),
+                    "stale completion must not install"
+                );
+                let state = client.db.inner.borrow();
+                assert!(state.upstream.is_none());
+                assert_eq!(state.upstream_generation, generation);
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn ownership_loss_during_retry_prevents_installation() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                for shutdown in [false, true] {
+                    let (mut first, _wire, first_admission) = successful_controlled_admission();
+                    let observed = Arc::clone(&first.observed);
+                    let (_replacement, _wire, replacement) = successful_controlled_admission();
+                    let connector = Arc::new(ControlledNativeConnector::new(vec![
+                        first_admission,
+                        replacement,
+                    ]));
+                    let client = JazzClient::connect_with_native_transport(
+                        make_native_context(if shutdown {
+                            "shutdown-during-retry"
+                        } else {
+                            "owner-drop-during-retry"
+                        }),
+                        connector.clone(),
+                    )
+                    .await
+                    .expect("connect");
+                    let inner = Rc::clone(&client.db.inner);
+                    let scheduler = Rc::clone(&inner.borrow().scheduler);
+                    let recovery = tokio::task::spawn_local(async move {
+                        let mut attempts = 0;
+                        recover_tick_driver_error(
+                            &inner,
+                            &scheduler,
+                            TickDriverErrorClass::Reconnect,
+                            &tick_reconnect_error(),
+                            &mut attempts,
+                        )
+                        .await
+                    });
+                    tokio::task::yield_now().await;
+
+                    if shutdown {
+                        client.shutdown().await.expect("shutdown");
+                        tokio::time::advance(TICK_DRIVER_RETRY_BASE_DELAY).await;
+                        recovery.await.expect("recovery task");
+                        assert_eq!(connector.connect_count(), 1);
+                    } else {
+                        first.send(NativeTransportTerminal::OwnerDropped);
+                        wait_for_terminal_observation(&observed).await;
+                        yield_until(
+                            || client.db.inner.borrow().upstream.is_none(),
+                            "OwnerDropped must detach",
+                        )
+                        .await;
+                        tokio::time::advance(TICK_DRIVER_RETRY_BASE_DELAY).await;
+                        recovery.await.expect("recovery task");
+                        assert_eq!(connector.connect_count(), 1);
+                        client.shutdown().await.expect("shutdown");
+                    }
+                }
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stale_exhaustion_does_not_poison_current_generation() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (_first, _wire, first) = successful_controlled_admission();
+                let (_replacement, _wire, replacement) = successful_controlled_admission();
+                let stale_reconnect =
+                    refused_controlled_admission("stale recovery must not reconnect");
+                let connector = Arc::new(ControlledNativeConnector::new(vec![
+                    first,
+                    replacement,
+                    stale_reconnect,
+                ]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("stale-exhaustion"),
+                    connector,
+                )
+                .await
+                .expect("connect");
+                let inner = Rc::clone(&client.db.inner);
+                let stale_generation = inner.borrow().upstream_generation;
+                let scheduler = Rc::clone(&inner.borrow().scheduler);
+                let (recovery_started, recovery_started_rx) = oneshot::channel();
+                let stale_inner = Rc::clone(&inner);
+                let stale_recovery = tokio::task::spawn_local(async move {
+                    let mut attempts = MAX_TICK_DRIVER_RECOVERY_ATTEMPTS - 1;
+                    recovery_started
+                        .send(())
+                        .expect("stale recovery owner remains observed");
+                    recover_tick_driver_error(
+                        &stale_inner,
+                        &scheduler,
+                        TickDriverErrorClass::Reconnect,
+                        &tick_reconnect_error(),
+                        &mut attempts,
+                    )
+                    .await;
+                    recover_tick_driver_error(
+                        &stale_inner,
+                        &scheduler,
+                        TickDriverErrorClass::Reconnect,
+                        &tick_reconnect_error(),
+                        &mut attempts,
+                    )
+                    .await;
+                });
+                recovery_started_rx
+                    .await
+                    .expect("stale recovery owner starts");
+                assert!(
+                    !stale_recovery.is_finished(),
+                    "old-generation recovery must be pending before replacement installation"
+                );
+
+                inner.borrow_mut().disconnect_upstream();
+                assert!(
+                    ClientDbInner::reconnect_upstream(&inner)
+                        .await
+                        .expect("replacement admission"),
+                    "newer replacement installs"
+                );
+                let current_generation = inner.borrow().upstream_generation;
+                assert_ne!(current_generation, stale_generation);
+                assert!(
+                    inner.borrow().upstream.is_some(),
+                    "newer replacement must be installed before stale exhaustion"
+                );
+
+                tokio::time::advance(tick_driver_retry_delay(MAX_TICK_DRIVER_RECOVERY_ATTEMPTS))
+                    .await;
+                stale_recovery.await.expect("stale recovery task");
+
+                let state = inner.borrow();
+                assert!(
+                    state.upstream.is_some(),
+                    "stale exhaustion must retain the newer upstream"
+                );
+                assert_eq!(
+                    state.upstream_generation, current_generation,
+                    "stale exhaustion must not advance the current generation"
+                );
+                assert!(
+                    state.tick_driver_error.is_none(),
+                    "stale exhaustion must not stop the current generation"
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn local_tick_work_remains_responsive_during_retry_delay() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (_first, wire, first) = successful_controlled_admission();
+                let (_replacement, _wire, replacement) = successful_controlled_admission();
+                let connector = Arc::new(ControlledNativeConnector::new(vec![first, replacement]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("responsive-during-retry"),
+                    connector,
+                )
+                .await
+                .expect("connect");
+                wire.fail_sends.store(true, Ordering::Release);
+                let sends = wire.send_count.load(Ordering::Acquire);
+                client
+                    .db
+                    .inner
+                    .borrow()
+                    .scheduler
+                    .wake(TickUrgency::Immediate);
+                wait_for_send_count(&wire, sends + 1).await;
+                wire.fail_sends.store(false, Ordering::Release);
+
+                let (_, _, transaction) = client
+                    .insert(
+                        "todos",
+                        crate::row_input!("title" => "local", "completed" => false),
+                    )
+                    .expect("insert");
+                let transaction = transaction.expect("committed transaction");
+                let retained = client.clone();
+                let local_wait = tokio::task::spawn_local(async move {
+                    retained
+                        .wait_for_transaction(transaction, DurabilityTier::Local)
+                        .await
+                });
+                for _ in 0..256 {
+                    if local_wait.is_finished() {
+                        break;
+                    }
+                    tokio::task::yield_now().await;
+                }
+                assert!(
+                    local_wait.is_finished(),
+                    "local tick work must not wait for retry delay"
+                );
+                local_wait.await.expect("task").expect("local durability");
             })
             .await;
     }

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 use std::cell::Cell;
 use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::future::Future;
 use std::ops::Deref;
 use std::pin::Pin;
@@ -32,7 +32,10 @@ use crate::protocol::ReadViewSpec as CoreReadViewSpec;
 use crate::query::{Aggregate as CoreAggregate, AggregateFunction as CoreAggregateFunction, Query};
 use crate::storage_codec_profile::epoch_1_storage_codec_profile;
 use crate::tools::OpenTransactionId;
-use crate::tools::native_transport_connector::{NativeTransportConnector, NativeTransportRequest};
+use crate::tools::native_transport_connector::{
+    NativeTransportConnector, NativeTransportRequest, NativeTransportTerminal,
+    NativeTransportTerminalFuture,
+};
 use crate::tools::public_api::types::{
     OrderedAdded, OrderedRemoved, OrderedUpdated, QueryResultField,
 };
@@ -192,6 +195,8 @@ struct ClientDbInner {
     connect_config: Option<ConnectConfig>,
     scheduler: Rc<TickSchedulerImpl>,
     upstream: Option<BackendConnection>,
+    upstream_generation: u64,
+    native_terminal_events: VecDeque<(u64, NativeTransportTerminal)>,
     write_map: HashMap<TransactionId, CoreTxId>,
     row_tables: HashMap<ObjectId, String>,
     transactions: HashMap<OpenTransactionId, ExclusiveTransactionState>,
@@ -853,6 +858,7 @@ impl ClientDb {
         .await?;
         let inner = Rc::new(RefCell::new(inner));
         if has_upstream {
+            ClientDbInner::connect_upstream_transport(&inner).await?;
             Self::spawn_local_tick_driver(Rc::downgrade(&inner), Rc::clone(&scheduler));
         }
         Ok(Rc::new(Self {
@@ -1314,6 +1320,53 @@ impl ClientDb {
         self.inner.borrow().ensure_tick_driver_running()
     }
 
+    fn spawn_native_terminal_watcher(
+        inner: Weak<RefCell<ClientDbInner>>,
+        scheduler: Rc<TickSchedulerImpl>,
+        generation: u64,
+        terminal: NativeTransportTerminalFuture,
+    ) {
+        tokio::task::spawn_local(async move {
+            let terminal = terminal.await;
+            let Some(inner) = inner.upgrade() else {
+                return;
+            };
+            inner
+                .borrow_mut()
+                .native_terminal_events
+                .push_back((generation, terminal));
+            scheduler.wake(TickUrgency::Immediate);
+        });
+    }
+
+    async fn handle_native_terminal(
+        inner: &Rc<RefCell<ClientDbInner>>,
+        generation: u64,
+        terminal: NativeTransportTerminal,
+    ) {
+        let reconnect = {
+            let mut inner_state = inner.borrow_mut();
+            if generation != inner_state.upstream_generation
+                || !matches!(inner_state.shutdown_state, ShutdownState::Open)
+            {
+                return;
+            }
+            match terminal {
+                NativeTransportTerminal::OwnerDropped => {
+                    inner_state.disconnect_upstream();
+                    false
+                }
+                NativeTransportTerminal::PeerClosed(_) | NativeTransportTerminal::Failed(_) => {
+                    inner_state.disconnect_upstream();
+                    true
+                }
+            }
+        };
+        if reconnect {
+            let _ = ClientDbInner::reconnect_upstream(inner).await;
+        }
+    }
+
     fn spawn_local_tick_driver(
         inner: Weak<RefCell<ClientDbInner>>,
         scheduler: Rc<TickSchedulerImpl>,
@@ -1327,6 +1380,14 @@ impl ClientDb {
                     let Some(inner) = inner.upgrade() else {
                         return;
                     };
+                    loop {
+                        let event = { inner.borrow_mut().native_terminal_events.pop_front() };
+                        let Some((generation, terminal)) = event else {
+                            break;
+                        };
+                        ClientDb::handle_native_terminal(&inner, generation, terminal).await;
+                    }
+
                     if urgency == TickUrgency::Deferred {
                         tokio::time::sleep(Duration::from_millis(1)).await;
                     } else if urgency == TickUrgency::AfterCurrentTurn {
@@ -1385,6 +1446,7 @@ impl ClientDbInner {
     }
 
     fn disconnect_upstream(&mut self) -> bool {
+        self.upstream_generation = self.upstream_generation.wrapping_add(1);
         let Some(connection) = self.upstream.take() else {
             return false;
         };
@@ -1466,12 +1528,14 @@ impl ClientDbInner {
         } else {
             None
         };
-        let mut inner = Self {
+        let inner = Self {
             db: Some(db),
             identity,
             connect_config,
             scheduler,
             upstream: None,
+            upstream_generation: 0,
+            native_terminal_events: VecDeque::new(),
             write_map: HashMap::new(),
             row_tables: HashMap::new(),
             transactions: HashMap::new(),
@@ -1483,56 +1547,53 @@ impl ClientDbInner {
             shutdown_state: ShutdownState::Open,
             shutdown_notify: Arc::new(tokio::sync::Notify::new()),
         };
-        inner.connect_upstream_transport().await?;
         Ok(inner)
     }
 
     async fn reconnect_upstream(inner: &Rc<RefCell<Self>>) -> Result<bool> {
+        Self::connect_upstream_transport(inner).await
+    }
+
+    async fn connect_upstream_transport(inner: &Rc<RefCell<Self>>) -> Result<bool> {
         let (db, identity, scheduler, config) = {
-            let inner = inner.borrow();
-            if !matches!(inner.shutdown_state, ShutdownState::Open) {
+            let inner_state = inner.borrow();
+            if !matches!(inner_state.shutdown_state, ShutdownState::Open) {
                 return Err(Self::shutdown_error());
             }
-            if inner.upstream.is_some() {
+            if inner_state.upstream.is_some() {
                 return Ok(false);
             }
-            let Some(config) = inner.connect_config.clone() else {
+            let Some(config) = inner_state.connect_config.clone() else {
                 return Ok(false);
             };
             (
-                inner.backend_clone()?,
-                inner.identity,
-                Rc::clone(&inner.scheduler),
+                inner_state.backend_clone()?,
+                inner_state.identity,
+                Rc::clone(&inner_state.scheduler),
                 config,
             )
         };
-        let connection = Self::connect_with_config(&db, identity, scheduler, config).await?;
-        let mut inner = inner.borrow_mut();
-        if !matches!(inner.shutdown_state, ShutdownState::Open) || inner.upstream.is_some() {
-            db.detach_connection(&connection);
-            return Ok(false);
-        }
-        inner.upstream = Some(connection);
-        Ok(true)
-    }
-
-    async fn connect_upstream_transport(&mut self) -> Result<()> {
-        if self.upstream.is_some() {
-            return Ok(());
-        }
-        let Some(config) = self.connect_config.clone() else {
-            return Ok(());
+        let (connection, terminal) =
+            Self::connect_with_config(&db, identity, Rc::clone(&scheduler), config).await?;
+        let generation = {
+            let mut inner_state = inner.borrow_mut();
+            if !matches!(inner_state.shutdown_state, ShutdownState::Open)
+                || inner_state.upstream.is_some()
+            {
+                db.detach_connection(&connection);
+                return Ok(false);
+            }
+            inner_state.upstream_generation = inner_state.upstream_generation.wrapping_add(1);
+            inner_state.upstream = Some(connection);
+            inner_state.upstream_generation
         };
-        self.upstream = Some(
-            Self::connect_with_config(
-                self.backend()?,
-                self.identity,
-                Rc::clone(&self.scheduler),
-                config,
-            )
-            .await?,
+        ClientDb::spawn_native_terminal_watcher(
+            Rc::downgrade(inner),
+            scheduler,
+            generation,
+            terminal,
         );
-        Ok(())
+        Ok(true)
     }
 
     async fn connect_with_config(
@@ -1540,7 +1601,7 @@ impl ClientDbInner {
         identity: CoreDbIdentity,
         scheduler: Rc<TickSchedulerImpl>,
         config: ConnectConfig,
-    ) -> Result<BackendConnection> {
+    ) -> Result<(BackendConnection, NativeTransportTerminalFuture)> {
         let wake = scheduler.wake_handle();
         let connected = config
             .connector
@@ -1556,7 +1617,7 @@ impl ClientDbInner {
             })
             .await
             .map_err(|error| JazzError::Connection(error.to_string()))?;
-        Ok(db
+        let connection = db
             .connect_upstream(Box::new(
                 WireTransportAdapter::new_with_session_context_and_delegated_sessions(
                     connected.transport,
@@ -1567,7 +1628,8 @@ impl ClientDbInner {
                     connected.permits_delegated_sessions,
                 ),
             ))
-            .await)
+            .await;
+        Ok((connection, connected.terminal))
     }
 
     fn ensure_transaction_open(&self, transaction_id: OpenTransactionId) -> Result<()> {


### PR DESCRIPTION
## Summary
- Retain native transport terminal futures after connection establishment.
- Route generation-tagged terminal outcomes through the existing tick driver.
- Reconnect recoverable peer failures while preventing reconnects for deliberate owner drops and shutdown races.

## Before
The native client discarded the terminal future returned by the transport connector. An idle socket closure could therefore leave the client treating a dead upstream as an idle connection.

## After
Terminal outcomes are observed through a weak generation-tagged watcher. Peer closures and recoverable failures use the existing reconnect path; deliberate owner drops, shutdown, and stale generations do not reconnect or detach replacement connections.

## Test plan
- [ ] Run the native terminal lifecycle regression tests.
- [ ] Run the Jazz library check with native transport testing features.
