### PR TITLE
Preserve database after unique-index rejection

### DIFF
--- a/crates/groove/src/db/schema_admission.rs
+++ b/crates/groove/src/db/schema_admission.rs
@@ -322,13 +322,19 @@ impl Database {
                 index: index.name,
             });
         }
-        if let Err(error) = self
+        match self
             .ivm_runtime
             .register_table_index(table, index, &self.storage)
             .await
         {
-            self.poisoned = true;
-            return Err(Error::IvmRuntime(error));
+            Ok(()) => {}
+            Err(error @ IvmRuntimeError::UniqueIndexViolation { .. }) => {
+                return Err(Error::IvmRuntime(error));
+            }
+            Err(error) => {
+                self.poisoned = true;
+                return Err(Error::IvmRuntime(error));
+            }
         }
         Ok(())
     }

--- a/crates/groove/src/db/tests/indices.rs
+++ b/crates/groove/src/db/tests/indices.rs
@@ -1290,6 +1290,122 @@ async fn persisted_indices_can_be_deleted_after_restart() {
 }
 
 #[futures_test::test]
+async fn rejected_live_unique_backfill_preserves_runtime_storage_and_usability() {
+    for records in [
+        [(7_u64, "Blue Train"), (8_u64, "Blue Train")],
+        [(8_u64, "Blue Train"), (7_u64, "Blue Train")],
+    ] {
+        let (storage, control) = TestStorage::controlled(&["albums", "indices"]);
+        let mut database = Database::new(albums_schema(), storage).await.unwrap();
+        let mut batch = database.open_batch();
+        for (id, title) in records {
+            batch.insert(
+                "albums",
+                vec![Value::U64(id), Value::String(title.to_owned())],
+            );
+        }
+        database.commit_batch(batch).await.unwrap();
+
+        let schema_before = database.ivm_runtime.schema().clone();
+        let stats_before = database.runtime_stats();
+        let nodes_before = database.ivm_runtime.retained_node_ids();
+        let index_prefix = b"albums\0unique_albums_by_title\0";
+        let index_bytes_before = database
+            .storage
+            .prefix("indices".to_owned(), index_prefix.to_vec())
+            .await
+            .unwrap();
+        let rows_before = database.primary_key_scan("albums", &[]).await.unwrap();
+        control.take_observed();
+
+        let index = IndexSchema::new("unique_albums_by_title", ["title"]).unique();
+        let error = database
+            .register_table_index("albums", index.clone())
+            .await
+            .expect_err("duplicate positive backfill must reject");
+        assert!(matches!(
+            error,
+            Error::IvmRuntime(IvmRuntimeError::UniqueIndexViolation { index: name })
+                if name == "albums.unique_albums_by_title"
+        ));
+        assert!(
+            !control
+                .take_observed()
+                .contains(&TestStorageOperation::WriteMany),
+            "rejected backfill must not submit registration writes"
+        );
+        assert_eq!(database.ivm_runtime.schema(), &schema_before);
+        assert_eq!(database.runtime_stats(), stats_before);
+        assert_eq!(database.ivm_runtime.retained_node_ids(), nodes_before);
+        assert_eq!(
+            database
+                .storage
+                .prefix("indices".to_owned(), index_prefix.to_vec())
+                .await
+                .unwrap(),
+            index_bytes_before
+        );
+        assert_eq!(
+            database.primary_key_scan("albums", &[]).await.unwrap(),
+            rows_before
+        );
+        assert!(database.ensure_usable().is_ok());
+        assert!(matches!(
+            database
+                .index_get(
+                    "albums",
+                    "unique_albums_by_title",
+                    &[Value::String("Blue Train".to_owned())],
+                )
+                .await,
+            Err(Error::IndexNotFound { table, index })
+                if table == "albums" && index == "unique_albums_by_title"
+        ));
+
+        let mut correction = database.open_batch();
+        correction.delete("albums", PrimaryKeyValue::U64(8));
+        correction.insert(
+            "albums",
+            vec![Value::U64(9), Value::String("Kind of Blue".to_owned())],
+        );
+        database.commit_batch(correction).await.unwrap();
+        database
+            .register_table_index("albums", index)
+            .await
+            .unwrap();
+        assert_eq!(
+            record_values(
+                database
+                    .index_get(
+                        "albums",
+                        "unique_albums_by_title",
+                        &[Value::String("Blue Train".to_owned())],
+                    )
+                    .await
+                    .unwrap()
+            ),
+            [vec![Value::U64(7), Value::String("Blue Train".to_owned())]]
+        );
+        assert_eq!(
+            record_values(
+                database
+                    .index_get(
+                        "albums",
+                        "unique_albums_by_title",
+                        &[Value::String("Kind of Blue".to_owned())],
+                    )
+                    .await
+                    .unwrap()
+            ),
+            [vec![
+                Value::U64(9),
+                Value::String("Kind of Blue".to_owned())
+            ]]
+        );
+    }
+}
+
+#[futures_test::test]
 async fn live_index_registration_rejects_while_a_publication_is_resident() {
     let storage =
         MemoryStorage::new(&["albums", "indices"]).expect("valid memory storage families");

--- a/crates/groove/src/db/tests/indices.rs
+++ b/crates/groove/src/db/tests/indices.rs
@@ -1414,6 +1414,30 @@ async fn rejected_live_unique_backfill_preserves_runtime_storage_and_usability()
     }
 }
 
