### PR TITLE
Meter shared physical storage classes once

### DIFF
--- a/crates/groove/src/db/facade.rs
+++ b/crates/groove/src/db/facade.rs
@@ -428,6 +428,18 @@ impl Database {
         Ok(self.storage.approximate_class_bytes(cf.to_owned()).await?)
     }
 
+    /// Return aggregate approximate live bytes for supplied logical column
+    /// families, counting shared backing classes only once.
+    pub async fn approximate_class_bytes_for_logical_families<'a>(
+        &self,
+        logical_families: impl IntoIterator<Item = &'a str>,
+    ) -> Result<Option<u64>, Error> {
+        Ok(self
+            .storage
+            .approximate_class_bytes_for_logical_families(logical_families)
+            .await?)
+    }
+
     /// Return the durable ordered key/value bytes of Groove's engine-owned
     /// large-value metadata class for a compatibility receipt.
     ///

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -823,6 +823,31 @@ impl LayoutStorage {
         Ok(storage)
     }
 
+    /// Aggregate approximate live bytes for the supplied logical column
+    /// families, counting each mapped physical class at most once.
+    pub(crate) async fn approximate_class_bytes_for_logical_families<'a>(
+        &self,
+        logical_families: impl IntoIterator<Item = &'a str>,
+    ) -> Result<Option<u64>, Error> {
+        let mut physical_families = BTreeSet::new();
+        for logical_cf in logical_families {
+            physical_families.insert(self.layout.map_cf(logical_cf)?.physical_cf);
+        }
+
+        let mut bytes = 0_u64;
+        for physical_cf in physical_families {
+            let Some(class_bytes) = self
+                .inner
+                .approximate_class_bytes(physical_cf.to_owned())
+                .await?
+            else {
+                return Ok(None);
+            };
+            bytes = bytes.saturating_add(class_bytes);
+        }
+        Ok(Some(bytes))
+    }
+
     pub fn into_inner(self) -> BoxedStorage {
         self.inner
     }
@@ -2380,6 +2405,242 @@ mod tests {
         ) -> StorageFuture<'static, Result<Self, Error>> {
             Box::pin(async move { Ok(Self(self.0.reopen(column_families).await?)) })
         }
