### PR TITLE
Bound native prepared-query cache retention

### DIFF
--- a/.changeset/bounded-prepared-query-cache.md
+++ b/.changeset/bounded-prepared-query-cache.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Bound native prepared-query retention with lease-aware eviction and cleanup during runtime shutdown.

--- a/packages/jazz-tools/src/runtime/napi.core.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.core.test.ts
@@ -1319,7 +1319,7 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
       expect(String(unsupported.notifications[1]?.[0])).toContain(
         "UnsupportedShapeCapability: fixture unsupported shape",
       );
-      expect(unsupported.notifications[1]?.[1]).toBeNull();
+      expect(unsupported.notifications[1]?.[1]).toBeUndefined();
 
       const rejected = openHarness("rejected");
       rejected.injectedEvents.push(serverFailureEvent);
@@ -1334,7 +1334,7 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
       expect(rejected.notifications).toHaveLength(2);
       expect(rejected.notifications[1]?.[0]).toBeInstanceOf(Error);
       expect(String(rejected.notifications[1]?.[0])).toContain("ServerFailure: QueryValidation");
-      expect(rejected.notifications[1]?.[1]).toBeNull();
+      expect(rejected.notifications[1]?.[1]).toBeUndefined();
 
       const closed = openHarness("closed");
       closed.injectedEvents.push(closedEvent);
@@ -1734,9 +1734,13 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
           author: Uint8Array,
         ): Uint8Array | Promise<Uint8Array>;
       };
-      prepareQuery(queryJson: string): unknown;
+      acquirePreparedQuery(queryJson: string): {
+        query: unknown;
+        release(): void;
+      };
     };
-    const query = raw.prepareQuery(JSON.stringify({ table: "todos" }));
+    const queryLease = raw.acquirePreparedQuery(JSON.stringify({ table: "todos" }));
+    const query = queryLease.query;
     const aliceAuthor = testExternalAuthorBytes(ALICE_ID);
     const bobAuthor = testExternalAuthorBytes(BOB_ID);
     await expect(
@@ -1745,6 +1749,7 @@ describe.skipIf(!hasJazzNapiBuild())("jazz-napi native runtime memory DB", () =>
     await expect(
       Promise.resolve().then(() => raw.db.all(query, undefined, transactionId, bobAuthor)),
     ).rejects.toThrow(/open transaction identity.*bound identity/i);
+    queryLease.release();
     await runtime.rollbackTransaction(transactionId);
   });
 

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -3997,7 +3997,6 @@ export class NativeRuntimeAdapter implements Runtime {
   }
 }
 