+async fn assert_poisoned_registration_lifecycle(database: &mut Database) {
+    assert!(matches!(
+        database.primary_key_scan("albums", &[]).await,
+        Err(Error::DatabasePoisoned)
+    ));
+
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(9), Value::String("Kind of Blue".to_owned())],
+    );
+    assert!(matches!(
+        database.commit_batch(batch).await,
+        Err(Error::DatabasePoisoned)
+    ));
+    assert!(matches!(
+        database
+            .register_table_index("albums", IndexSchema::new("other", ["title"]))
+            .await,
+        Err(Error::DatabasePoisoned)
+    ));
+    database.close().await.unwrap();
+}
+
 #[futures_test::test]
 async fn live_index_backfill_write_failure_remains_poisoning() {
     let (storage, control) = TestStorage::controlled(&["albums", "indices"]);
@@ -1424,6 +1448,17 @@ async fn live_index_backfill_write_failure_remains_poisoning() {
         vec![Value::U64(7), Value::String("Blue Train".to_owned())],
     );
     database.commit_batch(batch).await.unwrap();
+    let schema_before = database.ivm_runtime.schema().clone();
+    let stats_before = database.runtime_stats();
+    let nodes_before = database.ivm_runtime.retained_node_ids();
+    let index_bytes_before = database
+        .storage
+        .prefix(
+            "indices".to_owned(),
+            b"albums\0unique_albums_by_title\0".to_vec(),
+        )
+        .await
+        .unwrap();
     control.take_observed();
     control.fail_next(TestStorageOperation::WriteMany);
 
@@ -1449,10 +1484,21 @@ async fn live_index_backfill_write_failure_remains_poisoning() {
             .count(),
         1
     );
-    assert!(matches!(
-        database.ensure_usable(),
-        Err(Error::DatabasePoisoned)
-    ));
+    assert_eq!(database.ivm_runtime.schema(), &schema_before);
+    assert_eq!(database.runtime_stats(), stats_before);
+    assert_eq!(database.ivm_runtime.retained_node_ids(), nodes_before);
+    assert_eq!(
+        database
+            .storage
+            .prefix(
+                "indices".to_owned(),
+                b"albums\0unique_albums_by_title\0".to_vec(),
+            )
+            .await
+            .unwrap(),
+        index_bytes_before
+    );
+    assert_poisoned_registration_lifecycle(&mut database).await;
 }
 
 #[futures_test::test]
@@ -1468,6 +1514,17 @@ async fn live_index_hydration_io_failure_remains_poisoning() {
     );
     database.commit_batch(batch).await.unwrap();
     storage.evict_column_family("albums");
+    let schema_before = database.ivm_runtime.schema().clone();
+    let stats_before = database.runtime_stats();
+    let nodes_before = database.ivm_runtime.retained_node_ids();
+    let index_bytes_before = database
+        .storage
+        .prefix(
+            "indices".to_owned(),
+            b"albums\0unique_albums_by_title\0".to_vec(),
+        )
+        .await
+        .unwrap();
     control.take_observed();
     control.fail_next(TestStorageOperation::ScanOpen);
 
@@ -1488,10 +1545,21 @@ async fn live_index_hydration_io_failure_remains_poisoning() {
     let observed = control.take_observed();
     assert!(observed.contains(&TestStorageOperation::ScanOpen));
     assert!(!observed.contains(&TestStorageOperation::WriteMany));
-    assert!(matches!(
-        database.ensure_usable(),
-        Err(Error::DatabasePoisoned)
-    ));
+    assert_eq!(database.ivm_runtime.schema(), &schema_before);
+    assert_eq!(database.runtime_stats(), stats_before);
+    assert_eq!(database.ivm_runtime.retained_node_ids(), nodes_before);
+    assert_eq!(
+        database
+            .storage
+            .prefix(
+                "indices".to_owned(),
+                b"albums\0unique_albums_by_title\0".to_vec(),
+            )
+            .await
+            .unwrap(),
+        index_bytes_before
+    );
+    assert_poisoned_registration_lifecycle(&mut database).await;
 }
 
 #[futures_test::test]
