### PR TITLE
Allow aborting a streaming WASM write while a chunk is being stored

### DIFF
--- a/.changeset/bright-streams-abort.md
+++ b/.changeset/bright-streams-abort.md
@@ -1,0 +1,5 @@
+---
+"jazz-wasm": patch
+---
+
+Make `StreamingMutation.abort()` reliably settle a push that is already in flight, evicting staged upload state instead of returning early while the storage operation continues.

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -273,45 +273,93 @@ struct WasmStreamingMutationState {
     base: Option<BranchViewBase>,
 }
 
+enum WasmStreamingMutationLifecycle {
+    Open(Box<WasmStreamingMutationState>),
+    PushInFlight {
+        completion: oneshot::Receiver<Box<WasmStreamingMutationState>>,
+    },
+    AbortClaimed,
+    Closed,
+}
+
+enum WasmStreamingMutationAbortClaim {
+    Immediate(Box<WasmStreamingMutationState>),
+    AfterPush(oneshot::Receiver<Box<WasmStreamingMutationState>>),
+}
+
 #[wasm_bindgen(js_name = StreamingMutation)]
 pub struct WasmStreamingMutation {
-    state: Rc<RefCell<Option<WasmStreamingMutationState>>>,
+    state: Rc<RefCell<WasmStreamingMutationLifecycle>>,
+}
+
+fn streaming_mutation_closed() -> JsValue {
+    JsValue::from_str("streaming mutation is closed")
 }
 
 #[wasm_bindgen]
 impl WasmStreamingMutation {
     pub fn push(&self, chunk: Vec<u8>) -> js_sys::Promise {
         let state_cell = Rc::clone(&self.state);
-        future_to_promise(async move {
-            let mut state = state_cell
-                .borrow_mut()
-                .take()
-                .ok_or_else(|| JsValue::from_str("streaming mutation is closed"))?;
-            let result = match &state.db {
-                WasmDbInner::Memory(db) => {
-                    db.push_streaming_value_upload(&mut state.upload, &chunk)
-                        .await
-                }
-                #[cfg(target_arch = "wasm32")]
-                WasmDbInner::Browser(db) => {
-                    db.push_streaming_value_upload(&mut state.upload, &chunk)
-                        .await
-                }
-                WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
+        let (mut state, completion_tx) = {
+            let mut lifecycle = state_cell.borrow_mut();
+            let current =
+                std::mem::replace(&mut *lifecycle, WasmStreamingMutationLifecycle::Closed);
+            let WasmStreamingMutationLifecycle::Open(state) = current else {
+                *lifecycle = current;
+                return js_sys::Promise::reject(&streaming_mutation_closed());
             };
-            result.map_err(to_js_error)?;
-            *state_cell.borrow_mut() = Some(state);
-            Ok(JsValue::UNDEFINED)
+            let (completion_tx, completion) = oneshot::channel();
+            *lifecycle = WasmStreamingMutationLifecycle::PushInFlight { completion };
+            (state, completion_tx)
+        };
+
+        future_to_promise(async move {
+            let result = match &state.db {
+                WasmDbInner::Memory(db) => db
+                    .push_streaming_value_upload(&mut state.upload, &chunk)
+                    .await
+                    .map_err(to_js_error),
+                #[cfg(target_arch = "wasm32")]
+                WasmDbInner::Browser(db) => db
+                    .push_streaming_value_upload(&mut state.upload, &chunk)
+                    .await
+                    .map_err(to_js_error),
+                WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
+            };
+            let mut lifecycle = state_cell.borrow_mut();
+            match &mut *lifecycle {
+                WasmStreamingMutationLifecycle::AbortClaimed => {
+                    // The abort claim is made synchronously. Deliver the state to the
+                    // aborting operation even when push failed.
+                    let _ = completion_tx.send(state);
+                }
+                WasmStreamingMutationLifecycle::PushInFlight { .. } => {
+                    *lifecycle = if result.is_ok() {
+                        WasmStreamingMutationLifecycle::Open(state)
+                    } else {
+                        WasmStreamingMutationLifecycle::Closed
+                    };
+                }
+                _ => unreachable!("streaming mutation push completion lost its lifecycle"),
+            }
+            result.map(|()| JsValue::UNDEFINED)
         })
     }
 
     pub fn finish(&self) -> js_sys::Promise {
         let state_cell = Rc::clone(&self.state);
+        let state = {
+            let mut lifecycle = state_cell.borrow_mut();
+            let current =
+                std::mem::replace(&mut *lifecycle, WasmStreamingMutationLifecycle::Closed);
+            let WasmStreamingMutationLifecycle::Open(state) = current else {
+                *lifecycle = current;
+                return js_sys::Promise::reject(&streaming_mutation_closed());
+            };
+            *state
+        };
+
         future_to_promise(async move {
-            let state = state_cell
-                .borrow_mut()
-                .take()
-                .ok_or_else(|| JsValue::from_str("streaming mutation is closed"))?;
             let write = match &state.db {
                 WasmDbInner::Memory(db) => wasm_write_memory(
                     Rc::clone(db),
@@ -350,7 +398,7 @@ impl WasmStreamingMutation {
                     .await
                     .map_err(to_js_error)?,
                 ),
-                WasmDbInner::Closed => Err(JsValue::from_str("WasmDb is closed")),
+                WasmDbInner::Closed => Err(streaming_mutation_closed()),
             }?;
             Ok(write.into())
         })
@@ -358,17 +406,47 @@ impl WasmStreamingMutation {
 
     pub fn abort(&self) -> js_sys::Promise {
         let state_cell = Rc::clone(&self.state);
-        future_to_promise(async move {
-            let Some(state) = state_cell.borrow_mut().take() else {
-                return Ok(JsValue::FALSE);
-            };
-            match &state.db {
-                WasmDbInner::Memory(db) => db.abort_streaming_value_upload(state.upload).await,
-                #[cfg(target_arch = "wasm32")]
-                WasmDbInner::Browser(db) => db.abort_streaming_value_upload(state.upload).await,
-                WasmDbInner::Closed => return Err(JsValue::from_str("WasmDb is closed")),
+        let claim = {
+            let mut lifecycle = state_cell.borrow_mut();
+            match std::mem::replace(&mut *lifecycle, WasmStreamingMutationLifecycle::Closed) {
+                WasmStreamingMutationLifecycle::Open(state) => {
+                    *lifecycle = WasmStreamingMutationLifecycle::AbortClaimed;
+                    Some(WasmStreamingMutationAbortClaim::Immediate(state))
+                }
+                WasmStreamingMutationLifecycle::PushInFlight { completion } => {
+                    *lifecycle = WasmStreamingMutationLifecycle::AbortClaimed;
+                    Some(WasmStreamingMutationAbortClaim::AfterPush(completion))
+                }
+                state => {
+                    *lifecycle = state;
+                    None
+                }
             }
-            .map_err(to_js_error)?;
+        };
+        let Some(claim) = claim else {
+            return js_sys::Promise::resolve(&JsValue::FALSE);
+        };
+        future_to_promise(async move {
+            let state = match claim {
+                WasmStreamingMutationAbortClaim::Immediate(state) => *state,
+                WasmStreamingMutationAbortClaim::AfterPush(completion) => {
+                    *completion.await.map_err(|_| streaming_mutation_closed())?
+                }
+            };
+            let result = match &state.db {
+                WasmDbInner::Memory(db) => db
+                    .abort_streaming_value_upload(state.upload)
+                    .await
+                    .map_err(to_js_error),
+                #[cfg(target_arch = "wasm32")]
+                WasmDbInner::Browser(db) => db
+                    .abort_streaming_value_upload(state.upload)
+                    .await
+                    .map_err(to_js_error),
+                WasmDbInner::Closed => Err(streaming_mutation_closed()),
+            };
+            *state_cell.borrow_mut() = WasmStreamingMutationLifecycle::Closed;
+            result?;
             Ok(JsValue::TRUE)
         })
     }
@@ -2435,20 +2513,22 @@ impl WasmDb {
         }
         .map_err(to_js_error)?;
         Ok(WasmStreamingMutation {
-            state: Rc::new(RefCell::new(Some(WasmStreamingMutationState {
-                db: inner,
-                upload,
-                mutation,
-                table,
-                row_id,
-                cells,
-                column,
-                identity,
-                attribution,
-                updated_at_ms,
-                head,
-                base,
-            }))),
+            state: Rc::new(RefCell::new(WasmStreamingMutationLifecycle::Open(
+                Box::new(WasmStreamingMutationState {
+                    db: inner,
+                    upload,
+                    mutation,
+                    table,
+                    row_id,
+                    cells,
+                    column,
+                    identity,
+                    attribution,
+                    updated_at_ms,
+                    head,
+                    base,
+                }),
+            ))),
         })
     }
 

--- a/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
@@ -50,6 +50,7 @@ function createTestPageStore() {
         started: () => void;
         wait: Promise<void>;
         release: () => void;
+        failAfterRelease: boolean;
       }
     | undefined;
 
@@ -70,6 +71,7 @@ function createTestPageStore() {
         pendingGate = undefined;
         gate.started();
         await gate.wait;
+        if (gate.failAfterRelease) throw new Error("injected page-store commit failure");
       }
       for (let index = 0; index < pageIds.length; index += 1) {
         pages.set(pageIds[index]!, new Uint8Array(pageBytes[index]!));
@@ -87,10 +89,15 @@ function createTestPageStore() {
 
   return {
     pageStore,
-    armCommitGate() {
+    armCommitGate(failAfterRelease = false) {
       const wait = deferredVoid();
       const started = deferredVoid();
-      pendingGate = { started: started.resolve, wait: wait.promise, release: wait.resolve };
+      pendingGate = {
+        started: started.resolve,
+        wait: wait.promise,
+        release: wait.resolve,
+        failAfterRelease,
+      };
       return { started: started.promise, release: wait.resolve };
     },
   };
@@ -194,7 +201,7 @@ describe.skipIf(!hasJazzWasmBuild())("WASM streaming mutations", () => {
 
   it("hands failed in-flight push ownership to abort without retaining staged chunks", async () => {
     const { db, runtime, pageStore, author } = await createBrowserWasmFixture();
-    const commitGate = pageStore.armCommitGate();
+    const commitGate = pageStore.armCommitGate(true);
     const upload = db.beginStreamingMutationEncoded(
       "todos",
       uuidBytes("00000000-0000-4000-8000-000000000130"),
@@ -205,9 +212,11 @@ describe.skipIf(!hasJazzWasmBuild())("WASM streaming mutations", () => {
       "insert",
       author,
     );
-    const pushRejected = expect(upload.push(Uint8Array.of(0xff))).rejects.toThrow();
+    const pushRejected = expect(
+      upload.push(new TextEncoder().encode("failed push")),
+    ).rejects.toThrow(/injected page-store commit failure/);
     try {
-      await withWatchdog(commitGate.started, "invalid-text push entered storage");
+      await withWatchdog(commitGate.started, "failed push entered storage");
       const abort = upload.abort();
       commitGate.release();
       await pushRejected;

--- a/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
@@ -108,6 +108,7 @@ async function createBrowserWasmFixture() {
     pageStore.pageStore,
     encodeSchema(streamingApp.wasmSchema),
     openConfig(node, author, 1, true),
+    "wasm-streaming-abort-owner",
   );
   const runtime = NativeRuntimeAdapter.fromDb(db, streamingApp.wasmSchema, node, author, 1, true);
   onTestFinished(async () => {

--- a/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 import { schema as s } from "../index.js";
 import type { TxId, WriteReceipt } from "./client.js";
-import { createWasmRuntime, hasJazzWasmBuild } from "./testing/wasm-runtime-test-utils.js";
+import {
+  encodeCellsForRow,
+  encodeSchema,
+  NativeRuntimeAdapter,
+} from "./native-runtime/native-runtime-adapter.js";
+import { openConfig } from "./native-runtime/native-codec.js";
+import {
+  createWasmRuntime,
+  hasJazzWasmBuild,
+  loadWasmModuleForTest,
+} from "./testing/wasm-runtime-test-utils.js";
 
 const app = s.defineApp({
   todos: s.table({
@@ -10,6 +20,107 @@ const app = s.defineApp({
     metadata: s.json().optional(),
   }),
 });
+const streamingApp = s.defineApp({
+  todos: s.table({
+    title: s.string().optional(),
+    done: s.boolean(),
+  }),
+});
+
+type PageStoreMetadata = {
+  pageSize: number;
+  generation: number;
+  rootPageId: number | null;
+  nextPageId: number;
+};
+
+function deferredVoid() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function createTestPageStore() {
+  let persistedMetadata: PageStoreMetadata | null = null;
+  const pages = new Map<number, Uint8Array>();
+  let pendingGate:
+    | {
+        started: () => void;
+        wait: Promise<void>;
+        release: () => void;
+      }
+    | undefined;
+
+  const pageStore = {
+    metadata: async () => persistedMetadata,
+    readPage: async (pageId: number) => pages.get(pageId) ?? null,
+    commitPages: async (
+      expectedGeneration: number,
+      pageSize: number,
+      rootPageId: number,
+      nextPageId: number,
+      pageIds: number[],
+      pageBytes: Uint8Array[],
+      deletedPageIds: number[],
+    ) => {
+      const gate = pendingGate;
+      if (gate) {
+        pendingGate = undefined;
+        gate.started();
+        await gate.wait;
+      }
+      for (let index = 0; index < pageIds.length; index += 1) {
+        pages.set(pageIds[index]!, new Uint8Array(pageBytes[index]!));
+      }
+      for (const pageId of deletedPageIds) pages.delete(pageId);
+      persistedMetadata = {
+        pageSize,
+        generation: expectedGeneration + 1,
+        rootPageId: rootPageId < 0 ? null : rootPageId,
+        nextPageId,
+      };
+      return persistedMetadata;
+    },
+  };
+
+  return {
+    pageStore,
+    armCommitGate() {
+      const wait = deferredVoid();
+      const started = deferredVoid();
+      pendingGate = { started: started.resolve, wait: wait.promise, release: wait.resolve };
+      return { started: started.promise, release: wait.resolve };
+    },
+  };
+}
+
+async function createBrowserWasmFixture() {
+  const wasmModule = await loadWasmModuleForTest();
+  const node = new Uint8Array(16);
+  node[0] = 1;
+  const author = new TextEncoder().encode(
+    JSON.stringify(["urn:jazz:test", "wasm-streaming-abort:author"]),
+  );
+  const pageStore = createTestPageStore();
+  const db = await wasmModule.WasmDb.openBrowser(
+    pageStore.pageStore,
+    encodeSchema(streamingApp.wasmSchema),
+    openConfig(node, author, 1, true),
+  );
+  const runtime = NativeRuntimeAdapter.fromDb(db, streamingApp.wasmSchema, node, author, 1, true);
+  onTestFinished(async () => {
+    await runtime.close?.();
+  });
+  return { db, runtime, pageStore, author };
+}
+
+function uuidBytes(value: string): Uint8Array {
+  return Uint8Array.from(value.replaceAll("-", "").match(/../g)!, (byte) =>
+    Number.parseInt(byte, 16),
+  );
+}
 
 async function committedTxId(receipt: WriteReceipt): Promise<TxId> {
   if (receipt.kind !== "committed") throw new Error("expected committed write receipt");
@@ -34,6 +145,69 @@ async function withWatchdog<T>(promise: Promise<T>, label: string, timeoutMs = 3
 }
 
 describe.skipIf(!hasJazzWasmBuild())("WASM streaming mutations", () => {
+  it("waits for an in-flight WASM push before aborting its staged upload", async () => {
+    const { db, runtime, pageStore, author } = await createBrowserWasmFixture();
+    const commitGate = pageStore.armCommitGate();
+    const upload = db.beginStreamingMutationEncoded(
+      "todos",
+      uuidBytes("00000000-0000-4000-8000-000000000128"),
+      encodeCellsForRow(streamingApp.wasmSchema.todos!, {
+        done: { type: "Boolean", value: false },
+      }),
+      "title",
+      "insert",
+      author,
+    );
+
+    const push = upload.push(new TextEncoder().encode("gated push"));
+    await commitGate.started;
+
+    let abortSettled = false;
+    const abort = upload.abort().then((result: boolean) => {
+      abortSettled = true;
+      return result;
+    });
+    await Promise.resolve();
+    expect(abortSettled).toBe(false);
+
+    commitGate.release();
+    await expect(push).resolves.toBeUndefined();
+    await expect(abort).resolves.toBe(true);
+    expect(abortSettled).toBe(true);
+    await expect(runtime.query(JSON.stringify({ table: "todos" }))).resolves.toEqual([]);
+
+    db.setLargeValueStagingPolicy(Number.MAX_SAFE_INTEGER, 60_000, 0);
+    // Expiry uses the platform clock; advance one event-loop turn past maxAgeMs=0.
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await expect(db.evictExpiredStagedLargeValues()).resolves.toBe(0);
+  });
+
+  it("keeps abort terminal across synchronous finish and repeated abort calls", async () => {
+    const { db, runtime, author } = await createBrowserWasmFixture();
+    const upload = db.beginStreamingMutationEncoded(
+      "todos",
+      uuidBytes("00000000-0000-4000-8000-000000000129"),
+      encodeCellsForRow(streamingApp.wasmSchema.todos!, {
+        done: { type: "Boolean", value: false },
+      }),
+      "title",
+      "insert",
+      author,
+    );
+
+    await expect(
+      upload.push(new TextEncoder().encode("preserved push result")),
+    ).resolves.toBeUndefined();
+    const abort = upload.abort();
+    const finish = upload.finish();
+    const repeatedAbort = upload.abort();
+
+    await expect(abort).resolves.toBe(true);
+    await expect(repeatedAbort).resolves.toBe(false);
+    await expect(finish).rejects.toThrow(/closed/i);
+    await expect(runtime.query(JSON.stringify({ table: "todos" }))).resolves.toEqual([]);
+  });
+
   it("selects and filters public provenance authors as canonical text", async () => {
     const appId = "wasm-public-provenance";
     const author = JSON.stringify(["urn:jazz:test", `${appId}:test:default:author`]);

--- a/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/wasm-streaming-mutations.test.ts
@@ -161,24 +161,64 @@ describe.skipIf(!hasJazzWasmBuild())("WASM streaming mutations", () => {
     );
 
     const push = upload.push(new TextEncoder().encode("gated push"));
-    await commitGate.started;
+    try {
+      await withWatchdog(commitGate.started, "push entered storage");
+      let abortSettled = false;
+      const abort = upload.abort().then((result: boolean) => {
+        abortSettled = true;
+        return result;
+      });
+      const finishRejected = expect(upload.finish()).rejects.toThrow(/closed/i);
+      const secondPushRejected = expect(upload.push(Uint8Array.of(65))).rejects.toThrow(/closed/i);
+      const duplicate = upload.abort();
+      await Promise.all([finishRejected, secondPushRejected]);
+      await expect(duplicate).resolves.toBe(false);
+      expect(abortSettled).toBe(false);
 
-    let abortSettled = false;
-    const abort = upload.abort().then((result: boolean) => {
-      abortSettled = true;
-      return result;
-    });
-    await Promise.resolve();
-    expect(abortSettled).toBe(false);
-
-    commitGate.release();
-    await expect(push).resolves.toBeUndefined();
-    await expect(abort).resolves.toBe(true);
-    expect(abortSettled).toBe(true);
+      commitGate.release();
+      await expect(push).resolves.toBeUndefined();
+      await expect(abort).resolves.toBe(true);
+      expect(abortSettled).toBe(true);
+      await expect(upload.finish()).rejects.toThrow(/closed/i);
+      await expect(upload.push(Uint8Array.of(65))).rejects.toThrow(/closed/i);
+    } finally {
+      commitGate.release();
+    }
     await expect(runtime.query(JSON.stringify({ table: "todos" }))).resolves.toEqual([]);
 
     db.setLargeValueStagingPolicy(Number.MAX_SAFE_INTEGER, 60_000, 0);
     // Expiry uses the platform clock; advance one event-loop turn past maxAgeMs=0.
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await expect(db.evictExpiredStagedLargeValues()).resolves.toBe(0);
+  });
+
+  it("hands failed in-flight push ownership to abort without retaining staged chunks", async () => {
+    const { db, runtime, pageStore, author } = await createBrowserWasmFixture();
+    const commitGate = pageStore.armCommitGate();
+    const upload = db.beginStreamingMutationEncoded(
+      "todos",
+      uuidBytes("00000000-0000-4000-8000-000000000130"),
+      encodeCellsForRow(streamingApp.wasmSchema.todos!, {
+        done: { type: "Boolean", value: false },
+      }),
+      "title",
+      "insert",
+      author,
+    );
+    const pushRejected = expect(upload.push(Uint8Array.of(0xff))).rejects.toThrow();
+    try {
+      await withWatchdog(commitGate.started, "invalid-text push entered storage");
+      const abort = upload.abort();
+      commitGate.release();
+      await pushRejected;
+      await expect(abort).resolves.toBe(true);
+      await expect(upload.abort()).resolves.toBe(false);
+      await expect(upload.finish()).rejects.toThrow(/closed/i);
+    } finally {
+      commitGate.release();
+    }
+    await expect(runtime.query(JSON.stringify({ table: "todos" }))).resolves.toEqual([]);
+    db.setLargeValueStagingPolicy(Number.MAX_SAFE_INTEGER, 60_000, 0);
     await new Promise((resolve) => setTimeout(resolve, 2));
     await expect(db.evictExpiredStagedLargeValues()).resolves.toBe(0);
   });


### PR DESCRIPTION
🤖 Make abort work while a streaming write is still storing a chunk.

A large value can be written incrementally through a streaming upload. If the caller invokes the existing abort() method while push() is waiting for storage, abort must still cancel that upload. Previously it could report false (nothing to cancel) because the pending push temporarily held the upload state. The write could then continue without the requested cleanup.

Now abort records the cancellation immediately, waits for the pending chunk operation to return, then cleans up the upload. That handoff also works if storing the chunk fails. The abort promise settles after its cleanup; a second abort cannot claim the same upload.

Before, push temporarily removed the upload state, so abort could report false while the upload was still active. The lifecycle now distinguishes open, push-in-flight, abort-claimed and closed. Abort claims synchronously and receives the upload state after either a successful or failed push. Competing push/finish and repeated abort cannot steal that ownership.

For example, a page-store commit can be suspended during push, abort can claim cleanup, and releasing the commit lets push finish before abort removes staged chunks. The same handoff works when that commit rejects. Existing Db.close admission remains unchanged: this does not let retained uploads mutate storage after database shutdown starts. This is a low-level ownership fix, not a new AbortSignal API or producer-loop contract, and changes no persisted/wire encoding.

Selective current-main port8997b365bc on c0863c80b3. Independent adversarial source review found no production blockers. The sealed streaming suite passes10 tests, including successful/error handoff, competing operations and repeated abort. Restoring the original lifecycle produces exactly2 failures/8 passes; restoring and resealing returns10/10. Worker-bridge browser suite passes72 with1 expected failure and2 skips; sealed Jazz Tools build and artifact producer pass. Coordinator independently rebuilt sealed artifacts and reran streaming10/10. Clippy, formatting, lint and sensitive-data checks pass. Fresh GitHub CI passes at8997b365bc, including Rust, workspace, differential, storage compatibility and TypeScript checks.
