### PR TITLE
Make recursive evaluation failures atomic

### DIFF
--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -4651,6 +4651,28 @@ async fn direct_record_store_rejects_record_containing_durable_keys_at_schema_ad
 }
 
 #[futures_test::test]
+async fn ownerless_commits_advance_tick_metrics() {
+    let storage = MemoryStorage::new(&["albums"]).expect("valid memory storage families");
+    let mut database = Database::new(albums_schema(), storage).await.unwrap();
+
+    let mut first = database.open_batch();
+    first.insert(
+        "albums",
+        vec![Value::U64(1), Value::String("Blue Train".to_owned())],
+    );
+    database.commit_batch(first).await.unwrap();
+    assert_eq!(database.last_commit_metrics().unwrap().tick.tick, 1);
+
+    let mut second = database.open_batch();
+    second.insert(
+        "albums",
+        vec![Value::U64(2), Value::String("Giant Steps".to_owned())],
+    );
+    database.commit_batch(second).await.unwrap();
+    assert_eq!(database.last_commit_metrics().unwrap().tick.tick, 2);
+}
+
+#[futures_test::test]
 async fn commit_metrics_split_storage_and_tick_work() {
     let storage = MemoryStorage::new(&["albums"]).expect("valid memory storage families");
     let mut database = Database::new(albums_schema(), storage).await.unwrap();

--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -3020,6 +3020,13 @@ async fn external_chunk_backend_error_cannot_forge_publication_durability_failur
 
     provider_ready.set(true);
     database.flush().await.unwrap();
+    assert_eq!(
+        database
+            .ivm_runtime
+            .deferred_publication_bookkeeping_counts(),
+        (0, 0, 0),
+        "an aborted assigned resident publication must leave no durable, completed, or deferred bookkeeping"
+    );
     assert!(!database.poisoned);
     let waker = futures::task::noop_waker();
     let mut context = std::task::Context::from_waker(&waker);

--- a/crates/groove/src/db/tests/graphs/recursion.rs
+++ b/crates/groove/src/db/tests/graphs/recursion.rs
@@ -1210,3 +1210,54 @@ async fn recursive_graphs_fail_when_frontier_exceeds_max_iters() {
         Error::IvmRuntime(IvmRuntimeError::RecursiveIterationLimit { max_iters: 1, .. })
     ));
 }
+
+/// A scoped recursive failure on the resident Database path must not install
+/// the partially evaluated closure. A fresh subscription must rebuild from
+/// the persisted rows without inheriting that failed state.
+#[futures_test::test]
+async fn resident_recursive_limit_discards_staged_closure() {
+    let storage = MemoryStorage::new(&["edges"]).expect("valid memory storage families");
+    let mut database = Database::new(edges_schema(), storage).await.unwrap();
+
+    let mut seed = database.open_batch();
+    insert_edge(&mut seed, 1, 1, 2);
+    database.commit_batch(seed).await.unwrap();
+
+    let failed = database
+        .subscribe_one_sink(reachability_graph(1))
+        .await
+        .unwrap();
+    assert_eq!(
+        failed.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+
+    let before_stats = database.runtime_stats();
+    let mut update = database.open_batch();
+    insert_edge(&mut update, 2, 2, 3);
+    insert_edge(&mut update, 3, 3, 4);
+    database.commit_batch(update).await.unwrap();
+    assert_eq!(
+        database.runtime_stats(),
+        before_stats,
+        "a scoped resident failure must not install partial evaluator state"
+    );
+    assert!(
+        failed.recv().is_err(),
+        "the scoped failure must fail its subscription"
+    );
+
+    let mut rollback = database.open_batch();
+    rollback.delete("edges", PrimaryKeyValue::U64(2));
+    database.commit_batch(rollback).await.unwrap();
+
+    let subscription = database
+        .subscribe_one_sink(reachability_graph(1))
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)],
+        "a fresh resident subscription must not inherit the failed staged closure"
+    );
+}

--- a/crates/groove/src/db/tests/graphs/recursion.rs
+++ b/crates/groove/src/db/tests/graphs/recursion.rs
@@ -1285,6 +1285,7 @@ async fn resident_recursive_limit_discards_staged_closure() {
 
     let mut rollback = database.open_batch();
     rollback.delete("edges", PrimaryKeyValue::U64(2));
+    rollback.delete("edges", PrimaryKeyValue::U64(3));
     database.commit_batch(rollback).await.unwrap();
 
     let subscription = database

--- a/crates/groove/src/db/tests/graphs/recursion.rs
+++ b/crates/groove/src/db/tests/graphs/recursion.rs
@@ -1237,10 +1237,46 @@ async fn resident_recursive_limit_discards_staged_closure() {
     insert_edge(&mut update, 2, 2, 3);
     insert_edge(&mut update, 3, 3, 4);
     database.commit_batch(update).await.unwrap();
+    let after_stats = database.runtime_stats();
     assert_eq!(
-        database.runtime_stats(),
-        before_stats,
-        "a scoped resident failure must not install partial evaluator state"
+        after_stats.graph_nodes, before_stats.graph_nodes,
+        "a failed subscription must not alter the installed graph"
+    );
+    assert_eq!(
+        after_stats.active_subscriptions, before_stats.active_subscriptions,
+        "the failed subscription remains observable through its failure channel"
+    );
+    assert_eq!(
+        after_stats.recursive_state_count, 0,
+        "failed subscription teardown must remove recursive operator state"
+    );
+    assert_eq!(
+        after_stats.recursive_accumulated_rows, 0,
+        "failed recursion must not retain a partial closure"
+    );
+    assert_eq!(
+        after_stats.recursive_accumulated_encoded_bytes, 0,
+        "failed recursion must not retain encoded partial closure state"
+    );
+    assert_eq!(
+        after_stats.arrangement_count, before_stats.arrangement_count,
+        "failed recursion must not install or remove committed arrangements"
+    );
+    assert_eq!(
+        after_stats.arrangement_rows, before_stats.arrangement_rows,
+        "failed recursion must not advance committed arrangement rows"
+    );
+    assert_eq!(
+        after_stats.arrangement_encoded_bytes, before_stats.arrangement_encoded_bytes,
+        "failed recursion must not advance encoded arrangement state"
+    );
+    assert!(
+        after_stats.eval_memo_entries <= before_stats.eval_memo_entries,
+        "failed recursion must not install partial evaluator memo entries"
+    );
+    assert!(
+        after_stats.eval_memo_bytes <= before_stats.eval_memo_bytes,
+        "failed recursion must not install partial evaluator memo bytes"
     );
     assert!(
         failed.recv().is_err(),

--- a/crates/groove/src/db/tests/subscriptions/mod.rs
+++ b/crates/groove/src/db/tests/subscriptions/mod.rs
@@ -342,6 +342,54 @@ async fn cancelling_cold_hydration_releases_completed_barriers() {
     );
 }
 
+/// Cancelling a parked hydration with multiple roots must not let its staged
+/// state reappear after the roots are garbage-collected.
+#[futures_test::test]
+async fn cancelled_parked_multi_root_hydration_drops_gc_state() {
+    let (storage, control) = TestStorage::controlled(&["albums", "artists"]);
+    let mut database = Database::new(albums_artists_schema(), storage.clone())
+        .await
+        .unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![
+            Value::U64(1),
+            Value::U64(1),
+            Value::String("cancelled album".to_owned()),
+        ],
+    );
+    batch.insert(
+        "artists",
+        vec![Value::U64(1), Value::String("cancelled artist".to_owned())],
+    );
+    database.commit_batch(batch).await.unwrap();
+
+    storage.evict_all();
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let subscription = database
+        .subscribe([
+            ("albums", GraphBuilder::table("albums")),
+            ("artists", GraphBuilder::table("artists")),
+        ])
+        .unwrap();
+    assert!(database.has_pending_progress());
+    assert!(database.unsubscribe(subscription.id()));
+
+    control.resume_operation(TestStorageOperation::ScanOpen);
+    for _ in 0..32 {
+        database.drive_ready_progress().await.unwrap();
+        if !database.has_pending_progress() {
+            break;
+        }
+    }
+    assert!(!database.has_pending_progress());
+    let stats = database.runtime_stats();
+    assert_eq!(stats.active_subscriptions, 0);
+    assert_eq!(stats.eval_memo_entries, 0);
+    assert_eq!(stats.graph_nodes, 0);
+}
+
 /// A large entirely resident graph is CPU work, not a storage wait. The direct
 /// async API owns and drains that resident continuation chain before returning;
 /// the owner-loop API instead yields bounded turns and wakes its owner. Both

--- a/crates/groove/src/ivm/runtime/evaluation_session.rs
+++ b/crates/groove/src/ivm/runtime/evaluation_session.rs
@@ -533,6 +533,11 @@ impl<'a> EvaluationRequests<'a> {
         !self.pending.is_empty()
     }
 
+    pub(super) fn retain(&mut self, retained: &HashSet<EvaluationRequestKey>) {
+        self.pending.retain(|key, _| retained.contains(key));
+        self.ready.retain(|key, _| retained.contains(key));
+    }
+
     pub(super) fn drain_ready(
         &mut self,
     ) -> Result<

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -1942,13 +1942,16 @@ impl TickEvaluator<'_> {
                     top_by_sort_key(output_desc, delta.raw(), top_by)?,
                     delta.record.clone(),
                 );
-                state.value_mut().groups.update(group_prefix.clone(), |group| {
-                    let weight = group.entry(order_key.clone()).or_default();
-                    *weight += delta.weight;
-                    if *weight == 0 {
-                        group.remove(&order_key);
-                    }
-                });
+                state
+                    .value_mut()
+                    .groups
+                    .update(group_prefix.clone(), |group| {
+                        let weight = group.entry(order_key.clone()).or_default();
+                        *weight += delta.weight;
+                        if *weight == 0 {
+                            group.remove(&order_key);
+                        }
+                    });
             }
         }
         state

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -17,7 +17,6 @@ fn plan_expr_fields(expressions: &[PlanExpr]) -> BTreeSet<String> {
         .collect()
 }
 use crate::storage::StorageFuture;
-use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 
 #[derive(Clone, Debug)]
@@ -45,58 +44,190 @@ struct PendingStreamingChecksum {
     output: Vec<RecordDelta>,
 }
 
