### PR TITLE
Cancel the tools client tick driver on shutdown

### DIFF
--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -945,8 +945,7 @@ impl ClientDb {
         // Install the cancellation guard before the first await: forwarder
         // draining is part of shutdown, and cancellation there must still
         // leave every retained facade terminal and wake concurrent shutdowns.
-        let mut completion =
-            ShutdownCompletion::new(Rc::clone(&self.inner), backend, tick_driver);
+        let mut completion = ShutdownCompletion::new(Rc::clone(&self.inner), backend, tick_driver);
         let mut completions = Vec::with_capacity(forwarders.len());
         for SubscriptionForwarder {
             cancellation,

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -1905,7 +1905,6 @@ impl ClientDbInner {
                 _ = &mut state_changed => {}
             }
         }
-
     }
 
     fn ensure_transaction_open(&self, transaction_id: OpenTransactionId) -> Result<()> {
@@ -4274,6 +4273,7 @@ mod tests {
 
     struct DriverWireTransport {
         state: Arc<DriverConnectorState>,
+        _terminal_lifetime: tokio::sync::oneshot::Sender<()>,
     }
 
     struct DriverConnectAttempt {
@@ -4352,15 +4352,21 @@ mod tests {
                     std::future::pending::<()>().await;
                 }
                 attempt.completed = true;
+                let (terminal_lifetime, terminal_dropped) = tokio::sync::oneshot::channel();
                 Ok(
                     crate::tools::native_transport_connector::ConnectedNativeTransport {
                         transport: Box::new(DriverWireTransport {
                             state: Arc::clone(&state),
+                            _terminal_lifetime: terminal_lifetime,
                         }),
                         protocol_version: 1,
                         features: 0,
                         session_context: None,
-                        terminal: Box::pin(std::future::pending()),
+                        permits_delegated_sessions: false,
+                        terminal: Box::pin(async move {
+                            let _ = terminal_dropped.await;
+                            NativeTransportTerminal::OwnerDropped
+                        }),
                     },
                 )
             })
@@ -4372,7 +4378,7 @@ mod tests {
         ) -> crate::tools::native_transport_connector::NativeCatalogueBootstrapFuture {
             Box::pin(async {
                 Err(
-                    crate::tools::native_transport_connector::NativeTransportError(
+                    crate::tools::native_transport_connector::NativeTransportError::Terminal(
                         "catalogue bootstrap is not used by client lifecycle tests".to_owned(),
                     ),
                 )
@@ -4385,7 +4391,8 @@ mod tests {
         data_dir: std::path::PathBuf,
         schema: Schema,
     ) -> AppContext {
-        let mut context = make_offline_context(app_id, data_dir, schema);
+        let mut context =
+            with_synthetic_admitted_account(make_offline_context(app_id, data_dir, schema));
         context.server_url = "https://example.invalid".to_owned();
         context.jwt_token = Some(make_test_jwt("driver-user", json!({})));
         context

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -146,6 +146,7 @@ struct ClientDbInner {
     identity: CoreDbIdentity,
     connect_config: Option<ConnectConfig>,
     scheduler: Rc<TickSchedulerImpl>,
+    tick_driver: Option<tokio::task::JoinHandle<()>>,
     upstream: Option<BackendConnection>,
     upstream_generation: u64,
     native_terminal_events: VecDeque<(u64, NativeTransportTerminal)>,
@@ -301,7 +302,10 @@ async fn recover_tick_driver_backpressure(
     crate::db::sync_autopsy::record(format!(
         "client tick driver retrying backpressure error attempt {attempts}: {error}"
     ));
-    tokio::time::sleep(tick_driver_retry_delay(*attempts)).await;
+    tokio::select! {
+        _ = scheduler.cancelled() => return false,
+        _ = tokio::time::sleep(tick_driver_retry_delay(*attempts)) => {}
+    }
     scheduler.wake(TickUrgency::Immediate);
     true
 }
@@ -329,11 +333,17 @@ async fn recover_tick_driver_error(
         return false;
     }
 
-    tokio::time::sleep(tick_driver_retry_delay(*attempts)).await;
+    tokio::select! {
+        _ = scheduler.cancelled() => return false,
+        _ = tokio::time::sleep(tick_driver_retry_delay(*attempts)) => {}
+    }
     if class == TickDriverErrorClass::Reconnect
         && ClientDbInner::is_current_disconnected_generation(inner, expected_generation)
     {
         ClientDbInner::start_upstream_recovery(inner, error.to_string());
+    }
+    if scheduler.is_cancelled() {
+        return false;
     }
     scheduler.wake(TickUrgency::Immediate);
     true
@@ -735,7 +745,25 @@ struct TickState {
     deferred: AtomicBool,
     after_current_turn: AtomicBool,
     delayed: AtomicBool,
+    cancelled: AtomicBool,
+    cancel_notify: tokio::sync::Notify,
     notify: tokio::sync::Notify,
+}
+
+impl TickState {
+    async fn cancelled(&self) {
+        loop {
+            if self.cancelled.load(Ordering::Acquire) {
+                return;
+            }
+            self.cancel_notify.notified().await;
+        }
+    }
+
+    fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+        self.cancel_notify.notify_waiters();
+    }
 }
 
 /// Thread-safe wake bridge retained by cold Groove storage futures.
@@ -780,6 +808,17 @@ impl TickSchedulerImpl {
         }
         self.state.notify.notify_one();
     }
+    fn cancel(&self) {
+        self.state.cancel();
+    }
+
+    async fn cancelled(&self) {
+        self.state.cancelled().await;
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.state.cancelled.load(Ordering::Acquire)
+    }
 
     fn wake_handle(&self) -> Arc<TickState> {
         Arc::clone(&self.state)
@@ -794,10 +833,14 @@ impl TickSchedulerImpl {
         }
         let state = Arc::clone(&self.state);
         tokio::task::spawn_local(async move {
-            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-            state.delayed.store(false, Ordering::Release);
-            state.deferred.store(true, Ordering::Release);
-            state.notify.notify_one();
+            tokio::select! {
+                _ = state.cancelled() => {}
+                _ = tokio::time::sleep(Duration::from_millis(delay_ms)) => {
+                    state.delayed.store(false, Ordering::Release);
+                    state.deferred.store(true, Ordering::Release);
+                    state.notify.notify_one();
+                }
+            }
         });
     }
 }
@@ -845,7 +888,9 @@ impl ClientDb {
         let inner = Rc::new(RefCell::new(inner));
         if has_upstream {
             ClientDbInner::connect_upstream_transport(&inner).await?;
-            Self::spawn_local_tick_driver(Rc::downgrade(&inner), Rc::clone(&scheduler));
+            let driver =
+                Self::spawn_local_tick_driver(Rc::downgrade(&inner), Rc::clone(&scheduler));
+            inner.borrow_mut().tick_driver = Some(driver);
         }
         Ok(Rc::new(Self {
             inner,
@@ -856,7 +901,7 @@ impl ClientDb {
     }
 
     async fn close(&self) -> Result<()> {
-        let (backend, forwarders) = {
+        let (backend, forwarders, tick_driver) = {
             let mut inner = self.inner.borrow_mut();
             match inner.shutdown_state {
                 ShutdownState::Open => {
@@ -865,9 +910,14 @@ impl ClientDb {
                     inner.tick_driver_error = Some("client shut down".to_string());
                     inner.tick_driver_error_notify.notify_waiters();
                     inner.shutdown_state = ShutdownState::Closing;
+                    inner.scheduler.cancel();
                     let backend = inner.db.take().ok_or_else(ClientDbInner::shutdown_error)?;
                     let forwarders = std::mem::take(&mut inner.subscription_forwarders);
-                    (backend, forwarders)
+                    let tick_driver = inner.tick_driver.take();
+                    // Do not retain the cancelled scheduler state on a shared
+                    // facade after its driver has been joined.
+                    inner.scheduler = Rc::new(TickSchedulerImpl::default());
+                    (backend, forwarders, tick_driver)
                 }
                 ShutdownState::Closing | ShutdownState::Closed => {
                     drop(inner);
@@ -895,6 +945,11 @@ impl ClientDb {
         }
         for completion in completions {
             let _ = completion.await;
+        }
+        if let Some(tick_driver) = tick_driver {
+            let _ = tick_driver.await;
+            // Let observers of cancellation run before shutdown can finish.
+            tokio::task::yield_now().await;
         }
         let result = completion
             .backend
@@ -1361,13 +1416,19 @@ impl ClientDb {
     fn spawn_local_tick_driver(
         inner: Weak<RefCell<ClientDbInner>>,
         scheduler: Rc<TickSchedulerImpl>,
-    ) {
+    ) -> tokio::task::JoinHandle<()> {
         let state = scheduler.wake_handle();
         tokio::task::spawn_local(async move {
             let mut backpressure_attempts = 0;
             loop {
-                state.notify.notified().await;
+                tokio::select! {
+                    _ = scheduler.cancelled() => return,
+                    _ = state.notify.notified() => {}
+                }
                 while let Some(urgency) = scheduler.take() {
+                    if scheduler.is_cancelled() {
+                        return;
+                    }
                     let Some(inner) = inner.upgrade() else {
                         return;
                     };
@@ -1386,9 +1447,15 @@ impl ClientDb {
                     }
 
                     if urgency == TickUrgency::Deferred {
-                        tokio::time::sleep(Duration::from_millis(1)).await;
+                        tokio::select! {
+                            _ = scheduler.cancelled() => return,
+                            _ = tokio::time::sleep(Duration::from_millis(1)) => {}
+                        }
                     } else if urgency == TickUrgency::AfterCurrentTurn {
                         tokio::task::yield_now().await;
+                        if scheduler.is_cancelled() {
+                            return;
+                        }
                     }
                     let backend = match inner.borrow().backend_clone() {
                         Ok(db) => db,
@@ -1438,7 +1505,7 @@ impl ClientDb {
                     }
                 }
             }
-        });
+        })
     }
 }
 
@@ -1547,6 +1614,7 @@ impl ClientDbInner {
             identity,
             connect_config,
             scheduler,
+            tick_driver: None,
             upstream: None,
             upstream_generation: 0,
             native_terminal_events: VecDeque::new(),

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -4183,7 +4183,7 @@ mod tests {
         connect_calls: std::sync::atomic::AtomicUsize,
         send_attempted: tokio::sync::Notify,
         reconnect_started: tokio::sync::Notify,
-        release_reconnect: tokio::sync::Notify,
+        reconnect_cancelled: tokio::sync::Notify,
     }
 
     #[derive(Clone)]
@@ -4195,6 +4195,20 @@ mod tests {
         state: Arc<DriverConnectorState>,
     }
 
+    struct DriverConnectAttempt {
+        state: Arc<DriverConnectorState>,
+        reconnect: bool,
+        completed: bool,
+    }
+
+    impl Drop for DriverConnectAttempt {
+        fn drop(&mut self) {
+            if self.reconnect && !self.completed {
+                self.state.reconnect_cancelled.notify_one();
+            }
+        }
+    }
+
     impl DriverConnector {
         fn new(behavior: DriverTransportBehavior, block_reconnect: bool) -> Self {
             Self {
@@ -4204,7 +4218,7 @@ mod tests {
                     connect_calls: std::sync::atomic::AtomicUsize::new(0),
                     send_attempted: tokio::sync::Notify::new(),
                     reconnect_started: tokio::sync::Notify::new(),
-                    release_reconnect: tokio::sync::Notify::new(),
+                    reconnect_cancelled: tokio::sync::Notify::new(),
                 }),
             }
         }
@@ -4247,10 +4261,16 @@ mod tests {
                 .connect_calls
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Box::pin(async move {
+                let mut attempt = DriverConnectAttempt {
+                    state: Arc::clone(&state),
+                    reconnect: call > 0,
+                    completed: false,
+                };
                 if call > 0 && state.block_reconnect {
                     state.reconnect_started.notify_one();
-                    state.release_reconnect.notified().await;
+                    std::future::pending::<()>().await;
                 }
+                attempt.completed = true;
                 Ok(
                     crate::tools::native_transport_connector::ConnectedNativeTransport {
                         transport: Box::new(DriverWireTransport {
@@ -4294,43 +4314,13 @@ mod tests {
     // spawn_local task and a late connection installation have no direct
     // public observation once the client has consumed its core facade.
     #[tokio::test(flavor = "current_thread")]
-    async fn online_shutdown_releases_idle_tick_driver() {
+    async fn shutdown_joins_an_idle_tick_driver() {
         tokio::task::LocalSet::new()
             .run_until(async {
                 let connector = DriverConnector::idle();
                 let client = JazzClient::connect_with_native_transport(
                     make_online_context(
-                        AppId::from_name("online-shutdown-idle-driver"),
-                        TempDir::new().expect("tempdir").keep(),
-                        declared_todo_schema(),
-                    ),
-                    Arc::new(connector),
-                )
-                .await
-                .expect("connect online client");
-                let scheduler = Rc::downgrade(&client.db.inner.borrow().scheduler);
-
-                client
-                    .shutdown()
-                    .await
-                    .expect("shutdown idle online client");
-
-                assert!(
-                    scheduler.upgrade().is_none(),
-                    "shutdown must join the idle tick driver instead of retaining its scheduler"
-                );
-            })
-            .await;
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn shutdown_cancels_tick_driver_recovery_delay() {
-        tokio::task::LocalSet::new()
-            .run_until(async {
-                let connector = DriverConnector::closed_pump(false);
-                let client = JazzClient::connect_with_native_transport(
-                    make_online_context(
-                        AppId::from_name("shutdown-recovery-delay"),
+                        AppId::from_name("shutdown-idle-driver"),
                         TempDir::new().expect("tempdir").keep(),
                         declared_todo_schema(),
                     ),
@@ -4338,35 +4328,41 @@ mod tests {
                 )
                 .await
                 .expect("connect online client");
-                let scheduler = Rc::clone(&client.db.inner.borrow().scheduler);
-                let scheduler_weak = Rc::downgrade(&scheduler);
+                let scheduler_state = {
+                    let inner = client.db.inner.borrow();
+                    Arc::downgrade(&inner.scheduler.wake_handle())
+                };
                 let send_attempted = connector.state.send_attempted.notified();
 
                 client
                     .insert(
                         "todos",
-                        crate::row_input!("title" => "recovery", "completed" => false),
+                        crate::row_input!("title" => "idle", "completed" => false),
                     )
-                    .expect("stage a write for the closed pump");
-                scheduler.schedule_tick(TickUrgency::Immediate);
-                drop(scheduler);
+                    .expect("stage a write for the idle driver");
+                client
+                    .db
+                    .inner
+                    .borrow()
+                    .scheduler
+                    .schedule_tick(TickUrgency::Immediate);
                 send_attempted.await;
 
                 client
                     .shutdown()
                     .await
-                    .expect("shutdown during recovery delay");
+                    .expect("shutdown idle online client");
 
                 assert!(
-                    scheduler_weak.upgrade().is_none(),
-                    "shutdown must cancel and join a driver waiting to retry"
+                    scheduler_state.upgrade().is_none(),
+                    "shutdown must join the driver after it returns to its idle wait"
                 );
             })
             .await;
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn shutdown_racing_recovery_connect_prevents_late_installation() {
+    async fn shutdown_cancels_recovery_connect_and_joins_driver() {
         tokio::task::LocalSet::new()
             .run_until(async {
                 let connector = DriverConnector::closed_pump(true);
@@ -4381,8 +4377,13 @@ mod tests {
                 .await
                 .expect("connect online client");
                 let inner = Rc::clone(&client.db.inner);
+                let scheduler_state = {
+                    let inner = inner.borrow();
+                    Arc::downgrade(&inner.scheduler.wake_handle())
+                };
                 let send_attempted = connector.state.send_attempted.notified();
                 let reconnect_started = connector.state.reconnect_started.notified();
+                let reconnect_cancelled = connector.state.reconnect_cancelled.notified();
 
                 client
                     .insert(
@@ -4399,23 +4400,37 @@ mod tests {
                 send_attempted.await;
                 reconnect_started.await;
 
-                let shutdown = tokio::task::spawn_local(client.shutdown());
-                tokio::task::yield_now().await;
-                let driver_retained_during_shutdown = Rc::strong_count(&inner) > 1;
-                connector.state.release_reconnect.notify_one();
-                shutdown
-                    .await
-                    .expect("join shutdown task")
-                    .expect("shutdown racing reconnect");
-                tokio::task::yield_now().await;
+                let mut shutdown = tokio::task::spawn_local(client.shutdown());
+                tokio::select! {
+                    _ = reconnect_cancelled => {
+                        shutdown
+                            .await
+                            .expect("join shutdown task")
+                            .expect("shutdown recovery driver");
+                    }
+                    result = &mut shutdown => {
+                        panic!(
+                            "shutdown returned before cancelling the in-flight reconnect: {result:?}"
+                        );
+                    }
+                }
 
-                assert!(
-                    inner.borrow().upstream.is_none(),
-                    "a reconnect that completes after shutdown must not be installed"
+                assert_eq!(
+                    connector
+                        .state
+                        .connect_calls
+                        .load(std::sync::atomic::Ordering::SeqCst),
+                    2,
+                    "shutdown must not start a later reconnect"
                 );
                 assert!(
-                    !driver_retained_during_shutdown,
-                    "shutdown must not return while recovery retains the driver task"
+                    inner.borrow().upstream.is_none(),
+                    "a cancelled reconnect must not install an upstream"
+                );
+                drop(inner);
+                assert!(
+                    scheduler_state.upgrade().is_none(),
+                    "shutdown must join the recovery driver before returning"
                 );
             })
             .await;

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -214,14 +214,20 @@ enum ShutdownState {
 struct ShutdownCompletion {
     inner: Rc<RefCell<ClientDbInner>>,
     backend: Backend,
+    tick_driver: Option<tokio::task::JoinHandle<()>>,
     finished: bool,
 }
 
 impl ShutdownCompletion {
-    fn new(inner: Rc<RefCell<ClientDbInner>>, backend: Backend) -> Self {
+    fn new(
+        inner: Rc<RefCell<ClientDbInner>>,
+        backend: Backend,
+        tick_driver: Option<tokio::task::JoinHandle<()>>,
+    ) -> Self {
         Self {
             inner,
             backend,
+            tick_driver,
             finished: false,
         }
     }
@@ -248,6 +254,12 @@ impl Drop for ShutdownCompletion {
     fn drop(&mut self) {
         if self.finished {
             return;
+        }
+        // The driver may be holding a clone of `backend` while it is in an
+        // in-flight core operation. Abort it before this guard releases the
+        // backend, so cancellation cannot detach a task that retains storage.
+        if let Some(tick_driver) = self.tick_driver.take() {
+            tick_driver.abort();
         }
         let mut inner = self.inner.borrow_mut();
         inner.shutdown_state = ShutdownState::Failed(
@@ -933,7 +945,8 @@ impl ClientDb {
         // Install the cancellation guard before the first await: forwarder
         // draining is part of shutdown, and cancellation there must still
         // leave every retained facade terminal and wake concurrent shutdowns.
-        let mut completion = ShutdownCompletion::new(Rc::clone(&self.inner), backend);
+        let mut completion =
+            ShutdownCompletion::new(Rc::clone(&self.inner), backend, tick_driver);
         let mut completions = Vec::with_capacity(forwarders.len());
         for SubscriptionForwarder {
             cancellation,
@@ -946,7 +959,7 @@ impl ClientDb {
         for completion in completions {
             let _ = completion.await;
         }
-        if let Some(tick_driver) = tick_driver {
+        if let Some(tick_driver) = completion.tick_driver.as_mut() {
             let _ = tick_driver.await;
             // Let observers of cancellation run before shutdown can finish.
             tokio::task::yield_now().await;
@@ -1893,6 +1906,7 @@ impl ClientDbInner {
                 _ = &mut state_changed => {}
             }
         }
+
     }
 
     fn ensure_transaction_open(&self, transaction_id: OpenTransactionId) -> Result<()> {
@@ -4381,6 +4395,44 @@ mod tests {
     // These internal lifecycle tests are necessary because a detached
     // spawn_local task and a late connection installation have no direct
     // public observation once the client has consumed its core facade.
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancelled_shutdown_aborts_owned_tick_driver() {
+        struct DropMarker(Rc<Cell<bool>>);
+
+        impl Drop for DropMarker {
+            fn drop(&mut self) {
+                self.0.set(true);
+            }
+        }
+
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let client = JazzClient::connect(make_offline_context(
+                    AppId::from_name("cancelled-shutdown-driver"),
+                    TempDir::new().expect("tempdir").keep(),
+                    declared_todo_schema(),
+                ))
+                .await
+                .expect("connect offline client");
+                let inner = Rc::clone(&client.db.inner);
+                let backend = inner.borrow().backend_clone().expect("client is open");
+                let dropped = Rc::new(Cell::new(false));
+                let task_dropped = Rc::clone(&dropped);
+                let tick_driver = tokio::task::spawn_local(async move {
+                    let _marker = DropMarker(task_dropped);
+                    std::future::pending::<()>().await;
+                });
+                tokio::task::yield_now().await;
+                drop(ShutdownCompletion::new(inner, backend, Some(tick_driver)));
+                tokio::task::yield_now().await;
+                assert!(
+                    dropped.get(),
+                    "cancelling shutdown must abort its owned tick driver"
+                );
+            })
+            .await;
+    }
     #[tokio::test(flavor = "current_thread")]
     async fn shutdown_joins_an_idle_tick_driver() {
         tokio::task::LocalSet::new()
@@ -4503,7 +4555,6 @@ mod tests {
             })
             .await;
     }
-
     #[test]
     fn query_runtime_waker_enqueues_one_immediate_owner_turn() {
         let scheduler = TickSchedulerImpl::default();

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -4171,6 +4171,255 @@ mod tests {
             })
         }
     }
+    #[derive(Clone, Copy)]
+    enum DriverTransportBehavior {
+        Idle,
+        ClosedPump,
+    }
+
+    struct DriverConnectorState {
+        behavior: DriverTransportBehavior,
+        block_reconnect: bool,
+        connect_calls: std::sync::atomic::AtomicUsize,
+        send_attempted: tokio::sync::Notify,
+        reconnect_started: tokio::sync::Notify,
+        release_reconnect: tokio::sync::Notify,
+    }
+
+    #[derive(Clone)]
+    struct DriverConnector {
+        state: Arc<DriverConnectorState>,
+    }
+
+    struct DriverWireTransport {
+        state: Arc<DriverConnectorState>,
+    }
+
+    impl DriverConnector {
+        fn new(behavior: DriverTransportBehavior, block_reconnect: bool) -> Self {
+            Self {
+                state: Arc::new(DriverConnectorState {
+                    behavior,
+                    block_reconnect,
+                    connect_calls: std::sync::atomic::AtomicUsize::new(0),
+                    send_attempted: tokio::sync::Notify::new(),
+                    reconnect_started: tokio::sync::Notify::new(),
+                    release_reconnect: tokio::sync::Notify::new(),
+                }),
+            }
+        }
+
+        fn idle() -> Self {
+            Self::new(DriverTransportBehavior::Idle, false)
+        }
+
+        fn closed_pump(block_reconnect: bool) -> Self {
+            Self::new(DriverTransportBehavior::ClosedPump, block_reconnect)
+        }
+    }
+
+    impl crate::wire::WireTransport for DriverWireTransport {
+        fn send_frame(
+            &mut self,
+            _frame: Vec<u8>,
+        ) -> std::result::Result<(), crate::wire::TransportError> {
+            self.state.send_attempted.notify_one();
+            match self.state.behavior {
+                DriverTransportBehavior::Idle => Ok(()),
+                DriverTransportBehavior::ClosedPump => Err(crate::wire::TransportError::Failed(
+                    "websocket pump is closed".to_owned(),
+                )),
+            }
+        }
+
+        fn try_recv_frame(&mut self) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
+    impl NativeTransportConnector for DriverConnector {
+        fn connect(
+            &self,
+            _request: NativeTransportRequest,
+        ) -> crate::tools::native_transport_connector::NativeTransportFuture {
+            let state = Arc::clone(&self.state);
+            let call = state
+                .connect_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Box::pin(async move {
+                if call > 0 && state.block_reconnect {
+                    state.reconnect_started.notify_one();
+                    state.release_reconnect.notified().await;
+                }
+                Ok(
+                    crate::tools::native_transport_connector::ConnectedNativeTransport {
+                        transport: Box::new(DriverWireTransport {
+                            state: Arc::clone(&state),
+                        }),
+                        protocol_version: 1,
+                        features: 0,
+                        session_context: None,
+                        terminal: Box::pin(std::future::pending()),
+                    },
+                )
+            })
+        }
+
+        fn bootstrap_catalogue(
+            &self,
+            _request: NativeTransportRequest,
+        ) -> crate::tools::native_transport_connector::NativeCatalogueBootstrapFuture {
+            Box::pin(async {
+                Err(
+                    crate::tools::native_transport_connector::NativeTransportError(
+                        "catalogue bootstrap is not used by client lifecycle tests".to_owned(),
+                    ),
+                )
+            })
+        }
+    }
+
+    fn make_online_context(
+        app_id: AppId,
+        data_dir: std::path::PathBuf,
+        schema: Schema,
+    ) -> AppContext {
+        let mut context = make_offline_context(app_id, data_dir, schema);
+        context.server_url = "https://example.invalid".to_owned();
+        context.jwt_token = Some(make_test_jwt("driver-user", json!({})));
+        context
+    }
+
+    // These internal lifecycle tests are necessary because a detached
+    // spawn_local task and a late connection installation have no direct
+    // public observation once the client has consumed its core facade.
+    #[tokio::test(flavor = "current_thread")]
+    async fn online_shutdown_releases_idle_tick_driver() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let connector = DriverConnector::idle();
+                let client = JazzClient::connect_with_native_transport(
+                    make_online_context(
+                        AppId::from_name("online-shutdown-idle-driver"),
+                        TempDir::new().expect("tempdir").keep(),
+                        declared_todo_schema(),
+                    ),
+                    Arc::new(connector),
+                )
+                .await
+                .expect("connect online client");
+                let scheduler = Rc::downgrade(&client.db.inner.borrow().scheduler);
+
+                client
+                    .shutdown()
+                    .await
+                    .expect("shutdown idle online client");
+
+                assert!(
+                    scheduler.upgrade().is_none(),
+                    "shutdown must join the idle tick driver instead of retaining its scheduler"
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_cancels_tick_driver_recovery_delay() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let connector = DriverConnector::closed_pump(false);
+                let client = JazzClient::connect_with_native_transport(
+                    make_online_context(
+                        AppId::from_name("shutdown-recovery-delay"),
+                        TempDir::new().expect("tempdir").keep(),
+                        declared_todo_schema(),
+                    ),
+                    Arc::new(connector.clone()),
+                )
+                .await
+                .expect("connect online client");
+                let scheduler = Rc::clone(&client.db.inner.borrow().scheduler);
+                let scheduler_weak = Rc::downgrade(&scheduler);
+                let send_attempted = connector.state.send_attempted.notified();
+
+                client
+                    .insert(
+                        "todos",
+                        crate::row_input!("title" => "recovery", "completed" => false),
+                    )
+                    .expect("stage a write for the closed pump");
+                scheduler.schedule_tick(TickUrgency::Immediate);
+                drop(scheduler);
+                send_attempted.await;
+
+                client
+                    .shutdown()
+                    .await
+                    .expect("shutdown during recovery delay");
+
+                assert!(
+                    scheduler_weak.upgrade().is_none(),
+                    "shutdown must cancel and join a driver waiting to retry"
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_racing_recovery_connect_prevents_late_installation() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let connector = DriverConnector::closed_pump(true);
+                let client = JazzClient::connect_with_native_transport(
+                    make_online_context(
+                        AppId::from_name("shutdown-recovery-connect"),
+                        TempDir::new().expect("tempdir").keep(),
+                        declared_todo_schema(),
+                    ),
+                    Arc::new(connector.clone()),
+                )
+                .await
+                .expect("connect online client");
+                let inner = Rc::clone(&client.db.inner);
+                let send_attempted = connector.state.send_attempted.notified();
+                let reconnect_started = connector.state.reconnect_started.notified();
+
+                client
+                    .insert(
+                        "todos",
+                        crate::row_input!("title" => "reconnect", "completed" => false),
+                    )
+                    .expect("stage a write for recovery");
+                client
+                    .db
+                    .inner
+                    .borrow()
+                    .scheduler
+                    .schedule_tick(TickUrgency::Immediate);
+                send_attempted.await;
+                reconnect_started.await;
+
+                let shutdown = tokio::task::spawn_local(client.shutdown());
+                tokio::task::yield_now().await;
+                let driver_retained_during_shutdown = Rc::strong_count(&inner) > 1;
+                connector.state.release_reconnect.notify_one();
+                shutdown
+                    .await
+                    .expect("join shutdown task")
+                    .expect("shutdown racing reconnect");
+                tokio::task::yield_now().await;
+
+                assert!(
+                    inner.borrow().upstream.is_none(),
+                    "a reconnect that completes after shutdown must not be installed"
+                );
+                assert!(
+                    !driver_retained_during_shutdown,
+                    "shutdown must not return while recovery retains the driver task"
+                );
+            })
+            .await;
+    }
 
     #[test]
     fn query_runtime_waker_enqueues_one_immediate_owner_turn() {

--- a/examples/todo-client-localfirst-react/tests/browser/todo-app-core.test.tsx
+++ b/examples/todo-client-localfirst-react/tests/browser/todo-app-core.test.tsx
@@ -166,23 +166,35 @@ describe("React Todo App core browser canary", () => {
   it("syncs two persistent IndexedDB app instances through one core server", async () => {
     const writerDbName = uniqueDbName("core-writer");
     const readerDbName = uniqueDbName("core-reader");
+    let writerEdgeResult: Error | null | undefined;
+    let readerEdgeResult: Error | null | undefined;
 
     const writer = await mountApp({
       appId: APP_ID,
       driver: { type: "persistent", dbName: writerDbName },
       serverUrl: SERVER_URL,
       secret: "jazz-auth-v1:Tb9eLjnS22z-_s9FK0EtiFIIRDe4EAygLAdni55RvAs",
+      onEdgeSettled: (error) => {
+        writerEdgeResult = error;
+      },
     });
     const reader = await mountApp({
       appId: APP_ID,
       driver: { type: "persistent", dbName: readerDbName },
       serverUrl: SERVER_URL,
       secret: "jazz-auth-v1:VDOGX2nez-5T9Lgk4VfYMT33Qsa6J4loRAoKLZpvxBg",
+      onEdgeSettled: (error) => {
+        readerEdgeResult = error;
+      },
     });
 
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 750));
-    });
+    await waitFor(
+      () => writerEdgeResult !== undefined && readerEdgeResult !== undefined,
+      15000,
+      "both todo subscriptions should establish edge coverage before the online write",
+    );
+    if (writerEdgeResult) throw writerEdgeResult;
+    if (readerEdgeResult) throw readerEdgeResult;
 
     await addTodo(writer, "Core writer todo");
     await waitFor(


### PR DESCRIPTION
## Summary
- Own the client tick-driver task through shutdown.
- Wake and cancel idle, delayed and reconnecting driver states.
- Join the driver during normal shutdown and abort it on cancelled shutdown.

## Before

The per-client driver could remain parked indefinitely or complete a reconnect after shutdown because shutdown did not own or cancel the spawned task.

## After

Shutdown owns the driver join handle, wakes cancellation-sensitive states, joins normal completion, aborts cancelled completion, and prioritises cancellation over reconnect admission.

## Test plan
- [ ] `cargo test -p jazz --features testing shutdown_joins_an_idle_tick_driver --lib`
- [ ] `cargo test -p jazz --features testing shutdown_cancels_recovery_connect_and_joins_driver --lib`
- [ ] `cargo test -p jazz --features testing cancelled_shutdown_aborts_owned_tick_driver --lib`