@@ -1514,6 +1582,22 @@ async fn live_index_non_unique_runtime_error_remains_poisoning() {
         )
         .await
         .unwrap();
+    let schema_before = database.ivm_runtime.schema().clone();
+    let stats_before = database.runtime_stats();
+    let nodes_before = database.ivm_runtime.retained_node_ids();
+    let index_bytes_before = database
+        .storage
+        .prefix(
+            "indices".to_owned(),
+            b"albums\0unique_albums_by_title\0".to_vec(),
+        )
+        .await
+        .unwrap();
+    let table_bytes_before = database
+        .storage
+        .prefix("albums".to_owned(), Vec::new())
+        .await
+        .unwrap();
     control.take_observed();
 
     let error = database
@@ -1532,10 +1616,29 @@ async fn live_index_non_unique_runtime_error_remains_poisoning() {
             .take_observed()
             .contains(&TestStorageOperation::WriteMany)
     );
-    assert!(matches!(
-        database.ensure_usable(),
-        Err(Error::DatabasePoisoned)
-    ));
+    assert_eq!(database.ivm_runtime.schema(), &schema_before);
+    assert_eq!(database.runtime_stats(), stats_before);
+    assert_eq!(database.ivm_runtime.retained_node_ids(), nodes_before);
+    assert_eq!(
+        database
+            .storage
+            .prefix(
+                "indices".to_owned(),
+                b"albums\0unique_albums_by_title\0".to_vec(),
+            )
+            .await
+            .unwrap(),
+        index_bytes_before
+    );
+    assert_eq!(
+        database
+            .storage
+            .prefix("albums".to_owned(), Vec::new())
+            .await
+            .unwrap(),
+        table_bytes_before
+    );
+    assert_poisoned_registration_lifecycle(&mut database).await;
 }
 
 #[futures_test::test]

--- a/crates/groove/src/db/tests/indices.rs
+++ b/crates/groove/src/db/tests/indices.rs
@@ -1361,6 +1361,15 @@ async fn rejected_live_unique_backfill_preserves_runtime_storage_and_usability()
             Err(Error::IndexNotFound { table, index })
                 if table == "albums" && index == "unique_albums_by_title"
         ));
+        let retry_error = database
+            .register_table_index("albums", index.clone())
+            .await
+            .expect_err("the duplicate must continue rejecting before correction");
+        assert!(matches!(
+            retry_error,
+            Error::IvmRuntime(IvmRuntimeError::UniqueIndexViolation { index: name })
+                if name == "albums.unique_albums_by_title"
+        ));
 
         let mut correction = database.open_batch();
         correction.delete("albums", PrimaryKeyValue::U64(8));
@@ -1403,6 +1412,130 @@ async fn rejected_live_unique_backfill_preserves_runtime_storage_and_usability()
             ]]
         );
     }