+pub(super) type CollectByOrderKey = (Vec<TopBySortPart>, Bytes);
+pub(super) type CollectByGroup = BTreeMap<CollectByOrderKey, i64>;
+
+#[derive(Clone, Debug)]
+pub(super) struct CollectByGroups {
+    base: Rc<BTreeMap<Vec<u8>, CollectByGroup>>,
+    overlay: Rc<BTreeMap<Vec<u8>, Option<CollectByGroup>>>,
+    cleared: bool,
+}
+
+impl Default for CollectByGroups {
+    fn default() -> Self {
+        Self {
+            base: Rc::default(),
+            overlay: Rc::default(),
+            cleared: false,
+        }
+    }
+}
+
+impl CollectByGroups {
+    pub(super) fn get(&self, key: &[u8]) -> Option<&CollectByGroup> {
+        if let Some(group) = self.overlay.get(key) {
+            return group.as_ref();
+        }
+        (!self.cleared).then(|| self.base.get(key)).flatten()
+    }
+
+    pub(super) fn update(&mut self, key: Vec<u8>, update: impl FnOnce(&mut CollectByGroup)) {
+        let current = self.get(&key).cloned().unwrap_or_default();
+        let group = Rc::make_mut(&mut self.overlay)
+            .entry(key)
+            .or_insert(Some(current))
+            .as_mut()
+            .expect("group updates always install a present overlay");
+        update(group);
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.cleared = true;
+        Rc::make_mut(&mut self.overlay).clear();
+    }
+
+    pub(super) fn remove_empty_touched<I>(&mut self, groups: I)
+    where
+        I: IntoIterator<Item = Vec<u8>>,
+    {
+        let empty = groups
+            .into_iter()
+            .filter(|group| self.get(group).is_some_and(BTreeMap::is_empty))
+            .collect::<Vec<_>>();
+        let overlay = Rc::make_mut(&mut self.overlay);
+        for group in empty {
+            overlay.insert(group, None);
+        }
+    }
+
+    pub(super) fn keys_set(&self) -> BTreeSet<Vec<u8>> {
+        let mut keys = if self.cleared {
+            BTreeSet::new()
+        } else {
+            self.base.keys().cloned().collect()
+        };
+        for (key, group) in self.overlay.iter() {
+            if group.is_some() {
+                keys.insert(key.clone());
+            } else {
+                keys.remove(key);
+            }
+        }
+        keys
+    }
+
+    fn commit_overlay(&mut self) {
+        if self.overlay.is_empty() && !self.cleared {
+            return;
+        }
+        let overlay = std::mem::take(&mut self.overlay);
+        let overlay = Rc::try_unwrap(overlay).unwrap_or_else(|overlay| (*overlay).clone());
+        let base = Rc::make_mut(&mut self.base);
+        if self.cleared {
+            base.clear();
+            self.cleared = false;
+        }
+        for (key, group) in overlay {
+            match group {
+                Some(group) => {
+                    base.insert(key, group);
+                }
+                None => {
+                    base.remove(&key);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct CollectByRoots {
+    base: Rc<BTreeMap<CollectByOrderKey, i64>>,
+    overlay: Rc<BTreeMap<CollectByOrderKey, Option<i64>>>,
+    cleared: bool,
+}
+
+impl Default for CollectByRoots {
+    fn default() -> Self {
+        Self {
+            base: Rc::default(),
+            overlay: Rc::default(),
+            cleared: false,
+        }
+    }
+}
+
+impl CollectByRoots {
+    pub(super) fn get(&self, key: &CollectByOrderKey) -> Option<&i64> {
+        if let Some(weight) = self.overlay.get(key) {
+            return weight.as_ref();
+        }
+        (!self.cleared).then(|| self.base.get(key)).flatten()
+    }
+
+    pub(super) fn insert(&mut self, key: CollectByOrderKey, weight: i64) {
+        Rc::make_mut(&mut self.overlay).insert(key, Some(weight));
+    }
+
+    pub(super) fn remove(&mut self, key: &CollectByOrderKey) {
+        Rc::make_mut(&mut self.overlay).insert(key.clone(), None);
+    }
+
+    pub(super) fn count_positive_before(&self, key: &CollectByOrderKey) -> usize {
+        let mut keys = if self.cleared {
+            BTreeSet::new()
+        } else {
+            self.base.keys().cloned().collect()
+        };
+        keys.extend(self.overlay.keys().cloned());
+        keys.into_iter()
+            .filter(|candidate| candidate < key)
+            .filter(|candidate| self.get(candidate).is_some_and(|weight| *weight > 0))
+            .count()
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.cleared = true;
+        Rc::make_mut(&mut self.overlay).clear();
+    }
+
+    fn commit_overlay(&mut self) {
+        if self.overlay.is_empty() && !self.cleared {
+            return;
+        }
+        let overlay = std::mem::take(&mut self.overlay);
+        let overlay = Rc::try_unwrap(overlay).unwrap_or_else(|overlay| (*overlay).clone());
+        let base = Rc::make_mut(&mut self.base);
+        if self.cleared {
+            base.clear();
+            self.cleared = false;
+        }
+        for (key, weight) in overlay {
+            match weight {
+                Some(weight) => {
+                    base.insert(key, weight);
+                }
+                None => {
+                    base.remove(&key);
+                }
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub(super) struct CollectByIncrementalState {
-    payload: Rc<CollectByIncrementalPayload>,
-}
-
-#[derive(Clone, Debug, Default)]
-pub(super) struct CollectByIncrementalPayload {
     pub(super) groups: CollectByGroups,
-    pub(super) roots: BTreeMap<CollectByOrderKey, i64>,
+    pub(super) roots: CollectByRoots,
 }
 
-impl Deref for CollectByIncrementalState {
-    type Target = CollectByIncrementalPayload;
-
-    fn deref(&self) -> &Self::Target {
-        &self.payload
+impl CollectByIncrementalState {
+    pub(super) fn commit_overlay(&mut self) {
+        self.groups.commit_overlay();
+        self.roots.commit_overlay();
     }
 }
-
-impl DerefMut for CollectByIncrementalState {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        Rc::make_mut(&mut self.payload)
-    }
-}
-
-#[cfg(test)]
-mod collect_by_state_tests {
-    use super::*;
-
-    #[test]
-    fn collect_by_snapshot_clone_shares_group_base_until_touched_group_write() {
-        let mut original = CollectByIncrementalState::default();
-        original.groups.update(vec![1], |group| {
-            group.insert((Vec::new(), Bytes::from_static(b"one")), 1);
-        });
-        original.groups.update(vec![2], |group| {
-            group.insert((Vec::new(), Bytes::from_static(b"two")), 1);
-        });
-        let mut prepared = original.clone();
-        assert!(Rc::ptr_eq(&original.groups.base, &prepared.groups.base));
-
-        prepared.groups.update(vec![1], |group| {
-            group.insert((Vec::new(), Bytes::from_static(b"updated")), 1);
-        });
-        assert!(Rc::ptr_eq(&original.groups.base, &prepared.groups.base));
-        assert_eq!(original.groups.get(&[1]), prepared.groups.base.get(&[1]));
-        assert_ne!(original.groups.get(&[1]), prepared.groups.get(&[1]));
-    }
-}
-
-pub(super) type CollectByOrderKey = (Vec<TopBySortPart>, Bytes);
-type CollectByGroups = BTreeMap<Vec<u8>, BTreeMap<CollectByOrderKey, i64>>;
 
 #[derive(Clone, Debug, Default)]
 pub(super) struct TopByIncrementalState {
@@ -110,16 +241,63 @@ impl TopByIncrementalState {
     where
         I: IntoIterator<Item = Vec<u8>>,
     {
-        for group in groups {
-            if self.groups.get(&group).is_some_and(BTreeMap::is_empty) {
-                self.groups.remove(&group);
-            }
-        }
+        self.groups.remove_empty_touched(groups);
+    }
+
+    pub(super) fn commit_overlay(&mut self) {
+        self.groups.commit_overlay();
     }
 
     #[cfg(test)]
     pub(super) fn group_count(&self) -> usize {
-        self.groups.len()
+        self.groups.keys_set().len()
+    }
+}
+#[cfg(test)]
+mod collect_by_state_tests {
+    use super::*;
+
+    #[test]
+    fn collect_by_snapshot_clone_shares_group_base_until_touched_group_write() {
+        let mut original = CollectByIncrementalState::default();
+        original.groups.update(vec![1], |group| {
+            group.insert((Vec::new(), Bytes::from_static(b"one")), 1);
+        });
+        original.groups.update(vec![2], |group| {
+            group.insert((Vec::new(), Bytes::from_static(b"two")), 1);
+        });
+        original.groups.commit_overlay();
+
+        let mut prepared = original.clone();
+        assert!(Rc::ptr_eq(&original.groups.base, &prepared.groups.base));
+        prepared.groups.update(vec![1], |group| {
+            group.insert((Vec::new(), Bytes::from_static(b"updated")), 1);
+        });
+        assert!(Rc::ptr_eq(&original.groups.base, &prepared.groups.base));
+        assert_eq!(
+            original.groups.get(&[1u8]),
+            prepared.groups.base.get(&vec![1u8])
+        );
+        assert_ne!(original.groups.get(&[1u8]), prepared.groups.get(&[1u8]));
+    }
+    #[test]
+    fn top_by_snapshot_clone_shares_group_base_until_touched_group_write() {
+        let mut original = TopByIncrementalState::default();
+        original.groups.update(vec![1], |group| {
+            group.insert((Vec::new(), Bytes::from_static(b"one")), 1);
+        });
+        original.groups.update(vec![2], |group| {
+            group.insert((Vec::new(), Bytes::from_static(b"two")), 1);
+        });
+        original.groups.commit_overlay();
+
+        let mut prepared = original.clone();
+        assert!(Rc::ptr_eq(&original.groups.base, &prepared.groups.base));
+        prepared.groups.update(vec![1], |group| {
+            group.insert((Vec::new(), Bytes::from_static(b"updated")), 1);
+        });
+        assert!(Rc::ptr_eq(&original.groups.base, &prepared.groups.base));
+        assert_ne!(original.groups.get(&[1u8]), prepared.groups.get(&[1u8]));
     }
 }
 
@@ -1759,21 +1937,18 @@ impl TickEvaluator<'_> {
             state.value_mut().groups.clear();
         }
         for (group_prefix, group_deltas) in &touched_groups {
-            let group = state
-                .value_mut()
-                .groups
-                .entry(group_prefix.clone())
-                .or_default();
             for delta in group_deltas {
                 let order_key = (
                     top_by_sort_key(output_desc, delta.raw(), top_by)?,
                     delta.record.clone(),
                 );
-                let weight = group.entry(order_key.clone()).or_default();
-                *weight += delta.weight;
-                if *weight == 0 {
-                    group.remove(&order_key);
-                }
+                state.value_mut().groups.update(group_prefix.clone(), |group| {
+                    let weight = group.entry(order_key.clone()).or_default();
+                    *weight += delta.weight;
+                    if *weight == 0 {
+                        group.remove(&order_key);
+                    }
+                });
             }
         }
         state

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -75,13 +75,23 @@ mod collect_by_state_tests {
     use super::*;
 
     #[test]
-    fn collect_by_snapshot_clone_shares_payload_until_first_write() {
-        let original = CollectByIncrementalState::default();
+    fn collect_by_snapshot_clone_shares_group_base_until_touched_group_write() {
+        let mut original = CollectByIncrementalState::default();
+        original.groups.update(vec![1], |group| {
+            group.insert((Vec::new(), Bytes::from_static(b"one")), 1);
+        });
+        original.groups.update(vec![2], |group| {
+            group.insert((Vec::new(), Bytes::from_static(b"two")), 1);
+        });
         let mut prepared = original.clone();
-        assert!(Rc::ptr_eq(&original.payload, &prepared.payload));
+        assert!(Rc::ptr_eq(&original.groups.base, &prepared.groups.base));
 
-        prepared.groups.clear();
-        assert!(!Rc::ptr_eq(&original.payload, &prepared.payload));
+        prepared.groups.update(vec![1], |group| {
+            group.insert((Vec::new(), Bytes::from_static(b"updated")), 1);
+        });
+        assert!(Rc::ptr_eq(&original.groups.base, &prepared.groups.base));
+        assert_eq!(original.groups.get(&[1]), prepared.groups.base.get(&[1]));
+        assert_ne!(original.groups.get(&[1]), prepared.groups.get(&[1]));
     }
 }
 

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -47,21 +47,11 @@ struct PendingStreamingChecksum {
 pub(super) type CollectByOrderKey = (Vec<TopBySortPart>, Bytes);
 pub(super) type CollectByGroup = BTreeMap<CollectByOrderKey, i64>;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(super) struct CollectByGroups {
     base: Rc<BTreeMap<Vec<u8>, CollectByGroup>>,
     overlay: Rc<BTreeMap<Vec<u8>, Option<CollectByGroup>>>,
     cleared: bool,
-}
-
-impl Default for CollectByGroups {
-    fn default() -> Self {
-        Self {
-            base: Rc::default(),
-            overlay: Rc::default(),
-            cleared: false,
-        }
-    }
 }
 
 impl CollectByGroups {
@@ -141,21 +131,11 @@ impl CollectByGroups {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(super) struct CollectByRoots {
     base: Rc<BTreeMap<CollectByOrderKey, i64>>,
     overlay: Rc<BTreeMap<CollectByOrderKey, Option<i64>>>,
     cleared: bool,
-}
-
-impl Default for CollectByRoots {
-    fn default() -> Self {
-        Self {
-            base: Rc::default(),
-            overlay: Rc::default(),
-            cleared: false,
-        }
-    }
 }
 
 impl CollectByRoots {

--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -470,28 +470,6 @@ impl AntiJoinState {
 }
 
 impl ArrangementState {
-    /// Fold only the touched buckets into the shared base at tick commit.
-    /// Callers drop the previous live arrangement before invoking this method,
-    /// making both COW maps uniquely owned in the common path.
-    pub(super) fn commit_overlay(&mut self) {
-        if self.overlay.is_empty() {
-            return;
-        }
-        let overlay = std::mem::take(&mut self.overlay);
-        let overlay = Rc::try_unwrap(overlay).unwrap_or_else(|overlay| (*overlay).clone());
-        let index = Rc::make_mut(&mut self.index);
-        for (key, bucket) in overlay {
-            match bucket {
-                Some(bucket) => {
-                    index.insert(key, bucket);
-                }
-                None => {
-                    index.remove(&key);
-                }
-            }
-        }
-    }
-
     pub(super) fn clone_keys<'a>(&self, keys: impl IntoIterator<Item = &'a Vec<u8>>) -> Self {
         let mut index = HashMap::default();
         for key in keys {

--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -43,13 +43,32 @@ pub(super) fn touched_join_keys(
 pub(super) struct JoinState;
 
 #[derive(Clone, Debug, Default)]
-pub(super) struct AntiJoinState;
+pub(super) struct ArrangementState {
+    /// Immutable base buckets are shared between evaluator snapshots. Updates
+    /// retain only touched buckets in the overlay, rather than cloning the
+    /// complete join index.
+    index: Rc<JoinIndex>,
+    overlay: Rc<HashMap<JoinKey, Option<JoinBucket>>>,
+}
 
 #[derive(Clone, Debug, Default)]
-pub(super) struct ArrangementState {
-    /// key -> record multiset. Records are kept as encoded bytes so probing can
-    /// build output records without rehydrating whole tables.
-    index: Rc<JoinIndex>,
+pub(super) struct AntiJoinState;
+
+enum JoinLookup<'a> {
+    Arrangement(&'a ArrangementState),
+    Index(&'a JoinIndex),
+}
+
+impl JoinLookup<'_> {
+    fn bucket(&self, key: &JoinKey) -> Option<&JoinBucket> {
+        match self {
+            Self::Arrangement(arrangement) => match arrangement.overlay.get(key) {
+                Some(bucket) => bucket.as_ref(),
+                None => arrangement.index.get(key),
+            },
+            Self::Index(index) => index.get(key),
+        }
+    }
 }
 
 impl JoinState {
@@ -169,7 +188,7 @@ impl JoinState {
                 &mut output,
                 &context,
                 &keyed_left_delta,
-                &right_arrangement.value().index,
+                &JoinLookup::Arrangement(right_arrangement.value()),
                 JoinProbeSide::LeftDelta,
                 1,
             )?;
@@ -190,7 +209,7 @@ impl JoinState {
             &mut output,
             &context,
             &keyed_left_delta,
-            &right_arrangement.value().index,
+            &JoinLookup::Arrangement(right_arrangement.value()),
             JoinProbeSide::LeftDelta,
             1,
         )?;
@@ -198,7 +217,7 @@ impl JoinState {
             &mut output,
             &context,
             &keyed_right_delta,
-            &left_arrangement.value().index,
+            &JoinLookup::Arrangement(left_arrangement.value()),
             JoinProbeSide::RightDelta,
             1,
         )?;
@@ -210,7 +229,7 @@ impl JoinState {
             &mut output,
             &context,
             &keyed_right_delta,
-            &left_delta_index,
+            &JoinLookup::Index(&left_delta_index),
             JoinProbeSide::RightDelta,
             -1,
         )?;
@@ -455,43 +474,50 @@ impl ArrangementState {
         let mut index = HashMap::default();
         for key in keys {
             let key = JoinKey::from_slice(key);
-            if let Some(bucket) = self.index.get(&key) {
+            if let Some(bucket) = self.bucket(&key) {
                 index.insert(key, bucket.clone());
             }
         }
         Self {
             index: Rc::new(index),
+            overlay: Rc::default(),
         }
     }
 
     pub(super) fn replace_keys<'a>(
         &mut self,
         keys: impl IntoIterator<Item = &'a Vec<u8>>,
-        mut replacement: Self,
+        replacement: Self,
     ) {
+        let overlay = Rc::make_mut(&mut self.overlay);
         for key in keys {
             let key = JoinKey::from_slice(key);
-            if let Some(bucket) = Rc::make_mut(&mut replacement.index).remove(&key) {
-                Rc::make_mut(&mut self.index).insert(key, bucket);
-            } else {
-                Rc::make_mut(&mut self.index).remove(&key);
-            }
+            overlay.insert(key.clone(), replacement.bucket(&key).cloned());
         }
     }
 
     pub(super) fn row_count(&self) -> usize {
-        self.index
-            .values()
+        let mut keys = self.index.keys().cloned().collect::<HashSet<_>>();
+        keys.extend(self.overlay.keys().cloned());
+        keys.into_iter()
+            .filter_map(|key| self.bucket(&key))
             .map(|bucket| bucket.values().filter(|weight| **weight != 0).count())
             .sum()
     }
 
     pub(super) fn encoded_bytes(&self) -> usize {
-        self.index
-            .iter()
-            .map(|(key, bucket)| {
-                key.len() + bucket.keys().map(|record| record.len()).sum::<usize>()
+        let mut keys = self.index.keys().cloned().collect::<HashSet<_>>();
+        keys.extend(self.overlay.keys().cloned());
+        keys.into_iter()
+            .filter_map(|key| {
+                self.bucket(&key).map(|bucket| {
+                    (
+                        key.len(),
+                        bucket.keys().map(|record| record.len()).sum::<usize>(),
+                    )
+                })
             })
+            .map(|(key_len, record_bytes)| key_len + record_bytes)
             .sum()
     }
 
@@ -502,23 +528,43 @@ impl ArrangementState {
     ) {
         match update_mode {
             ArrangementUpdateMode::Accumulate => {
-                apply_join_delta_to_index(Rc::make_mut(&mut self.index), deltas);
+                let mut buckets = HashMap::<JoinKey, JoinBucket>::default();
+                for delta in deltas {
+                    let bucket = buckets
+                        .entry(delta.key.clone())
+                        .or_insert_with(|| self.bucket(&delta.key).cloned().unwrap_or_default());
+                    let next_weight = bucket.get(&delta.delta.record).copied().unwrap_or_default()
+                        + delta.delta.weight;
+                    if next_weight == 0 {
+                        bucket.remove(&delta.delta.record);
+                    } else {
+                        bucket.insert(delta.delta.record.clone(), next_weight);
+                    }
+                }
+                let overlay = Rc::make_mut(&mut self.overlay);
+                for (key, bucket) in buckets {
+                    overlay.insert(key, (!bucket.is_empty()).then_some(bucket));
+                }
             }
             ArrangementUpdateMode::Replace => {
                 self.index = Rc::new(build_join_delta_index(deltas));
+                self.overlay = Rc::default();
             }
         }
     }
 
     fn key_count(&self, key: &[u8]) -> i64 {
-        self.index
-            .get(key)
+        self.bucket(key)
             .map(|bucket| bucket.values().sum())
             .unwrap_or_default()
     }
 
     fn bucket(&self, key: &[u8]) -> Option<&JoinBucket> {
-        self.index.get(key)
+        let key = JoinKey::from_slice(key);
+        match self.overlay.get(&key) {
+            Some(bucket) => bucket.as_ref(),
+            None => self.index.get(&key),
+        }
     }
 
     pub(super) fn apply_record_deltas(
@@ -534,8 +580,7 @@ impl ArrangementState {
     }
 
     pub(super) fn records_for_key(&self, key: &[u8]) -> Vec<(Bytes, i64)> {
-        self.index
-            .get(key)
+        self.bucket(key)
             .into_iter()
             .flat_map(|bucket| bucket.iter())
             .filter_map(|(record, weight)| (*weight > 0).then_some((record.clone(), *weight)))
@@ -600,16 +645,11 @@ struct JoinChangeContext<'a> {
 struct JoinOutputBuffer {
     /// All encoded joined rows, stored one after another.
     bytes: BytesMut,
+    deltas: Vec<(Range<usize>, i64)>,
     /// Where each row is inside `bytes`, together with its weight.
     ///
     /// For example, `(0..20, 1)` means “the row in bytes `0..20` has weight
     /// `+1`.”
-    deltas: Vec<(Range<usize>, i64)>,
-    /// Temporary work area for fields such as strings, bytes, and arrays.
-    ///
-    /// Each item stores which input row owns the field (`0` for left, `1` for
-    /// right) and where the field's bytes are in that row. The encoder clears
-    /// and reuses this vector for every joined row.
     variable_scratch: Vec<(usize, Range<usize>)>,
 }
 
@@ -627,7 +667,7 @@ fn append_join_deltas(
     output: &mut JoinOutputBuffer,
     context: &JoinChangeContext<'_>,
     delta_records: &[KeyedRecordDelta<'_>],
-    stored: &JoinIndex,
+    stored: &JoinLookup<'_>,
     side: JoinProbeSide,
     sign: i64,
 ) -> Result<(), IvmRuntimeError> {
@@ -635,7 +675,7 @@ fn append_join_deltas(
         if delta.delta.weight == 0 {
             continue;
         }
-        let Some(bucket) = stored.get(&delta.key) else {
+        let Some(bucket) = stored.bucket(&delta.key) else {
             continue;
         };
         for (stored_record, right_weight) in bucket {
@@ -1087,6 +1127,7 @@ mod tests {
         index.insert(JoinKey::from_slice(b"one"), bucket);
         let original = ArrangementState {
             index: Rc::new(index),
+            overlay: Rc::default(),
         };
 
         let mut prepared = original.clone();
@@ -1097,8 +1138,10 @@ mod tests {
 
         let mut second_bucket = HashMap::default();
         second_bucket.insert(Bytes::from_static(b"row-two"), 1);
-        Rc::make_mut(&mut prepared.index).insert(JoinKey::from_slice(b"two"), second_bucket);
-        assert!(!Rc::ptr_eq(&original.index, &prepared.index));
+        Rc::make_mut(&mut prepared.overlay)
+            .insert(JoinKey::from_slice(b"two"), Some(second_bucket));
+        assert!(Rc::ptr_eq(&original.index, &prepared.index));
+        assert!(!Rc::ptr_eq(&original.overlay, &prepared.overlay));
         assert_eq!(original.row_count(), 1);
         assert_eq!(prepared.row_count(), 2);
     }

--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -496,6 +496,25 @@ impl ArrangementState {
         }
     }
 
+    pub(super) fn commit_overlay(&mut self) {
+        if self.overlay.is_empty() {
+            return;
+        }
+        let overlay = std::mem::take(&mut self.overlay);
+        let overlay = Rc::try_unwrap(overlay).unwrap_or_else(|overlay| (*overlay).clone());
+        let index = Rc::make_mut(&mut self.index);
+        for (key, bucket) in overlay {
+            match bucket {
+                Some(bucket) => {
+                    index.insert(key, bucket);
+                }
+                None => {
+                    index.remove(&key);
+                }
+            }
+        }
+    }
+
     pub(super) fn row_count(&self) -> usize {
         let mut keys = self.index.keys().cloned().collect::<HashSet<_>>();
         keys.extend(self.overlay.keys().cloned());

--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -470,6 +470,28 @@ impl AntiJoinState {
 }
 
 impl ArrangementState {
+    /// Fold only the touched buckets into the shared base at tick commit.
+    /// Callers drop the previous live arrangement before invoking this method,
+    /// making both COW maps uniquely owned in the common path.
+    pub(super) fn commit_overlay(&mut self) {
+        if self.overlay.is_empty() {
+            return;
+        }
+        let overlay = std::mem::take(&mut self.overlay);
+        let overlay = Rc::try_unwrap(overlay).unwrap_or_else(|overlay| (*overlay).clone());
+        let index = Rc::make_mut(&mut self.index);
+        for (key, bucket) in overlay {
+            match bucket {
+                Some(bucket) => {
+                    index.insert(key, bucket);
+                }
+                None => {
+                    index.remove(&key);
+                }
+            }
+        }
+    }
+
     pub(super) fn clone_keys<'a>(&self, keys: impl IntoIterator<Item = &'a Vec<u8>>) -> Self {
         let mut index = HashMap::default();
         for key in keys {

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -21,7 +21,7 @@ use super::{
     ArrangementUpdateMode, AsOf, EvalContext, GraphRuntimeView, IvmRuntimeError, NodeState,
     RecordDelta, RecordDeltas, ScopeId, StaticScanBounds, SubTick, TableDelta, VariantProjection,
     VariantProjectionKey, consolidate_deltas, plan_expr_names, project_binding_source_deltas,
-    scan_bounds,
+    scan_bounds, touched_join_keys,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -607,15 +607,20 @@ pub(super) async fn recursive_delta(
     emitted.extend(seed_frontier.clone());
 
     let mut frontier = if has_table_delta {
-        // Table-side positive deltas must probe the existing recursive closure
-        // as well as any newly accepted seed rows. Step arrangements usually
-        // provide that old closure, but maintained routed graphs can have
-        // sibling recursive nodes whose arrangements are not populated on this
-        // exact path. Feeding the accumulated set is conservative: duplicate
-        // derivations are filtered by `accept_positive`.
+        // A changed table can extend paths which end at the changed row's
+        // join key. Select only those already-known paths; replaying every
+        // accumulated fact would turn an isolated edge into a full closure
+        // recomputation.
+        let mut deltas = seed_frontier.clone();
+        deltas.extend(affected_recursive_frontier(
+            &runtime,
+            recursive,
+            &recursive_state.accumulated_deltas(),
+            step,
+        )?);
         RecordDeltas {
             descriptor: output_desc,
-            deltas: recursive_state.accumulated_deltas(),
+            deltas: consolidate_deltas(deltas),
         }
     } else {
         RecordDeltas {
@@ -656,6 +661,174 @@ pub(super) async fn recursive_delta(
     }
 
     Ok(RecursiveDeltaProgress::Ready(consolidate_deltas(emitted)))
+}
+fn affected_recursive_frontier(
+    runtime: &GraphRuntimeView<'_>,
+    recursive: &RecursiveOp,
+    accumulated: &[RecordDelta],
+    step: NodeId,
+) -> Result<Vec<RecordDelta>, IvmRuntimeError> {
+    let mut selected = HashSet::<Bytes>::default();
+    let mut pending = vec![step];
+    let mut seen = HashSet::default();
+    while let Some(node) = pending.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        let graph_node = runtime
+            .graph
+            .node(node)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+        match &graph_node.descriptor.operator {
+            OpType::Join(join) => {
+                let [left, right] = graph_node.descriptor.inputs.as_slice() else {
+                    return Err(IvmRuntimeError::GraphInputArityMismatch(node));
+                };
+                let left_frontier = contains_frontier(runtime.graph, *left, &recursive.frontier)?;
+                let right_frontier = contains_frontier(runtime.graph, *right, &recursive.frontier)?;
+                if left_frontier != right_frontier {
+                    let (changed_input, changed_fields, frontier_fields, frontier_desc) =
+                        if left_frontier
+                            && contains_changed_table(runtime.graph, *right, runtime.table_deltas)?
+                        {
+                            (
+                                *right,
+                                plan_expr_names(&join.right_key),
+                                plan_expr_names(&join.left_key),
+                                join.left_descriptor,
+                            )
+                        } else if right_frontier
+                            && contains_changed_table(runtime.graph, *left, runtime.table_deltas)?
+                        {
+                            (
+                                *left,
+                                plan_expr_names(&join.left_key),
+                                plan_expr_names(&join.right_key),
+                                join.right_descriptor,
+                            )
+                        } else {
+                            pending.extend([*left, *right]);
+                            continue;
+                        };
+                    let mut touched = HashSet::<Vec<u8>>::default();
+                    collect_changed_join_keys(
+                        runtime.graph,
+                        changed_input,
+                        runtime.table_deltas,
+                        &changed_fields,
+                        join.comparison,
+                        &mut touched,
+                    )?;
+                    for delta in accumulated {
+                        for key in
+                            super::join::join_keys(&frontier_desc, delta.raw(), &frontier_fields)?
+                        {
+                            if touched.contains(key.as_slice()) {
+                                selected.insert(delta.record.clone());
+                                break;
+                            }
+                        }
+                    }
+                }
+                pending.extend([*left, *right]);
+            }
+            _ => pending.extend(graph_node.descriptor.inputs.iter().copied()),
+        }
+    }
+    Ok(selected
+        .into_iter()
+        .map(|record| RecordDelta { record, weight: 1 })
+        .collect())
+}
+
+fn contains_frontier(
+    graph: &IvmGraph,
+    root: NodeId,
+    binding: &super::FrontierName,
+) -> Result<bool, IvmRuntimeError> {
+    let mut pending = vec![root];
+    let mut seen = HashSet::default();
+    while let Some(node) = pending.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        let graph_node = graph
+            .node(node)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+        if matches!(
+            &graph_node.descriptor.operator,
+            OpType::FrontierSource(source) if source.binding == *binding
+        ) {
+            return Ok(true);
+        }
+        pending.extend(graph_node.descriptor.inputs.iter().copied());
+    }
+    Ok(false)
+}
+
+fn contains_changed_table(
+    graph: &IvmGraph,
+    root: NodeId,
+    table_deltas: &[TableDelta],
+) -> Result<bool, IvmRuntimeError> {
+    let changed = table_deltas
+        .iter()
+        .filter(|delta| !delta.deltas.is_empty())
+        .map(|delta| delta.table.as_str())
+        .collect::<HashSet<_>>();
+    let mut pending = vec![root];
+    let mut seen = HashSet::default();
+    while let Some(node) = pending.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        let graph_node = graph
+            .node(node)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+        if matches!(
+            &graph_node.descriptor.operator,
+            OpType::TableSource(source) if changed.contains(source.table.as_str())
+        ) {
+            return Ok(true);
+        }
+        pending.extend(graph_node.descriptor.inputs.iter().copied());
+    }
+    Ok(false)
+}
+
+fn collect_changed_join_keys(
+    graph: &IvmGraph,
+    root: NodeId,
+    table_deltas: &[TableDelta],
+    fields: &[String],
+    comparison: crate::ivm::ValueComparison,
+    keys: &mut HashSet<Vec<u8>>,
+) -> Result<(), IvmRuntimeError> {
+    let mut pending = vec![root];
+    let mut seen = HashSet::default();
+    while let Some(node) = pending.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        let graph_node = graph
+            .node(node)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+        if let OpType::TableSource(source) = &graph_node.descriptor.operator {
+            for delta in table_deltas
+                .iter()
+                .filter(|delta| delta.table == source.table && !delta.deltas.is_empty())
+            {
+                keys.extend(touched_join_keys(
+                    &delta.descriptor,
+                    fields,
+                    &delta.deltas,
+                    comparison,
+                )?);
+            }
+        }
+        pending.extend(graph_node.descriptor.inputs.iter().copied());
+    }
+    Ok(())
 }
 
 fn has_table_delta_for_cached_tables(

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -21,7 +21,7 @@ use super::{
     ArrangementUpdateMode, AsOf, EvalContext, GraphRuntimeView, IvmRuntimeError, NodeState,
     RecordDelta, RecordDeltas, ScopeId, StaticScanBounds, SubTick, TableDelta, VariantProjection,
     VariantProjectionKey, consolidate_deltas, plan_expr_names, project_binding_source_deltas,
-    scan_bounds, touched_join_keys,
+    scan_bounds,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -31,6 +31,10 @@ pub(super) struct RecursiveState {
     /// at weight 1. Bag recursion can diverge on cycles, and non-monotone
     /// recursion needs a DRed/DBSP design before we accept negative frontiers.
     accumulated: Rc<HashMap<Bytes, i64>>,
+    /// Positive additions are staged until the owning tick reaches Ready.
+    /// The pending map is deliberately separate from `accumulated`: a
+    /// prepared tick shares the latter with the committed runtime state.
+    staged_positive: Rc<HashMap<Bytes, i64>>,
     /// Positive incremental ticks rely on step-side arrangements already
     /// containing the full base/accumulated state after a recompute.
     step_arrangements_hydrated: bool,
@@ -227,6 +231,7 @@ impl RecursiveState {
             .collect()
     }
 
+    #[cfg(test)]
     fn accept_positive(
         &mut self,
         deltas: Vec<RecordDelta>,
@@ -250,6 +255,41 @@ impl RecursiveState {
             });
         }
         Ok(consolidate_deltas(accepted))
+    }
+
+    fn accept_positive_staged(
+        &mut self,
+        deltas: Vec<RecordDelta>,
+    ) -> Result<Vec<RecordDelta>, IvmRuntimeError> {
+        reject_non_positive_frontier_deltas(&deltas)?;
+        let mut accepted = Vec::new();
+        let staged = Rc::make_mut(&mut self.staged_positive);
+        for delta in consolidate_deltas(deltas) {
+            if delta.weight <= 0 {
+                return Err(IvmRuntimeError::UnsupportedNonMonotoneRecursion);
+            }
+            if self.accumulated.contains_key(&delta.record) || staged.contains_key(&delta.record) {
+                continue;
+            }
+            staged.insert(delta.record.clone(), 1);
+            accepted.push(RecordDelta {
+                record: delta.record,
+                weight: 1,
+            });
+        }
+        Ok(consolidate_deltas(accepted))
+    }
+
+    /// Install staged positive facts after the committed operator entry has
+    /// been removed. At that point the COW map is uniquely owned, so folding
+    /// only the new facts does not copy the complete closure.
+    pub(super) fn commit_staged_positive(&mut self) {
+        if self.staged_positive.is_empty() {
+            return;
+        }
+        let staged = std::mem::take(&mut self.staged_positive);
+        let staged = Rc::try_unwrap(staged).unwrap_or_else(|staged| (*staged).clone());
+        Rc::make_mut(&mut self.accumulated).extend(staged);
     }
 
     pub(super) fn replace_with(&mut self, next: HashMap<Bytes, i64>) -> Vec<RecordDelta> {
@@ -276,6 +316,7 @@ impl RecursiveState {
         self.accumulated = Rc::new(next);
         self.step_arrangements_hydrated = false;
         self.pending_hydration = None;
+        self.staged_positive = Rc::default();
         consolidate_deltas(deltas)
     }
 }
@@ -497,7 +538,6 @@ pub(super) async fn recursive_delta(
     step: NodeId,
 ) -> Result<RecursiveDeltaProgress, IvmRuntimeError> {
     let has_recompute_table_delta = has_recompute_table_delta_for_recursion(&runtime, seed, step)?;
-    let has_table_delta = has_table_delta_for_cached_tables(&runtime, recursive);
     let has_recompute_binding_delta =
         has_recompute_binding_delta_for_recursion(&runtime, seed, step)?;
     let has_binding_deltas = !runtime.binding_deltas.is_empty();
@@ -513,7 +553,7 @@ pub(super) async fn recursive_delta(
         }
         if std::env::var_os("JAZZ_CLOSURE_TRACE").is_some() {
             eprintln!(
-                "CLOSURE_TRACE event=recursive_recompute node={node:?} scope={:?} has_recompute_table_delta={has_recompute_table_delta} has_table_delta={has_table_delta} has_recompute_binding_delta={has_recompute_binding_delta} has_binding_deltas={has_binding_deltas} state_empty={} step_hydrated={} total_recomputes={}",
+                "CLOSURE_TRACE event=recursive_recompute node={node:?} scope={:?} has_recompute_table_delta={has_recompute_table_delta} has_recompute_binding_delta={has_recompute_binding_delta} has_binding_deltas={has_binding_deltas} state_empty={} step_hydrated={} total_recomputes={}",
                 runtime.scope,
                 recursive_state.is_empty(),
                 recursive_state.step_arrangements_hydrated(),
@@ -595,10 +635,10 @@ pub(super) async fn recursive_delta(
     if seed_delta.descriptor != output_desc {
         return Err(IvmRuntimeError::GraphOutputMismatch);
     }
-    let seed_frontier = recursive_state.accept_positive(seed_delta.deltas)?;
+    let seed_frontier = recursive_state.accept_positive_staged(seed_delta.deltas)?;
     if std::env::var_os("JAZZ_CLOSURE_TRACE").is_some() {
         eprintln!(
-            "CLOSURE_TRACE event=recursive_positive node={node:?} scope={:?} seed_delta={} seed_frontier={} has_table_delta={has_table_delta} has_binding_deltas={has_binding_deltas}",
+            "CLOSURE_TRACE event=recursive_positive node={node:?} scope={:?} seed_delta={} seed_frontier={} has_binding_deltas={has_binding_deltas}",
             runtime.scope,
             seed_delta_count,
             seed_frontier.len(),
@@ -606,27 +646,12 @@ pub(super) async fn recursive_delta(
     }
     emitted.extend(seed_frontier.clone());
 
-    let mut frontier = if has_table_delta {
-        // A changed table can extend paths which end at the changed row's
-        // join key. Select only those already-known paths; replaying every
-        // accumulated fact would turn an isolated edge into a full closure
-        // recomputation.
-        let mut deltas = seed_frontier.clone();
-        deltas.extend(affected_recursive_frontier(
-            &runtime,
-            recursive,
-            &recursive_state.accumulated_deltas(),
-            step,
-        )?);
-        RecordDeltas {
-            descriptor: output_desc,
-            deltas: consolidate_deltas(deltas),
-        }
-    } else {
-        RecordDeltas {
-            descriptor: output_desc,
-            deltas: seed_frontier,
-        }
+    // Always run the step once with the actual seed frontier. Its child graph
+    // owns table transforms (filters/projects/renames), so deriving a frontier
+    // by inspecting raw table deltas is both incomplete and descriptor-unsafe.
+    let mut frontier = RecordDeltas {
+        descriptor: output_desc,
+        deltas: seed_frontier,
     };
     let mut sub_tick = 1;
     let mut must_run_step = true;
@@ -648,7 +673,7 @@ pub(super) async fn recursive_delta(
         if step_delta.descriptor != output_desc {
             return Err(IvmRuntimeError::GraphOutputMismatch);
         }
-        let accepted = recursive_state.accept_positive(step_delta.deltas)?;
+        let accepted = recursive_state.accept_positive_staged(step_delta.deltas)?;
         if accepted.is_empty() {
             break;
         }
@@ -661,184 +686,6 @@ pub(super) async fn recursive_delta(
     }
 
     Ok(RecursiveDeltaProgress::Ready(consolidate_deltas(emitted)))
-}
-fn affected_recursive_frontier(
-    runtime: &GraphRuntimeView<'_>,
-    recursive: &RecursiveOp,
-    accumulated: &[RecordDelta],
-    step: NodeId,
-) -> Result<Vec<RecordDelta>, IvmRuntimeError> {
-    let mut selected = HashSet::<Bytes>::default();
-    let mut pending = vec![step];
-    let mut seen = HashSet::default();
-    while let Some(node) = pending.pop() {
-        if !seen.insert(node) {
-            continue;
-        }
-        let graph_node = runtime
-            .graph
-            .node(node)
-            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
-        match &graph_node.descriptor.operator {
-            OpType::Join(join) => {
-                let [left, right] = graph_node.descriptor.inputs.as_slice() else {
-                    return Err(IvmRuntimeError::GraphInputArityMismatch(node));
-                };
-                let left_frontier = contains_frontier(runtime.graph, *left, &recursive.frontier)?;
-                let right_frontier = contains_frontier(runtime.graph, *right, &recursive.frontier)?;
-                if left_frontier != right_frontier {
-                    let (changed_input, changed_fields, frontier_fields, frontier_desc) =
-                        if left_frontier
-                            && contains_changed_table(runtime.graph, *right, runtime.table_deltas)?
-                        {
-                            (
-                                *right,
-                                plan_expr_names(&join.right_key),
-                                plan_expr_names(&join.left_key),
-                                join.left_descriptor,
-                            )
-                        } else if right_frontier
-                            && contains_changed_table(runtime.graph, *left, runtime.table_deltas)?
-                        {
-                            (
-                                *left,
-                                plan_expr_names(&join.left_key),
-                                plan_expr_names(&join.right_key),
-                                join.right_descriptor,
-                            )
-                        } else {
-                            pending.extend([*left, *right]);
-                            continue;
-                        };
-                    let mut touched = HashSet::<Vec<u8>>::default();
-                    collect_changed_join_keys(
-                        runtime.graph,
-                        changed_input,
-                        runtime.table_deltas,
-                        &changed_fields,
-                        join.comparison,
-                        &mut touched,
-                    )?;
-                    for delta in accumulated {
-                        for key in
-                            super::join::join_keys(&frontier_desc, delta.raw(), &frontier_fields)?
-                        {
-                            if touched.contains(key.as_slice()) {
-                                selected.insert(delta.record.clone());
-                                break;
-                            }
-                        }
-                    }
-                }
-                pending.extend([*left, *right]);
-            }
-            _ => pending.extend(graph_node.descriptor.inputs.iter().copied()),
-        }
-    }
-    Ok(selected
-        .into_iter()
-        .map(|record| RecordDelta { record, weight: 1 })
-        .collect())
-}
-
-fn contains_frontier(
-    graph: &IvmGraph,
-    root: NodeId,
-    binding: &super::FrontierName,
-) -> Result<bool, IvmRuntimeError> {
-    let mut pending = vec![root];
-    let mut seen = HashSet::default();
-    while let Some(node) = pending.pop() {
-        if !seen.insert(node) {
-            continue;
-        }
-        let graph_node = graph
-            .node(node)
-            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
-        if matches!(
-            &graph_node.descriptor.operator,
-            OpType::FrontierSource(source) if source.binding == *binding
-        ) {
-            return Ok(true);
-        }
-        pending.extend(graph_node.descriptor.inputs.iter().copied());
-    }
-    Ok(false)
-}
-
-fn contains_changed_table(
-    graph: &IvmGraph,
-    root: NodeId,
-    table_deltas: &[TableDelta],
-) -> Result<bool, IvmRuntimeError> {
-    let changed = table_deltas
-        .iter()
-        .filter(|delta| !delta.deltas.is_empty())
-        .map(|delta| delta.table.as_str())
-        .collect::<HashSet<_>>();
-    let mut pending = vec![root];
-    let mut seen = HashSet::default();
-    while let Some(node) = pending.pop() {
-        if !seen.insert(node) {
-            continue;
-        }
-        let graph_node = graph
-            .node(node)
-            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
-        if matches!(
-            &graph_node.descriptor.operator,
-            OpType::TableSource(source) if changed.contains(source.table.as_str())
-        ) {
-            return Ok(true);
-        }
-        pending.extend(graph_node.descriptor.inputs.iter().copied());
-    }
-    Ok(false)
-}
-
-fn collect_changed_join_keys(
-    graph: &IvmGraph,
-    root: NodeId,
-    table_deltas: &[TableDelta],
-    fields: &[String],
-    comparison: crate::ivm::ValueComparison,
-    keys: &mut HashSet<Vec<u8>>,
-) -> Result<(), IvmRuntimeError> {
-    let mut pending = vec![root];
-    let mut seen = HashSet::default();
-    while let Some(node) = pending.pop() {
-        if !seen.insert(node) {
-            continue;
-        }
-        let graph_node = graph
-            .node(node)
-            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
-        if let OpType::TableSource(source) = &graph_node.descriptor.operator {
-            for delta in table_deltas
-                .iter()
-                .filter(|delta| delta.table == source.table && !delta.deltas.is_empty())
-            {
-                keys.extend(touched_join_keys(
-                    &delta.descriptor,
-                    fields,
-                    &delta.deltas,
-                    comparison,
-                )?);
-            }
-        }
-        pending.extend(graph_node.descriptor.inputs.iter().copied());
-    }
-    Ok(())
-}
-
-fn has_table_delta_for_cached_tables(
-    runtime: &GraphRuntimeView<'_>,
-    recursive: &RecursiveOp,
-) -> bool {
-    runtime
-        .table_deltas
-        .iter()
-        .any(|table_delta| recursive.read_tables.contains(&table_delta.table))
 }
 
 fn has_recompute_table_delta_for_recursion(

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -639,36 +639,46 @@ impl IncrementalEvaluation<'_> {
             .operator_states
             .retain(|key, _| !self.relevant_nodes.contains(&key.node));
         for state in self.operator_states.values_mut() {
-            if let OperatorState::Recursive(recursive) = state {
-                recursive.value_mut().commit_staged_positive();
+            match state {
+                OperatorState::Recursive(recursive) => {
+                    recursive.value_mut().commit_staged_positive();
+                }
+                OperatorState::TopBy(top_by) => {
+                    top_by.value_mut().commit_overlay();
+                }
+                OperatorState::CollectBy(collect_by) => {
+                    collect_by.commit_overlay();
+                }
+                _ => {}
             }
         }
         runtime
             .operator_states
-            .extend(std::mem::take(&mut self.operator_states));
-
+            .extend(std::mem::take(&mut self.operator_states).into_iter().filter(
+                |(key, _)| runtime.graph.node(key.node).is_some(),
+            ));
         runtime
             .arrangement_states
-            .retain(|key, _| !self.relevant_nodes.contains(&key.input));
-        for state in self.arrangement_states.values_mut() {
-            state.value_mut().commit_overlay();
-        }
-        runtime
-            .arrangement_states
-            .extend(std::mem::take(&mut self.arrangement_states));
+            .extend(
+                std::mem::take(&mut self.arrangement_states)
+                    .into_iter()
+                    .filter(|(key, _)| runtime.graph.node(key.input).is_some()),
+            );
         runtime
             .arrangement_keys_by_input
-            .retain(|node, _| !self.relevant_nodes.contains(node));
-        runtime
-            .arrangement_keys_by_input
-            .extend(std::mem::take(&mut self.arrangement_keys_by_input));
+            .extend(
+                std::mem::take(&mut self.arrangement_keys_by_input)
+                    .into_iter()
+                    .filter(|(node, _)| runtime.graph.node(*node).is_some()),
+            );
 
         runtime
             .eval_memo
-            .retain(|key, _| !self.relevant_nodes.contains(&key.node));
-        runtime
-            .eval_memo
-            .extend(std::mem::take(&mut self.eval_memo));
+            .extend(
+                std::mem::take(&mut self.eval_memo)
+                    .into_iter()
+                    .filter(|(key, _)| runtime.graph.node(key.node).is_some()),
+            );
         runtime.eval_memo_bytes = runtime
             .eval_memo
             .values()
@@ -679,6 +689,9 @@ impl IncrementalEvaluation<'_> {
         // evaluation snapshot. Preserve their current live value when a
         // suspended continuation resumes after lifecycle activity.
         for node in &self.relevant_nodes {
+            if runtime.graph.node(*node).is_none() {
+                continue;
+            }
             match (self.node_meta.get_mut(node), runtime.node_meta.get(node)) {
                 (Some(meta), Some(live)) => meta.retainers = live.retainers.clone(),
                 (None, Some(live)) => {
@@ -692,7 +705,11 @@ impl IncrementalEvaluation<'_> {
             .retain(|node, _| !self.relevant_nodes.contains(node));
         runtime
             .node_meta
-            .extend(std::mem::take(&mut self.node_meta));
+            .extend(
+                std::mem::take(&mut self.node_meta)
+                    .into_iter()
+                    .filter(|(node, _)| runtime.graph.node(*node).is_some()),
+            );
         runtime.table_frontiers = std::mem::take(&mut self.table_frontiers);
         runtime.binding_frontiers = std::mem::take(&mut self.binding_frontiers);
         runtime.current_tick = self.current_tick;
@@ -1392,14 +1409,25 @@ impl<'a> EvaluationSession<'a> {
         }
     }
 
-    fn install(self, runtime: &mut IvmRuntime) {
+    fn install(mut self, runtime: &mut IvmRuntime) {
         for node in &self.relevant_nodes {
             runtime.operator_states.remove(&OperatorStateKey {
                 scope: ScopeId::root(),
                 node: *node,
             });
         }
-        runtime.operator_states.extend(self.operator_states);
+        for state in self.operator_states.values_mut() {
+            match state {
+                OperatorState::TopBy(top_by) => top_by.value_mut().commit_overlay(),
+                OperatorState::CollectBy(collect_by) => collect_by.commit_overlay(),
+                _ => {}
+            }
+        }
+        runtime.operator_states.extend(
+            self.operator_states
+                .into_iter()
+                .filter(|(key, _)| runtime.graph.node(key.node).is_some()),
+        );
         for node in &self.relevant_nodes {
             if let Some(keys) = runtime.arrangement_keys_by_input.get(node) {
                 for key in keys {
@@ -1407,17 +1435,29 @@ impl<'a> EvaluationSession<'a> {
                 }
             }
         }
-        runtime.arrangement_states.extend(self.arrangement_states);
+        runtime.arrangement_states.extend(
+            self.arrangement_states
+                .into_iter()
+                .filter(|(key, _)| runtime.graph.node(key.input).is_some()),
+        );
         for node in &self.relevant_nodes {
             runtime.arrangement_keys_by_input.remove(node);
         }
         runtime
             .arrangement_keys_by_input
-            .extend(self.arrangement_keys_by_input);
+            .extend(
+                self.arrangement_keys_by_input
+                    .into_iter()
+                    .filter(|(node, _)| runtime.graph.node(*node).is_some()),
+            );
         runtime
             .eval_memo
             .retain(|key, _| !self.relevant_nodes.contains(&key.node));
-        runtime.eval_memo.extend(self.eval_memo);
+        runtime.eval_memo.extend(
+            self.eval_memo
+                .into_iter()
+                .filter(|(key, _)| runtime.graph.node(key.node).is_some()),
+        );
         runtime.eval_memo_bytes = runtime
             .eval_memo
             .values()
@@ -1427,7 +1467,11 @@ impl<'a> EvaluationSession<'a> {
         for node in &self.relevant_nodes {
             runtime.node_meta.remove(node);
         }
-        runtime.node_meta.extend(self.node_meta);
+        runtime.node_meta.extend(
+            self.node_meta
+                .into_iter()
+                .filter(|(node, _)| runtime.graph.node(*node).is_some()),
+        );
     }
 }
 

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -82,6 +82,9 @@ pub(super) struct IncrementalEvaluation<'a> {
     node_meta: HashMap<NodeId, NodeRuntimeMeta>,
     pending_binding_retractions: usize,
     pending_notifications: Vec<(SubscriptionId, QueuedMultisinkDeltas)>,
+    /// A scoped resident failure invalidates the live slice and discards all
+    /// staged state. No continuation or publication may install it later.
+    discarded: bool,
 }
 
 #[derive(Clone)]
@@ -617,9 +620,18 @@ impl IncrementalEvaluation<'_> {
         self.terminal_deltas.retain(|node, _| !nodes.contains(node));
         self.root_ordering_windows
             .retain(|node, _| !nodes.contains(node));
+        self.discarded = true;
+        self.pending_subscription_outputs.clear();
+        self.terminal_deltas.clear();
+        self.root_ordering_windows.clear();
+        self.pending_notifications.clear();
+        self.published_subscriptions.clear();
     }
 
     fn install(&mut self, runtime: &mut IvmRuntime) {
+        if self.discarded {
+            return;
+        }
         // Drop the committed entries before folding staged COW state. This
         // makes recursive closures and arrangement bases uniquely owned while
         // leaving unrelated graph state untouched.
@@ -663,6 +675,18 @@ impl IncrementalEvaluation<'_> {
             .map(|entry| entry.payload_bytes)
             .sum();
         runtime.memo_use_clock = runtime.memo_use_clock.max(self.memo_use_clock);
+        // Retainers are owned by graph lifecycle operations, not by this
+        // evaluation snapshot. Preserve their current live value when a
+        // suspended continuation resumes after lifecycle activity.
+        for node in &self.relevant_nodes {
+            match (self.node_meta.get_mut(node), runtime.node_meta.get(node)) {
+                (Some(meta), Some(live)) => meta.retainers = live.retainers.clone(),
+                (None, Some(live)) => {
+                    self.node_meta.insert(*node, live.clone());
+                }
+                _ => {}
+            }
+        }
         runtime
             .node_meta
             .retain(|node, _| !self.relevant_nodes.contains(node));
@@ -682,6 +706,9 @@ impl IncrementalEvaluation<'_> {
         runtime: &mut IvmRuntime,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), EvaluationFailure>> {
+        if self.discarded {
+            return Poll::Ready(Ok(()));
+        }
         let ready = self.requests.poll(cx);
         if ready == 0 {
             self.requests.poll_eager_retry(cx);
@@ -2222,6 +2249,7 @@ impl IvmRuntime {
             node_meta,
             pending_binding_retractions,
             pending_notifications: Vec::new(),
+            discarded: false,
         })
     }
 
@@ -2572,5 +2600,112 @@ fn bump_input_frontiers_staged(
     ) {
         let meta = node_meta.entry(node).or_default();
         meta.input_generation = meta.input_generation.wrapping_add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{
+        ColumnSchema, ColumnType, DatabaseSchema, IntegerKeyType, PrimaryKey, TableSchema,
+    };
+    use crate::storage::MemoryStorage;
+
+    #[futures_test::test]
+    async fn resumed_install_preserves_live_retainer_changes() {
+        let schema = DatabaseSchema::new([TableSchema::new(
+            "edges",
+            [
+                ColumnSchema::new("id", ColumnType::U64),
+                ColumnSchema::new("src", ColumnType::U64),
+                ColumnSchema::new("dst", ColumnType::U64),
+            ],
+        )
+        .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+        let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+        let storage =
+            Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+        let output = runtime
+            .add_dedup_graph(&GraphBuilder::table("edges").project(["src", "dst"]))
+            .unwrap()
+            .node;
+        runtime.add_retainer(output, Retainer::PreparedShape("old".to_owned()));
+        let edges = schema.table("edges").unwrap().record_schema();
+        let record = edges
+            .create(&[Value::U64(1), Value::U64(1), Value::U64(2)])
+            .unwrap();
+        let mut evaluation = runtime
+            .begin_tick_with_params(
+                vec![TableDelta {
+                    variant_tag: 0,
+                    table: "edges".to_owned(),
+                    descriptor: edges,
+                    deltas: vec![RecordDelta {
+                        record: record.into(),
+                        weight: 1,
+                    }],
+                }],
+                Vec::new(),
+                OwnedStorage::new(Rc::clone(&storage)),
+                None,
+            )
+            .await
+            .unwrap();
+
+        runtime.add_retainer(output, Retainer::Subscription("new".to_owned()));
+        evaluation.install(&mut runtime);
+
+        let retainers = &runtime.node_meta.get(&output).unwrap().retainers;
+        assert!(retainers.contains(&Retainer::PreparedShape("old".to_owned())));
+        assert!(retainers.contains(&Retainer::Subscription("new".to_owned())));
+    }
+
+    #[futures_test::test]
+    async fn abandoned_resident_evaluation_cannot_install_frontiers() {
+        let schema = DatabaseSchema::new([TableSchema::new(
+            "edges",
+            [
+                ColumnSchema::new("id", ColumnType::U64),
+                ColumnSchema::new("src", ColumnType::U64),
+                ColumnSchema::new("dst", ColumnType::U64),
+            ],
+        )
+        .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+        let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+        let storage =
+            Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+        let output = runtime
+            .add_dedup_graph(&GraphBuilder::table("edges").project(["src", "dst"]))
+            .unwrap()
+            .node;
+        runtime.add_retainer(output, Retainer::PreparedShape("retained".to_owned()));
+        let edges = schema.table("edges").unwrap().record_schema();
+        let record = edges
+            .create(&[Value::U64(1), Value::U64(1), Value::U64(2)])
+            .unwrap();
+        let mut evaluation = runtime
+            .begin_tick_with_params(
+                vec![TableDelta {
+                    variant_tag: 0,
+                    table: "edges".to_owned(),
+                    descriptor: edges,
+                    deltas: vec![RecordDelta {
+                        record: record.into(),
+                        weight: 1,
+                    }],
+                }],
+                Vec::new(),
+                OwnedStorage::new(Rc::clone(&storage)),
+                None,
+            )
+            .await
+            .unwrap();
+        let before_tick = runtime.current_tick;
+        let before_frontiers = runtime.table_frontiers.clone();
+        evaluation.abandon(&HashSet::default());
+        evaluation.install(&mut runtime);
+
+        assert_eq!(runtime.current_tick, before_tick);
+        assert_eq!(runtime.table_frontiers, before_frontiers);
     }
 }

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -67,6 +67,18 @@ pub(super) struct IncrementalEvaluation<'a> {
     notification_publication: Option<PublicationId>,
     defer_notifications_until_durable: bool,
     pending_resident_publication: Option<PendingResidentPublication>,
+    /// All evaluator-owned state is prepared here and installed only after the
+    /// complete direct tick reaches Ready. This keeps failed ticks atomic while
+    /// allowing a suspended evaluation to retain its exact continuation.
+    operator_states: HashMap<OperatorStateKey, OperatorState>,
+    arrangement_states: HashMap<ArrangementKey, AsOf<ArrangementState, SubTick>>,
+    arrangement_keys_by_input: HashMap<NodeId, HashSet<ArrangementKey>>,
+    eval_memo: HashMap<EvalMemoKey, EvalMemoEntry>,
+    eval_memo_bytes: usize,
+    memo_use_clock: u64,
+    node_meta: HashMap<NodeId, NodeRuntimeMeta>,
+    pending_binding_retractions: usize,
+    pending_notifications: Vec<(SubscriptionId, QueuedMultisinkDeltas)>,
 }
 
 #[derive(Clone)]
@@ -180,6 +192,7 @@ impl PendingIncrementalState {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum PendingEvaluation {
     Incremental(IncrementalEvaluation<'static>),
     SubscriptionHydration(PendingSubscriptionHydration),
@@ -603,6 +616,22 @@ impl IncrementalEvaluation<'_> {
             .retain(|node, _| !nodes.contains(node));
     }
 
+    fn install(&mut self, runtime: &mut IvmRuntime) {
+        runtime.operator_states = std::mem::take(&mut self.operator_states);
+        runtime.arrangement_states = std::mem::take(&mut self.arrangement_states);
+        runtime.arrangement_keys_by_input = std::mem::take(&mut self.arrangement_keys_by_input);
+        runtime.eval_memo = std::mem::take(&mut self.eval_memo);
+        runtime.eval_memo_bytes = self.eval_memo_bytes;
+        runtime.memo_use_clock = self.memo_use_clock;
+        runtime.node_meta = std::mem::take(&mut self.node_meta);
+        runtime.table_frontiers = std::mem::take(&mut self.table_frontiers);
+        runtime.binding_frontiers = std::mem::take(&mut self.binding_frontiers);
+        runtime.current_tick = self.current_tick;
+        runtime
+            .pending_binding_retractions
+            .drain(..self.pending_binding_retractions);
+    }
+
     fn poll(
         &mut self,
         runtime: &mut IvmRuntime,
@@ -624,7 +653,7 @@ impl IncrementalEvaluation<'_> {
             inputs.install(ready);
         }
 
-        let mut dropped_subscriptions = Vec::new();
+        let dropped_subscriptions = Vec::new();
         let mut evaluator = TickEvaluator {
             schema: &runtime.schema,
             graph: &runtime.graph,
@@ -633,15 +662,15 @@ impl IncrementalEvaluation<'_> {
             binding_deltas: &self.binding_deltas,
             binding_snapshots: &self.binding_snapshots,
             current_tick: self.current_tick,
-            operator_states: &mut runtime.operator_states,
-            arrangement_states: &mut runtime.arrangement_states,
-            arrangement_keys_by_input: &mut runtime.arrangement_keys_by_input,
-            eval_memo: &mut runtime.eval_memo,
-            eval_memo_bytes: &mut runtime.eval_memo_bytes,
+            operator_states: &mut self.operator_states,
+            arrangement_states: &mut self.arrangement_states,
+            arrangement_keys_by_input: &mut self.arrangement_keys_by_input,
+            eval_memo: &mut self.eval_memo,
+            eval_memo_bytes: &mut self.eval_memo_bytes,
             table_frontiers: &self.table_frontiers,
             binding_frontiers: &self.binding_frontiers,
-            memo_use_clock: &mut runtime.memo_use_clock,
-            node_meta: &mut runtime.node_meta,
+            memo_use_clock: &mut self.memo_use_clock,
+            node_meta: &mut self.node_meta,
             storage: Some(self.storage.as_ref()),
             evaluation_inputs: self.evaluation_inputs.as_mut(),
             context: EvalContext::root(),
@@ -898,28 +927,7 @@ impl IncrementalEvaluation<'_> {
                 .or(self.notification_publication);
             queued.publication = notification_publication;
             if !queued.deltas.is_empty() {
-                if let Some(pending) = &self.pending_resident_publication
-                    && notification_publication.is_none()
-                {
-                    pending
-                        .notifications
-                        .borrow_mut()
-                        .push((*subscription_id, queued));
-                } else if self.defer_notifications_until_durable
-                    && notification_publication.is_some_and(|publication| {
-                        !runtime
-                            .durable_notification_publications
-                            .contains(&publication)
-                    })
-                {
-                    runtime
-                        .deferred_notifications
-                        .entry(notification_publication.expect("checked publication"))
-                        .or_default()
-                        .push((*subscription_id, queued));
-                } else if subscription.sender.send(queued).is_err() {
-                    dropped_subscriptions.push(*subscription_id);
-                }
+                self.pending_notifications.push((*subscription_id, queued));
             }
             self.published_subscriptions.insert(*subscription_id);
         }
@@ -931,9 +939,40 @@ impl IncrementalEvaluation<'_> {
         }
 
         drop(evaluator);
+        self.install(runtime);
         runtime
             .operator_states
             .retain(|key, _| key.scope == ScopeId::root());
+        let notifications = std::mem::take(&mut self.pending_notifications);
+        let mut dropped_subscriptions = dropped_subscriptions;
+        for (subscription_id, queued) in notifications {
+            if self.defer_notifications_until_durable
+                && queued.publication.is_some_and(|publication| {
+                    !runtime
+                        .durable_notification_publications
+                        .contains(&publication)
+                })
+            {
+                runtime
+                    .deferred_notifications
+                    .entry(queued.publication.expect("checked publication"))
+                    .or_default()
+                    .push((subscription_id, queued));
+            } else if let Some(pending) = &self.pending_resident_publication
+                && queued.publication.is_none()
+            {
+                pending
+                    .notifications
+                    .borrow_mut()
+                    .push((subscription_id, queued));
+            } else if runtime
+                .multisink_subscriptions
+                .get(&subscription_id)
+                .is_some_and(|subscription| subscription.sender.send(queued).is_err())
+            {
+                dropped_subscriptions.push(subscription_id);
+            }
+        }
         for subscription_id in dropped_subscriptions {
             runtime.unsubscribe(subscription_id);
         }
@@ -1991,9 +2030,18 @@ impl IvmRuntime {
             changed_tables.iter().copied(),
             changed_bindings.iter().copied(),
         );
-        // Do not commit tick lifecycle state until fallible durable evaluation
-        // has completed. In particular, queued binding retractions must remain
-        // retryable when preparing a tick encounters a storage error.
+        // Every mutable evaluator map is a prepared snapshot. The maps are
+        // shallow clones where their values use COW, so a suspended or failed
+        // tick cannot mutate committed runtime state.
+        let mut operator_states = self.operator_states.clone();
+        let mut arrangement_states = self.arrangement_states.clone();
+        let mut arrangement_keys_by_input = self.arrangement_keys_by_input.clone();
+        let mut eval_memo = self.eval_memo.clone();
+        let mut eval_memo_bytes = self.eval_memo_bytes;
+        let mut memo_use_clock = self.memo_use_clock;
+        let mut node_meta = self.node_meta.clone();
+        let mut table_frontiers = self.table_frontiers.clone();
+        let mut binding_frontiers = self.binding_frontiers.clone();
         let current_tick = self.current_tick + 1;
         let table_delta_records = table_deltas
             .iter()
@@ -2004,12 +2052,25 @@ impl IvmRuntime {
             &affected_nodes,
             current_tick,
             storage.as_ref(),
+            &mut operator_states,
+            &mut arrangement_states,
+            &mut arrangement_keys_by_input,
+            &mut eval_memo,
+            &mut eval_memo_bytes,
+            &mut memo_use_clock,
+            &mut node_meta,
+            &table_frontiers,
+            &binding_frontiers,
         )
         .await?;
-        self.current_tick = current_tick;
-        self.bump_input_frontiers(&table_deltas, &binding_deltas);
-        self.pending_binding_retractions
-            .drain(..pending_binding_retractions);
+        bump_input_frontiers_staged(
+            &self.graph,
+            &table_deltas,
+            &binding_deltas,
+            &mut table_frontiers,
+            &mut binding_frontiers,
+            &mut node_meta,
+        );
         let metrics = TickMetrics {
             tick: current_tick,
             table_delta_records,
@@ -2061,8 +2122,8 @@ impl IvmRuntime {
             table_deltas,
             binding_deltas,
             binding_snapshots,
-            table_frontiers: self.table_frontiers.clone(),
-            binding_frontiers: self.binding_frontiers.clone(),
+            table_frontiers,
+            binding_frontiers,
             current_tick,
             metrics,
             storage,
@@ -2078,6 +2139,15 @@ impl IvmRuntime {
             notification_publication,
             defer_notifications_until_durable,
             pending_resident_publication,
+            operator_states,
+            arrangement_states,
+            arrangement_keys_by_input,
+            eval_memo,
+            eval_memo_bytes,
+            memo_use_clock,
+            node_meta,
+            pending_binding_retractions,
+            pending_notifications: Vec::new(),
         })
     }
 
@@ -2086,32 +2156,14 @@ impl IvmRuntime {
         table_deltas: &[TableDelta],
         binding_deltas: &[BindingDelta],
     ) {
-        let mut changed_tables = Vec::new();
-        for delta in table_deltas.iter().filter(|delta| !delta.deltas.is_empty()) {
-            *self.table_frontiers.entry(delta.table.clone()).or_default() += 1;
-            changed_tables.push(delta.table.as_str());
-        }
-        let mut changed_bindings = Vec::new();
-        for delta in binding_deltas
-            .iter()
-            .filter(|delta| !delta.deltas.is_empty())
-        {
-            *self
-                .binding_frontiers
-                .entry(delta.shape.clone())
-                .or_default() += 1;
-            changed_bindings.push(delta.shape.as_str());
-        }
-        if changed_tables.is_empty() && changed_bindings.is_empty() {
-            return;
-        }
-        for node in self.graph.affected_nodes(
-            changed_tables.iter().copied(),
-            changed_bindings.iter().copied(),
-        ) {
-            let meta = self.node_meta.entry(node).or_default();
-            meta.input_generation = meta.input_generation.wrapping_add(1);
-        }
+        bump_input_frontiers_staged(
+            &self.graph,
+            table_deltas,
+            binding_deltas,
+            &mut self.table_frontiers,
+            &mut self.binding_frontiers,
+            &mut self.node_meta,
+        );
     }
 
     fn evict_eval_memo(&mut self) {
@@ -2303,12 +2355,22 @@ impl IvmRuntime {
         Ok(false)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn tick_durable_nodes(
-        &mut self,
+        &self,
         table_deltas: &[TableDelta],
         affected_nodes: &std::collections::HashSet<NodeId>,
         current_tick: u64,
         storage: &dyn OrderedKvStorage,
+        operator_states: &mut HashMap<OperatorStateKey, OperatorState>,
+        arrangement_states: &mut HashMap<ArrangementKey, AsOf<ArrangementState, SubTick>>,
+        arrangement_keys_by_input: &mut HashMap<NodeId, HashSet<ArrangementKey>>,
+        eval_memo: &mut HashMap<EvalMemoKey, EvalMemoEntry>,
+        eval_memo_bytes: &mut usize,
+        memo_use_clock: &mut u64,
+        node_meta: &mut HashMap<NodeId, NodeRuntimeMeta>,
+        table_frontiers: &HashMap<String, u64>,
+        binding_frontiers: &HashMap<String, u64>,
     ) -> Result<(), IvmRuntimeError> {
         let durable_nodes = affected_nodes
             .iter()
@@ -2341,15 +2403,15 @@ impl IvmRuntime {
                     binding_deltas: &[],
                     binding_snapshots: &binding_snapshots,
                     current_tick,
-                    operator_states: &mut self.operator_states,
-                    arrangement_states: &mut self.arrangement_states,
-                    arrangement_keys_by_input: &mut self.arrangement_keys_by_input,
-                    eval_memo: &mut self.eval_memo,
-                    eval_memo_bytes: &mut self.eval_memo_bytes,
-                    table_frontiers: &self.table_frontiers,
-                    binding_frontiers: &self.binding_frontiers,
-                    memo_use_clock: &mut self.memo_use_clock,
-                    node_meta: &mut self.node_meta,
+                    operator_states,
+                    arrangement_states,
+                    arrangement_keys_by_input,
+                    eval_memo,
+                    eval_memo_bytes,
+                    table_frontiers,
+                    binding_frontiers,
+                    memo_use_clock,
+                    node_meta,
                     storage: Some(storage),
                     evaluation_inputs: None,
                     context: EvalContext::root(),
@@ -2404,4 +2466,37 @@ fn subscription_snapshot_from_hydrated(
         sinks,
         terminal_sinks: BTreeMap::new(),
     })
+}
+
+fn bump_input_frontiers_staged(
+    graph: &IvmGraph,
+    table_deltas: &[TableDelta],
+    binding_deltas: &[BindingDelta],
+    table_frontiers: &mut HashMap<String, u64>,
+    binding_frontiers: &mut HashMap<String, u64>,
+    node_meta: &mut HashMap<NodeId, NodeRuntimeMeta>,
+) {
+    let mut changed_tables = Vec::new();
+    for delta in table_deltas.iter().filter(|delta| !delta.deltas.is_empty()) {
+        *table_frontiers.entry(delta.table.clone()).or_default() += 1;
+        changed_tables.push(delta.table.as_str());
+    }
+    let mut changed_bindings = Vec::new();
+    for delta in binding_deltas
+        .iter()
+        .filter(|delta| !delta.deltas.is_empty())
+    {
+        *binding_frontiers.entry(delta.shape.clone()).or_default() += 1;
+        changed_bindings.push(delta.shape.as_str());
+    }
+    if changed_tables.is_empty() && changed_bindings.is_empty() {
+        return;
+    }
+    for node in graph.affected_nodes(
+        changed_tables.iter().copied(),
+        changed_bindings.iter().copied(),
+    ) {
+        let meta = node_meta.entry(node).or_default();
+        meta.input_generation = meta.input_generation.wrapping_add(1);
+    }
 }

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -652,33 +652,27 @@ impl IncrementalEvaluation<'_> {
                 _ => {}
             }
         }
-        runtime
-            .operator_states
-            .extend(std::mem::take(&mut self.operator_states).into_iter().filter(
-                |(key, _)| runtime.graph.node(key.node).is_some(),
-            ));
-        runtime
-            .arrangement_states
-            .extend(
-                std::mem::take(&mut self.arrangement_states)
-                    .into_iter()
-                    .filter(|(key, _)| runtime.graph.node(key.input).is_some()),
-            );
-        runtime
-            .arrangement_keys_by_input
-            .extend(
-                std::mem::take(&mut self.arrangement_keys_by_input)
-                    .into_iter()
-                    .filter(|(node, _)| runtime.graph.node(*node).is_some()),
-            );
+        runtime.operator_states.extend(
+            std::mem::take(&mut self.operator_states)
+                .into_iter()
+                .filter(|(key, _)| runtime.graph.node(key.node).is_some()),
+        );
+        runtime.arrangement_states.extend(
+            std::mem::take(&mut self.arrangement_states)
+                .into_iter()
+                .filter(|(key, _)| runtime.graph.node(key.input).is_some()),
+        );
+        runtime.arrangement_keys_by_input.extend(
+            std::mem::take(&mut self.arrangement_keys_by_input)
+                .into_iter()
+                .filter(|(node, _)| runtime.graph.node(*node).is_some()),
+        );
 
-        runtime
-            .eval_memo
-            .extend(
-                std::mem::take(&mut self.eval_memo)
-                    .into_iter()
-                    .filter(|(key, _)| runtime.graph.node(key.node).is_some()),
-            );
+        runtime.eval_memo.extend(
+            std::mem::take(&mut self.eval_memo)
+                .into_iter()
+                .filter(|(key, _)| runtime.graph.node(key.node).is_some()),
+        );
         runtime.eval_memo_bytes = runtime
             .eval_memo
             .values()
@@ -703,13 +697,11 @@ impl IncrementalEvaluation<'_> {
         runtime
             .node_meta
             .retain(|node, _| !self.relevant_nodes.contains(node));
-        runtime
-            .node_meta
-            .extend(
-                std::mem::take(&mut self.node_meta)
-                    .into_iter()
-                    .filter(|(node, _)| runtime.graph.node(*node).is_some()),
-            );
+        runtime.node_meta.extend(
+            std::mem::take(&mut self.node_meta)
+                .into_iter()
+                .filter(|(node, _)| runtime.graph.node(*node).is_some()),
+        );
         runtime.table_frontiers = std::mem::take(&mut self.table_frontiers);
         runtime.binding_frontiers = std::mem::take(&mut self.binding_frontiers);
         runtime.current_tick = self.current_tick;
@@ -1443,13 +1435,11 @@ impl<'a> EvaluationSession<'a> {
         for node in &self.relevant_nodes {
             runtime.arrangement_keys_by_input.remove(node);
         }
-        runtime
-            .arrangement_keys_by_input
-            .extend(
-                self.arrangement_keys_by_input
-                    .into_iter()
-                    .filter(|(node, _)| runtime.graph.node(*node).is_some()),
-            );
+        runtime.arrangement_keys_by_input.extend(
+            self.arrangement_keys_by_input
+                .into_iter()
+                .filter(|(node, _)| runtime.graph.node(*node).is_some()),
+        );
         runtime
             .eval_memo
             .retain(|key, _| !self.relevant_nodes.contains(&key.node));

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -70,9 +70,9 @@ pub(super) struct IncrementalEvaluation<'a> {
     notification_publication: Option<PublicationId>,
     defer_notifications_until_durable: bool,
     pending_resident_publication: Option<PendingResidentPublication>,
-    /// All evaluator-owned state is prepared here and installed only after the
-    /// complete direct tick reaches Ready. This keeps failed ticks atomic while
-    /// allowing a suspended evaluation to retain its exact continuation.
+    /// Prepared evaluator state is installed one closed publication group at a
+    /// time. Groups own subscription multisinks, retained roots, durable roots,
+    /// and every transitive dependency of those roots.
     operator_states: HashMap<OperatorStateKey, OperatorState>,
     arrangement_states: HashMap<ArrangementKey, AsOf<ArrangementState, SubTick>>,
     arrangement_keys_by_input: HashMap<NodeId, HashSet<ArrangementKey>>,
@@ -82,9 +82,11 @@ pub(super) struct IncrementalEvaluation<'a> {
     node_meta: HashMap<NodeId, NodeRuntimeMeta>,
     pending_binding_retractions: usize,
     pending_notifications: Vec<(SubscriptionId, QueuedMultisinkDeltas)>,
-    /// A scoped resident failure invalidates the live slice and discards all
-    /// staged state. No continuation or publication may install it later.
-    discarded: bool,
+    publication_groups: Vec<PublicationGroup>,
+    table_frontier_advances: HashMap<String, u64>,
+    binding_frontier_advances: HashMap<String, u64>,
+    tick_globals_committed: bool,
+    commit_ownerless_tick_globals_on_success: bool,
 }
 
 #[derive(Clone)]
@@ -94,6 +96,95 @@ struct PendingResidentPublication {
     completed: Rc<Cell<bool>>,
     defer_notifications_until_durable: bool,
     chunk_provider: Option<crate::chunks::OwnedChunkProvider>,
+}
+
+#[derive(Default)]
+struct PublicationOwner {
+    roots: HashSet<NodeId>,
+    subscription: Option<SubscriptionId>,
+}
+
+#[derive(Default)]
+struct CoalescedPublicationOwner {
+    subscriptions: HashSet<SubscriptionId>,
+    unowned: bool,
+}
+
+#[derive(Default)]
+struct PublicationGroup {
+    nodes: HashSet<NodeId>,
+    root_owners: HashMap<NodeId, HashSet<SubscriptionId>>,
+    unowned_roots: HashSet<NodeId>,
+    subscriptions: HashSet<SubscriptionId>,
+}
+
+fn publication_group_root(parents: &mut [usize], mut owner: usize) -> usize {
+    while parents[owner] != owner {
+        parents[owner] = parents[parents[owner]];
+        owner = parents[owner];
+    }
+    owner
+}
+
+fn publication_groups(graph: &IvmGraph, owners: Vec<PublicationOwner>) -> Vec<PublicationGroup> {
+    let mut coalesced = HashMap::<Vec<NodeId>, CoalescedPublicationOwner>::default();
+    for owner in owners {
+        let mut roots = owner.roots.into_iter().collect::<Vec<_>>();
+        roots.sort_unstable();
+        let combined = coalesced.entry(roots).or_default();
+        if let Some(subscription) = owner.subscription {
+            combined.subscriptions.insert(subscription);
+        } else {
+            combined.unowned = true;
+        }
+    }
+    let owners = coalesced.into_iter().collect::<Vec<_>>();
+
+    let mut owner_nodes = Vec::with_capacity(owners.len());
+    for (roots, _) in &owners {
+        let mut nodes = HashSet::<NodeId>::default();
+        for root in roots {
+            graph.mark_ancestors(*root, &mut nodes);
+        }
+        owner_nodes.push(nodes);
+    }
+
+    let mut parents = (0..owners.len()).collect::<Vec<_>>();
+    let mut first_owner_by_node = HashMap::default();
+    for (owner, nodes) in owner_nodes.iter().enumerate() {
+        for node in nodes {
+            if let Some(previous) = first_owner_by_node.insert(*node, owner) {
+                let owner_root = publication_group_root(&mut parents, owner);
+                let previous_root = publication_group_root(&mut parents, previous);
+                if owner_root != previous_root {
+                    parents[owner_root] = previous_root;
+                }
+            }
+        }
+    }
+
+    let mut groups = HashMap::<usize, PublicationGroup>::default();
+    for (owner_index, ((roots, owner), nodes)) in owners.into_iter().zip(owner_nodes).enumerate() {
+        let root = publication_group_root(&mut parents, owner_index);
+        let group = groups.entry(root).or_default();
+        group.nodes.extend(nodes);
+        group
+            .subscriptions
+            .extend(owner.subscriptions.iter().copied());
+        for root in roots {
+            if !owner.subscriptions.is_empty() {
+                group
+                    .root_owners
+                    .entry(root)
+                    .or_default()
+                    .extend(owner.subscriptions.iter().copied());
+            }
+            if owner.unowned {
+                group.unowned_roots.insert(root);
+            }
+        }
+    }
+    groups.into_values().collect()
 }
 
 pub(crate) struct ResidentTick {
@@ -138,18 +229,18 @@ struct PendingIncrementalState {
 }
 
 impl PendingIncrementalState {
-    /// Select each hydration whose snapshot overlaps `nodes`, plus every
+    /// Select each uninstalled evaluation which overlaps `nodes`, plus every
     /// evaluation which is temporally ahead of it on any registered node.
     /// Repeat to closure because one predecessor may itself wait behind an
     /// evaluation on a different node.
-    fn hydration_admission_evaluations(&self, nodes: &HashSet<NodeId>) -> HashSet<u64> {
+    fn admission_evaluations(&self, nodes: &HashSet<NodeId>) -> HashSet<u64> {
         let mut selected = self
             .evaluations
             .iter()
             .filter_map(|(evaluation_id, evaluation)| {
-                (matches!(evaluation, PendingEvaluation::SubscriptionHydration(_))
-                    && evaluation.work_queue().overlaps(nodes))
-                .then_some(*evaluation_id)
+                evaluation
+                    .overlaps_uninstalled(nodes)
+                    .then_some(*evaluation_id)
             })
             .collect::<HashSet<_>>();
         loop {
@@ -171,9 +262,8 @@ impl PendingIncrementalState {
         }
     }
 
-    /// Release evaluations queued behind `evaluation_id` at completed graph
-    /// nodes. Snapshot hydration calls this only after its isolated state is
-    /// installed; incremental evaluations can release nodes as they complete.
+    /// Release evaluations queued behind `evaluation_id` only after the
+    /// predecessor's private state has installed or been pruned.
     fn release_temporal_successors(
         &mut self,
         evaluation_id: u64,
@@ -196,6 +286,30 @@ impl PendingIncrementalState {
             }
         }
     }
+
+    fn remove_temporal_ownership(
+        &mut self,
+        evaluation_id: u64,
+        nodes: impl IntoIterator<Item = NodeId>,
+    ) {
+        for node in nodes {
+            let Some(waiters) = self.waiters_by_node.get_mut(&node) else {
+                continue;
+            };
+            let was_front = waiters.front() == Some(&evaluation_id);
+            waiters.retain(|waiter| *waiter != evaluation_id);
+            let successor = waiters.front().copied();
+            if waiters.is_empty() {
+                self.waiters_by_node.remove(&node);
+            }
+            if was_front
+                && let Some(successor) = successor
+                && let Some(later) = self.evaluations.get_mut(&successor)
+            {
+                later.work_queue_mut().temporal_ready(node);
+            }
+        }
+    }
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -208,29 +322,178 @@ struct PendingSubscriptionHydration {
     subscription_id: SubscriptionId,
     outputs: BTreeMap<String, CompiledNode>,
     initial: Arc<Mutex<Option<MultisinkDeltas>>>,
-    session: EvaluationSession<'static>,
-    binding_snapshots: HashMap<String, RecordDeltas>,
+    capture: Option<PendingHydrationCapture<'static>>,
+    active: Option<ActiveSubscriptionHydration>,
     hydrate_arrangements: bool,
     metrics: TickMetrics,
+}
+
+struct PendingHydrationCapture<'a> {
+    topology: HydrationTopology,
+    storage: OwnedStorage<'a>,
+    requests: EvaluationRequests<'a>,
+    requests_started: bool,
+    binding_snapshots: Option<HashMap<String, RecordDeltas>>,
+    binding_frontier_advance: Option<String>,
+}
+
+struct ActiveSubscriptionHydration {
+    session: EvaluationSession<'static>,
+    binding_snapshots: HashMap<String, RecordDeltas>,
+}
+impl PendingSubscriptionHydration {
+    fn work_queue(&self) -> &EvaluationWorkQueue {
+        if let Some(capture) = &self.capture {
+            &capture.topology.work_queue
+        } else {
+            &self
+                .active
+                .as_ref()
+                .expect("subscription hydration has dormant or active state")
+                .session
+                .work_queue
+        }
+    }
+
+    fn work_queue_mut(&mut self) -> &mut EvaluationWorkQueue {
+        if let Some(capture) = &mut self.capture {
+            &mut capture.topology.work_queue
+        } else {
+            &mut self
+                .active
+                .as_mut()
+                .expect("subscription hydration has dormant or active state")
+                .session
+                .work_queue
+        }
+    }
+
+    fn activate_after_temporal_release(&mut self, runtime: &IvmRuntime) -> bool {
+        if self.active.is_some() {
+            return true;
+        }
+        let capture = self
+            .capture
+            .as_ref()
+            .expect("dormant subscription hydration owns capture parameters");
+        if !capture.topology.work_queue.temporal_waiting.is_empty() {
+            return false;
+        }
+        let capture = self
+            .capture
+            .take()
+            .expect("eligible subscription hydration owns capture parameters");
+        let (session, binding_snapshots) = capture.capture(runtime);
+        self.active = Some(ActiveSubscriptionHydration {
+            session,
+            binding_snapshots,
+        });
+        true
+    }
+
+    fn has_resident_continuation(&self) -> bool {
+        if let Some(capture) = &self.capture {
+            let work_queue = &capture.topology.work_queue;
+            // A dormant hydration is resident-runnable only when this direct
+            // turn may activate it without opening preserved cold storage.
+            // Admission owners bypass this predicate and activate once their
+            // temporal predecessors release.
+            work_queue.temporal_waiting.is_empty()
+                && work_queue.requests().next().is_none()
+                && work_queue.has_resident_continuation()
+        } else {
+            self.work_queue().has_resident_continuation()
+        }
+    }
+}
+
+impl<'a> PendingHydrationCapture<'a> {
+    fn new(
+        runtime: &IvmRuntime,
+        topology: HydrationTopology,
+        storage: OwnedStorage<'a>,
+        binding_snapshots: Option<HashMap<String, RecordDeltas>>,
+        binding_frontier_advance: Option<String>,
+    ) -> Self {
+        let mut requests = EvaluationRequests::new();
+        for request in topology.work_queue.requests().cloned() {
+            requests.request(
+                request,
+                &storage,
+                Some(&runtime.chunk_provider),
+                &runtime.schema,
+            );
+        }
+        Self {
+            topology,
+            storage,
+            requests_started: false,
+            requests,
+            binding_snapshots,
+            binding_frontier_advance,
+        }
+    }
+
+    fn start_requests(&mut self, cx: &mut Context<'_>) {
+        if self.requests_started {
+            return;
+        }
+        self.requests_started = true;
+        let _ = self.requests.poll(cx);
+    }
+
+    fn capture(
+        self,
+        runtime: &IvmRuntime,
+    ) -> (EvaluationSession<'a>, HashMap<String, RecordDeltas>) {
+        let Self {
+            topology,
+            storage,
+            requests,
+            binding_snapshots,
+            requests_started: _,
+            binding_frontier_advance,
+        } = self;
+        let binding_snapshots =
+            binding_snapshots.unwrap_or_else(|| runtime.binding_snapshot_deltas());
+        let mut session = EvaluationSession::hydration(runtime, topology, storage, requests);
+        if let Some(shape) = binding_frontier_advance {
+            session.advance_binding_input(&runtime.graph, &shape);
+        }
+        (session, binding_snapshots)
+    }
 }
 
 impl PendingEvaluation {
     fn work_queue_mut(&mut self) -> &mut EvaluationWorkQueue {
         match self {
             Self::Incremental(evaluation) => &mut evaluation.work_queue,
-            Self::SubscriptionHydration(evaluation) => &mut evaluation.session.work_queue,
+            Self::SubscriptionHydration(evaluation) => evaluation.work_queue_mut(),
         }
     }
 
     fn work_queue(&self) -> &EvaluationWorkQueue {
         match self {
             Self::Incremental(evaluation) => &evaluation.work_queue,
-            Self::SubscriptionHydration(evaluation) => &evaluation.session.work_queue,
+            Self::SubscriptionHydration(evaluation) => evaluation.work_queue(),
+        }
+    }
+
+    fn overlaps_uninstalled(&self, nodes: &HashSet<NodeId>) -> bool {
+        match self {
+            Self::Incremental(evaluation) => evaluation
+                .publication_groups
+                .iter()
+                .any(|group| !group.nodes.is_disjoint(nodes)),
+            Self::SubscriptionHydration(evaluation) => evaluation.work_queue().overlaps(nodes),
         }
     }
 
     fn has_resident_continuation(&self) -> bool {
-        self.work_queue().has_resident_continuation()
+        match self {
+            Self::Incremental(evaluation) => evaluation.work_queue.has_resident_continuation(),
+            Self::SubscriptionHydration(evaluation) => evaluation.has_resident_continuation(),
+        }
     }
 }
 
@@ -276,6 +539,12 @@ enum EvaluationEntry {
     Complete,
 }
 
+struct HydrationTopology {
+    relevant_nodes: HashSet<NodeId>,
+    roots: VecDeque<NodeId>,
+    work_queue: EvaluationWorkQueue,
+}
+
 struct EvaluationWorkQueue {
     pending: VecDeque<NodeId>,
     visited: HashSet<NodeId>,
@@ -284,7 +553,7 @@ struct EvaluationWorkQueue {
     request_dependents: std::collections::BTreeMap<EvaluationRequestKey, Vec<NodeId>>,
     runnable: VecDeque<NodeId>,
     roots: HashSet<NodeId>,
-    completed_events: Vec<NodeId>,
+    released_events: Vec<NodeId>,
     temporal_waiting: HashMap<NodeId, usize>,
 }
 
@@ -299,7 +568,7 @@ impl EvaluationWorkQueue {
             request_dependents: std::collections::BTreeMap::new(),
             runnable: VecDeque::new(),
             roots: roots.into_iter().collect(),
-            completed_events: Vec::new(),
+            released_events: Vec::new(),
             temporal_waiting: HashMap::default(),
         }
     }
@@ -455,8 +724,10 @@ impl EvaluationWorkQueue {
     }
 
     fn complete(&mut self, node: NodeId) {
+        if self.is_complete(node) {
+            return;
+        }
         self.entries.insert(node, EvaluationEntry::Complete);
-        self.completed_events.push(node);
         let dependents = self.dependents.get(&node).cloned().unwrap_or_default();
         for dependent in dependents {
             let Some(EvaluationEntry::Waiting(remaining)) = self.entries.get_mut(&dependent) else {
@@ -492,18 +763,14 @@ impl EvaluationWorkQueue {
         self.entries.get(&node) == Some(&EvaluationEntry::Complete)
     }
 
-    fn roots_complete(&self) -> bool {
-        self.roots.iter().all(|node| self.is_complete(*node))
-    }
-
     fn incomplete_nodes(&self) -> impl Iterator<Item = NodeId> + '_ {
         self.entries
             .iter()
             .filter_map(|(node, entry)| (*entry != EvaluationEntry::Complete).then_some(*node))
     }
 
-    /// Every node registered with a snapshot hydration is a single temporal
-    /// barrier: successors may use none of its isolated state until install.
+    /// Every node registered with an evaluation remains a temporal barrier
+    /// until its publication group installs or is pruned.
     fn registered_nodes(&self) -> Vec<NodeId> {
         self.entries.keys().copied().collect()
     }
@@ -555,16 +822,25 @@ impl EvaluationWorkQueue {
         }
     }
 
-    fn abandon(&mut self, nodes: &HashSet<NodeId>) {
+    fn release_ownership(&mut self, nodes: &HashSet<NodeId>) {
+        self.pending.retain(|node| !nodes.contains(node));
         self.runnable.retain(|node| !nodes.contains(node));
-        self.request_dependents
-            .retain(|_, dependents| !dependents.iter().all(|node| nodes.contains(node)));
-        for node in nodes {
-            if self.entries.contains_key(node) {
-                self.entries.insert(*node, EvaluationEntry::Complete);
-                self.temporal_waiting.remove(node);
+        self.roots.retain(|node| !nodes.contains(node));
+        self.entries.retain(|node, _| !nodes.contains(node));
+        self.temporal_waiting
+            .retain(|node, _| !nodes.contains(node));
+        self.dependents.retain(|node, dependents| {
+            if nodes.contains(node) {
+                return false;
             }
-        }
+            dependents.retain(|dependent| !nodes.contains(dependent));
+            true
+        });
+        self.request_dependents.retain(|_, dependents| {
+            dependents.retain(|node| !nodes.contains(node));
+            !dependents.is_empty()
+        });
+        self.released_events.extend(nodes.iter().copied());
     }
 
     fn add_temporal_blockers(&mut self, blockers: &HashMap<NodeId, usize>) {
@@ -609,37 +885,252 @@ impl EvaluationWorkQueue {
         }
     }
 
-    fn drain_completed_events(&mut self) -> Vec<NodeId> {
-        std::mem::take(&mut self.completed_events)
+    fn drain_released_events(&mut self) -> Vec<NodeId> {
+        std::mem::take(&mut self.released_events)
+    }
+}
+impl HydrationTopology {
+    fn discover(runtime: &IvmRuntime, roots: VecDeque<NodeId>) -> Result<Self, IvmRuntimeError> {
+        let (relevant_nodes, work_queue) =
+            EvaluationWorkQueue::new(roots.iter().copied()).discover_hydration(&runtime.graph)?;
+        let mut topology = Self {
+            relevant_nodes,
+            roots,
+            work_queue,
+        };
+        topology.resolve_resident_requests(runtime);
+        Ok(topology)
+    }
+
+    /// Freeze the storage requests owned by this topology before it enters the
+    /// temporal worklist. Mutable evaluator state is captured later, after
+    /// predecessors install, but their newly installed memo must not erase a
+    /// request that was cold when this evaluation claimed its queue position.
+    fn resolve_resident_requests(&mut self, runtime: &IvmRuntime) {
+        // Recursive hydration rebuilds internal arrangements from complete
+        // source snapshots, so a leaf memo alone cannot satisfy those inputs.
+        // Walk all recursive inputs together to keep classification linear in
+        // the reachable graph slice even when it contains sibling recursion.
+        let mut pending_recursive_inputs = VecDeque::new();
+        for node in &self.relevant_nodes {
+            let Some(graph_node) = runtime.graph.node(*node) else {
+                continue;
+            };
+            if matches!(graph_node.descriptor.operator, OpType::Recursive(_)) {
+                pending_recursive_inputs.extend(graph_node.descriptor.inputs.iter().copied());
+            }
+        }
+        let mut recursive_inputs = HashSet::<NodeId>::default();
+        while let Some(node) = pending_recursive_inputs.pop_front() {
+            if !recursive_inputs.insert(node) {
+                continue;
+            }
+            if let Some(graph_node) = runtime.graph.node(node) {
+                pending_recursive_inputs.extend(graph_node.descriptor.inputs.iter().copied());
+            }
+        }
+        let resident_source_nodes = self
+            .relevant_nodes
+            .iter()
+            .filter_map(|node| {
+                if recursive_inputs.contains(node) {
+                    return None;
+                }
+                let meta = runtime.node_meta.get(node)?;
+                let signature = meta.input_signature.as_ref()?;
+                let key = EvalMemoKey {
+                    scope: ScopeId::root(),
+                    node: *node,
+                    input_signature_hash: signature.hash,
+                    tick_epoch: None,
+                    sub_tick: 0,
+                    context_digest: 0,
+                };
+                runtime
+                    .eval_memo
+                    .get(&key)
+                    .is_some_and(|entry| entry.input_watermark == meta.input_generation)
+                    .then_some(*node)
+            })
+            .collect::<HashSet<_>>();
+        self.work_queue
+            .storage_already_resident(&resident_source_nodes);
     }
 }
 
 impl IncrementalEvaluation<'_> {
-    fn abandon(&mut self, nodes: &HashSet<NodeId>) {
-        self.work_queue.abandon(nodes);
+    fn pending_owned_nodes(&self) -> HashSet<NodeId> {
+        self.publication_groups
+            .iter()
+            .flat_map(|group| group.nodes.iter().copied())
+            .collect()
+    }
+
+    fn commit_tick_globals(&mut self, runtime: &mut IvmRuntime) {
+        if self.tick_globals_committed {
+            return;
+        }
+        for (table, frontier) in std::mem::take(&mut self.table_frontier_advances) {
+            let live = runtime.table_frontiers.entry(table).or_default();
+            *live = (*live).max(frontier);
+        }
+        for (binding, frontier) in std::mem::take(&mut self.binding_frontier_advances) {
+            let live = runtime.binding_frontiers.entry(binding).or_default();
+            *live = (*live).max(frontier);
+        }
+        runtime.current_tick = runtime.current_tick.max(self.current_tick);
+        runtime
+            .pending_binding_retractions
+            .drain(..self.pending_binding_retractions);
+        self.pending_binding_retractions = 0;
+        self.tick_globals_committed = true;
+    }
+
+    fn prune_staged_nodes(&mut self, nodes: &HashSet<NodeId>) {
+        self.operator_states
+            .retain(|key, _| !nodes.contains(&key.node));
+        self.arrangement_states
+            .retain(|key, _| !nodes.contains(&key.input));
+        self.arrangement_keys_by_input
+            .retain(|node, _| !nodes.contains(node));
+        let mut removed_memo_bytes = 0usize;
+        self.eval_memo.retain(|key, entry| {
+            let keep = !nodes.contains(&key.node);
+            if !keep {
+                removed_memo_bytes = removed_memo_bytes.saturating_add(entry.payload_bytes);
+            }
+            keep
+        });
+        self.eval_memo_bytes = self.eval_memo_bytes.saturating_sub(removed_memo_bytes);
+        self.node_meta.retain(|node, _| !nodes.contains(node));
+        self.pending_subscription_outputs
+            .retain(|node, _| !nodes.contains(node));
         self.terminal_deltas.retain(|node, _| !nodes.contains(node));
         self.root_ordering_windows
             .retain(|node, _| !nodes.contains(node));
-        self.discarded = true;
-        self.pending_subscription_outputs.clear();
-        self.terminal_deltas.clear();
-        self.root_ordering_windows.clear();
-        self.pending_notifications.clear();
-        self.published_subscriptions.clear();
+        self.relevant_nodes.retain(|node| !nodes.contains(node));
     }
 
-    fn install(&mut self, runtime: &mut IvmRuntime) {
-        if self.discarded {
-            return;
+    fn prune_failure(&mut self, runtime: &mut IvmRuntime, nodes: &HashSet<NodeId>) {
+        let failed_subscriptions = self
+            .affected_subscriptions
+            .iter()
+            .filter(|subscription| {
+                runtime
+                    .multisink_subscriptions
+                    .get(subscription)
+                    .is_some_and(|subscription| subscription.failed)
+            })
+            .copied()
+            .collect::<HashSet<_>>();
+        let mut released = HashSet::default();
+        let mut retained_groups = Vec::with_capacity(self.publication_groups.len());
+        for mut group in std::mem::take(&mut self.publication_groups) {
+            group
+                .subscriptions
+                .retain(|subscription| !failed_subscriptions.contains(subscription));
+            group.root_owners.retain(|root, owners| {
+                owners.retain(|owner| !failed_subscriptions.contains(owner));
+                !owners.is_empty() && !nodes.contains(root)
+            });
+            group.unowned_roots.retain(|root| !nodes.contains(root));
+            let mut retained_nodes = HashSet::default();
+            for root in group.root_owners.keys().chain(group.unowned_roots.iter()) {
+                runtime.graph.mark_ancestors(*root, &mut retained_nodes);
+            }
+            retained_nodes.retain(|node| !nodes.contains(node));
+            released.extend(group.nodes.difference(&retained_nodes).copied());
+            if retained_nodes.is_empty() {
+                continue;
+            }
+            group.nodes = retained_nodes;
+            retained_groups.push(group);
         }
-        // Drop the committed entries before folding staged COW state. This
-        // makes recursive closures and arrangement bases uniquely owned while
-        // leaving unrelated graph state untouched.
+        self.publication_groups = retained_groups;
+        released.extend(nodes.iter().copied());
+        self.prune_staged_nodes(&released);
+        self.affected_nodes.retain(|node| !released.contains(node));
+        self.work_queue.release_ownership(&released);
+        self.pending_notifications
+            .retain(|(subscription, _)| !failed_subscriptions.contains(subscription));
+        let live_requests = self.work_queue.requests().cloned().collect::<HashSet<_>>();
+        self.requests.retain(&live_requests);
+    }
+
+    fn abort_unowned_failure(&mut self) -> Vec<NodeId> {
+        let released = self
+            .work_queue
+            .registered_nodes()
+            .into_iter()
+            .collect::<HashSet<_>>();
+        self.publication_groups.clear();
+        self.pending_notifications.clear();
+        self.affected_subscriptions.clear();
+        self.published_subscriptions.clear();
+        self.table_frontier_advances.clear();
+        self.binding_frontier_advances.clear();
+        self.pending_binding_retractions = 0;
+        self.commit_ownerless_tick_globals_on_success = false;
+        self.tick_globals_committed = true;
+        self.prune_staged_nodes(&released);
+        self.affected_nodes.clear();
+        self.work_queue.release_ownership(&released);
+        self.requests = EvaluationRequests::new();
+        self.evaluation_inputs = None;
+        self.work_queue.drain_released_events()
+    }
+
+    fn dispatch_notifications(
+        &self,
+        runtime: &mut IvmRuntime,
+        notifications: Vec<(SubscriptionId, QueuedMultisinkDeltas)>,
+    ) {
+        let mut dropped_subscriptions = Vec::new();
+        for (subscription_id, queued) in notifications {
+            if self.defer_notifications_until_durable
+                && queued.publication.is_some_and(|publication| {
+                    !runtime
+                        .durable_notification_publications
+                        .contains(&publication)
+                })
+            {
+                runtime
+                    .deferred_notifications
+                    .entry(queued.publication.expect("checked publication"))
+                    .or_default()
+                    .push((subscription_id, queued));
+            } else if let Some(pending) = &self.pending_resident_publication
+                && queued.publication.is_none()
+            {
+                pending
+                    .notifications
+                    .borrow_mut()
+                    .push((subscription_id, queued));
+            } else if runtime
+                .multisink_subscriptions
+                .get(&subscription_id)
+                .is_some_and(|subscription| subscription.sender.send(queued).is_err())
+            {
+                dropped_subscriptions.push(subscription_id);
+            }
+        }
+        for subscription_id in dropped_subscriptions {
+            runtime.unsubscribe(subscription_id);
+        }
+    }
+
+    fn install_group(&mut self, runtime: &mut IvmRuntime, group: PublicationGroup) {
+        self.commit_tick_globals(runtime);
+        let nodes = group.nodes;
+
         runtime
             .operator_states
-            .retain(|key, _| !self.relevant_nodes.contains(&key.node));
-        for state in self.operator_states.values_mut() {
-            match state {
+            .retain(|key, _| !nodes.contains(&key.node));
+        for (key, mut state) in self
+            .operator_states
+            .extract_if(|key, _| nodes.contains(&key.node))
+        {
+            match &mut state {
                 OperatorState::Recursive(recursive) => {
                     recursive.value_mut().commit_staged_positive();
                 }
@@ -651,38 +1142,62 @@ impl IncrementalEvaluation<'_> {
                 }
                 _ => {}
             }
+            if key.scope == ScopeId::root() && runtime.graph.node(key.node).is_some() {
+                runtime.operator_states.insert(key, state);
+            }
         }
-        runtime.operator_states.extend(
-            std::mem::take(&mut self.operator_states)
-                .into_iter()
-                .filter(|(key, _)| runtime.graph.node(key.node).is_some()),
-        );
-        runtime.arrangement_states.extend(
-            std::mem::take(&mut self.arrangement_states)
-                .into_iter()
-                .filter(|(key, _)| runtime.graph.node(key.input).is_some()),
-        );
-        runtime.arrangement_keys_by_input.extend(
-            std::mem::take(&mut self.arrangement_keys_by_input)
-                .into_iter()
-                .filter(|(node, _)| runtime.graph.node(*node).is_some()),
-        );
 
-        runtime.eval_memo.extend(
-            std::mem::take(&mut self.eval_memo)
-                .into_iter()
-                .filter(|(key, _)| runtime.graph.node(key.node).is_some()),
-        );
+        runtime
+            .arrangement_states
+            .retain(|key, _| !nodes.contains(&key.input));
+        for (key, mut state) in self
+            .arrangement_states
+            .extract_if(|key, _| nodes.contains(&key.input))
+        {
+            state.value_mut().commit_overlay();
+            if runtime.graph.node(key.input).is_some() {
+                runtime.arrangement_states.insert(key, state);
+            }
+        }
+        runtime
+            .arrangement_keys_by_input
+            .retain(|node, _| !nodes.contains(node));
+        for (node, keys) in self
+            .arrangement_keys_by_input
+            .extract_if(|node, _| nodes.contains(node))
+        {
+            if runtime.graph.node(node).is_some() {
+                runtime.arrangement_keys_by_input.insert(node, keys);
+            }
+        }
+
+        let mut removed_live_memo_bytes = 0usize;
+        runtime.eval_memo.retain(|key, entry| {
+            let keep = !nodes.contains(&key.node);
+            if !keep {
+                removed_live_memo_bytes =
+                    removed_live_memo_bytes.saturating_add(entry.payload_bytes);
+            }
+            keep
+        });
         runtime.eval_memo_bytes = runtime
+            .eval_memo_bytes
+            .saturating_sub(removed_live_memo_bytes);
+        let mut installed_memo_bytes = 0usize;
+        for (key, entry) in self
             .eval_memo
-            .values()
-            .map(|entry| entry.payload_bytes)
-            .sum();
+            .extract_if(|key, _| nodes.contains(&key.node))
+        {
+            self.eval_memo_bytes = self.eval_memo_bytes.saturating_sub(entry.payload_bytes);
+            if runtime.graph.node(key.node).is_some() {
+                installed_memo_bytes = installed_memo_bytes.saturating_add(entry.payload_bytes);
+                runtime.eval_memo.insert(key, entry);
+            }
+        }
+        runtime.eval_memo_bytes = runtime.eval_memo_bytes.saturating_add(installed_memo_bytes);
         runtime.memo_use_clock = runtime.memo_use_clock.max(self.memo_use_clock);
-        // Retainers are owned by graph lifecycle operations, not by this
-        // evaluation snapshot. Preserve their current live value when a
-        // suspended continuation resumes after lifecycle activity.
-        for node in &self.relevant_nodes {
+
+        for node in &nodes {
             if runtime.graph.node(*node).is_none() {
                 continue;
             }
@@ -694,20 +1209,68 @@ impl IncrementalEvaluation<'_> {
                 _ => {}
             }
         }
-        runtime
-            .node_meta
-            .retain(|node, _| !self.relevant_nodes.contains(node));
-        runtime.node_meta.extend(
-            std::mem::take(&mut self.node_meta)
-                .into_iter()
-                .filter(|(node, _)| runtime.graph.node(*node).is_some()),
-        );
-        runtime.table_frontiers = std::mem::take(&mut self.table_frontiers);
-        runtime.binding_frontiers = std::mem::take(&mut self.binding_frontiers);
-        runtime.current_tick = self.current_tick;
-        runtime
-            .pending_binding_retractions
-            .drain(..self.pending_binding_retractions);
+        runtime.node_meta.retain(|node, _| !nodes.contains(node));
+        for (node, meta) in self.node_meta.extract_if(|node, _| nodes.contains(node)) {
+            if runtime.graph.node(node).is_some() {
+                runtime.node_meta.insert(node, meta);
+            }
+        }
+
+        let mut retained_notifications = Vec::with_capacity(self.pending_notifications.len());
+        let mut notifications = Vec::new();
+        for notification in std::mem::take(&mut self.pending_notifications) {
+            if group.subscriptions.contains(&notification.0) {
+                notifications.push(notification);
+            } else {
+                retained_notifications.push(notification);
+            }
+        }
+        self.pending_notifications = retained_notifications;
+        self.prune_staged_nodes(&nodes);
+        self.work_queue.release_ownership(&nodes);
+        self.dispatch_notifications(runtime, notifications);
+    }
+
+    fn install_ready_groups(&mut self, runtime: &mut IvmRuntime) {
+        let mut index = 0;
+        while index < self.publication_groups.len() {
+            let ready = {
+                let group = &self.publication_groups[index];
+                group
+                    .nodes
+                    .iter()
+                    .all(|node| self.work_queue.is_complete(*node))
+                    && group.subscriptions.iter().all(|subscription| {
+                        self.published_subscriptions.contains(subscription)
+                            || runtime
+                                .multisink_subscriptions
+                                .get(subscription)
+                                .is_none_or(|subscription| subscription.failed)
+                    })
+            };
+            if !ready {
+                index += 1;
+                continue;
+            }
+            let group = self.publication_groups.swap_remove(index);
+            self.install_group(runtime, group);
+        }
+    }
+
+    #[cfg(test)]
+    fn install(&mut self, runtime: &mut IvmRuntime) {
+        for group in std::mem::take(&mut self.publication_groups) {
+            self.install_group(runtime, group);
+        }
+    }
+
+    #[cfg(test)]
+    fn abandon(&mut self, _nodes: &HashSet<NodeId>) {
+        self.publication_groups.clear();
+        self.table_frontier_advances.clear();
+        self.binding_frontier_advances.clear();
+        self.pending_binding_retractions = 0;
+        self.tick_globals_committed = true;
     }
 
     fn poll(
@@ -715,9 +1278,6 @@ impl IncrementalEvaluation<'_> {
         runtime: &mut IvmRuntime,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), EvaluationFailure>> {
-        if self.discarded {
-            return Poll::Ready(Ok(()));
-        }
         let ready = self.requests.poll(cx);
         if ready == 0 {
             self.requests.poll_eager_retry(cx);
@@ -734,7 +1294,6 @@ impl IncrementalEvaluation<'_> {
             inputs.install(ready);
         }
 
-        let dropped_subscriptions = Vec::new();
         let mut evaluator = TickEvaluator {
             schema: &runtime.schema,
             graph: &runtime.graph,
@@ -1014,49 +1573,16 @@ impl IncrementalEvaluation<'_> {
         }
         self.terminal_deltas = std::mem::take(&mut evaluator.terminal_deltas);
         self.root_ordering_windows = std::mem::take(&mut evaluator.root_ordering_windows);
+        drop(evaluator);
+        self.install_ready_groups(runtime);
 
-        if self.requests.has_pending() || !self.work_queue.roots_complete() {
+        if self.requests.has_pending() || !self.publication_groups.is_empty() {
             return Poll::Pending;
         }
+        if std::mem::take(&mut self.commit_ownerless_tick_globals_on_success) {
+            self.commit_tick_globals(runtime);
+        }
 
-        drop(evaluator);
-        self.install(runtime);
-        runtime
-            .operator_states
-            .retain(|key, _| key.scope == ScopeId::root());
-        let notifications = std::mem::take(&mut self.pending_notifications);
-        let mut dropped_subscriptions = dropped_subscriptions;
-        for (subscription_id, queued) in notifications {
-            if self.defer_notifications_until_durable
-                && queued.publication.is_some_and(|publication| {
-                    !runtime
-                        .durable_notification_publications
-                        .contains(&publication)
-                })
-            {
-                runtime
-                    .deferred_notifications
-                    .entry(queued.publication.expect("checked publication"))
-                    .or_default()
-                    .push((subscription_id, queued));
-            } else if let Some(pending) = &self.pending_resident_publication
-                && queued.publication.is_none()
-            {
-                pending
-                    .notifications
-                    .borrow_mut()
-                    .push((subscription_id, queued));
-            } else if runtime
-                .multisink_subscriptions
-                .get(&subscription_id)
-                .is_some_and(|subscription| subscription.sender.send(queued).is_err())
-            {
-                dropped_subscriptions.push(subscription_id);
-            }
-        }
-        for subscription_id in dropped_subscriptions {
-            runtime.unsubscribe(subscription_id);
-        }
         debug_assert!(
             runtime.affected_recursive_nodes_are_current(&self.affected_nodes, self.current_tick)
         );
@@ -1089,11 +1615,15 @@ impl IncrementalEvaluation<'_> {
 impl<'a> EvaluationSession<'a> {
     fn hydration(
         runtime: &IvmRuntime,
-        roots: VecDeque<NodeId>,
+        topology: HydrationTopology,
         storage: OwnedStorage<'a>,
-    ) -> Result<Self, IvmRuntimeError> {
-        let (relevant_nodes, mut work_queue) =
-            EvaluationWorkQueue::new(roots.iter().copied()).discover_hydration(&runtime.graph)?;
+        requests: EvaluationRequests<'a>,
+    ) -> Self {
+        let HydrationTopology {
+            relevant_nodes,
+            roots,
+            work_queue,
+        } = topology;
         // Installed operator state is root-scoped. Recursive child scopes are
         // scratch state and are cleared before an evaluation is installed.
         // Probe by reachable node instead of scanning state owned by unrelated
@@ -1145,60 +1675,7 @@ impl<'a> EvaluationSession<'a> {
                     .map(|meta| (*node, meta))
             })
             .collect::<HashMap<_, _>>();
-        // Recursive hydration rebuilds internal arrangements from complete
-        // source snapshots, so a leaf memo alone cannot satisfy those inputs.
-        // Walk all recursive inputs together to keep classification linear in
-        // the reachable graph slice even when it contains sibling recursion.
-        let mut pending_recursive_inputs = VecDeque::new();
-        for node in &relevant_nodes {
-            let Some(graph_node) = runtime.graph.node(*node) else {
-                continue;
-            };
-            if matches!(graph_node.descriptor.operator, OpType::Recursive(_)) {
-                pending_recursive_inputs.extend(graph_node.descriptor.inputs.iter().copied());
-            }
-        }
-        let mut recursive_inputs = HashSet::<NodeId>::default();
-        while let Some(node) = pending_recursive_inputs.pop_front() {
-            if !recursive_inputs.insert(node) {
-                continue;
-            }
-            if let Some(graph_node) = runtime.graph.node(node) {
-                pending_recursive_inputs.extend(graph_node.descriptor.inputs.iter().copied());
-            }
-        }
-        let resident_source_nodes = node_meta
-            .iter()
-            .filter_map(|(node, meta)| {
-                if recursive_inputs.contains(node) {
-                    return None;
-                }
-                let signature = meta.input_signature.as_ref()?;
-                let key = EvalMemoKey {
-                    scope: ScopeId::root(),
-                    node: *node,
-                    input_signature_hash: signature.hash,
-                    tick_epoch: None,
-                    sub_tick: 0,
-                    context_digest: 0,
-                };
-                eval_memo
-                    .get(&key)
-                    .is_some_and(|entry| entry.input_watermark == meta.input_generation)
-                    .then_some(*node)
-            })
-            .collect::<HashSet<_>>();
-        work_queue.storage_already_resident(&resident_source_nodes);
-        let mut requests = EvaluationRequests::new();
-        for request in work_queue.requests().cloned().collect::<Vec<_>>() {
-            requests.request(
-                request,
-                &storage,
-                Some(&runtime.chunk_provider),
-                &runtime.schema,
-            );
-        }
-        Ok(Self {
+        Self {
             relevant_nodes,
             roots: roots.into_iter().collect(),
             outputs: HashMap::default(),
@@ -1215,7 +1692,7 @@ impl<'a> EvaluationSession<'a> {
             requests,
             evaluation_inputs: EvaluationInputs::default(),
             work_queue,
-        })
+        }
     }
 
     fn advance_binding_input(&mut self, graph: &IvmGraph, shape: &str) {
@@ -1455,6 +1932,18 @@ impl<'a> EvaluationSession<'a> {
             .sum();
         runtime.memo_use_clock = runtime.memo_use_clock.max(self.memo_use_clock);
         for node in &self.relevant_nodes {
+            if runtime.graph.node(*node).is_none() {
+                continue;
+            }
+            match (self.node_meta.get_mut(node), runtime.node_meta.get(node)) {
+                (Some(meta), Some(live)) => meta.retainers = live.retainers.clone(),
+                (None, Some(live)) => {
+                    self.node_meta.insert(*node, live.clone());
+                }
+                _ => {}
+            }
+        }
+        for node in &self.relevant_nodes {
             runtime.node_meta.remove(node);
         }
         runtime.node_meta.extend(
@@ -1474,7 +1963,7 @@ impl IvmRuntime {
         binding_snapshots: Option<HashMap<String, RecordDeltas>>,
         binding_frontier_advance: Option<&str>,
         initial: Arc<Mutex<Option<MultisinkDeltas>>>,
-    ) -> Result<(), IvmRuntimeError> {
+    ) -> Result<Option<u64>, IvmRuntimeError> {
         let mut seen_roots = HashSet::new();
         let roots = outputs
             .values()
@@ -1485,10 +1974,11 @@ impl IvmRuntime {
         let hydrate_arrangements = roots.iter().copied().try_fold(false, |found, root| {
             Ok::<_, IvmRuntimeError>(found || self.output_depends_on_aggregate(root)?)
         })?;
-        let mut session = EvaluationSession::hydration(self, roots, storage)?;
-        if let Some(shape) = binding_frontier_advance {
-            session.advance_binding_input(&self.graph, shape);
-        }
+        let mut topology = HydrationTopology::discover(self, roots)?;
+        // Preserve whether discovery found raw CPU work before temporal
+        // blockers hide it. Only this opening may spend a targeted normal
+        // owner turn on the new hydration.
+        let direct_poll_candidate = topology.work_queue.has_resident_continuation();
         let temporal_blockers = {
             let pending = self.pending_incremental.0.borrow();
             pending
@@ -1497,13 +1987,21 @@ impl IvmRuntime {
                 .map(|node| (*node, 1))
                 .collect::<HashMap<_, _>>()
         };
-        session.work_queue.add_temporal_blockers(&temporal_blockers);
+        topology
+            .work_queue
+            .add_temporal_blockers(&temporal_blockers);
         let evaluation = PendingEvaluation::SubscriptionHydration(PendingSubscriptionHydration {
             subscription_id,
             outputs,
             initial,
-            session,
-            binding_snapshots: binding_snapshots.unwrap_or_else(|| self.binding_snapshot_deltas()),
+            capture: Some(PendingHydrationCapture::new(
+                self,
+                topology,
+                storage,
+                binding_snapshots,
+                binding_frontier_advance.map(str::to_owned),
+            )),
+            active: None,
             hydrate_arrangements,
             metrics: TickMetrics::default(),
         });
@@ -1519,19 +2017,21 @@ impl IvmRuntime {
         }
         pending.evaluations.insert(evaluation_id, evaluation);
         pending.order.push_back(evaluation_id);
-        Ok(())
+        Ok(direct_poll_candidate.then_some(evaluation_id))
     }
 
     fn fail_evaluation_nodes(&mut self, failure: &EvaluationFailure) {
         self.operator_states
             .retain(|key, _| !failure.affected_nodes.contains(&key.node));
-        self.eval_memo
-            .retain(|key, _| !failure.affected_nodes.contains(&key.node));
-        self.eval_memo_bytes = self
-            .eval_memo
-            .values()
-            .map(|entry| entry.payload_bytes)
-            .sum();
+        let mut removed_memo_bytes = 0usize;
+        self.eval_memo.retain(|key, entry| {
+            let keep = !failure.affected_nodes.contains(&key.node);
+            if !keep {
+                removed_memo_bytes = removed_memo_bytes.saturating_add(entry.payload_bytes);
+            }
+            keep
+        });
+        self.eval_memo_bytes = self.eval_memo_bytes.saturating_sub(removed_memo_bytes);
         for node in &failure.affected_nodes {
             if let Some(keys) = self.arrangement_keys_by_input.remove(node) {
                 for key in keys {
@@ -1642,28 +2142,26 @@ impl IvmRuntime {
             .graph
             .affected_nodes(changed_tables.iter().copied(), std::iter::empty());
 
-        // Hydration evaluates an isolated snapshot and installs that snapshot
-        // atomically. Do not begin a resident tick which overlaps its graph
-        // slice: beginning mutates durable evaluator state and input
-        // generations before the work queue can attach temporal blockers, so
-        // a later hydration install would otherwise roll those mutations back.
+        // No evaluation may snapshot a graph slice still privately owned by an
+        // earlier publication. Drive overlapping owners to installation or
+        // pruning first; disjoint resident ticks remain independent.
         std::future::poll_fn(|cx| {
             let selected = self
                 .pending_incremental
                 .0
                 .borrow()
-                .hydration_admission_evaluations(&affected_nodes);
+                .admission_evaluations(&affected_nodes);
             if selected.is_empty() {
                 return Poll::Ready(Ok(()));
             }
-            match self.poll_incremental(cx, false, Some(&selected)) {
+            match self.poll_incremental(cx, false, Some(&selected), None) {
                 Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
                 Poll::Ready(Ok(())) | Poll::Pending => {
                     if self
                         .pending_incremental
                         .0
                         .borrow()
-                        .hydration_admission_evaluations(&affected_nodes)
+                        .admission_evaluations(&affected_nodes)
                         .is_empty()
                     {
                         Poll::Ready(Ok(()))
@@ -1704,7 +2202,7 @@ impl IvmRuntime {
                         if failure.kind == EvaluationFailureKind::Scoped =>
                     {
                         self.fail_evaluation_nodes(failure);
-                        evaluation.abandon(&failure.affected_nodes);
+                        evaluation.prune_failure(self, &failure.affected_nodes);
                     }
                     Poll::Pending if !evaluation.work_queue.runnable.is_empty() => {
                         // A resumable operator deliberately yielded while it
@@ -1724,11 +2222,12 @@ impl IvmRuntime {
             Poll::Ready(Ok(())) => {}
             Poll::Ready(Err(failure)) => return Err(failure.into_error()),
             Poll::Pending => {
-                evaluation.work_queue.drain_completed_events();
+                evaluation.work_queue.drain_released_events();
+                let owned_nodes = evaluation.pending_owned_nodes();
                 let mut pending = self.pending_incremental.0.borrow_mut();
                 let evaluation_id = pending.next_id;
                 pending.next_id = pending.next_id.saturating_add(1);
-                for node in evaluation.work_queue.incomplete_nodes() {
+                for node in owned_nodes {
                     pending
                         .waiters_by_node
                         .entry(node)
@@ -1817,7 +2316,15 @@ impl IvmRuntime {
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), IvmRuntimeError>> {
-        self.poll_incremental(cx, false, None)
+        self.poll_incremental(cx, false, None, None)
+    }
+
+    pub(crate) fn poll_pending_incremental_evaluation(
+        &mut self,
+        cx: &mut Context<'_>,
+        evaluation_id: u64,
+    ) -> Poll<Result<(), IvmRuntimeError>> {
+        self.poll_incremental(cx, false, None, Some(evaluation_id))
     }
 
     /// Poll only evaluations that have retained an explicit in-memory
@@ -1828,7 +2335,7 @@ impl IvmRuntime {
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), IvmRuntimeError>> {
-        self.poll_incremental(cx, true, None)
+        self.poll_incremental(cx, true, None, None)
     }
 
     fn poll_incremental(
@@ -1836,11 +2343,34 @@ impl IvmRuntime {
         cx: &mut Context<'_>,
         resident_only: bool,
         selected_evaluations: Option<&HashSet<u64>>,
+        selected_evaluation: Option<u64>,
     ) -> Poll<Result<(), IvmRuntimeError>> {
+        debug_assert!(selected_evaluations.is_none() || selected_evaluation.is_none());
         let slot = Rc::clone(&self.pending_incremental.0);
         let mut state = std::mem::take(&mut *slot.borrow_mut());
         if state.order.is_empty() {
             return Poll::Ready(Ok(()));
+        }
+        if let Some(selected) = selected_evaluations {
+            debug_assert!(!resident_only);
+            // Admission owns the selected temporal dependency closure. Start
+            // each dormant request at its original cold/resident point before
+            // ordered predecessor installation, without capturing mutable
+            // evaluator state or activating the hydration.
+            for evaluation_id in &state.order {
+                if !selected.contains(evaluation_id) {
+                    continue;
+                }
+                let Some(PendingEvaluation::SubscriptionHydration(hydration)) =
+                    state.evaluations.get_mut(evaluation_id)
+                else {
+                    continue;
+                };
+                let Some(capture) = hydration.capture.as_mut() else {
+                    continue;
+                };
+                capture.start_requests(cx);
+            }
         }
         let mut retained_order = VecDeque::new();
         while let Some(evaluation_id) = state.order.pop_front() {
@@ -1848,7 +2378,9 @@ impl IvmRuntime {
                 .evaluations
                 .remove(&evaluation_id)
                 .expect("pending evaluation order references a live session");
-            if selected_evaluations.is_some_and(|selected| !selected.contains(&evaluation_id)) {
+            if selected_evaluation.is_some_and(|selected| selected != evaluation_id)
+                || selected_evaluations.is_some_and(|selected| !selected.contains(&evaluation_id))
+            {
                 state.evaluations.insert(evaluation_id, evaluation);
                 retained_order.push_back(evaluation_id);
                 continue;
@@ -1860,39 +2392,53 @@ impl IvmRuntime {
             }
             let progress = match &mut evaluation {
                 PendingEvaluation::Incremental(incremental) => incremental.poll(self, cx),
-                PendingEvaluation::SubscriptionHydration(hydration) => hydration
-                    .session
-                    .poll(
-                        self,
-                        &hydration.binding_snapshots,
-                        hydration.hydrate_arrangements,
-                        &mut hydration.metrics,
-                        cx,
-                    )
-                    .map_err(|error| EvaluationFailure {
-                        kind: EvaluationFailureKind::Scoped,
-                        affected_nodes: hydration.session.work_queue.incomplete_nodes().collect(),
-                        error: Arc::new(error),
-                    }),
+                PendingEvaluation::SubscriptionHydration(hydration) => {
+                    if !hydration.activate_after_temporal_release(self) {
+                        Poll::Pending
+                    } else {
+                        let active = hydration
+                            .active
+                            .as_mut()
+                            .expect("eligible subscription hydration is active");
+                        active
+                            .session
+                            .poll(
+                                self,
+                                &active.binding_snapshots,
+                                hydration.hydrate_arrangements,
+                                &mut hydration.metrics,
+                                cx,
+                            )
+                            .map_err(|error| EvaluationFailure {
+                                kind: EvaluationFailureKind::Scoped,
+                                affected_nodes: active
+                                    .session
+                                    .work_queue
+                                    .incomplete_nodes()
+                                    .collect(),
+                                error: Arc::new(error),
+                            })
+                    }
+                }
             };
-            // A hydration session owns a private snapshot of all reachable
-            // state. Its completed interior nodes are not safe handoff points:
-            // a later incremental evaluation would run against the old live
-            // runtime, then lose its changes when hydration installs. Treat
-            // the whole session as one temporal barrier instead.
+            // Hydration remains one barrier. Incremental groups release their
+            // node ownership only after state and notification installation.
             if matches!(evaluation, PendingEvaluation::Incremental(_)) {
-                let completed = evaluation.work_queue_mut().drain_completed_events();
-                state.release_temporal_successors(evaluation_id, completed);
+                let released = evaluation.work_queue_mut().drain_released_events();
+                state.release_temporal_successors(evaluation_id, released);
             }
             match progress {
                 Poll::Ready(Ok(())) => {
                     if let PendingEvaluation::SubscriptionHydration(hydration) = evaluation {
+                        let active = hydration
+                            .active
+                            .expect("completed subscription hydration is active");
                         let snapshot = subscription_snapshot_from_hydrated(
                             &hydration.outputs,
-                            &hydration.session.outputs,
+                            &active.session.outputs,
                         );
-                        let completed = hydration.session.work_queue.registered_nodes();
-                        hydration.session.install(self);
+                        let completed = active.session.work_queue.registered_nodes();
+                        active.session.install(self);
                         state.release_temporal_successors(evaluation_id, completed);
                         self.record_hydration_memo_metrics(&hydration.metrics);
                         self.evict_eval_memo();
@@ -1940,29 +2486,33 @@ impl IvmRuntime {
                         return Poll::Ready(Err(failure.into_error()));
                     }
                     self.fail_evaluation_nodes(&failure);
-                    let released_nodes =
-                        if matches!(&evaluation, PendingEvaluation::SubscriptionHydration(_)) {
-                            evaluation.work_queue().registered_nodes()
+                    if failure.affected_nodes.is_empty()
+                        && let PendingEvaluation::Incremental(incremental) = &mut evaluation
+                    {
+                        // An empty scoped failure has no safe publication-group
+                        // seam. Roll back every remaining operation-local group,
+                        // then retain the shell so its ordinary completion path
+                        // settles the pending resident publication.
+                        let released = incremental.abort_unowned_failure();
+                        state.remove_temporal_ownership(evaluation_id, released);
+                        state.evaluations.insert(evaluation_id, evaluation);
+                        state.order.push_front(evaluation_id);
+                        continue;
+                    }
+                    let requeue_incremental =
+                        if let PendingEvaluation::Incremental(incremental) = &mut evaluation {
+                            incremental.prune_failure(self, &failure.affected_nodes);
+                            let released = incremental.work_queue.drain_released_events();
+                            state.remove_temporal_ownership(evaluation_id, released);
+                            true
                         } else {
-                            evaluation
-                                .work_queue()
-                                .incomplete_nodes()
-                                .collect::<Vec<_>>()
+                            let released_nodes = evaluation.work_queue().registered_nodes();
+                            state.remove_temporal_ownership(evaluation_id, released_nodes);
+                            false
                         };
-                    for node in released_nodes {
-                        let Some(waiters) = state.waiters_by_node.get_mut(&node) else {
-                            continue;
-                        };
-                        waiters.retain(|waiter| *waiter != evaluation_id);
-                        let successor = waiters.front().copied();
-                        if waiters.is_empty() {
-                            state.waiters_by_node.remove(&node);
-                        }
-                        if let Some(successor) = successor
-                            && let Some(later) = state.evaluations.get_mut(&successor)
-                        {
-                            later.work_queue_mut().temporal_ready(node);
-                        }
+                    if requeue_incremental {
+                        state.evaluations.insert(evaluation_id, evaluation);
+                        state.order.push_front(evaluation_id);
                     }
                 }
                 Poll::Pending => {
@@ -2136,12 +2686,73 @@ impl IvmRuntime {
             changed_tables.iter().copied(),
             changed_bindings.iter().copied(),
         );
-        // Capture only the graph slice reached from changed inputs. The
-        // evaluator may need unchanged sibling inputs (for example the other
-        // side of a join), so discovery walks ancestors of every affected
-        // node, while unrelated graph state remains in the live runtime.
-        let (relevant_nodes, _) = EvaluationWorkQueue::new(affected_nodes.iter().copied())
-            .discover_incremental(&self.graph)?;
+        let affected_subscriptions = affected_nodes
+            .iter()
+            .filter_map(|node| self.subscriptions_by_output_node.get(node))
+            .flatten()
+            .copied()
+            .collect::<HashSet<_>>();
+        let retained_roots = affected_nodes
+            .iter()
+            .filter(|node| {
+                self.node_meta.get(node).is_some_and(|meta| {
+                    meta.retainers
+                        .iter()
+                        .any(|retainer| !matches!(retainer, Retainer::Subscription(_)))
+                }) && self
+                    .graph
+                    .node(**node)
+                    .is_some_and(|node| !node.is_durable())
+            })
+            .copied()
+            .collect::<HashSet<_>>();
+        let durable_roots = affected_nodes
+            .iter()
+            .filter(|node| {
+                self.graph
+                    .node(**node)
+                    .is_some_and(|node| node.is_durable())
+            })
+            .copied()
+            .collect::<HashSet<_>>();
+        let mut owners = Vec::new();
+        for subscription_id in &affected_subscriptions {
+            let Some(subscription) = self
+                .multisink_subscriptions
+                .get(subscription_id)
+                .filter(|subscription| !subscription.failed)
+            else {
+                continue;
+            };
+            let roots = subscription
+                .outputs
+                .values()
+                .filter(|output| affected_nodes.contains(&output.node))
+                .flat_map(|output| [Some(output.node), output.root_ordering_node])
+                .flatten()
+                .collect::<HashSet<_>>();
+            if !roots.is_empty() {
+                owners.push(PublicationOwner {
+                    roots,
+                    subscription: Some(*subscription_id),
+                });
+            }
+        }
+        owners.extend(
+            retained_roots
+                .iter()
+                .chain(durable_roots.iter())
+                .copied()
+                .map(|root| PublicationOwner {
+                    roots: HashSet::from_iter([root]),
+                    subscription: None,
+                }),
+        );
+        let publication_groups = publication_groups(&self.graph, owners);
+        let relevant_nodes = publication_groups
+            .iter()
+            .flat_map(|group| group.nodes.iter().copied())
+            .collect::<HashSet<_>>();
         let mut operator_states = self
             .operator_states
             .iter()
@@ -2210,48 +2821,48 @@ impl IvmRuntime {
             table_delta_records,
             ..TickMetrics::default()
         };
+        let table_frontier_advances = table_deltas
+            .iter()
+            .filter(|delta| !delta.deltas.is_empty())
+            .filter_map(|delta| {
+                table_frontiers
+                    .get(&delta.table)
+                    .map(|frontier| (delta.table.clone(), *frontier))
+            })
+            .collect::<HashMap<_, _>>();
+        let binding_frontier_advances = binding_deltas
+            .iter()
+            .filter(|delta| !delta.deltas.is_empty())
+            .filter_map(|delta| {
+                binding_frontiers
+                    .get(&delta.shape)
+                    .map(|frontier| (delta.shape.clone(), *frontier))
+            })
+            .collect::<HashMap<_, _>>();
         let binding_snapshots = self.binding_snapshot_deltas();
-        let affected_subscriptions = affected_nodes
+        let commit_ownerless_tick_globals_on_success = publication_groups.is_empty();
+        let active_roots = publication_groups
             .iter()
-            .filter_map(|node| self.subscriptions_by_output_node.get(node))
-            .flatten()
-            .copied()
+            .flat_map(|group| {
+                group
+                    .root_owners
+                    .keys()
+                    .chain(group.unowned_roots.iter())
+                    .copied()
+            })
             .collect::<HashSet<_>>();
-        let mut retained_roots = affected_nodes
-            .iter()
-            .filter(|node| {
-                self.node_meta
-                    .get(node)
-                    .is_some_and(|meta| !meta.retainers.is_empty())
-                    && self
-                        .graph
-                        .node(**node)
-                        .is_some_and(|node| !node.is_durable())
-            })
-            .copied()
-            .collect::<Vec<_>>();
-        retained_roots.sort_unstable();
-        let mut active_roots = affected_subscriptions
-            .iter()
-            .filter_map(|subscription| self.multisink_subscriptions.get(subscription))
-            .flat_map(|subscription| {
-                subscription
-                    .outputs
-                    .values()
-                    .filter(|output| affected_nodes.contains(&output.node))
-                    .flat_map(|output| [Some(output.node), output.root_ordering_node])
-                    .flatten()
-            })
-            .collect::<Vec<_>>();
-        active_roots.sort_unstable();
-        active_roots.dedup();
-        active_roots.extend(retained_roots.iter().copied());
-        active_roots.sort_unstable();
-        active_roots.dedup();
         let requests = EvaluationRequests::new();
         let evaluation_inputs = Some(EvaluationInputs::default());
-        let (_, work_queue) =
+        let (_, mut work_queue) =
             EvaluationWorkQueue::new(active_roots).discover_incremental(&self.graph)?;
+        let mut durable_prepared_nodes = HashSet::<NodeId>::default();
+        for root in &durable_roots {
+            self.graph
+                .mark_ancestors(*root, &mut durable_prepared_nodes);
+        }
+        for node in durable_prepared_nodes {
+            work_queue.complete(node);
+        }
         Ok(IncrementalEvaluation {
             table_deltas,
             binding_deltas,
@@ -2283,7 +2894,11 @@ impl IvmRuntime {
             node_meta,
             pending_binding_retractions,
             pending_notifications: Vec::new(),
-            discarded: false,
+            publication_groups,
+            table_frontier_advances,
+            binding_frontier_advances,
+            tick_globals_committed: false,
+            commit_ownerless_tick_globals_on_success,
         })
     }
 
@@ -2403,7 +3018,6 @@ impl IvmRuntime {
         binding_frontier_advance: Option<&str>,
     ) -> Result<HashMap<NodeId, RecordDeltas>, IvmRuntimeError> {
         let roots = roots.into_iter().collect::<VecDeque<_>>();
-        let binding_snapshots = binding_snapshots.unwrap_or_else(|| self.binding_snapshot_deltas());
         let mut metrics = TickMetrics::default();
         if roots.is_empty() {
             return Err(IvmRuntimeError::UnsupportedOperator);
@@ -2412,10 +3026,41 @@ impl IvmRuntime {
             && roots.iter().copied().try_fold(false, |found, root| {
                 Ok::<_, IvmRuntimeError>(found || self.output_depends_on_aggregate(root)?)
             })?;
-        let mut session = EvaluationSession::hydration(self, roots, owned_storage)?;
-        if let Some(shape) = binding_frontier_advance {
-            session.advance_binding_input(&self.graph, shape);
-        }
+        let capture = PendingHydrationCapture::new(
+            self,
+            HydrationTopology::discover(self, roots)?,
+            owned_storage,
+            binding_snapshots,
+            binding_frontier_advance.map(str::to_owned),
+        );
+        std::future::poll_fn(|cx| {
+            let selected = self
+                .pending_incremental
+                .0
+                .borrow()
+                .admission_evaluations(&capture.topology.relevant_nodes);
+            if selected.is_empty() {
+                return Poll::Ready(Ok(()));
+            }
+            match self.poll_incremental(cx, false, Some(&selected), None) {
+                Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+                Poll::Ready(Ok(())) | Poll::Pending => {
+                    if self
+                        .pending_incremental
+                        .0
+                        .borrow()
+                        .admission_evaluations(&capture.topology.relevant_nodes)
+                        .is_empty()
+                    {
+                        Poll::Ready(Ok(()))
+                    } else {
+                        Poll::Pending
+                    }
+                }
+            }
+        })
+        .await?;
+        let (mut session, binding_snapshots) = capture.capture(self);
         std::future::poll_fn(|cx| {
             session.poll(
                 self,

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -55,9 +55,12 @@ pub(super) struct IncrementalEvaluation<'a> {
     requests: EvaluationRequests<'a>,
     evaluation_inputs: Option<EvaluationInputs>,
     work_queue: EvaluationWorkQueue,
+    /// Graph slice whose state is staged by this evaluation. Unrelated
+    /// runtime state remains live and is merged only when the tick commits.
+    relevant_nodes: HashSet<NodeId>,
     published_subscriptions: HashSet<SubscriptionId>,
-    affected_nodes: HashSet<NodeId>,
     affected_subscriptions: HashSet<SubscriptionId>,
+    affected_nodes: HashSet<NodeId>,
     /// Relational output retained while logical terminal materialization waits
     /// for immutable chunks. Re-evaluating after operator state advances can
     /// correctly yield an empty delta, so publication owns this exact value.
@@ -617,13 +620,55 @@ impl IncrementalEvaluation<'_> {
     }
 
     fn install(&mut self, runtime: &mut IvmRuntime) {
-        runtime.operator_states = std::mem::take(&mut self.operator_states);
-        runtime.arrangement_states = std::mem::take(&mut self.arrangement_states);
-        runtime.arrangement_keys_by_input = std::mem::take(&mut self.arrangement_keys_by_input);
-        runtime.eval_memo = std::mem::take(&mut self.eval_memo);
-        runtime.eval_memo_bytes = self.eval_memo_bytes;
-        runtime.memo_use_clock = self.memo_use_clock;
-        runtime.node_meta = std::mem::take(&mut self.node_meta);
+        // Drop the committed entries before folding staged COW state. This
+        // makes recursive closures and arrangement bases uniquely owned while
+        // leaving unrelated graph state untouched.
+        runtime
+            .operator_states
+            .retain(|key, _| !self.relevant_nodes.contains(&key.node));
+        for state in self.operator_states.values_mut() {
+            if let OperatorState::Recursive(recursive) = state {
+                recursive.value_mut().commit_staged_positive();
+            }
+        }
+        runtime
+            .operator_states
+            .extend(std::mem::take(&mut self.operator_states));
+
+        runtime
+            .arrangement_states
+            .retain(|key, _| !self.relevant_nodes.contains(&key.input));
+        for state in self.arrangement_states.values_mut() {
+            state.value_mut().commit_overlay();
+        }
+        runtime
+            .arrangement_states
+            .extend(std::mem::take(&mut self.arrangement_states));
+        runtime
+            .arrangement_keys_by_input
+            .retain(|node, _| !self.relevant_nodes.contains(node));
+        runtime
+            .arrangement_keys_by_input
+            .extend(std::mem::take(&mut self.arrangement_keys_by_input));
+
+        runtime
+            .eval_memo
+            .retain(|key, _| !self.relevant_nodes.contains(&key.node));
+        runtime
+            .eval_memo
+            .extend(std::mem::take(&mut self.eval_memo));
+        runtime.eval_memo_bytes = runtime
+            .eval_memo
+            .values()
+            .map(|entry| entry.payload_bytes)
+            .sum();
+        runtime.memo_use_clock = runtime.memo_use_clock.max(self.memo_use_clock);
+        runtime
+            .node_meta
+            .retain(|node, _| !self.relevant_nodes.contains(node));
+        runtime
+            .node_meta
+            .extend(std::mem::take(&mut self.node_meta));
         runtime.table_frontiers = std::mem::take(&mut self.table_frontiers);
         runtime.binding_frontiers = std::mem::take(&mut self.binding_frontiers);
         runtime.current_tick = self.current_tick;
@@ -2030,16 +2075,44 @@ impl IvmRuntime {
             changed_tables.iter().copied(),
             changed_bindings.iter().copied(),
         );
-        // Every mutable evaluator map is a prepared snapshot. The maps are
-        // shallow clones where their values use COW, so a suspended or failed
-        // tick cannot mutate committed runtime state.
-        let mut operator_states = self.operator_states.clone();
-        let mut arrangement_states = self.arrangement_states.clone();
-        let mut arrangement_keys_by_input = self.arrangement_keys_by_input.clone();
-        let mut eval_memo = self.eval_memo.clone();
-        let mut eval_memo_bytes = self.eval_memo_bytes;
+        // Capture only the graph slice reached from changed inputs. The
+        // evaluator may need unchanged sibling inputs (for example the other
+        // side of a join), so discovery walks ancestors of every affected
+        // node, while unrelated graph state remains in the live runtime.
+        let (relevant_nodes, _) = EvaluationWorkQueue::new(affected_nodes.iter().copied())
+            .discover_incremental(&self.graph)?;
+        let mut operator_states = self
+            .operator_states
+            .iter()
+            .filter(|(key, _)| relevant_nodes.contains(&key.node))
+            .map(|(key, state)| (key.clone(), state.clone()))
+            .collect::<HashMap<_, _>>();
+        let mut arrangement_states = self
+            .arrangement_states
+            .iter()
+            .filter(|(key, _)| relevant_nodes.contains(&key.input))
+            .map(|(key, state)| (key.clone(), state.clone()))
+            .collect::<HashMap<_, _>>();
+        let mut arrangement_keys_by_input = self
+            .arrangement_keys_by_input
+            .iter()
+            .filter(|(input, _)| relevant_nodes.contains(input))
+            .map(|(input, keys)| (*input, keys.clone()))
+            .collect::<HashMap<_, _>>();
+        let mut eval_memo = self
+            .eval_memo
+            .iter()
+            .filter(|(key, _)| relevant_nodes.contains(&key.node))
+            .map(|(key, entry)| (key.clone(), entry.clone()))
+            .collect::<HashMap<_, _>>();
+        let mut eval_memo_bytes = eval_memo.values().map(|entry| entry.payload_bytes).sum();
         let mut memo_use_clock = self.memo_use_clock;
-        let mut node_meta = self.node_meta.clone();
+        let mut node_meta = self
+            .node_meta
+            .iter()
+            .filter(|(node, _)| relevant_nodes.contains(node))
+            .map(|(node, meta)| (*node, meta.clone()))
+            .collect::<HashMap<_, _>>();
         let mut table_frontiers = self.table_frontiers.clone();
         let mut binding_frontiers = self.binding_frontiers.clone();
         let current_tick = self.current_tick + 1;
@@ -2131,6 +2204,7 @@ impl IvmRuntime {
             evaluation_inputs,
             work_queue,
             published_subscriptions: HashSet::default(),
+            relevant_nodes,
             affected_nodes,
             affected_subscriptions,
             pending_subscription_outputs: HashMap::default(),

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -2500,9 +2500,10 @@ impl IvmRuntime {
                 progress_waker,
             );
         }
-        let multisink = self.subscribe_staged(vec![(DEFAULT_SINK.to_owned(), graph)], storage)?;
+        let (multisink, direct_poll_evaluation) =
+            self.subscribe_staged(vec![(DEFAULT_SINK.to_owned(), graph)], storage)?;
         let subscription = self.single_sink_subscription(multisink, DEFAULT_SINK)?;
-        self.poll_ready_subscription_work_now_with_waker(progress_waker)?;
+        self.poll_ready_subscription_work_now_with_waker(progress_waker, direct_poll_evaluation)?;
         Ok(subscription)
     }
 
@@ -2535,8 +2536,8 @@ impl IvmRuntime {
             .into_iter()
             .map(|(sink, graph)| (sink.into(), graph))
             .collect::<Vec<_>>();
-        let subscription = self.subscribe_staged(sinks, storage)?;
-        self.poll_ready_subscription_work_now_with_waker(progress_waker)?;
+        let (subscription, direct_poll_evaluation) = self.subscribe_staged(sinks, storage)?;
+        self.poll_ready_subscription_work_now_with_waker(progress_waker, direct_poll_evaluation)?;
         Ok(subscription)
     }
 
@@ -2546,12 +2547,22 @@ impl IvmRuntime {
     fn poll_ready_subscription_work_now_with_waker(
         &mut self,
         progress_waker: Option<&Waker>,
+        direct_poll_evaluation: Option<u64>,
     ) -> Result<(), IvmRuntimeError> {
         let mut cx = Context::from_waker(progress_waker.unwrap_or(Waker::noop()));
         match self.poll_pending_incremental(&mut cx) {
             Poll::Ready(result) => result,
             Poll::Pending if progress_waker.is_some() => Ok(()),
             Poll::Pending => {
+                // A newly opened hydration with raw topology work gets one
+                // normal owner turn. Targeting its evaluation keeps unrelated
+                // cold hydrations parked before the strict resident sweep.
+                if let Some(evaluation_id) = direct_poll_evaluation
+                    && let Poll::Ready(Err(error)) =
+                        self.poll_pending_incremental_evaluation(&mut cx, evaluation_id)
+                {
+                    return Err(error);
+                }
                 // A direct opening owns every explicitly retained CPU slice,
                 // including one queued behind an older cold hydration. Do not
                 // infer that ownership from a wake: scan the runtime's
@@ -2572,7 +2583,7 @@ impl IvmRuntime {
         &mut self,
         sinks: Vec<(String, GraphBuilder)>,
         storage: &Rc<S>,
-    ) -> Result<MultisinkSubscription, IvmRuntimeError>
+    ) -> Result<(MultisinkSubscription, Option<u64>), IvmRuntimeError>
     where
         S: OrderedKvStorage + 'static,
     {
@@ -2635,7 +2646,7 @@ impl IvmRuntime {
         );
         self.index_subscription_outputs(subscription_id, &outputs);
         let initial = Arc::new(Mutex::new(None));
-        self.enqueue_subscription_hydration(
+        let direct_poll_evaluation = self.enqueue_subscription_hydration(
             subscription_id,
             outputs,
             OwnedStorage::new(Rc::clone(storage)),
@@ -2643,13 +2654,16 @@ impl IvmRuntime {
             None,
             Arc::clone(&initial),
         )?;
-        Ok(MultisinkSubscription {
-            id: subscription_id,
-            initial,
-            receiver,
-            waiter,
-            _receiver_liveness: receiver_liveness,
-        })
+        Ok((
+            MultisinkSubscription {
+                id: subscription_id,
+                initial,
+                receiver,
+                waiter,
+                _receiver_liveness: receiver_liveness,
+            },
+            direct_poll_evaluation,
+        ))
     }
 
     pub async fn prepare<I, S>(
@@ -2790,13 +2804,13 @@ impl IvmRuntime {
     where
         S: OrderedKvStorage + 'static,
     {
-        let subscription = self.bind_shape_with_public_fields_staged(
+        let (subscription, direct_poll_evaluation) = self.bind_shape_with_public_fields_staged(
             shape_id,
             binding_values,
             public_fields,
             storage,
         )?;
-        self.poll_ready_subscription_work_now_with_waker(progress_waker)?;
+        self.poll_ready_subscription_work_now_with_waker(progress_waker, direct_poll_evaluation)?;
         Ok(subscription)
     }
 
@@ -2806,7 +2820,7 @@ impl IvmRuntime {
         binding_values: &[Value],
         public_fields: BTreeMap<String, Vec<String>>,
         storage: &Rc<S>,
-    ) -> Result<MultisinkSubscription, IvmRuntimeError>
+    ) -> Result<(MultisinkSubscription, Option<u64>), IvmRuntimeError>
     where
         S: OrderedKvStorage + 'static,
     {
@@ -2818,7 +2832,7 @@ impl IvmRuntime {
         let binding_record = shape.binding_descriptor.create(binding_values)?;
         let binding_key = BindingKey(binding_record);
         let subscription_id = self.next_subscription_id();
-        let (outputs, binding_snapshots) = {
+        let outputs = {
             let mut install = super::graph_lifecycle::EphemeralGraphInstall::new(self);
             let runtime = install.runtime();
             runtime.logical_nodes_requested += shape
@@ -2839,26 +2853,7 @@ impl IvmRuntime {
             let binding_shape = runtime.binding_source_shape_name(shape_id)?;
             let cancelled_retraction =
                 runtime.cancel_pending_binding_retraction(&binding_shape, &binding_key);
-            let binding_delta = runtime.provisional_binding_delta(shape_id, &binding_key)?;
-            let mut binding_snapshots = runtime.binding_snapshot_deltas();
-            let snapshot = binding_snapshots
-                .entry(binding_delta.shape.clone())
-                .or_insert_with(|| RecordDeltas {
-                    descriptor: binding_delta.descriptor,
-                    deltas: Vec::new(),
-                });
-            for delta in &binding_delta.deltas {
-                if delta.weight > 0
-                    && !snapshot
-                        .deltas
-                        .iter()
-                        .any(|existing| existing.record == delta.record)
-                {
-                    snapshot.deltas.push(delta.clone());
-                }
-            }
             let installed_delta = runtime.add_binding_ref(shape_id, binding_key.clone())?;
-            debug_assert_eq!(installed_delta.deltas, binding_delta.deltas);
             if !cancelled_retraction {
                 runtime.bump_input_frontiers(&[], std::slice::from_ref(&installed_delta));
             }
@@ -2866,7 +2861,7 @@ impl IvmRuntime {
                 runtime.retain_as_subscription(subscription_id, output.node);
             }
             install.commit();
-            (outputs, binding_snapshots)
+            outputs
         };
         let (sender, receiver) = mpsc::channel();
         let waiter = Arc::new(Mutex::new(None));
@@ -2890,21 +2885,24 @@ impl IvmRuntime {
         );
         self.index_subscription_outputs(subscription_id, &outputs);
         let initial = Arc::new(Mutex::new(None));
-        self.enqueue_subscription_hydration(
+        let direct_poll_evaluation = self.enqueue_subscription_hydration(
             subscription_id,
             outputs,
             OwnedStorage::new(Rc::clone(storage)),
-            Some(binding_snapshots),
+            None,
             Some(&shape.shape),
             Arc::clone(&initial),
         )?;
-        Ok(MultisinkSubscription {
-            id: subscription_id,
-            initial,
-            receiver,
-            waiter,
-            _receiver_liveness: receiver_liveness,
-        })
+        Ok((
+            MultisinkSubscription {
+                id: subscription_id,
+                initial,
+                receiver,
+                waiter,
+                _receiver_liveness: receiver_liveness,
+            },
+            direct_poll_evaluation,
+        ))
     }
 
     pub async fn prepare_one_sink(
@@ -3004,14 +3002,14 @@ impl IvmRuntime {
     where
         S: OrderedKvStorage + 'static,
     {
-        let multisink = self.bind_shape_with_public_fields_staged(
+        let (multisink, direct_poll_evaluation) = self.bind_shape_with_public_fields_staged(
             shape_id,
             binding_values,
             BTreeMap::new(),
             storage,
         )?;
         let subscription = self.single_sink_subscription(multisink, DEFAULT_SINK)?;
-        self.poll_ready_subscription_work_now_with_waker(progress_waker)?;
+        self.poll_ready_subscription_work_now_with_waker(progress_waker, direct_poll_evaluation)?;
         Ok(subscription)
     }
 
@@ -3034,14 +3032,14 @@ impl IvmRuntime {
             &public_output,
         )?;
         let public_fields = descriptor_field_names(&public_output)?;
-        let multisink = self.bind_shape_with_public_fields_staged(
+        let (multisink, direct_poll_evaluation) = self.bind_shape_with_public_fields_staged(
             shape_id,
             binding_values,
             [(DEFAULT_SINK.to_owned(), public_fields)].into(),
             storage,
         )?;
         let subscription = self.single_sink_subscription(multisink, DEFAULT_SINK)?;
-        self.poll_ready_subscription_work_now_with_waker(progress_waker)?;
+        self.poll_ready_subscription_work_now_with_waker(progress_waker, direct_poll_evaluation)?;
         Ok(subscription)
     }
 
@@ -3541,30 +3539,6 @@ impl IvmRuntime {
         self.pending_binding_retractions
             .retain(|pending| !pending.deltas.is_empty());
         cancelled
-    }
-
-    fn provisional_binding_delta(
-        &self,
-        shape_id: PreparedShapeId,
-        binding: &BindingKey,
-    ) -> Result<BindingDelta, IvmRuntimeError> {
-        let shape = self.binding_source_shape_name(shape_id)?;
-        let source = self
-            .binding_sources
-            .get(&shape)
-            .ok_or_else(|| IvmRuntimeError::BindingSourceNotFound(shape.clone()))?;
-        Ok(BindingDelta {
-            shape,
-            descriptor: source.descriptor,
-            deltas: if source.refcounts.contains_key(binding) {
-                Vec::new()
-            } else {
-                vec![RecordDelta {
-                    record: binding.0.clone().into(),
-                    weight: 1,
-                }]
-            },
-        })
     }
 
     fn add_binding_ref_for_shape(

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -512,6 +512,24 @@ fn recursive_reach_graph_with_limit(max_iters: usize) -> GraphBuilder {
     GraphBuilder::recursive(seed, step, "frontier", max_iters)
 }
 
+fn recursive_reach_with_renamed_inputs_graph() -> GraphBuilder {
+    let descriptor = RecordDescriptor::new([("from", ColumnType::U64), ("to", ColumnType::U64)]);
+    let seed = GraphBuilder::table("edges").project_fields([
+        crate::ivm::ProjectField::renamed("src", "from"),
+        crate::ivm::ProjectField::renamed("dst", "to"),
+    ]);
+    let edge_pairs = GraphBuilder::table("edges").project_fields([
+        crate::ivm::ProjectField::renamed("src", "edge_from"),
+        crate::ivm::ProjectField::renamed("dst", "edge_to"),
+    ]);
+    let frontier = GraphBuilder::frontier_source("frontier", descriptor);
+    let step = GraphBuilder::join(frontier, edge_pairs, ["to"], ["edge_from"]).project_fields([
+        crate::ivm::ProjectField::renamed("left.from", "from"),
+        crate::ivm::ProjectField::renamed("right.edge_to", "to"),
+    ]);
+    GraphBuilder::recursive(seed, step, "frontier", 16)
+}
+
 async fn write_edge_rows(
     storage: &impl OrderedKvStorage,
     edges: &RecordDescriptor,
@@ -2136,6 +2154,39 @@ async fn recursive_positive_tick_commits_new_facts_exactly_once() {
         subscription.try_recv().is_err(),
         "one positive recursive tick must publish exactly one notification"
     );
+}
+
+/// Positive recursive maintenance must let the step graph transform both the
+/// frontier and table inputs before the join computes new paths.
+#[futures_test::test]
+async fn recursive_positive_tick_applies_transforms_before_join() {
+    let schema = edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let storage = Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+    let edges = schema.table("edges").unwrap().record_schema();
+    write_edge_rows(&storage, &edges, &[(1, 1, 2)]).await;
+
+    let subscription = runtime
+        .subscribe_one_sink(recursive_reach_with_renamed_inputs_graph(), &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+
+    runtime
+        .tick(vec![edge_table_delta(edges, &[(2, 2, 3)])], &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [
+            (vec![Value::U64(1), Value::U64(3)], 1),
+            (vec![Value::U64(2), Value::U64(3)], 1),
+        ]
+    );
+    assert!(subscription.try_recv().is_err());
 }
 
 /// The positive path accepts new facts before discovering that the next

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::schema::{
     ColumnSchema, ColumnType, DatabaseSchema, IndexSchema, IntegerKeyType, PrimaryKey,
 };
-use crate::storage::{MemoryStorage, RecordStore};
+use crate::storage::{MemoryStorage, OwnedStorage, RecordStore};
 use std::rc::Rc;
 
 #[futures_test::test]
@@ -2252,6 +2252,59 @@ async fn recursive_iteration_limit_rolls_back_partial_positive_tick() {
     assert!(
         subscription.try_recv().is_err(),
         "a failed recursive tick must not expose staged facts"
+    );
+}
+
+/// Resident Database writes use the same staged evaluator as direct ticks, but
+/// scoped failures must discard it rather than install its partial closure.
+#[futures_test::test]
+async fn resident_recursive_iteration_limit_discards_staged_state() {
+    let schema = edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let storage = Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+    let edges = schema.table("edges").unwrap().record_schema();
+    write_edge_rows(&storage, &edges, &[(1, 1, 2)]).await;
+
+    let subscription = runtime
+        .subscribe_one_sink(recursive_reach_graph_with_limit(1), &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+    let output = runtime.subscription_output_node(subscription.id()).unwrap();
+    let before_state = recursive_state_snapshot(&runtime, output);
+    let before_stats = runtime.stats();
+    let before_tick = runtime.current_tick;
+    let before_frontiers = runtime.table_frontiers.clone();
+    runtime
+        .tick_resident_staged(
+            vec![edge_table_delta(edges, &[(2, 2, 3), (3, 3, 4)])],
+            OwnedStorage::new(Rc::clone(&storage)),
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        recursive_state_snapshot(&runtime, output),
+        before_state,
+        "a scoped resident failure must discard partial recursive state"
+    );
+    assert_eq!(
+        runtime.stats(),
+        before_stats,
+        "a scoped resident failure must not install staged state"
+    );
+    assert_eq!(
+        runtime.current_tick, before_tick,
+        "a scoped resident failure must not advance logical time"
+    );
+    assert_eq!(
+        runtime.table_frontiers, before_frontiers,
+        "a scoped resident failure must not advance input frontiers"
     );
 }
 

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -5,6 +5,16 @@ use crate::schema::{
 use crate::storage::{MemoryStorage, OwnedStorage, RecordStore};
 use std::rc::Rc;
 
+impl IvmRuntime {
+    pub(crate) fn deferred_publication_bookkeeping_counts(&self) -> (usize, usize, usize) {
+        (
+            self.durable_notification_publications.len(),
+            self.completed_deferred_publications.len(),
+            self.deferred_notifications.len(),
+        )
+    }
+}
+
 #[futures_test::test]
 async fn terminal_collect_canonicalization_emits_net_remove_before_net_insert() {
     let record = |label: u8| Bytes::from(vec![label]);

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -571,22 +571,22 @@ fn edge_table_delta(edges: RecordDescriptor, rows: &[(u64, u64, u64)]) -> TableD
 fn recursive_state_snapshot(
     runtime: &IvmRuntime,
     node: NodeId,
-) -> (Vec<RecordDelta>, bool, Option<u64>) {
+) -> Option<(Vec<RecordDelta>, bool, Option<u64>)> {
     let key = OperatorStateKey {
         scope: ScopeId::root(),
         node,
     };
     let Some(OperatorState::Recursive(state)) = runtime.operator_states.get(&key) else {
-        panic!("recursive state missing for {node:?}");
+        return None;
     };
     let state = state.value();
     let mut accumulated = state.accumulated_deltas();
     accumulated.sort_by(|left, right| left.record.cmp(&right.record));
-    (
+    Some((
         accumulated,
         state.step_arrangements_hydrated(),
         state.hydrated_input_generation(),
-    )
+    ))
 }
 
 fn recursive_reach_from_graph(src: u64) -> GraphBuilder {
@@ -2275,9 +2275,20 @@ async fn resident_recursive_iteration_limit_discards_staged_state() {
     );
     let output = runtime.subscription_output_node(subscription.id()).unwrap();
     let before_state = recursive_state_snapshot(&runtime, output);
+    assert!(
+        before_state.is_some(),
+        "the initial resident evaluation must install recursive state"
+    );
     let before_stats = runtime.stats();
     let before_tick = runtime.current_tick;
     let before_frontiers = runtime.table_frontiers.clone();
+    let before_retained_nodes = runtime.retained_node_ids();
+    let before_output_retainers = runtime
+        .node_meta
+        .get(&output)
+        .expect("subscription output must have live runtime metadata")
+        .retainers
+        .clone();
     runtime
         .tick_resident_staged(
             vec![edge_table_delta(edges, &[(2, 2, 3), (3, 3, 4)])],
@@ -2290,13 +2301,48 @@ async fn resident_recursive_iteration_limit_discards_staged_state() {
 
     assert_eq!(
         recursive_state_snapshot(&runtime, output),
-        before_state,
-        "a scoped resident failure must discard partial recursive state"
+        None,
+        "a scoped resident failure must remove recursive state instead of installing its partial closure"
+    );
+    let after_stats = runtime.stats();
+    assert_eq!(
+        after_stats.recursive_state_count, 0,
+        "a scoped resident failure must not retain recursive operator state"
     );
     assert_eq!(
-        runtime.stats(),
-        before_stats,
-        "a scoped resident failure must not install staged state"
+        after_stats.recursive_accumulated_rows, 0,
+        "a scoped resident failure must not retain a partial recursive closure"
+    );
+    assert_eq!(
+        after_stats.recursive_accumulated_encoded_bytes, 0,
+        "a scoped resident failure must not retain encoded recursive state"
+    );
+    assert!(
+        after_stats.arrangement_count <= before_stats.arrangement_count
+            && after_stats.arrangement_rows <= before_stats.arrangement_rows
+            && after_stats.arrangement_encoded_bytes <= before_stats.arrangement_encoded_bytes,
+        "a scoped resident failure must not retain staged arrangement state"
+    );
+    assert!(
+        after_stats.eval_memo_entries <= before_stats.eval_memo_entries
+            && after_stats.eval_memo_bytes <= before_stats.eval_memo_bytes,
+        "a scoped resident failure must not retain staged evaluator memo state"
+    );
+    assert!(
+        subscription.recv().is_err(),
+        "a scoped resident failure must fail the affected subscription without output"
+    );
+    assert!(
+        subscription.try_recv().is_err(),
+        "a scoped resident failure must not leak a staged notification"
+    );
+    assert!(
+        runtime.pending_binding_retractions.is_empty(),
+        "a scoped resident failure must not leak binding retractions"
+    );
+    assert!(
+        runtime.deferred_notifications.is_empty(),
+        "a scoped resident failure must not leak deferred notifications"
     );
     assert_eq!(
         runtime.current_tick, before_tick,
@@ -2305,6 +2351,24 @@ async fn resident_recursive_iteration_limit_discards_staged_state() {
     assert_eq!(
         runtime.table_frontiers, before_frontiers,
         "a scoped resident failure must not advance input frontiers"
+    );
+    assert_eq!(
+        runtime.retained_node_ids(),
+        before_retained_nodes,
+        "a scoped resident failure must preserve live graph retainers"
+    );
+    assert!(
+        runtime.graph().node(output).is_some(),
+        "a scoped resident failure must preserve the retained output graph node"
+    );
+    assert_eq!(
+        runtime
+            .node_meta
+            .get(&output)
+            .expect("retained subscription output metadata must remain live")
+            .retainers,
+        before_output_retainers,
+        "a scoped resident failure must preserve live output retainers"
     );
 }
 

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -498,6 +498,10 @@ async fn top_by_distinguishes_finite_max_from_unbounded_limit() {
 }
 
 fn recursive_reach_graph() -> GraphBuilder {
+    recursive_reach_graph_with_limit(16)
+}
+
+fn recursive_reach_graph_with_limit(max_iters: usize) -> GraphBuilder {
     let seed = GraphBuilder::table("edges").project(["src", "dst"]);
     let edge_pairs = GraphBuilder::table("edges").project(["src", "dst"]);
     let frontier = GraphBuilder::frontier_source("frontier", reach_descriptor());
@@ -505,7 +509,66 @@ fn recursive_reach_graph() -> GraphBuilder {
         crate::ivm::ProjectField::renamed("left.src", "src"),
         crate::ivm::ProjectField::renamed("right.dst", "dst"),
     ]);
-    GraphBuilder::recursive(seed, step, "frontier", 16)
+    GraphBuilder::recursive(seed, step, "frontier", max_iters)
+}
+
+async fn write_edge_rows(
+    storage: &impl OrderedKvStorage,
+    edges: &RecordDescriptor,
+    rows: &[(u64, u64, u64)],
+) {
+    let store = RecordStore::new(storage, "edges", edges);
+    let operations = rows
+        .iter()
+        .map(|(id, src, dst)| {
+            let record = edges
+                .create(&[Value::U64(*id), Value::U64(*src), Value::U64(*dst)])
+                .unwrap();
+            let encoded = crate::records::encode_variant_record(0, &record);
+            let key = id.to_be_bytes();
+            store.set(&key, &encoded)
+        })
+        .collect();
+    store.write_many(operations).await.unwrap();
+}
+
+fn edge_table_delta(edges: RecordDescriptor, rows: &[(u64, u64, u64)]) -> TableDelta {
+    TableDelta {
+        variant_tag: 0,
+        table: "edges".to_owned(),
+        descriptor: edges,
+        deltas: rows
+            .iter()
+            .map(|(id, src, dst)| RecordDelta {
+                record: edges
+                    .create(&[Value::U64(*id), Value::U64(*src), Value::U64(*dst)])
+                    .unwrap()
+                    .into(),
+                weight: 1,
+            })
+            .collect(),
+    }
+}
+
+fn recursive_state_snapshot(
+    runtime: &IvmRuntime,
+    node: NodeId,
+) -> (Vec<RecordDelta>, bool, Option<u64>) {
+    let key = OperatorStateKey {
+        scope: ScopeId::root(),
+        node,
+    };
+    let Some(OperatorState::Recursive(state)) = runtime.operator_states.get(&key) else {
+        panic!("recursive state missing for {node:?}");
+    };
+    let state = state.value();
+    let mut accumulated = state.accumulated_deltas();
+    accumulated.sort_by(|left, right| left.record.cmp(&right.record));
+    (
+        accumulated,
+        state.step_arrangements_hydrated(),
+        state.hydrated_input_generation(),
+    )
 }
 
 fn recursive_reach_from_graph(src: u64) -> GraphBuilder {
@@ -2035,6 +2098,151 @@ async fn recursive_recompute_reuses_graph_nodes_without_persisting_contextual_ch
             .all(|key| key.scope == ScopeId::root()),
         "recursive recomputation should not leave per-context child state in runtime"
     );
+}
+
+/// A positive recursive update is visible only once the tick is ready.  The
+/// public subscription receives the seed edge and its newly derived path as a
+/// single committed delta, with no duplicate delivery.
+#[futures_test::test]
+async fn recursive_positive_tick_commits_new_facts_exactly_once() {
+    let schema = edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let storage = Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+    let edges = schema.table("edges").unwrap().record_schema();
+    write_edge_rows(&storage, &edges, &[(1, 1, 2)]).await;
+
+    let subscription = runtime
+        .subscribe_one_sink(recursive_reach_graph_with_limit(16), &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+
+    let metrics = runtime
+        .tick(vec![edge_table_delta(edges, &[(2, 2, 3)])], &storage)
+        .await
+        .unwrap();
+    assert_eq!(metrics.table_delta_records, 1);
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [
+            (vec![Value::U64(1), Value::U64(3)], 1),
+            (vec![Value::U64(2), Value::U64(3)], 1),
+        ]
+    );
+    assert!(
+        subscription.try_recv().is_err(),
+        "one positive recursive tick must publish exactly one notification"
+    );
+}
+
+/// The positive path accepts new facts before discovering that the next
+/// iteration exceeds its safety bound.  A semantic failure must not commit
+/// that partial closure, advance the tick/frontier counters, or retain
+/// changed arrangement/memo accounting.
+#[futures_test::test]
+async fn recursive_iteration_limit_rolls_back_partial_positive_tick() {
+    // This runtime-level seam is intentional: Database fail-stop makes the
+    // post-error operator state inaccessible, while rollback must cover the
+    // closure, arrangement, memo, and logical-time state together.
+    let schema = edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let storage = Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+    let edges = schema.table("edges").unwrap().record_schema();
+    write_edge_rows(&storage, &edges, &[(1, 1, 2)]).await;
+
+    let subscription = runtime
+        .subscribe_one_sink(recursive_reach_graph_with_limit(1), &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+
+    let output = runtime.subscription_output_node(subscription.id()).unwrap();
+    let before_state = recursive_state_snapshot(&runtime, output);
+    let before_stats = runtime.stats();
+    let before_tick = runtime.current_tick;
+    let before_table_frontiers = runtime.table_frontiers.clone();
+
+    let error = runtime
+        .tick(
+            vec![edge_table_delta(edges, &[(2, 2, 3), (3, 3, 4)])],
+            &storage,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        IvmRuntimeError::RecursiveIterationLimit { max_iters: 1, .. }
+    ));
+
+    assert_eq!(
+        recursive_state_snapshot(&runtime, output),
+        before_state,
+        "failed recursion must retain the last committed closure and arrangement state"
+    );
+    assert_eq!(
+        runtime.stats(),
+        before_stats,
+        "failed recursion must not retain staged arrangement or memo accounting"
+    );
+    assert_eq!(
+        runtime.current_tick, before_tick,
+        "a failed recursive tick must not advance logical time"
+    );
+    assert_eq!(
+        runtime.table_frontiers, before_table_frontiers,
+        "a failed recursive tick must not advance input frontiers"
+    );
+    assert!(
+        subscription.try_recv().is_err(),
+        "a failed recursive tick must not expose staged facts"
+    );
+}
+
+/// A large existing closure is a scale canary for the positive path: adding an
+/// isolated edge must process only the new frontier, not feed every old fact
+/// back through the recursive step.
+#[futures_test::test]
+async fn recursive_positive_tick_does_not_reprocess_full_existing_closure() {
+    let schema = edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let storage = Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+    let edges = schema.table("edges").unwrap().record_schema();
+    let rows = (1..=48).map(|id| (id, id, id + 1)).collect::<Vec<_>>();
+    write_edge_rows(&storage, &edges, &rows).await;
+
+    let subscription = runtime
+        .subscribe_one_sink(recursive_reach_graph_with_limit(64), &storage)
+        .await
+        .unwrap();
+    let initial = subscription.recv().unwrap();
+    assert!(
+        initial.deltas.len() > 100,
+        "fixture must establish a meaningfully large recursive closure"
+    );
+
+    let metrics = runtime
+        .tick(
+            vec![edge_table_delta(edges, &[(10_000, 10_000, 10_001)])],
+            &storage,
+        )
+        .await
+        .unwrap();
+    assert!(
+        metrics.records_processed < 128,
+        "isolated positive edge should not reprocess the full closure: {} records",
+        metrics.records_processed
+    );
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(10_000), Value::U64(10_001)], 1)]
+    );
+    assert!(subscription.try_recv().is_err());
 }
 
 #[futures_test::test]

--- a/crates/groove/src/ivm/runtime/windows.rs
+++ b/crates/groove/src/ivm/runtime/windows.rs
@@ -604,9 +604,7 @@ fn update_collect_by_root_terminal_state(
             }
         });
     }
-    state
-        .groups
-        .remove_empty_touched(touched_group_keys.into_iter());
+    state.groups.remove_empty_touched(touched_group_keys);
     if !emit {
         return Ok(Vec::new());
     }

--- a/crates/groove/src/ivm/runtime/windows.rs
+++ b/crates/groove/src/ivm/runtime/windows.rs
@@ -292,9 +292,7 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
             encoded_record_key_part(input_desc, delta.raw(), &collect_by.group_field_indices)
         })
         .collect::<Result<BTreeSet<_>, _>>()?;
-    let root_groups_before = direct_tree_slot
-        .is_none()
-        .then(|| state.groups.keys_set());
+    let root_groups_before = direct_tree_slot.is_none().then(|| state.groups.keys_set());
     let mut operations = Vec::new();
     for delta in &deltas {
         let group_key =
@@ -444,7 +442,9 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
             debug_assert!(before_index.is_some());
         }
     }
-    state.groups.remove_empty_touched(touched_group_keys.iter().cloned());
+    state
+        .groups
+        .remove_empty_touched(touched_group_keys.iter().cloned());
     if let Some(root_groups_before) = root_groups_before {
         let root_groups_after = state.groups.keys_set();
         operations.retain(|operation| {

--- a/crates/groove/src/ivm/runtime/windows.rs
+++ b/crates/groove/src/ivm/runtime/windows.rs
@@ -286,9 +286,15 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
     // consumers and cancels transient insert/delete pairs within one batch.
     let deltas =
         canonical_collect_by_terminal_deltas(input_desc, collect_by, direct_tree_slot, deltas)?;
+    let touched_group_keys = deltas
+        .iter()
+        .map(|delta| {
+            encoded_record_key_part(input_desc, delta.raw(), &collect_by.group_field_indices)
+        })
+        .collect::<Result<BTreeSet<_>, _>>()?;
     let root_groups_before = direct_tree_slot
         .is_none()
-        .then(|| state.groups.keys().cloned().collect::<BTreeSet<_>>());
+        .then(|| state.groups.keys_set());
     let mut operations = Vec::new();
     for delta in &deltas {
         let group_key =
@@ -307,15 +313,8 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
             } else {
                 state.roots.insert(state_key.clone(), after_weight);
             }
-            if !emit || (before_weight > 0) == (after_weight > 0) {
-                continue;
-            }
             if after_weight > 0 {
-                let index = state
-                    .roots
-                    .range(..state_key)
-                    .filter(|(_, weight)| **weight > 0)
-                    .count();
+                let index = state.roots.count_positive_before(&state_key);
                 let record = collect_by_tree_parent_from_records(
                     input_desc,
                     output_desc,
@@ -366,20 +365,29 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
             sort_directions,
         )?;
         let state_key = (sort_key, delta.record.clone());
-        let group = state.groups.entry(group_key.clone()).or_default();
-        let before_weight = group.get(&state_key).copied().unwrap_or_default();
+        let before_weight = state
+            .groups
+            .get(&group_key)
+            .and_then(|group| group.get(&state_key))
+            .copied()
+            .unwrap_or_default();
         let before_index = (before_weight > 0).then(|| {
-            group
+            state
+                .groups
+                .get(&group_key)
+                .expect("positive state weight has a group")
                 .range(..state_key.clone())
                 .filter(|(_, weight)| **weight > 0)
                 .count()
         });
         let after_weight = before_weight + delta.weight;
-        if after_weight == 0 {
-            group.remove(&state_key);
-        } else {
-            group.insert(state_key.clone(), after_weight);
-        }
+        state.groups.update(group_key.clone(), |group| {
+            if after_weight == 0 {
+                group.remove(&state_key);
+            } else {
+                group.insert(state_key.clone(), after_weight);
+            }
+        });
         if !emit || (before_weight > 0) == (after_weight > 0) {
             continue;
         }
@@ -409,8 +417,11 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
         let child_key = encoded_record_key_part(child_descriptor, &child_record, &[0])?;
         let path = vec![TerminalPathSegment::Collection(collection_field.to_owned())];
         if after_weight > 0 {
-            let index = group
-                .range(..state_key)
+            let index = state
+                .groups
+                .get(&group_key)
+                .expect("positive state weight has a group")
+                .range(..state_key.clone())
                 .filter(|(_, weight)| **weight > 0)
                 .count();
             operations.push(TerminalOperation {
@@ -433,9 +444,9 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
             debug_assert!(before_index.is_some());
         }
     }
-    state.groups.retain(|_, group| !group.is_empty());
+    state.groups.remove_empty_touched(touched_group_keys.iter().cloned());
     if let Some(root_groups_before) = root_groups_before {
-        let root_groups_after = state.groups.keys().cloned().collect::<BTreeSet<_>>();
+        let root_groups_after = state.groups.keys_set();
         operations.retain(|operation| {
             root_groups_before.contains(&operation.root_key)
                 && root_groups_after.contains(&operation.root_key)
@@ -561,9 +572,11 @@ fn update_collect_by_root_terminal_state(
         state.roots.clear();
     }
     let mut before = BTreeMap::<Vec<u8>, Option<Bytes>>::new();
+    let mut touched_group_keys = BTreeSet::new();
     for delta in deltas {
         let group_key =
             encoded_record_key_part(input_desc, delta.raw(), &collect_by.group_field_indices)?;
+        touched_group_keys.insert(group_key.clone());
         if emit && !before.contains_key(&group_key) {
             let rendered = state.groups.get(&group_key).map_or(Ok(None), |group| {
                 let records = group
@@ -576,15 +589,24 @@ fn update_collect_by_root_terminal_state(
         }
         let sort_key = collect_by_sort_key(input_desc, delta.raw(), collect_by)?;
         let state_key = (sort_key, delta.record.clone());
-        let group = state.groups.entry(group_key).or_default();
-        let weight = group.get(&state_key).copied().unwrap_or_default() + delta.weight;
-        if weight == 0 {
-            group.remove(&state_key);
-        } else {
-            group.insert(state_key, weight);
-        }
+        let before_weight = state
+            .groups
+            .get(&group_key)
+            .and_then(|group| group.get(&state_key))
+            .copied()
+            .unwrap_or_default();
+        let weight = before_weight + delta.weight;
+        state.groups.update(group_key, |group| {
+            if weight == 0 {
+                group.remove(&state_key);
+            } else {
+                group.insert(state_key, weight);
+            }
+        });
     }
-    state.groups.retain(|_, group| !group.is_empty());
+    state
+        .groups
+        .remove_empty_touched(touched_group_keys.into_iter());
     if !emit {
         return Ok(Vec::new());
     }
@@ -605,8 +627,9 @@ fn update_collect_by_root_terminal_state(
             (None, Some(record)) => TerminalEdit::Insert {
                 index: state
                     .groups
-                    .keys()
-                    .take_while(|key| *key < &root_key)
+                    .keys_set()
+                    .into_iter()
+                    .take_while(|key| key < &root_key)
                     .count(),
                 key: root_key.clone(),
                 value: record.to_vec(),

--- a/crates/groove/tests/async_hydration_session.rs
+++ b/crates/groove/tests/async_hydration_session.rs
@@ -170,6 +170,19 @@ fn edge_pairs() -> GraphBuilder {
     GraphBuilder::table("edges").project(["src", "dst"])
 }
 
+fn edge_counts_by_src() -> GraphBuilder {
+    GraphBuilder::aggregate(
+        GraphBuilder::table("edges"),
+        ["src"],
+        [AggregateExpr {
+            function: AggregateFunction::Count,
+            expression: None,
+            distinct: false,
+            output_name: Some("dst".to_owned()),
+        }],
+    )
+}
+
 fn reachability_graph() -> GraphBuilder {
     let descriptor = RecordDescriptor::new([("src", ColumnType::U64), ("dst", ColumnType::U64)]);
     let frontier = GraphBuilder::frontier_source("frontier", descriptor);
@@ -1234,6 +1247,191 @@ fn resumed_recursive_slice_preserves_later_publications_and_live_retainers() {
     let persistence = block_on(latest.persist());
     assert_eq!(
         database.finish_persistence(persistence).unwrap(),
+        latest_publication
+    );
+    assert_eq!(
+        database.durable_publication_frontier(),
+        Some(latest_publication)
+    );
+}
+
+#[test]
+fn overlapping_stateful_hydration_waits_for_uninstalled_resident_predecessor() {
+    let (storage, control) = TestStorage::controlled(&["albums", "edges"]);
+    let mut database = block_on(Database::new(albums_and_edges_schema(), storage.clone())).unwrap();
+    let mut seed = database.open_batch();
+    seed.insert("edges", vec![Value::U64(1), Value::U64(1), Value::U64(2)]);
+    seed.insert("edges", vec![Value::U64(2), Value::U64(2), Value::U64(3)]);
+    block_on(database.commit_batch(seed)).unwrap();
+    let frontier_before_predecessor = database.durable_publication_frontier();
+
+    let publication_driver =
+        block_on(database.subscribe_one_sink(GraphBuilder::table("albums"))).unwrap();
+    assert!(
+        block_on(database.next_subscription(&publication_driver))
+            .unwrap()
+            .is_empty()
+    );
+
+    let resident = block_on(database.subscribe_one_sink(GraphBuilder::union([
+        edge_counts_by_src(),
+        reachability_graph(),
+    ])))
+    .unwrap();
+    assert!(
+        !block_on(database.next_subscription(&resident))
+            .unwrap()
+            .is_empty()
+    );
+
+    storage.evict_scans("edges");
+    control.take_observed();
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let mut predecessor = database.open_batch();
+    predecessor.delete("edges", PrimaryKeyValue::U64(2));
+    predecessor.insert(
+        "albums",
+        vec![Value::U64(1), Value::String("Speak No Evil".into())],
+    );
+    let mut predecessor_future = Box::pin(database.apply_batch(predecessor));
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    let predecessor = match predecessor_future.as_mut().poll(&mut context) {
+        Poll::Ready(Ok(applied)) => applied,
+        _ => panic!("resident publication must return while its graph state is suspended"),
+    };
+    drop(predecessor_future);
+    let predecessor_publication = predecessor.publication();
+    let published_driver_update = next_subscription_with_publication_bounded(
+        &mut database,
+        &publication_driver,
+        "resident publication driver",
+    );
+    assert_eq!(
+        published_driver_update.publication,
+        Some(predecessor_publication)
+    );
+    assert_eq!(published_driver_update.deltas.deltas.len(), 1);
+    assert!(resident.try_recv().is_err());
+    assert_eq!(
+        control
+            .observed()
+            .iter()
+            .filter(|operation| **operation == TestStorageOperation::ScanOpen)
+            .count(),
+        1,
+        "the predecessor must remain suspended on its retained storage request"
+    );
+
+    let hydrated = block_on(database.subscribe_one_sink(edge_counts_by_src())).unwrap();
+    assert!(hydrated.try_recv().is_err());
+
+    control.resume_operation(TestStorageOperation::ScanOpen);
+    let predecessor_update = next_subscription_with_publication_bounded(
+        &mut database,
+        &resident,
+        "resumed overlapping predecessor",
+    );
+    assert_eq!(
+        predecessor_update.publication,
+        Some(predecessor_publication)
+    );
+    assert_eq!(predecessor_update.deltas.deltas.len(), 3);
+
+    let hydration = next_subscription_with_publication_bounded(
+        &mut database,
+        &hydrated,
+        "overlapping stateful hydration",
+    );
+    assert_eq!(hydration.publication, None);
+    assert_eq!(
+        hydration.deltas.to_values().unwrap(),
+        vec![(vec![Value::U64(1), Value::U64(1)], 1)],
+        "hydration must snapshot the predecessor's installed aggregate state"
+    );
+    assert_eq!(
+        database.durable_publication_frontier(),
+        frontier_before_predecessor
+    );
+
+    let predecessor_persistence = block_on(predecessor.persist());
+    assert_eq!(
+        database
+            .finish_persistence(predecessor_persistence)
+            .unwrap(),
+        predecessor_publication
+    );
+    assert_eq!(
+        database.durable_publication_frontier(),
+        Some(predecessor_publication)
+    );
+
+    let mut latest = database.open_batch();
+    latest.insert("edges", vec![Value::U64(3), Value::U64(2), Value::U64(4)]);
+    let latest = block_on(database.apply_batch(latest)).unwrap();
+    let latest_publication = latest.publication();
+
+    let resident_update = next_subscription_with_publication_bounded(
+        &mut database,
+        &resident,
+        "resident state after overlapping hydration",
+    );
+    assert_eq!(resident_update.publication, Some(latest_publication));
+    let resident_values = resident_update.deltas.to_values().unwrap();
+    assert_eq!(
+        resident_values.len(),
+        3,
+        "the stale hydration must not roll back the predecessor's aggregate state"
+    );
+    for expected in [
+        vec![Value::U64(2), Value::U64(1)],
+        vec![Value::U64(2), Value::U64(4)],
+        vec![Value::U64(1), Value::U64(4)],
+    ] {
+        assert!(
+            resident_values
+                .iter()
+                .any(|(row, weight)| *weight == 1 && row == &expected),
+            "the resident update must contain {expected:?}"
+        );
+    }
+
+    let hydrated_update = next_subscription_with_publication_bounded(
+        &mut database,
+        &hydrated,
+        "hydrated state after overlapping hydration",
+    );
+    assert_eq!(hydrated_update.publication, Some(latest_publication));
+    assert_eq!(
+        hydrated_update.deltas.to_values().unwrap(),
+        vec![(vec![Value::U64(2), Value::U64(1)], 1)],
+        "the hydrated subscription must advance from the predecessor's installed state"
+    );
+
+    let aggregate_rows = block_on(database.query_graph(edge_counts_by_src()))
+        .unwrap()
+        .to_values()
+        .unwrap();
+    assert_eq!(aggregate_rows.len(), 2);
+    for expected in [
+        vec![Value::U64(1), Value::U64(1)],
+        vec![Value::U64(2), Value::U64(1)],
+    ] {
+        assert!(
+            aggregate_rows
+                .iter()
+                .any(|(row, weight)| *weight == 1 && row == &expected),
+            "latest aggregate state must contain {expected:?}"
+        );
+    }
+    assert_eq!(
+        database.durable_publication_frontier(),
+        Some(predecessor_publication)
+    );
+
+    let latest_persistence = block_on(latest.persist());
+    assert_eq!(
+        database.finish_persistence(latest_persistence).unwrap(),
         latest_publication
     );
     assert_eq!(

--- a/crates/groove/tests/async_hydration_session.rs
+++ b/crates/groove/tests/async_hydration_session.rs
@@ -10,10 +10,11 @@ use futures::executor::block_on;
 use futures::task::{ArcWake, noop_waker, waker};
 use groove::db::{
     Database, Error as DatabaseError, GraphBuilder, NotificationTiming, PrimaryKeyValue,
+    PublicationUpdate, Subscription,
 };
 use groove::ivm::{
     AggregateExpr, AggregateFunction, LiteralValue, PlanExpr, ProjectField, PublicationId,
-    StaticScanSpec,
+    RecordDeltas, StaticScanSpec,
 };
 use groove::records::{RecordDescriptor, Value, ValueType, VariantRecord};
 use groove::schema::{
@@ -129,6 +130,40 @@ fn metric_aggregate(table: &str) -> GraphBuilder {
             output_name: Some("sum_score".to_owned()),
         }],
     )
+}
+
+fn album_counts_by_title() -> GraphBuilder {
+    GraphBuilder::aggregate(
+        GraphBuilder::table("albums"),
+        ["title"],
+        [AggregateExpr {
+            function: AggregateFunction::Count,
+            expression: None,
+            distinct: false,
+            output_name: Some("album_count".to_owned()),
+        }],
+    )
+}
+
+fn next_subscription_with_publication_bounded(
+    database: &mut Database,
+    subscription: &Subscription,
+    description: &str,
+) -> PublicationUpdate<RecordDeltas> {
+    const POLL_LIMIT: usize = 256;
+
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    for _ in 0..POLL_LIMIT {
+        match database.poll_subscription_with_publication(subscription, &mut context) {
+            Poll::Ready(Ok(update)) => return update,
+            Poll::Ready(Err(error)) => {
+                panic!("{description} failed while polling through Database: {error:?}")
+            }
+            Poll::Pending => {}
+        }
+    }
+    panic!("{description} remained pending after {POLL_LIMIT} deterministic Database polls")
 }
 
 fn edge_pairs() -> GraphBuilder {
@@ -991,6 +1026,220 @@ fn later_resident_tick_runs_while_earlier_recursive_tick_is_suspended() {
         let persistence = block_on(publication.persist());
         database.finish_persistence(persistence).unwrap();
     }
+}
+
+#[test]
+fn resumed_recursive_slice_preserves_later_publications_and_live_retainers() {
+    let (storage, control) = TestStorage::controlled(&["albums", "edges"]);
+    let mut database = block_on(Database::new(albums_and_edges_schema(), storage.clone())).unwrap();
+    let mut seed = database.open_batch();
+    seed.insert("edges", vec![Value::U64(1), Value::U64(1), Value::U64(2)]);
+    seed.insert("edges", vec![Value::U64(2), Value::U64(2), Value::U64(3)]);
+    block_on(database.commit_batch(seed)).unwrap();
+    let frontier_before_suspension = database.durable_publication_frontier();
+
+    let albums = block_on(database.subscribe_one_sink(album_counts_by_title())).unwrap();
+    assert!(
+        block_on(database.next_subscription(&albums))
+            .unwrap()
+            .is_empty()
+    );
+    let reach = block_on(database.subscribe_one_sink(reachability_graph())).unwrap();
+    assert_eq!(
+        block_on(database.next_subscription(&reach))
+            .unwrap()
+            .deltas
+            .len(),
+        3
+    );
+
+    storage.evict_scans("edges");
+    control.take_observed();
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let mut first = database.open_batch();
+    first.insert(
+        "albums",
+        vec![Value::U64(1), Value::String("Speak No Evil".into())],
+    );
+    first.delete("edges", PrimaryKeyValue::U64(2));
+    let mut first = Box::pin(database.apply_batch(first));
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    let first_applied = match first.as_mut().poll(&mut context) {
+        Poll::Ready(Ok(applied)) => applied,
+        _ => panic!("resident application must complete while recursion is suspended"),
+    };
+    drop(first);
+    let first_publication = first_applied.publication();
+    let mut expected_album_publications = vec![first_publication];
+    let mut later_applied_batches = Vec::new();
+
+    for id in 2..=33 {
+        let mut later = database.open_batch();
+        later.insert(
+            "albums",
+            vec![Value::U64(id), Value::String(format!("resident-{id}"))],
+        );
+        let mut later = Box::pin(database.apply_batch(later));
+        let later_applied = match later.as_mut().poll(&mut context) {
+            Poll::Ready(Ok(applied)) => applied,
+            _ => panic!("later disjoint resident application must complete immediately"),
+        };
+        drop(later);
+        let later_publication = later_applied.publication();
+        expected_album_publications.push(later_publication);
+
+        later_applied_batches.push(later_applied);
+    }
+    let later_persistence_futures = later_applied_batches
+        .iter()
+        .map(|applied| applied.persist())
+        .collect::<Vec<_>>();
+    let last_later_publication = *expected_album_publications.last().unwrap();
+    assert_eq!(
+        database.durable_publication_frontier(),
+        frontier_before_suspension,
+        "later durable publications must not advance the frontier past the suspended predecessor"
+    );
+    assert!(reach.try_recv().is_err());
+
+    let mut later_albums_open = Box::pin(database.subscribe_one_sink(album_counts_by_title()));
+    let later_albums = match later_albums_open.as_mut().poll(&mut context) {
+        Poll::Ready(Ok(subscription)) => subscription,
+        Poll::Ready(Err(error)) => {
+            panic!("later aggregate subscription failed during suspended recursion: {error:?}")
+        }
+        Poll::Pending => {
+            panic!(
+                "later aggregate subscription must complete without waiting for suspended recursion"
+            )
+        }
+    };
+    drop(later_albums_open);
+
+    control.resume_operation(TestStorageOperation::ScanOpen);
+    let resumed = next_subscription_with_publication_bounded(
+        &mut database,
+        &reach,
+        "resumed recursive predecessor",
+    );
+    assert_eq!(resumed.publication, Some(first_publication));
+    assert_eq!(resumed.deltas.deltas.len(), 2);
+
+    for expected_publication in expected_album_publications.iter().copied() {
+        let update = next_subscription_with_publication_bounded(
+            &mut database,
+            &albums,
+            "ordered original aggregate update",
+        );
+        assert_eq!(update.publication, Some(expected_publication));
+        assert_eq!(update.deltas.deltas.len(), 1);
+    }
+    let later_hydration = next_subscription_with_publication_bounded(
+        &mut database,
+        &later_albums,
+        "later aggregate hydration",
+    );
+    assert_eq!(later_hydration.publication, None);
+    assert_eq!(later_hydration.deltas.deltas.len(), 33);
+    assert_eq!(
+        database.durable_publication_frontier(),
+        frontier_before_suspension,
+        "resuming the predecessor must not skip ordered persistence"
+    );
+
+    let first_persistence = block_on(first_applied.persist());
+    assert_eq!(
+        database.finish_persistence(first_persistence).unwrap(),
+        first_publication
+    );
+    assert_eq!(
+        database.durable_publication_frontier(),
+        Some(first_publication),
+        "persisting the resumed predecessor must not skip unpersisted later publications"
+    );
+
+    for (persistence, expected_publication) in later_persistence_futures
+        .into_iter()
+        .zip(expected_album_publications.iter().copied().skip(1))
+    {
+        let persistence = block_on(persistence);
+        assert_eq!(
+            database.finish_persistence(persistence).unwrap(),
+            expected_publication
+        );
+    }
+    assert_eq!(
+        database.durable_publication_frontier(),
+        Some(last_later_publication),
+        "finishing the retained later persistence receipts must release the contiguous frontier"
+    );
+
+    let mut latest = database.open_batch();
+    latest.update(
+        "albums",
+        vec![Value::U64(33), Value::String("latest-33".into())],
+    );
+    latest.insert("edges", vec![Value::U64(3), Value::U64(2), Value::U64(4)]);
+    let latest = block_on(database.apply_batch(latest)).unwrap();
+    let latest_publication = latest.publication();
+
+    for (subscription, description) in [
+        (&albums, "original aggregate post-resume update"),
+        (&later_albums, "later aggregate post-resume update"),
+    ] {
+        let update =
+            next_subscription_with_publication_bounded(&mut database, subscription, description);
+        assert_eq!(update.publication, Some(latest_publication));
+        assert_eq!(update.deltas.deltas.len(), 2);
+    }
+    let reach_update = next_subscription_with_publication_bounded(
+        &mut database,
+        &reach,
+        "recursive post-resume update",
+    );
+    assert_eq!(reach_update.publication, Some(latest_publication));
+    assert_eq!(reach_update.deltas.deltas.len(), 2);
+
+    let album_rows = block_on(database.query_graph(album_counts_by_title()))
+        .unwrap()
+        .to_values()
+        .unwrap();
+    assert_eq!(album_rows.len(), 33);
+    assert!(album_rows.iter().any(|(row, weight)| {
+        *weight == 1 && row == &vec![Value::String("resident-2".into()), Value::U64(1)]
+    }));
+    assert!(album_rows.iter().any(|(row, weight)| {
+        *weight == 1 && row == &vec![Value::String("latest-33".into()), Value::U64(1)]
+    }));
+
+    let reach_rows = block_on(database.query_graph(reachability_graph()))
+        .unwrap()
+        .to_values()
+        .unwrap();
+    assert_eq!(reach_rows.len(), 3);
+    for expected in [
+        vec![Value::U64(1), Value::U64(2)],
+        vec![Value::U64(1), Value::U64(4)],
+        vec![Value::U64(2), Value::U64(4)],
+    ] {
+        assert!(
+            reach_rows
+                .iter()
+                .any(|(row, weight)| *weight == 1 && row == &expected),
+            "latest recursive result must contain {expected:?}"
+        );
+    }
+
+    let persistence = block_on(latest.persist());
+    assert_eq!(
+        database.finish_persistence(persistence).unwrap(),
+        latest_publication
+    );
+    assert_eq!(
+        database.durable_publication_frontier(),
+        Some(latest_publication)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Stage recursive operator, arrangement and evaluator state per tick.
- Roll back direct iteration-limit failures without changing committed state.
- Discard staged resident failures without leaking closure rows, notifications, memo state or frontiers.

## Before

Recursive evaluation could mutate retained state before discovering an iteration-limit failure. Resident failures could then leave partial recursive state or derived work behind.

## After

Direct-tick failures preserve the last committed closure and logical state. Resident scoped failures remove staged recursive state and preserve live graph retainers, notifications and frontiers. Grouped state uses bounded overlays rather than cloning the full retained history.

## Test plan
- [ ] `cargo test -p groove recursive_ --lib`
- [ ] Verify direct rollback and resident-failure teardown through the recursive runtime and Database surfaces.