+    }
+
+    #[derive(Clone)]
+    struct MeteredStorage {
+        inner: MemoryStorage,
+        calls: Rc<RefCell<Vec<String>>>,
+    }
+
+    impl MeteredStorage {
+        fn new() -> (Self, Rc<RefCell<Vec<String>>>) {
+            let calls = Rc::new(RefCell::new(Vec::new()));
+            let inner = MemoryStorage::new(&[
+                CLASS_HISTORY_CF,
+                CLASS_REGISTER_CF,
+                CLASS_GLOBAL_CURRENT_CF,
+                CLASS_AHEAD_CURRENT_CF,
+                CLASS_CHANGES_CF,
+                CLASS_INDICES_CF,
+                CLASS_META_CF,
+            ])
+            .expect("valid physical class families");
+            (
+                Self {
+                    inner,
+                    calls: calls.clone(),
+                },
+                calls,
+            )
+        }
+    }
+
+    impl OrderedKvStorage for MeteredStorage {
+        fn get(
+            &self,
+            cf: String,
+            key: Vec<u8>,
+        ) -> StorageFuture<'_, Result<Option<super::Value>, Error>> {
+            self.inner.get(cf, key)
+        }
+
+        fn put_if_absent(
+            &self,
+            cf: String,
+            key: Vec<u8>,
+            value: Vec<u8>,
+        ) -> StorageFuture<'_, Result<Option<super::Value>, Error>> {
+            self.inner.put_if_absent(cf, key, value)
+        }
+
+        fn compare_and_delete(
+            &self,
+            cf: String,
+            key: Vec<u8>,
+            expected: Vec<u8>,
+        ) -> StorageFuture<'_, Result<bool, Error>> {
+            self.inner.compare_and_delete(cf, key, expected)
+        }
+
+        fn set(
+            &self,
+            cf: String,
+            key: Vec<u8>,
+            value: Vec<u8>,
+        ) -> StorageFuture<'_, Result<(), Error>> {
+            self.inner.set(cf, key, value)
+        }
+
+        fn delete(&self, cf: String, key: Vec<u8>) -> StorageFuture<'_, Result<(), Error>> {
+            self.inner.delete(cf, key)
+        }
+
+        fn scan(&self, request: ScanRequest) -> StorageFuture<'_, Result<StorageScan<'_>, Error>> {
+            self.inner.scan(request)
+        }
+
+        fn write_many(
+            &self,
+            operations: Vec<OwnedWriteOperation>,
+        ) -> StorageFuture<'_, Result<(), Error>> {
+            self.inner.write_many(operations)
+        }
+
+        fn approximate_class_bytes(
+            &self,
+            cf: String,
+        ) -> StorageFuture<'_, Result<Option<u64>, Error>> {
+            Box::pin(async move {
+                self.calls.borrow_mut().push(cf.clone());
+                match cf.as_str() {
+                    CLASS_HISTORY_CF => Ok(Some(40)),
+                    CLASS_REGISTER_CF => Err(Error::Backend {
+                        backend: "metered-test",
+                        message: "injected metering failure".to_owned(),
+                    }),
+                    CLASS_GLOBAL_CURRENT_CF => Ok(Some(u64::MAX)),
+                    CLASS_CHANGES_CF => Ok(None),
+                    CLASS_META_CF => Ok(Some(999)),
+                    _ => Ok(Some(1)),
+                }
+            })
+        }
+
+        fn column_family_names(&self) -> Option<Vec<String>> {
+            self.inner.column_family_names()
+        }
+    }
+
+    impl ReopenableStorage for MeteredStorage {
+        fn reopen(
+            self,
+            column_families: Vec<String>,
+        ) -> StorageFuture<'static, Result<Self, Error>> {
+            Box::pin(async move {
+                Ok(Self {
+                    inner: self.inner.reopen(column_families).await?,
+                    calls: self.calls,
+                })
+            })
+        }
+    }
+
+    async fn metered_class_layout() -> (LayoutStorage, Rc<RefCell<Vec<String>>>) {
+        let (backend, calls) = MeteredStorage::new();
+        let storage = LayoutStorage::new(backend, StorageLayout::jazz_class_v1())
+            .await
+            .expect("class layout opens");
+        (storage, calls)
+    }
+
+    #[futures_test::test]
+    async fn aggregate_meters_duplicate_logical_family_once() {
+        let (storage, calls) = metered_class_layout().await;
+
+        let bytes = storage
+            .approximate_class_bytes_for_logical_families([
+                "jazz_albums_history",
+                "jazz_albums_history",
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(bytes, Some(40));
+        assert_eq!(calls.borrow().as_slice(), [CLASS_HISTORY_CF]);
+    }
+
+    #[futures_test::test]
+    async fn aggregate_meters_shared_physical_history_class_once() {
+        let (storage, calls) = metered_class_layout().await;
+
+        let bytes = storage
+            .approximate_class_bytes_for_logical_families([
+                "jazz_albums_history",
+                "jazz_tracks_history",
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(bytes, Some(40));
+        assert_eq!(calls.borrow().as_slice(), [CLASS_HISTORY_CF]);
+    }
+
+    #[futures_test::test]
+    async fn aggregate_of_empty_logical_family_set_is_zero() {
+        let (storage, calls) = metered_class_layout().await;
+
+        let bytes = storage
+            .approximate_class_bytes_for_logical_families(std::iter::empty())
+            .await
+            .unwrap();
+
+        assert_eq!(bytes, Some(0));
+        assert!(calls.borrow().is_empty());
+    }
+
+    #[futures_test::test]
+    async fn aggregate_does_not_implicitly_meter_layout_metadata() {
+        let (storage, calls) = metered_class_layout().await;
+
+        let bytes = storage
+            .approximate_class_bytes_for_logical_families(["jazz_albums_history"])
+            .await
+            .unwrap();
+
+        assert_eq!(bytes, Some(40));
+        assert_eq!(calls.borrow().as_slice(), [CLASS_HISTORY_CF]);
+    }
+
+    #[futures_test::test]
+    async fn aggregate_returns_none_when_one_physical_class_cannot_be_metered() {
+        let (storage, calls) = metered_class_layout().await;
+
+        let bytes = storage
+            .approximate_class_bytes_for_logical_families(["jazz_global_changes"])
+            .await
+            .unwrap();
+
+        assert_eq!(bytes, None);
+        assert_eq!(calls.borrow().as_slice(), [CLASS_CHANGES_CF]);
+    }
+
+    #[futures_test::test]
+    async fn aggregate_propagates_backend_metering_error() {
+        let (storage, calls) = metered_class_layout().await;
+
+        let error = storage
+            .approximate_class_bytes_for_logical_families(["jazz_albums_register"])
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::Backend {
+                backend: "metered-test",
+                ..
+            }
+        ));
+        assert_eq!(calls.borrow().as_slice(), [CLASS_REGISTER_CF]);
+    }
+
+    #[futures_test::test]
+    async fn aggregate_saturates_physical_class_sum() {
+        let (storage, calls) = metered_class_layout().await;
+
+        let bytes = storage
+            .approximate_class_bytes_for_logical_families([
+                "jazz_albums_history",
+                "jazz_albums_global_current",
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(bytes, Some(u64::MAX));
+        assert_eq!(
+            calls.borrow().as_slice(),
+            [CLASS_GLOBAL_CURRENT_CF, CLASS_HISTORY_CF]
+        );
     }
 
     #[test]

--- a/crates/jazz/src/node/eviction.rs
+++ b/crates/jazz/src/node/eviction.rs
@@ -151,14 +151,13 @@ where
 
     /// Return metered edge-cache bytes, if every relevant class can be metered.
     pub async fn edge_cache_metered_bytes(&mut self) -> Result<Option<u64>, Error> {
-        let mut bytes = 0_u64;
-        for cf in self.edge_cache_metered_column_families().await? {
-            let Some(next) = self.database.approximate_class_bytes(&cf).await? else {
-                return Ok(None);
-            };
-            bytes = bytes.saturating_add(next);
-        }
-        Ok(Some(bytes))
+        let logical_families = self.edge_cache_metered_column_families().await?;
+        self.database
+            .approximate_class_bytes_for_logical_families(
+                logical_families.iter().map(String::as_str),
+            )
+            .await
+            .map_err(Error::from)
     }
 
     async fn evict_cold_inner(

--- a/crates/jazz/src/node/tests/sync/known_state.rs
+++ b/crates/jazz/src/node/tests/sync/known_state.rs
@@ -1243,6 +1243,84 @@ fn fast_known_state_requires_a_live_receipt_after_reopen_and_eviction() {
     assert_eq!(declaration, None);
 }
 
+#[test]
+fn two_table_edge_budget_counts_shared_physical_history_once_without_eviction() {
+    // This is intentionally an internal storage-boundary receipt: the edge
+    // budget is the observable policy seam, but only the backing storage can
+    // provide an independent byte count for its shared physical history class.
+    let test_schema = todos_notes_schema();
+    let (_writer_dir, mut writer) = open_node_with_schema(node(1), test_schema.clone());
+    let (_core_dir, mut core) = open_node_with_schema(node(9), test_schema.clone());
+    let column_families = test_schema.column_families();
+    let refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let storage = FailWriteManyMemoryStorage::new(&refs);
+    let mut reader = NodeState::new(node(3), test_schema, storage).unwrap();
+    let mut peer = PeerState::relay();
+    let rows = [
+        (
+            "todos",
+            row(0x76),
+            BTreeMap::from([("title".to_owned(), v("cached todo"))]),
+        ),
+        (
+            "notes",
+            row(0x77),
+            BTreeMap::from([("body".to_owned(), v("cached note"))]),
+        ),
+    ];
+
+    for (table, row_uuid, cells) in &rows {
+        commit_mergeable_global(
+            &mut writer,
+            &mut core,
+            MergeableCommit::new(*table, *row_uuid, 18).cells(cells.clone()),
+        );
+        let (shape, binding) = core.whole_table_shape_binding(table).unwrap();
+        let subscription = core.whole_table_subscription_key(table).unwrap();
+        let update = peer
+            .rehydrate_query_for_subscription_with_opts(
+                &mut core,
+                subscription,
+                &shape,
+                &binding,
+                RegisterShapeOptions::default(),
+            )
+            .unwrap()
+            .expect("expected view update");
+        reader.apply_sync_message_settled(update).unwrap();
+    }
+
+    let physical_history_bytes = reader
+        .database
+        .approximate_class_bytes("__groove_class_history")
+        .resolve()
+        .unwrap()
+        .expect("memory storage meters its physical history class");
+    assert!(physical_history_bytes > 0);
+    let report = reader
+        .enforce_edge_cache_budget(
+            &PeerEvictionPins::default(),
+            EdgeCacheBudget::new(physical_history_bytes),
+        )
+        .resolve()
+        .unwrap();
+
+    assert!(
+        report.is_none(),
+        "two logical history families share one {physical_history_bytes}-byte physical class, so the exact physical budget must not trigger eviction: {report:?}"
+    );
+    for (table, row_uuid, _) in rows {
+        assert_eq!(
+            reader.row_history(table, row_uuid).unwrap().len(),
+            1,
+            "a non-triggering physical budget must retain the cached {table} row"
+        );
+    }
+}
+
 #[derive(Clone, Copy)]
 enum EvictionFailurePath {
     ManualBatch,

--- a/crates/jazz/src/node/tests/sync/known_state.rs
+++ b/crates/jazz/src/node/tests/sync/known_state.rs
@@ -1257,8 +1257,8 @@ fn two_table_edge_budget_counts_shared_physical_history_once_without_eviction() 
         .map(String::as_str)
         .collect::<Vec<_>>();
     let storage = FailWriteManyMemoryStorage::new(&refs);
-    let mut reader = NodeState::new(node(3), test_schema, storage).unwrap();
-    let mut peer = PeerState::relay();
+    let mut reader =
+        NodeState::new_with_shared_test_catalogue(node(3), test_schema, storage).unwrap();
     let rows = [
         (
             "todos",
@@ -1280,7 +1280,8 @@ fn two_table_edge_budget_counts_shared_physical_history_once_without_eviction() 
         );
         let (shape, binding) = core.whole_table_shape_binding(table).unwrap();
         let subscription = core.whole_table_subscription_key(table).unwrap();
-        let update = peer
+        register_shape_binding(&mut reader, &shape, &binding);
+        let update = relay_with_system_binding(subscription)
             .rehydrate_query_for_subscription_with_opts(
                 &mut core,
                 subscription,


### PR DESCRIPTION
## Summary
- map logical storage families through the active Groove layout before metering
- deduplicate physical classes and meter each backend class once
- use the aggregate physical meter for Jazz edge-cache budgets

## Before
Jazz enumerated logical per-table history families and metered each independently. Under the class layout every history name maps to the same physical family, so two tables reported twice the actual history bytes and triggered premature eviction.

## After
Groove owns logical-to-physical aggregation behind the concrete Database interface. Empty, unavailable, error, metadata-exclusion, and saturating-sum behaviour is explicit, while Jazz supplies its existing logical family set once. Two logical history tables now contribute the shared physical class exactly once.

## Test plan
- [ ] Run the Groove aggregate metering contracts
- [ ] Run the two-table Jazz edge-budget regression
- [ ] Run the complete Groove and Jazz library suites