+}
+
+#[futures_test::test]
+async fn live_index_backfill_write_failure_remains_poisoning() {
+    let (storage, control) = TestStorage::controlled(&["albums", "indices"]);
+    let mut database = Database::new(albums_schema(), storage).await.unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(7), Value::String("Blue Train".to_owned())],
+    );
+    database.commit_batch(batch).await.unwrap();
+    control.take_observed();
+    control.fail_next(TestStorageOperation::WriteMany);
+
+    let error = database
+        .register_table_index(
+            "albums",
+            IndexSchema::new("unique_albums_by_title", ["title"]).unique(),
+        )
+        .await
+        .expect_err("registration write failure must be returned");
+    assert!(matches!(
+        error,
+        Error::IvmRuntime(IvmRuntimeError::Storage(crate::storage::Error::Backend {
+            backend: "test",
+            ..
+        }))
+    ));
+    assert_eq!(
+        control
+            .take_observed()
+            .into_iter()
+            .filter(|operation| *operation == TestStorageOperation::WriteMany)
+            .count(),
+        1
+    );
+    assert!(matches!(
+        database.ensure_usable(),
+        Err(Error::DatabasePoisoned)
+    ));
+}
+
+#[futures_test::test]
+async fn live_index_hydration_io_failure_remains_poisoning() {
+    let (storage, control) = TestStorage::controlled(&["albums", "indices"]);
+    let mut database = Database::new(albums_schema(), storage.clone())
+        .await
+        .unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(7), Value::String("Blue Train".to_owned())],
+    );
+    database.commit_batch(batch).await.unwrap();
+    storage.evict_column_family("albums");
+    control.take_observed();
+    control.fail_next(TestStorageOperation::ScanOpen);
+
+    let error = database
+        .register_table_index(
+            "albums",
+            IndexSchema::new("unique_albums_by_title", ["title"]).unique(),
+        )
+        .await
+        .expect_err("hydration IO failure must be returned");
+    assert!(matches!(
+        error,
+        Error::IvmRuntime(IvmRuntimeError::Storage(crate::storage::Error::Backend {
+            backend: "test",
+            ..
+        }))
+    ));
+    let observed = control.take_observed();
+    assert!(observed.contains(&TestStorageOperation::ScanOpen));
+    assert!(!observed.contains(&TestStorageOperation::WriteMany));
+    assert!(matches!(
+        database.ensure_usable(),
+        Err(Error::DatabasePoisoned)
+    ));
+}
+
+#[futures_test::test]
+async fn live_index_non_unique_runtime_error_remains_poisoning() {
+    let (storage, control) = TestStorage::controlled(&["albums", "indices"]);
+    let mut database = Database::new(albums_schema(), storage).await.unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(7), Value::String("Blue Train".to_owned())],
+    );
+    database.commit_batch(batch).await.unwrap();
+
+    database
+        .storage
+        .set(
+            "albums".to_owned(),
+            PrimaryKeyValue::U64(7).into_bytes(),
+            vec![0xff],
+        )
+        .await
+        .unwrap();
+    control.take_observed();
+
+    let error = database
+        .register_table_index(
+            "albums",
+            IndexSchema::new("unique_albums_by_title", ["title"]).unique(),
+        )
+        .await
+        .expect_err("record encoding failure must be returned");
+    assert!(matches!(
+        error,
+        Error::IvmRuntime(IvmRuntimeError::RecordEncoding(_))
+    ));
+    assert!(
+        !control
+            .take_observed()
+            .contains(&TestStorageOperation::WriteMany)
+    );
+    assert!(matches!(
+        database.ensure_usable(),
+        Err(Error::DatabasePoisoned)
+    ));
 }
 
 #[futures_test::test]

--- a/crates/groove/src/ivm/runtime/persist.rs
+++ b/crates/groove/src/ivm/runtime/persist.rs
@@ -265,3 +265,73 @@ fn arrangement_key_parts(value: crate::records::Value) -> Vec<crate::records::Va
         value => vec![value],
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ivm::RecordDelta;
+    use crate::storage::{TestStorage, TestStorageOperation};
+
+    #[futures_test::test]
+    async fn unique_index_positive_conflict_is_pre_submit_in_both_orders() {
+        for records in [
+            vec![
+                (b"same-key".to_vec(), b"record-a".to_vec()),
+                (b"same-key".to_vec(), b"record-b".to_vec()),
+            ],
+            vec![
+                (b"same-key".to_vec(), b"record-b".to_vec()),
+                (b"same-key".to_vec(), b"record-a".to_vec()),
+            ],
+        ] {
+            let (storage, control) = TestStorage::controlled(&["indices"]);
+            let durable_storage = DurableStorage {
+                column_family: "indices".to_owned(),
+                key_prefix: b"albums\0unique_albums_by_title\0".to_vec(),
+            };
+            let descriptor = index_record_descriptor();
+            let delta = RecordDeltas {
+                descriptor,
+                deltas: records
+                    .into_iter()
+                    .map(|(key, value)| RecordDelta {
+                        record: descriptor
+                            .create(&[
+                                crate::records::Value::Bytes(key),
+                                crate::records::Value::Bytes(value),
+                            ])
+                            .unwrap()
+                            .into(),
+                        weight: 1,
+                    })
+                    .collect(),
+            };
+            let before = storage
+                .prefix("indices".to_owned(), Vec::new())
+                .await
+                .unwrap();
+            control.take_observed();
+
+            let error = apply_index_persist_delta(&storage, &durable_storage, true, &delta)
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                error,
+                IvmRuntimeError::UniqueIndexViolation { index }
+                    if index == "albums.unique_albums_by_title"
+            ));
+            assert!(
+                !control
+                    .take_observed()
+                    .contains(&TestStorageOperation::WriteMany)
+            );
+            assert_eq!(
+                storage
+                    .prefix("indices".to_owned(), Vec::new())
+                    .await
+                    .unwrap(),
+                before
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Classify only registration-local pre-submit unique conflicts as clean rejections.

## Before
A runtime unique-index rejection poisoned the database even when registration had not written state.

## After
Positive conflicts in both insertion orders leave storage and the database facade usable. Write, I/O, and other runtime failures retain their existing poison semantics.

## Test plan
- [ ] Run the both-order pre-submit mechanism test.
- [ ] Run the live-index rejection, poison-guard, and public rejected-backfill tests.

No changeset is included because this is a Rust-only Groove change.