### PR TITLE
Validate invite codes for chat membership

### DIFF
--- a/examples/chat-react/tests/permissions/permissions.test.ts
+++ b/examples/chat-react/tests/permissions/permissions.test.ts
@@ -53,6 +53,107 @@ describe("chat permissions", () => {
     ]);
   });
 
+  it("allows self-membership with the current private chat join code", async () => {
+    const privateChat = await testApp.seed((db) =>
+      db.insert(app.chats, {
+        name: "Invite-only room",
+        isPublic: false,
+        joinCode: "invite-current",
+      }),
+    );
+
+    const bobDb = testApp.as(externalSession("bob"));
+
+    bobDb.expectAllowed((db) =>
+      db.insert(app.chatMembers, {
+        chatId: privateChat.id,
+        userId: bob,
+        joinCode: "invite-current",
+      }),
+    );
+  });
+
+  it("denies self-membership with a forged private chat join code", async () => {
+    const privateChat = await testApp.seed((db) =>
+      db.insert(app.chats, {
+        name: "Invite-only room",
+        isPublic: false,
+        joinCode: "invite-current",
+      }),
+    );
+
+    const bobDb = testApp.as(externalSession("bob"));
+
+    await bobDb.expectDenied((db) =>
+      db.insert(app.chatMembers, {
+        chatId: privateChat.id,
+        userId: bob,
+        joinCode: "invite-forged",
+      }),
+    );
+  });
+
+  it("denies self-membership with a stale private chat join code", async () => {
+    const privateChat = await testApp.seed((db) =>
+      db.insert(app.chats, {
+        name: "Invite-only room",
+        isPublic: false,
+        joinCode: "invite-old",
+      }),
+    );
+    await testApp.seed((db) =>
+      db.update(app.chats, privateChat.id, {
+        joinCode: "invite-new",
+      }),
+    );
+
+    const bobDb = testApp.as(externalSession("bob"));
+
+    await bobDb.expectDenied((db) =>
+      db.insert(app.chatMembers, {
+        chatId: privateChat.id,
+        userId: bob,
+        joinCode: "invite-old",
+      }),
+    );
+  });
+
+  it("denies self-membership without a join code for a private chat", async () => {
+    const privateChat = await testApp.seed((db) =>
+      db.insert(app.chats, {
+        name: "Invite-only room",
+        isPublic: false,
+      }),
+    );
+
+    const bobDb = testApp.as(externalSession("bob"));
+
+    await bobDb.expectDenied((db) =>
+      db.insert(app.chatMembers, {
+        chatId: privateChat.id,
+        userId: bob,
+      }),
+    );
+  });
+
+  it("allows self-membership without a join code for a public chat", async () => {
+    const publicChat = await testApp.seed((db) =>
+      db.insert(app.chats, {
+        name: "Public room",
+        isPublic: true,
+      }),
+    );
+
+    const bobDb = testApp.as(externalSession("bob"));
+
+    bobDb.expectAllowed((db) =>
+      db.insert(app.chatMembers, {
+        chatId: publicChat.id,
+        userId: bob,
+      }),
+    );
+  });
+
   it("allows chat name updates", async () => {
     await testApp.seed((db) =>
       db.insert(app.profiles, {


### PR DESCRIPTION
## Summary
- Require self-membership inserts to prove the target chat is public or the supplied private-chat invite code is current.
- Preserve public-chat membership without a join code.

## Before
A caller could insert a membership row for themselves using only a private chat ID. The caller-controlled join code was stored but never compared with the current chat row.

## After
Private membership inserts require matching chat ID, private visibility, and current join code. Forged, stale, and absent private codes are rejected; public-chat membership remains allowed without a code.

## Test plan
- [ ] Run the chat permission unit tests.
- [ ] Verify forged, stale, absent, and valid private invite codes.
- [ ] Verify public-chat membership without a code.