-
 function clearDeferredPlaceholderBuffer(subscription: SubscriptionState): void {
   subscription.deferredVisiblePublication = false;
   subscription.deferredVisibleReset = false;

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -4384,6 +4384,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === "boolean" || typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") return Number.isFinite(value) ? JSON.stringify(value) : "null";
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return "null";
+}
+
 function sessionClaims(
   rawClaims: unknown,
   session: { issuer: string; user_id: string; authMode?: string },

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1888,7 +1888,12 @@ export class NativeRuntimeAdapter implements Runtime {
       this.emitQueryCoverageTrace("attach");
       if (usesNativeRelationApi || queryHasArraySubqueries(coreQueryJson)) {
         if (pendingTx) {
-          const payload = await this.readRowsForContextAsync(query, opts, readContext, pendingTx.id);
+          const payload = await this.readRowsForContextAsync(
+            query,
+            opts,
+            readContext,
+            pendingTx.id,
+          );
           this.emitQueryCoverageTrace("covered");
           return rowsFromRelationSnapshot(
             readRelationSnapshot(payload),
@@ -2827,18 +2832,22 @@ export class NativeRuntimeAdapter implements Runtime {
     const kind = queryUsesNativeRelationApi(queryJson) ? "relation" : "query";
     const queryBytes =
       kind === "relation" ? relationQueryBytes(queryJson) : encodeQueryJson(queryJson, this.schema);
-    return this.preparedQueryCache.acquire(queryBytes, (encoded) => {
-      try {
-        const started = this.db.prepareQuery(encoded, kind);
-        if (isPendingNativeOperation<PreparedQuery>(started)) {
-          started.cancel();
-          throw new Error("native query preparation requires the asynchronous read boundary");
+    return this.preparedQueryCache.acquire(
+      queryBytes,
+      (encoded) => {
+        try {
+          const started = this.db.prepareQuery(encoded, kind);
+          if (isPendingNativeOperation<PreparedQuery>(started)) {
+            started.cancel();
+            throw new Error("native query preparation requires the asynchronous read boundary");
+          }
+          return started;
+        } catch (error) {
+          throw new Error(`Core prepareQuery failed for ${queryJson}: ${errorMessage(error)}`);
         }
-        return started;
-      } catch (error) {
-        throw new Error(`Core prepareQuery failed for ${queryJson}: ${errorMessage(error)}`);
-      }
-    }, kind);
+      },
+      kind,
+    );
   }
   /**
    * A strict remote query cannot materialize its local snapshot before an
@@ -2898,7 +2907,6 @@ export class NativeRuntimeAdapter implements Runtime {
     ) {
       await this.progressPeerTransport();
     }
-
   }
 
   private attachLocalReadCoverageInBackground(
@@ -6991,23 +6999,6 @@ function readU32Le(bytes: Uint8Array, offset: number): number {
     (bytes[offset + 2]! << 16) |
     (bytes[offset + 3]! << 24)
   );
-}
-
-
-/** Deterministic cache-key encoding for JSON-derived session claims. */
-function canonicalJson(value: unknown): string {
-  if (value === null || typeof value === "boolean" || typeof value === "string") {
-    return JSON.stringify(value);
-  }
-  if (typeof value === "number") return Number.isFinite(value) ? JSON.stringify(value) : "null";
-  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
-  if (isRecord(value)) {
-    return `{${Object.keys(value)
-      .sort()
-      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
-      .join(",")}}`;
-  }
-  return "null";
 }
 
 function sameBytes(left: Uint8Array, right: Uint8Array): boolean {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -6993,9 +6993,6 @@ function readU32Le(bytes: Uint8Array, offset: number): number {
   );
 }
 
-function bytesKey(bytes: Uint8Array): string {
-  return Array.from(bytes, (byte) => String.fromCharCode(byte)).join("");
-}
 
 /** Deterministic cache-key encoding for JSON-derived session claims. */
 function canonicalJson(value: unknown): string {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -34,6 +34,7 @@ import type {
 } from "../client.js";
 import type { Session } from "../context.js";
 import { SYSTEM_AUTHOR_ID } from "../system-identity.js";
+import { PreparedQueryCache, type PreparedQueryLease } from "./prepared-query-cache.js";
 import {
   LOCAL_FIRST_JWT_ISSUER,
   SYSTEM_SESSION_ISSUER,
@@ -517,7 +518,7 @@ type SubscriptionState = {
   terminalErrorDelivered?: boolean;
   sources: SubscriptionSourceState[];
   queryJson: string;
-  query: PreparedQuery | null;
+  preparedQueryLease: PreparedQueryLease<PreparedQuery> | null;
   identity?: Uint8Array;
   rows: RowState[];
   rowIndexByKey: Map<string, number>;
@@ -535,6 +536,7 @@ type SubscriptionState = {
   deferredPlaceholderBytes: number;
   callback?: (result: RuntimeSubscriptionDelta | Error) => void;
   cancelled: boolean;
+  terminal: boolean;
 };
 
 type SubscriptionOutputColumns = {
@@ -654,7 +656,7 @@ export class NativeRuntimeAdapter implements Runtime {
   private readonly scopeIsolatedRelay: boolean;
   private readonly schemaHash: string;
   private readonly trustedBackend: boolean;
-  private readonly preparedQueries = new Map<string, PreparedQuery>();
+  private readonly preparedQueryCache: PreparedQueryCache<PreparedQuery>;
   private readonly transactionOwner: TransactionOwnerState;
   private readonly pendingTxs: Map<string, PendingTx>;
   private readonly completedTxs: Map<string, CompletedTx>;
@@ -806,6 +808,7 @@ export class NativeRuntimeAdapter implements Runtime {
       opts?.selfSignedClientProof,
     );
     this.peerIdentity = author;
+    this.preparedQueryCache = new PreparedQueryCache();
     this.schemaHash = serializeRuntimeSchema(schema);
     if (opts?.db) {
       this.db = opts.db;
@@ -1162,17 +1165,12 @@ export class NativeRuntimeAdapter implements Runtime {
     if (this.closed && !alreadyMarkedClosed) return false;
     this.closed = true;
     for (const cancel of this.pendingNativeAdmissionCancels) cancel();
-    for (const subscription of this.subscriptions.values()) {
-      subscription.openingAbort?.abort();
-      for (const source of subscription.sources) {
-        closeSubscriptionSource(source.source);
-      }
+    for (const [handle, subscription] of this.subscriptions) {
+      this.terminateSubscription(handle, subscription);
     }
-    // Prepared plans and coverage receipts are valid only while this runtime
-    // is live. Release them before closing the native owner so long-lived JS
-    // Db wrappers cannot retain stale native graph/storage state through a
-    // cache after their context has shut down.
-    this.preparedQueries.clear();
+    // Leases keep in-flight users alive, but no prepared handle remains
+    // available for reuse after this runtime has shut down.
+    this.preparedQueryCache.clear();
     if (this !== this.ownerRuntime) {
       this.subscriptions.clear();
       // Query and subscription futures may still be unwinding through this
@@ -1878,38 +1876,43 @@ export class NativeRuntimeAdapter implements Runtime {
     // fresh remote receipt had just removed.
     const opts = readOptions(tier, queryIncludesDeleted(coreQueryJson), optionsJson);
     const readContext = this.nativeReadContext(session, pendingTx);
-    const query = await this.prepareQueryForRead(coreQueryJson, requestSession);
-    await this.waitForStrictRemoteQueryTransport(tier);
-    await this.processPendingPeerActivityBeforeRead();
-    if (this.closed) return [];
-    if (!pendingTx) {
-      this.attachLocalReadCoverageInBackground(tier, optionsJson, query, session);
-    }
-    this.emitQueryCoverageTrace("attach");
-    if (usesNativeRelationApi || queryHasArraySubqueries(coreQueryJson)) {
-      if (pendingTx) {
-        const payload = await this.readRowsForContextAsync(query, opts, readContext, pendingTx.id);
+    const queryLease = await this.prepareQueryForRead(coreQueryJson, requestSession);
+    try {
+      const query = queryLease.query;
+      await this.waitForStrictRemoteQueryTransport(tier);
+      await this.processPendingPeerActivityBeforeRead();
+      if (this.closed) return [];
+      if (!pendingTx) {
+        this.attachLocalReadCoverageInBackground(tier, optionsJson, queryLease, session);
+      }
+      this.emitQueryCoverageTrace("attach");
+      if (usesNativeRelationApi || queryHasArraySubqueries(coreQueryJson)) {
+        if (pendingTx) {
+          const payload = await this.readRowsForContextAsync(query, opts, readContext, pendingTx.id);
+          this.emitQueryCoverageTrace("covered");
+          return rowsFromRelationSnapshot(
+            readRelationSnapshot(payload),
+            this.schema,
+            subscriptionOutputColumns(coreQueryJson, this.schema).rootColumns,
+          );
+        }
+        const payload = await this.readRowsForContextAsync(query, opts, readContext);
         this.emitQueryCoverageTrace("covered");
         return rowsFromRelationSnapshot(
           readRelationSnapshot(payload),
           this.schema,
-          subscriptionOutputColumns(coreQueryJson, this.schema).rootColumns,
+          usesNativeRelationApi
+            ? undefined
+            : subscriptionOutputColumns(coreQueryJson, this.schema).rootColumns,
         );
       }
-      const payload = await this.readRowsForContextAsync(query, opts, readContext);
+      const projectedColumns = subscriptionOutputColumns(coreQueryJson, this.schema).rootColumns;
+      const rows = await this.readPlainRows(query, opts, session ?? undefined, pendingTx);
       this.emitQueryCoverageTrace("covered");
-      return rowsFromRelationSnapshot(
-        readRelationSnapshot(payload),
-        this.schema,
-        usesNativeRelationApi
-          ? undefined
-          : subscriptionOutputColumns(coreQueryJson, this.schema).rootColumns,
-      );
+      return rowsFromBatches(readRowBatches(rows), this.schema, projectedColumns);
+    } finally {
+      queryLease.release();
     }
-    const projectedColumns = subscriptionOutputColumns(coreQueryJson, this.schema).rootColumns;
-    const rows = await this.readPlainRows(query, opts, session ?? undefined, pendingTx);
-    this.emitQueryCoverageTrace("covered");
-    return rowsFromBatches(readRowBatches(rows), this.schema, projectedColumns);
   }
 
   createSubscription(
@@ -1933,7 +1936,7 @@ export class NativeRuntimeAdapter implements Runtime {
       sources: [],
       openingAbort: new AbortController(),
       queryJson,
-      query: null,
+      preparedQueryLease: null,
       identity,
       rows: [],
       rowIndexByKey: new Map(),
@@ -1952,27 +1955,43 @@ export class NativeRuntimeAdapter implements Runtime {
       deferredPlaceholderRows: 0,
       deferredPlaceholderBytes: 0,
       cancelled: false,
+      terminal: false,
     });
     const subscription = this.subscriptions.get(handle)!;
+    // Until source installation, the opener owns the lease even if cancellation
+    // has already removed the subscription from the public handle map.
+    let openingLease: PreparedQueryLease<PreparedQuery> | null = null;
+    const releaseOpeningLease = () => {
+      openingLease?.release();
+      openingLease = null;
+    };
     const install = (native: ReadableStream<unknown> | Subscription) => {
-      subscription.sources = [{ source: subscriptionSource(native), reading: false }];
+      const source = subscriptionSource(native);
       if (subscription.cancelled || this.closed) {
-        closeSubscriptionSourceState(subscription);
+        try {
+          closeSubscriptionSource(source);
+        } finally {
+          releaseOpeningLease();
+        }
         return;
       }
+      subscription.sources = [{ source, reading: false }];
+      subscription.preparedQueryLease = openingLease;
+      openingLease = null;
       if (subscription.callback) this.startSubscriptionReader(handle, subscription);
     };
     const fail = (error: unknown) => {
-      if (!subscription.cancelled && !this.closed)
+      releaseOpeningLease();
+      if (!subscription.cancelled)
         this.failSubscription(
           subscription,
           error instanceof Error ? error : new Error(String(error)),
         );
     };
-    const open = (query: PreparedQuery) => {
+    const open = (lease: PreparedQueryLease<PreparedQuery>) => {
+      openingLease = lease;
       if (subscription.cancelled || this.closed) throw new Error("native operation was cancelled");
-      subscription.query = query;
-      const native = this.subscribeForContext(query, opts, readContext);
+      const native = this.subscribeForContext(lease.query, opts, readContext);
       return isPendingNativeOperation<ReadableStream<unknown> | Subscription>(native)
         ? this.awaitNativeOperation(native, subscription.openingAbort!.signal)
         : native;
@@ -2016,11 +2035,7 @@ export class NativeRuntimeAdapter implements Runtime {
   unsubscribe(handle: number): void {
     const subscription = this.subscriptions.get(handle);
     if (!subscription) return;
-    subscription.cancelled = true;
-    subscription.openingAbort?.abort();
-    clearDeferredPlaceholderBuffer(subscription);
-    closeSubscriptionSourceState(subscription);
-    this.subscriptions.delete(handle);
+    this.terminateSubscription(handle, subscription);
   }
 
   connect(url: string, authJson: string): void {
@@ -2411,15 +2426,19 @@ export class NativeRuntimeAdapter implements Runtime {
 
   private readRow(table: string, rowId: Uint8Array, identity?: Uint8Array): RowState | undefined {
     if (!identity) return this.readRowForWriteMerge(table, rowId);
-    const query = this.prepareQuery(JSON.stringify({ table }));
-    const rows = this.readRowsForContext(
-      query,
-      readOptions(),
-      this.nativeReadContext({ identity } as RuntimeSession),
-    );
-    return rowsFromBatches(readRowBatches(rows), this.schema).find(
-      (row) => row.table === table && row.id === formatUuid(rowId),
-    );
+    const queryLease = this.acquirePreparedQuery(JSON.stringify({ table }));
+    try {
+      const rows = this.readRowsForContext(
+        queryLease.query,
+        readOptions(),
+        this.nativeReadContext({ identity } as RuntimeSession),
+      );
+      return rowsFromBatches(readRowBatches(rows), this.schema).find(
+        (row) => row.table === table && row.id === formatUuid(rowId),
+      );
+    } finally {
+      queryLease.release();
+    }
   }
 
   private readRowForWriteMerge(table: string, rowId: Uint8Array): RowState | undefined {
@@ -2433,22 +2452,26 @@ export class NativeRuntimeAdapter implements Runtime {
       );
       return rows[0];
     }
-    const query = this.prepareQuery(JSON.stringify({ table }));
-    const rows = this.db.all(query, {
-      ...(readOptions() as Record<string, unknown>),
-      sync: true,
-    });
-    if (typeof (rows as Promise<unknown>).then === "function") {
-      throw new Error("write merge requires the synchronous native read boundary");
-    }
-    if (isPendingNativeRead(rows)) {
-      throw new Error(
-        "write merge cannot synchronously hydrate a large value; use the exact local row reader",
+    const queryLease = this.acquirePreparedQuery(JSON.stringify({ table }));
+    try {
+      const rows = this.db.all(queryLease.query, {
+        ...(readOptions() as Record<string, unknown>),
+        sync: true,
+      });
+      if (typeof (rows as Promise<unknown>).then === "function") {
+        throw new Error("write merge requires the synchronous native read boundary");
+      }
+      if (isPendingNativeRead(rows)) {
+        throw new Error(
+          "write merge cannot synchronously hydrate a large value; use the exact local row reader",
+        );
+      }
+      return rowsFromBatches(readRowBatches(rows as Uint8Array), this.schema).find(
+        (row) => row.table === table && row.id === formatUuid(rowId),
       );
+    } finally {
+      queryLease.release();
     }
-    return rowsFromBatches(readRowBatches(rows as Uint8Array), this.schema).find(
-      (row) => row.table === table && row.id === formatUuid(rowId),
-    );
   }
 
   private rowStateFromValues(
@@ -2746,7 +2769,9 @@ export class NativeRuntimeAdapter implements Runtime {
     queryJson: string,
     session: RuntimeSession | null,
     signal?: AbortSignal,
-  ): PreparedQuery | Promise<PreparedQuery> {
+  ): PreparedQueryLease<PreparedQuery> | Promise<PreparedQueryLease<PreparedQuery>> {
+    if (this.closed || this.ownerRuntime.closed) throw new Error("Native runtime is closed");
+    if (signal?.aborted) throw new Error("native operation was cancelled");
     if (session && !session.backendAuthority && this.readAuthorizationHost !== "trusted-serving") {
       const key = canonicalJson(session.claims);
       if (key !== this.clientSessionClaimsKey) {
@@ -2770,51 +2795,49 @@ export class NativeRuntimeAdapter implements Runtime {
     queryJson: string,
     session: RuntimeSession | null,
     signal?: AbortSignal,
-  ): PreparedQuery | Promise<PreparedQuery> {
+  ): PreparedQueryLease<PreparedQuery> | Promise<PreparedQueryLease<PreparedQuery>> {
+    if (this.closed || this.ownerRuntime.closed) throw new Error("Native runtime is closed");
+    if (signal?.aborted) throw new Error("native operation was cancelled");
     const contextual =
       session && !session.backendAuthority && this.readAuthorizationHost === "trusted-serving";
     const kind = queryUsesNativeRelationApi(queryJson) ? "relation" : "query";
     const queryBytes =
       kind === "relation" ? relationQueryBytes(queryJson) : encodeQueryJson(queryJson, this.schema);
-    const key = `${kind}:${bytesKey(queryBytes)}`;
-    const cached = contextual ? undefined : this.preparedQueries.get(key);
-    if (cached) return cached;
-    const started = this.db.prepareQuery(
+    return this.preparedQueryCache.acquire(
       queryBytes,
+      (encoded) => {
+        const started = this.db.prepareQuery(
+          encoded,
+          kind,
+          contextual ? session.identity : undefined,
+          contextual ? session.claims : undefined,
+        );
+        return isPendingNativeOperation<PreparedQuery>(started)
+          ? this.awaitNativeOperation(started, signal)
+          : started;
+      },
       kind,
-      contextual ? session.identity : undefined,
-      contextual ? session.claims : undefined,
+      !contextual,
     );
-    const remember = (query: PreparedQuery) => {
-      if (!contextual) this.preparedQueries.set(key, query);
-      return query;
-    };
-    const query = isPendingNativeOperation<PreparedQuery>(started)
-      ? this.awaitNativeOperation(started, signal)
-      : started;
-    return query instanceof Promise ? query.then(remember) : remember(query);
   }
 
-  private prepareQuery(queryJson: string): PreparedQuery {
+  private acquirePreparedQuery(queryJson: string): PreparedQueryLease<PreparedQuery> {
+    if (this.closed || this.ownerRuntime.closed) throw new Error("Native runtime is closed");
     const kind = queryUsesNativeRelationApi(queryJson) ? "relation" : "query";
     const queryBytes =
       kind === "relation" ? relationQueryBytes(queryJson) : encodeQueryJson(queryJson, this.schema);
-    const key = `${kind}:${bytesKey(queryBytes)}`;
-    let query = this.preparedQueries.get(key);
-    if (!query) {
+    return this.preparedQueryCache.acquire(queryBytes, (encoded) => {
       try {
-        const started = this.db.prepareQuery(queryBytes, kind);
+        const started = this.db.prepareQuery(encoded, kind);
         if (isPendingNativeOperation<PreparedQuery>(started)) {
           started.cancel();
           throw new Error("native query preparation requires the asynchronous read boundary");
         }
-        query = started;
+        return started;
       } catch (error) {
         throw new Error(`Core prepareQuery failed for ${queryJson}: ${errorMessage(error)}`);
       }
-      this.preparedQueries.set(key, query);
-    }
-    return query;
+    }, kind);
   }
   /**
    * A strict remote query cannot materialize its local snapshot before an
@@ -2874,29 +2897,34 @@ export class NativeRuntimeAdapter implements Runtime {
     ) {
       await this.progressPeerTransport();
     }
+
   }
 
   private attachLocalReadCoverageInBackground(
     tier: string | null | undefined,
     optionsJson: string | null | undefined,
-    query: PreparedQuery,
+    queryLease: PreparedQueryLease<PreparedQuery>,
     session: RuntimeSession | null,
   ): void {
     if (tier != null && tier !== "local") return;
     if (!readPropagationIsFull(optionsJson)) return;
     if (this.nonDurableClient || !this.serverTransport) return;
-
+    const childLease = queryLease.retain();
     const refresh = async () => {
-      await this.serverCarrierPromise;
-      if (this.closed) return;
-      const edgeOptionsJson = JSON.stringify({ propagation: "full" });
-      await this.waitForStrictRemoteQueryTransport("edge");
-      if (this.closed) return;
-      await this.readRowsForContextAsync(
-        query,
-        readOptions("edge", false, edgeOptionsJson),
-        this.nativeReadContext(session),
-      );
+      try {
+        await this.serverCarrierPromise;
+        if (this.closed || !childLease.isCurrent()) return;
+        const edgeOptionsJson = JSON.stringify({ propagation: "full" });
+        await this.waitForStrictRemoteQueryTransport("edge");
+        if (this.closed || !childLease.isCurrent()) return;
+        await this.readRowsForContextAsync(
+          childLease.query,
+          readOptions("edge", false, edgeOptionsJson),
+          this.nativeReadContext(session),
+        );
+      } finally {
+        childLease.release();
+      }
     };
 
     void refresh().catch((error: unknown) => {
@@ -3204,9 +3232,12 @@ export class NativeRuntimeAdapter implements Runtime {
     try {
       while (!subscription.cancelled && this.subscriptions.get(handle) === subscription) {
         const next = await source.source.read();
-        if (next.done || subscription.cancelled) return;
+        if (next.done || subscription.cancelled) {
+          if (next.done) this.terminateSubscription(handle, subscription);
+          return;
+        }
         try {
-          this.applySubscriptionChunk(subscription, next.value);
+          this.applySubscriptionChunk(handle, subscription, next.value);
         } catch (error) {
           this.failSubscription(
             subscription,
@@ -3248,7 +3279,7 @@ export class NativeRuntimeAdapter implements Runtime {
         for (const event of batch) {
           if (subscription.cancelled || this.subscriptions.get(handle) !== subscription) return;
           try {
-            this.applySubscriptionChunk(subscription, event);
+            this.applySubscriptionChunk(handle, subscription, event);
           } catch (error) {
             this.failSubscription(
               subscription,
@@ -3274,12 +3305,14 @@ export class NativeRuntimeAdapter implements Runtime {
     }
   }
 
-  private applySubscriptionChunk(subscription: SubscriptionState, value: unknown): void {
+  private applySubscriptionChunk(
+    handle: number,
+    subscription: SubscriptionState,
+    value: unknown,
+  ): void {
     const chunk = normalizeSubscriptionChunk(value);
     if (chunk.type === "closed") {
-      clearDeferredPlaceholderBuffer(subscription);
-      closeSubscriptionSourceState(subscription);
-      subscription.cancelled = true;
+      this.terminateSubscription(handle, subscription);
       return;
     }
     if (chunk.type === "rejected") {
@@ -3815,22 +3848,43 @@ export class NativeRuntimeAdapter implements Runtime {
     }
   }
 
+  private terminateSubscription(handle: number, subscription: SubscriptionState): void {
+    if (this.subscriptions.get(handle) === subscription) this.subscriptions.delete(handle);
+    this.retireSubscriptionResources(subscription);
+  }
+
   private failSubscription(subscription: SubscriptionState, error: Error): void {
     if (subscription.cancelled) return;
+    subscription.terminalError = error;
+    this.retireSubscriptionResources(subscription);
+    // Keep the terminal state addressable until unsubscribe: an asynchronous
+    // opener may fail before executeSubscription installs the callback.
+    this.deliverSubscriptionFailure(subscription);
+  }
+
+  private retireSubscriptionResources(subscription: SubscriptionState): void {
+    if (subscription.terminal) return;
+    subscription.terminal = true;
     subscription.cancelled = true;
     subscription.openingAbort?.abort();
-    subscription.terminalError = error;
     clearDeferredPlaceholderBuffer(subscription);
-    for (const source of subscription.sources) {
-      try {
-        closeSubscriptionSource(source.source);
-      } catch (cleanupError) {
-        // Resource retirement must not replace the causal subscription error
-        // or prevent its once-only delivery to the application.
-        console.error("Jazz subscription source cleanup failed", cleanupError);
+    const lease = subscription.preparedQueryLease;
+    subscription.preparedQueryLease = null;
+    const sources = subscription.sources;
+    subscription.sources = [];
+    try {
+      for (const source of sources) {
+        try {
+          closeSubscriptionSource(source.source);
+        } catch (cleanupError) {
+          // Resource retirement must not replace the causal subscription error
+          // or prevent its once-only delivery to the application.
+          console.error("Jazz subscription source cleanup failed", cleanupError);
+        }
       }
+    } finally {
+      lease?.release();
     }
-    this.deliverSubscriptionFailure(subscription);
   }
 
   private deliverSubscriptionFailure(subscription: SubscriptionState): void {
@@ -3942,11 +3996,6 @@ export class NativeRuntimeAdapter implements Runtime {
   }
 }
 
-function closeSubscriptionSourceState(subscription: SubscriptionState): void {
-  for (const source of subscription.sources) {
-    closeSubscriptionSource(source.source);
-  }
-}
 
 function clearDeferredPlaceholderBuffer(subscription: SubscriptionState): void {
   subscription.deferredVisiblePublication = false;

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1967,7 +1967,7 @@ export class NativeRuntimeAdapter implements Runtime {
     };
     const install = (native: ReadableStream<unknown> | Subscription) => {
       const source = subscriptionSource(native);
-      if (subscription.cancelled || this.closed) {
+      if (subscription.cancelled || this.closed || this.ownerRuntime.closed) {
         try {
           closeSubscriptionSource(source);
         } finally {
@@ -1990,7 +1990,8 @@ export class NativeRuntimeAdapter implements Runtime {
     };
     const open = (lease: PreparedQueryLease<PreparedQuery>) => {
       openingLease = lease;
-      if (subscription.cancelled || this.closed) throw new Error("native operation was cancelled");
+      if (subscription.cancelled || this.closed || this.ownerRuntime.closed)
+        throw new Error("native operation was cancelled");
       const native = this.subscribeForContext(lease.query, opts, readContext);
       return isPendingNativeOperation<ReadableStream<unknown> | Subscription>(native)
         ? this.awaitNativeOperation(native, subscription.openingAbort!.signal)

--- a/packages/jazz-tools/src/runtime/native-runtime/prepared-query-cache.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/prepared-query-cache.ts
@@ -90,8 +90,10 @@ export class PreparedQueryCache<T extends object> {
   }
 
   isCurrentEntry(entry: PreparedQueryCacheEntry<T>): boolean {
-    return entry.generation === this.generation &&
-      (entry.key === undefined || this.entries.get(entry.key) === entry);
+    return (
+      entry.generation === this.generation &&
+      (entry.key === undefined || this.entries.get(entry.key) === entry)
+    );
   }
 
   retainEntry(entry: PreparedQueryCacheEntry<T>): void {

--- a/packages/jazz-tools/src/runtime/native-runtime/prepared-query-cache.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/prepared-query-cache.ts
@@ -1,0 +1,187 @@
+const MAX_PREPARED_QUERY_CACHE_ENTRIES = 256;
+const MAX_PREPARED_QUERY_CACHE_ENCODED_BYTES = 1_048_576;
+
+type PreparedQueryCacheEntry<T extends object> = {
+  readonly key: string | undefined;
+  readonly query: T;
+  readonly weight: number;
+  readonly generation: number;
+  leases: number;
+};
+
+export type PreparedQueryLease<T extends object> = {
+  readonly query: T;
+  retain(): PreparedQueryLease<T>;
+  release(): void;
+  isCurrent(): boolean;
+};
+
+/**
+ * Runtime-local exact-query retention with active-use pinning and inactive LRU
+ * admission. This module intentionally owns only adapter references; it does
+ * not own or dispose the native query's underlying Groove shape.
+ */
+export class PreparedQueryCache<T extends object> {
+  private readonly entries = new Map<string, PreparedQueryCacheEntry<T>>();
+  private readonly inactive = new Map<string, PreparedQueryCacheEntry<T>>();
+  private totalWeight = 0;
+  private generation = 0;
+
+  constructor(private readonly onEvict: (query: T) => void = () => {}) {}
+
+  acquire(
+    encodedQuery: Uint8Array,
+    prepare: (bytes: Uint8Array) => T,
+    kind?: "query" | "relation",
+    cacheable?: boolean,
+  ): PreparedQueryLease<T>;
+  acquire(
+    encodedQuery: Uint8Array,
+    prepare: (bytes: Uint8Array) => T | Promise<T>,
+    kind?: "query" | "relation",
+    cacheable?: boolean,
+  ): PreparedQueryLease<T> | Promise<PreparedQueryLease<T>>;
+  acquire(
+    encodedQuery: Uint8Array,
+    prepare: (bytes: Uint8Array) => T | Promise<T>,
+    kind: "query" | "relation" = "query",
+    cacheable = true,
+  ): PreparedQueryLease<T> | Promise<PreparedQueryLease<T>> {
+    // Contextual preparation carries an admitted identity/claims snapshot and
+    // must never be reused by another request, even with identical query bytes.
+    const key = cacheable ? `${kind}:${bytesKey(encodedQuery)}` : undefined;
+    const existing = key === undefined ? undefined : this.entries.get(key);
+    if (existing) return this.leaseRetain(existing);
+
+    const generation = this.generation;
+    const remember = (query: T): PreparedQueryLease<T> => {
+      if (generation !== this.generation) {
+        throw new Error("prepared query acquisition was invalidated");
+      }
+      // Independent pending preparations may complete in either order. Only
+      // one reusable entry owns this key; existing active leases stay pinned.
+      const current = key === undefined ? undefined : this.entries.get(key);
+      if (current) return this.leaseRetain(current);
+      const entry: PreparedQueryCacheEntry<T> = {
+        key,
+        query,
+        weight: encodedQuery.byteLength,
+        generation,
+        leases: 1,
+      };
+      if (key !== undefined) {
+        this.entries.set(key, entry);
+        this.totalWeight += entry.weight;
+        this.evictToBudget();
+      }
+      return new CacheLease(this, entry);
+    };
+    const query = prepare(encodedQuery);
+    return query instanceof Promise ? query.then(remember) : remember(query);
+  }
+
+  clear(): void {
+    this.generation += 1;
+    const removed = [...this.entries.values()];
+    this.entries.clear();
+    this.inactive.clear();
+    this.totalWeight = 0;
+    for (const entry of removed) this.notifyEviction(entry.query);
+  }
+
+  isCurrentEntry(entry: PreparedQueryCacheEntry<T>): boolean {
+    return entry.generation === this.generation &&
+      (entry.key === undefined || this.entries.get(entry.key) === entry);
+  }
+
+  retainEntry(entry: PreparedQueryCacheEntry<T>): void {
+    if (!this.isCurrentEntry(entry)) throw new Error("prepared query lease is stale");
+    if (entry.key !== undefined) this.inactive.delete(entry.key);
+    entry.leases += 1;
+  }
+
+  releaseEntry(entry: PreparedQueryCacheEntry<T>): void {
+    if (!this.isCurrentEntry(entry)) return;
+    if (entry.leases <= 0) return;
+    entry.leases -= 1;
+    if (entry.leases === 0 && entry.key !== undefined) {
+      this.inactive.delete(entry.key);
+      this.inactive.set(entry.key, entry);
+      this.evictToBudget();
+    }
+  }
+
+  evictToBudget(): void {
+    while (
+      (this.entries.size > MAX_PREPARED_QUERY_CACHE_ENTRIES ||
+        this.totalWeight > MAX_PREPARED_QUERY_CACHE_ENCODED_BYTES) &&
+      this.inactive.size > 0
+    ) {
+      const oldestKey = this.inactive.keys().next().value as string | undefined;
+      if (oldestKey === undefined) return;
+      const entry = this.inactive.get(oldestKey);
+      this.inactive.delete(oldestKey);
+      if (!entry || this.entries.get(oldestKey) !== entry) continue;
+      this.entries.delete(oldestKey);
+      this.totalWeight -= entry.weight;
+      this.notifyEviction(entry.query);
+    }
+  }
+
+  leaseIsCurrent(entry: PreparedQueryCacheEntry<T>): boolean {
+    return this.isCurrentEntry(entry);
+  }
+
+  leaseRetain(entry: PreparedQueryCacheEntry<T>): PreparedQueryLease<T> {
+    this.retainEntry(entry);
+    return new CacheLease(this, entry);
+  }
+
+  leaseRelease(entry: PreparedQueryCacheEntry<T>): void {
+    this.releaseEntry(entry);
+  }
+
+  leaseQuery(entry: PreparedQueryCacheEntry<T>): T {
+    return entry.query;
+  }
+  notifyEviction(query: T): void {
+    try {
+      this.onEvict(query);
+    } catch {
+      // Eviction bookkeeping is complete before cleanup is notified.
+    }
+  }
+
+}
+
+class CacheLease<T extends object> implements PreparedQueryLease<T> {
+  private released = false;
+
+  constructor(
+    private readonly cache: PreparedQueryCache<T>,
+    private readonly entry: PreparedQueryCacheEntry<T>,
+  ) {}
+
+  get query(): T {
+    return this.cache.leaseQuery(this.entry);
+  }
+
+  retain(): PreparedQueryLease<T> {
+    if (this.released) throw new Error("prepared query lease is already released");
+    return this.cache.leaseRetain(this.entry);
+  }
+
+  release(): void {
+    if (this.released) return;
+    this.released = true;
+    this.cache.leaseRelease(this.entry);
+  }
+
+  isCurrent(): boolean {
+    return !this.released && this.cache.leaseIsCurrent(this.entry);
+  }
+}
+
+function bytesKey(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => String.fromCharCode(byte)).join("");
+}

--- a/packages/jazz-tools/src/runtime/native-runtime/prepared-query-cache.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/prepared-query-cache.ts
@@ -151,7 +151,6 @@ export class PreparedQueryCache<T extends object> {
       // Eviction bookkeeping is complete before cleanup is notified.
     }
   }
-
 }
 
 class CacheLease<T extends object> implements PreparedQueryLease<T> {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -5750,7 +5750,7 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
               preparedQueries.push(query);
               return query;
             },
-            all: (query) => {
+            all: (query: unknown) => {
               lastReadQuery = query;
               return new Uint8Array([0]);
             },
@@ -6086,7 +6086,6 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
     expect(preparedQueries.at(-1)).not.toBe(failedQuery);
   });
 });
-
 
 describe("NativeRuntimeAdapter streaming inserts", () => {
   it("infers the physical kind and applies backpressure to async chunks", async () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -5211,28 +5211,30 @@ describe("NativeRuntimeAdapter server transport", () => {
       null,
       null,
     );
+    // The adapter state is intentionally inspected here to verify that
+    // termination clears deferred buffers on the object that was terminated.
+    const runtimeState = runtime as unknown as {
+      subscriptions: Map<
+        number,
+        {
+          cancelled: boolean;
+          deferredVisiblePublication: boolean;
+          deferredVisibleReset: boolean;
+          deferredTerminalOperations: unknown[];
+          deferredPlaceholderChunks: number;
+          deferredPlaceholderRows: number;
+          deferredPlaceholderBytes: number;
+        }
+      >;
+    };
+    const subscription = runtimeState.subscriptions.get(handle);
+    expect(subscription).toBeDefined();
 
     runtime.executeSubscription(handle, (...args: unknown[]) => callbacks.push(args));
     await Promise.resolve();
     await Promise.resolve();
 
     expect(callbacks).toEqual([]);
-    const subscription = (
-      runtime as unknown as {
-        subscriptions: Map<
-          number,
-          {
-            cancelled: boolean;
-            deferredVisiblePublication: boolean;
-            deferredVisibleReset: boolean;
-            deferredTerminalOperations: unknown[];
-            deferredPlaceholderChunks: number;
-            deferredPlaceholderRows: number;
-            deferredPlaceholderBytes: number;
-          }
-        >;
-      }
-    ).subscriptions.get(handle);
     expect(subscription?.cancelled).toBe(true);
     expect(subscription?.deferredVisiblePublication).toBe(false);
     expect(subscription?.deferredVisibleReset).toBe(false);

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -6027,10 +6027,12 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
     const failedQuery = preparedQueries.at(-1);
     failRead = false;
     for (let index = 0; index < 257; index += 1) {
-      await runtime.query(JSON.stringify({
-        table: "todos",
-        conditions: [{ column: "title", op: "eq", value: `coverage-${index}` }],
-      }));
+      await runtime.query(
+        JSON.stringify({
+          table: "todos",
+          conditions: [{ column: "title", op: "eq", value: `coverage-${index}` }],
+        }),
+      );
     }
     await expect(runtime.query(queryJson)).resolves.toEqual([]);
     expect(preparedQueries.at(-1)).not.toBe(failedQuery);
@@ -6077,14 +6079,19 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
     await expect(failed).resolves.toBe(failure);
     const failedQuery = preparedQueries.at(-1);
     for (let index = 0; index < 257; index += 1) {
-      await runtime.query(JSON.stringify({
-        table: "todos",
-        conditions: [{ column: "title", op: "eq", value: `background-${index}` }],
-      }), null, "local", JSON.stringify({ propagation: "local-only" }));
+      await runtime.query(
+        JSON.stringify({
+          table: "todos",
+          conditions: [{ column: "title", op: "eq", value: `background-${index}` }],
+        }),
+        null,
+        "local",
+        JSON.stringify({ propagation: "local-only" }),
+      );
     }
-    await expect(runtime.query(
-      queryJson, null, "local", JSON.stringify({ propagation: "local-only" }),
-    )).resolves.toEqual([]);
+    await expect(
+      runtime.query(queryJson, null, "local", JSON.stringify({ propagation: "local-only" })),
+    ).resolves.toEqual([]);
     expect(preparedQueries.at(-1)).not.toBe(failedQuery);
   });
 });
@@ -8241,28 +8248,31 @@ it("isolates throwing callbacks when replaying a deferred admission failure", as
 });
 
 it("keeps same-query admissions with different claims out of the shared prepared cache", async () => {
-  const admitted: unknown[] = [];
+  const rows = [
+    { table: "todos", rowId: new Uint8Array(16), title: "Draft proposal", team: "team-a" },
+    { table: "todos", rowId: new Uint8Array(16), title: "Review budget", team: "team-b" },
+  ];
+  const prepareQuery = vi.fn(
+    (
+      _query: Uint8Array,
+      _kind: "query" | "relation",
+      _identity: Uint8Array,
+      claims: { team: string },
+    ) => {
+      const prepared = { rows: encodeRows(rows.filter((row) => row.team === claims.team)) };
+      return { poll: () => prepared, setWake: () => {}, cancel: () => {} };
+    },
+  );
   const setClaims = vi.fn();
   const runtime = new NativeRuntimeAdapter(
     {
       openMemory: () =>
         fakeDb({
-          prepareQuery: (
-            _query: Uint8Array,
-            _kind: "query" | "relation",
-            identity: Uint8Array,
-            claims: unknown,
-          ) => {
-            const prepared = {
-              identity: new Uint8Array(identity),
-              claims: structuredClone(claims),
-            };
-            admitted.push(prepared);
-            return { poll: () => prepared, setWake: () => {}, cancel: () => {} };
-          },
+          prepareQuery,
+          all: (prepared: { rows: Uint8Array }) => prepared.rows,
           setIdentityClaims: setClaims,
           tick: () => undefined,
-        } as never),
+        }),
       openBrowser: async () => {
         throw new Error("unused");
       },
@@ -8274,21 +8284,34 @@ it("keeps same-query admissions with different claims out of the shared prepared
     true,
     { readAuthorizationHost: "trusted-serving" },
   );
-  const inner = runtime as unknown as Record<string, any>;
+  const queryJson = JSON.stringify({ table: "todos" });
   const session = {
-    identity: TEST_RUNTIME_AUTHOR,
-    claims: { team: "team-a" },
-    backendAuthority: false,
+    issuer: "https://issuer.example",
+    user_id: "same-user",
+    authMode: "external",
   };
-  const a = await inner.prepareQueryForRead(JSON.stringify({ table: "todos" }), session);
-  const b = await inner.prepareQueryForRead(JSON.stringify({ table: "todos" }), {
-    ...session,
-    claims: { team: "team-b" },
-  });
-  expect(a).not.toBe(b);
-  expect(admitted).toHaveLength(2);
-  expect(a.claims).toEqual({ team: "team-a" });
-  expect(b.claims).toEqual({ team: "team-b" });
-  expect(setClaims).not.toHaveBeenCalled();
-  await runtime.close();
+  const sessionA = JSON.stringify({ ...session, claims: { team: "team-a" } });
+  const sessionB = JSON.stringify({ ...session, claims: { team: "team-b" } });
+  const expectedA = [
+    {
+      table: "todos",
+      id: "00000000-0000-0000-0000-000000000000",
+      values: [{ type: "Text", value: "Draft proposal" }],
+    },
+  ];
+  try {
+    await expect(runtime.query(queryJson, sessionA, "local")).resolves.toEqual(expectedA);
+    await expect(runtime.query(queryJson, sessionB, "local")).resolves.toEqual([
+      {
+        table: "todos",
+        id: "00000000-0000-0000-0000-000000000000",
+        values: [{ type: "Text", value: "Review budget" }],
+      },
+    ]);
+    await expect(runtime.query(queryJson, sessionA, "local")).resolves.toEqual(expectedA);
+    expect(prepareQuery).toHaveBeenCalledTimes(3);
+    expect(setClaims).not.toHaveBeenCalled();
+  } finally {
+    await runtime.close();
+  }
 });

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -5750,7 +5750,7 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
               preparedQueries.push(query);
               return query;
             },
-            all: (query: unknown) => {
+            all: (query: object) => {
               lastReadQuery = query;
               return new Uint8Array([0]);
             },

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -5736,6 +5736,58 @@ describe("NativeRuntimeAdapter server transport", () => {
     });
   });
 });
+describe("NativeRuntimeAdapter prepared query retention", () => {
+  it("bounds flat literal preparation while active subscriptions stay pinned", async () => {
+    const preparedQueries: object[] = [];
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            prepareQuery: () => {
+              const query = {};
+              preparedQueries.push(query);
+              return query;
+            },
+            all: () => new Uint8Array([0]),
+            subscribe: () => ({ readAll: () => [] }),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    const query = (literal: string) =>
+      JSON.stringify({
+        table: "todos",
+        conditions: [{ column: "title", op: "eq", value: literal }],
+      });
+
+    const pinnedHandle = runtime.createSubscription(query("pinned"));
+    const pinnedQuery = preparedQueries.at(-1);
+    expect(pinnedQuery).toBeDefined();
+
+    for (let index = 0; index < 256; index += 1) {
+      await runtime.query(query(`literal-${index}`));
+    }
+    await expect(runtime.query(query("pinned"))).resolves.toEqual([]);
+    expect(preparedQueries.at(-1)).toBe(pinnedQuery);
+
+    runtime.unsubscribe(pinnedHandle);
+    for (let index = 256; index < 513; index += 1) {
+      await runtime.query(query(`literal-${index}`));
+    }
+    await expect(runtime.query(query("pinned"))).resolves.toEqual([]);
+    expect(preparedQueries.at(-1)).not.toBe(pinnedQuery);
+  });
+});
+
 
 describe("NativeRuntimeAdapter streaming inserts", () => {
   it("infers the physical kind and applies backpressure to async chunks", async () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -30,6 +30,7 @@ import {
   applySubscriptionDeltaWithRootDelta,
   type Transport,
 } from "./native-runtime-adapter.js";
+import { PreparedQueryCache } from "./prepared-query-cache.js";
 import { encodeSchema } from "./schema-codec.js";
 import { applySubscriptionDelta, SubscriptionManager } from "../subscription-manager.js";
 import { setNamedRowValuesEnumerable } from "./row-values-transport.js";
@@ -5739,6 +5740,7 @@ describe("NativeRuntimeAdapter server transport", () => {
 describe("NativeRuntimeAdapter prepared query retention", () => {
   it("bounds flat literal preparation while active subscriptions stay pinned", async () => {
     const preparedQueries: object[] = [];
+    let lastReadQuery: object | undefined;
     const runtime = new NativeRuntimeAdapter(
       {
         openMemory: () =>
@@ -5748,7 +5750,10 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
               preparedQueries.push(query);
               return query;
             },
-            all: () => new Uint8Array([0]),
+            all: (query) => {
+              lastReadQuery = query;
+              return new Uint8Array([0]);
+            },
             subscribe: () => ({ readAll: () => [] }),
             tick: () => undefined,
           }),
@@ -5777,7 +5782,7 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
       await runtime.query(query(`literal-${index}`));
     }
     await expect(runtime.query(query("pinned"))).resolves.toEqual([]);
-    expect(preparedQueries.at(-1)).toBe(pinnedQuery);
+    expect(lastReadQuery).toBe(pinnedQuery);
 
     runtime.unsubscribe(pinnedHandle);
     for (let index = 256; index < 513; index += 1) {
@@ -5785,6 +5790,145 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
     }
     await expect(runtime.query(query("pinned"))).resolves.toEqual([]);
     expect(preparedQueries.at(-1)).not.toBe(pinnedQuery);
+  });
+  it("evicts an individually oversized inactive query and keeps clear generation safe", () => {
+    let preparations = 0;
+    const cache = new PreparedQueryCache<object>(() => undefined);
+    const oversized = new Uint8Array(1_048_577);
+    const first = cache.acquire(oversized, () => {
+      preparations += 1;
+      return {};
+    });
+    first.release();
+    const second = cache.acquire(oversized, () => {
+      preparations += 1;
+      return {};
+    });
+    expect(preparations).toBe(2);
+
+    cache.clear();
+    const replacement = cache.acquire(oversized, () => {
+      preparations += 1;
+      return {};
+    });
+    first.release();
+    first.release();
+    second.release();
+    expect(replacement.isCurrent()).toBe(true);
+    const reused = cache.acquire(oversized, () => ({}));
+    expect(reused.query).toBe(replacement.query);
+    reused.release();
+    replacement.release();
+  });
+
+  it("releases flat subscription leases on native close and readable EOF", async () => {
+    const preparedQueries: object[] = [];
+    let subscriptionCount = 0;
+    let nativeClose = vi.fn(() => true);
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            prepareQuery: () => {
+              const query = {};
+              preparedQueries.push(query);
+              return query;
+            },
+            all: () => new Uint8Array([0]),
+            subscribe: () => {
+              subscriptionCount += 1;
+              if (subscriptionCount === 1) {
+                nativeClose = vi.fn(() => true);
+                return { readAll: () => [{ type: "closed" }], close: nativeClose };
+              }
+              return new ReadableStream({
+                start(controller) {
+                  controller.close();
+                },
+              });
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const queryJson = (literal: string) =>
+      JSON.stringify({
+        table: "todos",
+        conditions: [{ column: "title", op: "eq", value: literal }],
+      });
+
+    const nativeClosed = runtime.createSubscription(queryJson("closed"));
+    const closedQuery = preparedQueries.at(-1);
+    runtime.executeSubscription(nativeClosed, vi.fn());
+    await Promise.resolve();
+    expect(nativeClose).toHaveBeenCalledTimes(1);
+    for (let index = 0; index < 257; index += 1) await runtime.query(queryJson(`new-${index}`));
+    await runtime.query(queryJson("closed"));
+    expect(preparedQueries.at(-1)).not.toBe(closedQuery);
+
+    const eofHandle = runtime.createSubscription(queryJson("eof"));
+    const eofPrepared = preparedQueries.at(-1);
+    runtime.executeSubscription(eofHandle, vi.fn());
+    await Promise.resolve();
+    runtime.unsubscribe(eofHandle);
+    for (let index = 0; index < 257; index += 1) await runtime.query(queryJson(`eof-new-${index}`));
+    await runtime.query(queryJson("eof"));
+    expect(preparedQueries.at(-1)).not.toBe(eofPrepared);
+  });
+  it("pins a pending flat read until its native result is released", async () => {
+    const preparedQueries: object[] = [];
+    let delayedRead = true;
+    let resolveRead!: (bytes: Uint8Array) => void;
+    const pendingRead = new Promise<Uint8Array>((resolve) => {
+      resolveRead = resolve;
+    });
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            prepareQuery: () => {
+              const query = {};
+              preparedQueries.push(query);
+              return query;
+            },
+            allAsync: () => (delayedRead ? pendingRead : new Uint8Array([0])),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const queryJson = (literal: string) =>
+      JSON.stringify({
+        table: "todos",
+        conditions: [{ column: "title", op: "eq", value: literal }],
+      });
+
+    const target = runtime.query(queryJson("pending"));
+    await Promise.resolve();
+    delayedRead = false;
+    for (let index = 0; index < 256; index += 1) await runtime.query(queryJson(`read-${index}`));
+    expect(preparedQueries).toHaveLength(257);
+    resolveRead(new Uint8Array([0]));
+    await expect(target).resolves.toEqual([]);
+
+    for (let index = 256; index < 513; index += 1) await runtime.query(queryJson(`read-${index}`));
+    await runtime.query(queryJson("pending"));
+    expect(preparedQueries).toHaveLength(515);
   });
 });
 

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -6078,10 +6078,10 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
       await runtime.query(JSON.stringify({
         table: "todos",
         conditions: [{ column: "title", op: "eq", value: `background-${index}` }],
-      }), null, "local", JSON.stringify({ propagation: "localOnly" }));
+      }), null, "local", JSON.stringify({ propagation: "local-only" }));
     }
     await expect(runtime.query(
-      queryJson, null, "local", JSON.stringify({ propagation: "localOnly" }),
+      queryJson, null, "local", JSON.stringify({ propagation: "local-only" }),
     )).resolves.toEqual([]);
     expect(preparedQueries.at(-1)).not.toBe(failedQuery);
   });

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -5886,6 +5886,10 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
   it("pins a pending flat read until its native result is released", async () => {
     const preparedQueries: object[] = [];
     let delayedRead = true;
+    let readStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      readStarted = resolve;
+    });
     let resolveRead!: (bytes: Uint8Array) => void;
     const pendingRead = new Promise<Uint8Array>((resolve) => {
       resolveRead = resolve;
@@ -5899,7 +5903,11 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
               preparedQueries.push(query);
               return query;
             },
-            allAsync: () => (delayedRead ? pendingRead : new Uint8Array([0])),
+            all: () => {
+              if (!delayedRead) return new Uint8Array([0]);
+              readStarted();
+              return pendingRead;
+            },
             tick: () => undefined,
           }),
         openBrowser: async () => {
@@ -5919,7 +5927,7 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
       });
 
     const target = runtime.query(queryJson("pending"));
-    await Promise.resolve();
+    await started;
     delayedRead = false;
     for (let index = 0; index < 256; index += 1) await runtime.query(queryJson(`read-${index}`));
     expect(preparedQueries).toHaveLength(257);
@@ -5929,6 +5937,153 @@ describe("NativeRuntimeAdapter prepared query retention", () => {
     for (let index = 256; index < 513; index += 1) await runtime.query(queryJson(`read-${index}`));
     await runtime.query(queryJson("pending"));
     expect(preparedQueries).toHaveLength(515);
+  });
+  it("rejects flat acquisition after close without invoking native preparation", async () => {
+    let preparations = 0;
+    let subscriptions = 0;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            prepareQuery: () => {
+              preparations += 1;
+              return {};
+            },
+            all: () => new Uint8Array([0]),
+            subscribe: () => {
+              subscriptions += 1;
+              return { readAll: () => [] };
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const queryJson = JSON.stringify({
+      table: "todos",
+      conditions: [{ column: "title", op: "eq", value: "closed" }],
+    });
+
+    await runtime.close();
+    await expect(runtime.query(queryJson)).rejects.toThrow("Native runtime is closed");
+    const closedSubscription = runtime.createSubscription(queryJson);
+    const onError = vi.fn();
+    runtime.executeSubscription(closedSubscription, onError);
+    runtime.executeSubscription(closedSubscription, onError);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    expect(onError.mock.calls[0]?.[0].message).toBe("Native runtime is closed");
+    expect(preparations).toBe(0);
+    expect(subscriptions).toBe(0);
+  });
+  it("releases the prepared lease when foreground native coverage fails", async () => {
+    const preparedQueries: object[] = [];
+    const failure = new Error("coverage failure");
+    let failRead = true;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            prepareQuery: () => {
+              const query = {};
+              preparedQueries.push(query);
+              return query;
+            },
+            all: () => {
+              if (failRead) throw failure;
+              return new Uint8Array([0]);
+            },
+            connectUpstream: () => new FakeTransport([]),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    await runtime.connectUpstreamPeer();
+    const queryJson = JSON.stringify({
+      table: "todos",
+      conditions: [{ column: "title", op: "eq", value: "coverage" }],
+    });
+
+    await expect(
+      runtime.query(queryJson, null, "edge", JSON.stringify({ propagation: "full" })),
+    ).rejects.toBe(failure);
+    const failedQuery = preparedQueries.at(-1);
+    failRead = false;
+    for (let index = 0; index < 257; index += 1) {
+      await runtime.query(JSON.stringify({
+        table: "todos",
+        conditions: [{ column: "title", op: "eq", value: `coverage-${index}` }],
+      }));
+    }
+    await expect(runtime.query(queryJson)).resolves.toEqual([]);
+    expect(preparedQueries.at(-1)).not.toBe(failedQuery);
+  });
+  it("releases the prepared lease when background native coverage fails", async () => {
+    const preparedQueries: object[] = [];
+    const failure = new Error("background coverage failure");
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            prepareQuery: () => {
+              const query = {};
+              preparedQueries.push(query);
+              return query;
+            },
+            all: (_query: object, options: { tier?: string }) => {
+              if (options.tier === "edge") throw failure;
+              return new Uint8Array([0]);
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const failed = new Promise<Error>((resolve) => runtime.onServerTransportError(resolve));
+    Object.assign(runtime as object, {
+      serverTransport: new FakeTransport([]),
+      serverCarrier: {},
+      serverCarrierPromise: Promise.resolve(),
+    });
+    const queryJson = JSON.stringify({ table: "todos" });
+
+    await expect(
+      runtime.query(queryJson, null, null, JSON.stringify({ propagation: "full" })),
+    ).resolves.toEqual([]);
+    await expect(failed).resolves.toBe(failure);
+    const failedQuery = preparedQueries.at(-1);
+    for (let index = 0; index < 257; index += 1) {
+      await runtime.query(JSON.stringify({
+        table: "todos",
+        conditions: [{ column: "title", op: "eq", value: `background-${index}` }],
+      }), null, "local", JSON.stringify({ propagation: "localOnly" }));
+    }
+    await expect(runtime.query(
+      queryJson, null, "local", JSON.stringify({ propagation: "localOnly" }),
+    )).resolves.toEqual([]);
+    expect(preparedQueries.at(-1)).not.toBe(failedQuery);
   });
 });
 


### PR DESCRIPTION
## Summary
- Bound native prepared-query retention with lease-aware eviction and shutdown cleanup.

## Before
Full literal-byte query keys and native prepared objects were retained for the runtime lifetime.

## After
A 256-entry/1 MiB inactive LRU is pinned by active read, subscription, and coverage leases. Acquisition closes safely after runtime shutdown, and failed coverage detaches without retaining the prepared query.

## Test plan
- [ ] Run `pnpm --filter jazz-tools check`.
- [ ] Run the focused prepared-query Vitest tests.

The `jazz-tools` patch changeset is included.