### PR TITLE
Bound Inspector control session lifecycles

### DIFF
--- a/.changeset/inspector-control-port-lifecycle.md
+++ b/.changeset/inspector-control-port-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Bound Inspector control requests and close rejected attachment ports so failed or stale Inspector sessions cannot retain browser worker resources.

--- a/packages/inspector/src/contexts/host-link.test.tsx
+++ b/packages/inspector/src/contexts/host-link.test.tsx
@@ -2,13 +2,36 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { INSPECTOR_HOST_GLOBAL } from "jazz-tools";
 import {
+  openInspectorRuntimeSession,
   readInspectorHostConfig,
   readInspectorHostSchema,
   useHostSubscriptions,
 } from "./host-link.js";
 
+type TestPort = MessagePort & { dispatch(data: unknown): void };
+
+function createTestPort() {
+  const listeners = new Set<(event: MessageEvent) => void>();
+  const postMessage = vi.fn();
+  const port = {
+    addEventListener: vi.fn((type: string, listener: unknown) => {
+      if (type === "message") listeners.add(listener as (event: MessageEvent) => void);
+    }),
+    removeEventListener: vi.fn((type: string, listener: unknown) => {
+      if (type === "message") listeners.delete(listener as (event: MessageEvent) => void);
+    }),
+    start: vi.fn(),
+    postMessage,
+    close: vi.fn(),
+    dispatch(data: unknown) {
+      for (const listener of listeners) listener(new MessageEvent("message", { data }));
+    },
+  } as unknown as TestPort;
+  return { port, postMessage };
+}
+
 // In jsdom, window.parent === window, so installing on window.parent installs here.
-function installHost(subs: unknown[] = []) {
+function installHost(subs: unknown[] = [], openControlPort?: () => Promise<MessagePort>) {
   (window as unknown as Record<string, unknown>)[INSPECTOR_HOST_GLOBAL] = {
     getConnectionConfig: () => ({
       appId: "app1",
@@ -18,6 +41,7 @@ function installHost(subs: unknown[] = []) {
     }),
     getWasmSchema: () => ({ todos: { columns: [] } }),
     getActiveSubscriptions: () => subs,
+    openControlPort,
   };
 }
 
@@ -130,5 +154,84 @@ describe("host-link", () => {
     Object.defineProperty(window, "opener", { configurable: true, value: opener });
 
     expect(readInspectorHostConfig()).toMatchObject({ appId: "app1" });
+  });
+  it("bounds and cleans up a silent control request", async () => {
+    vi.useFakeTimers();
+    try {
+      const control = createTestPort();
+      installHost([], async () => control.port);
+      const opening = openInspectorRuntimeSession().then(
+        () => ({ kind: "resolved" as const }),
+        (error: unknown) => ({ kind: "rejected" as const, error }),
+      );
+      const deadline = new Promise<{ kind: "deadline" }>((resolve) => {
+        setTimeout(() => resolve({ kind: "deadline" }), 60_000);
+      });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await Promise.race([opening, deadline]);
+      expect(result.kind).toBe("rejected");
+      if (result.kind === "rejected") expect(result.error).toBeInstanceOf(Error);
+      expect(control.port.removeEventListener).toHaveBeenCalledOnce();
+      expect(control.port.close).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes the attached port when the host rejects attachment", async () => {
+    const control = createTestPort();
+    control.postMessage.mockImplementation((message: { id: number; type: string }) => {
+      if (message.type === "list-contexts") {
+        control.port.dispatch({
+          id: message.id,
+          type: "contexts",
+          contexts: [{ key: "ctx", appId: "app1", dbName: "db", schema: {} }],
+        });
+      } else if (message.type === "attach-context") {
+        control.port.dispatch({ id: message.id, type: "result", error: "attach failed" });
+      }
+    });
+    installHost([], async () => control.port);
+
+    const attachedPort = createTestPort();
+    const previousMessageChannel = globalThis.MessageChannel;
+    Object.defineProperty(globalThis, "MessageChannel", {
+      configurable: true,
+      value: class {
+        port1 = attachedPort.port;
+        port2 = createTestPort().port;
+      },
+    });
+    try {
+      const session = await openInspectorRuntimeSession();
+      await expect(session?.attach("ctx")).rejects.toThrow("attach failed");
+      expect(attachedPort.port.close).toHaveBeenCalledOnce();
+    } finally {
+      Object.defineProperty(globalThis, "MessageChannel", {
+        configurable: true,
+        value: previousMessageChannel,
+      });
+    }
+  });
+
+  it("closes a control session idempotently", async () => {
+    const control = createTestPort();
+    control.postMessage.mockImplementation((message: { id: number; type: string }) => {
+      if (message.type === "list-contexts") {
+        control.port.dispatch({ id: message.id, type: "contexts", contexts: [] });
+      }
+    });
+    installHost([], async () => control.port);
+
+    const session = await openInspectorRuntimeSession();
+    session?.close();
+    session?.close();
+
+    expect(control.postMessage).toHaveBeenCalledWith({ type: "close" });
+    expect(
+      control.postMessage.mock.calls.filter(([message]) => message.type === "close"),
+    ).toHaveLength(1);
+    expect(control.port.close).toHaveBeenCalledOnce();
   });
 });

--- a/packages/inspector/src/contexts/host-link.test.tsx
+++ b/packages/inspector/src/contexts/host-link.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { INSPECTOR_HOST_GLOBAL } from "jazz-tools";
 import {
+  closeInspectorRuntimePort,
   openInspectorRuntimeSession,
   readInspectorHostConfig,
   readInspectorHostSchema,
@@ -31,13 +32,16 @@ function createTestPort() {
 }
 
 // In jsdom, window.parent === window, so installing on window.parent installs here.
-function installHost(subs: unknown[] = [], openControlPort?: () => Promise<MessagePort>) {
+function installHost(
+  subs: unknown[] = [],
+  openControlPort?: (signal?: AbortSignal) => Promise<MessagePort>,
+) {
   (window as unknown as Record<string, unknown>)[INSPECTOR_HOST_GLOBAL] = {
     getConnectionConfig: () => ({
       appId: "app1",
       serverUrl: "http://server",
       env: "dev",
-      adminSecret: "sek",
+      jwtToken: "host-session-token",
     }),
     getWasmSchema: () => ({ todos: { columns: [] } }),
     getActiveSubscriptions: () => subs,
@@ -155,6 +159,66 @@ describe("host-link", () => {
 
     expect(readInspectorHostConfig()).toMatchObject({ appId: "app1" });
   });
+  it("protocol-closes runtime ports", async () => {
+    const channel = new MessageChannel();
+    channel.port2.start();
+    const closed = new Promise<unknown>((resolve) => {
+      channel.port2.addEventListener("message", (event) => resolve(event.data), { once: true });
+    });
+
+    closeInspectorRuntimePort(channel.port1);
+
+    await expect(closed).resolves.toEqual({ type: "close" });
+    channel.port2.close();
+  });
+
+  it("aborts the host control opening at the absolute deadline", async () => {
+    vi.useFakeTimers();
+    let openingSignal: AbortSignal | undefined;
+    try {
+      installHost(
+        [],
+        (signal) =>
+          new Promise<MessagePort>(() => {
+            openingSignal = signal;
+          }),
+      );
+      const opening = openInspectorRuntimeSession({ deadline: Date.now() + 100 }).then(
+        () => ({ kind: "resolved" as const }),
+        (error: unknown) => ({ kind: "rejected" as const, error }),
+      );
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      const result = await opening;
+      expect(result.kind).toBe("rejected");
+      if (result.kind === "rejected") {
+        expect(result.error).toMatchObject({ message: expect.stringContaining("cancelled") });
+      }
+      expect(openingSignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("propagates an external abort into host control opening", async () => {
+    const controller = new AbortController();
+    let openingSignal: AbortSignal | undefined;
+    installHost(
+      [],
+      (signal) =>
+        new Promise<MessagePort>(() => {
+          openingSignal = signal;
+        }),
+    );
+    const opening = openInspectorRuntimeSession({ signal: controller.signal });
+
+    controller.abort();
+
+    await expect(opening).rejects.toThrow("cancelled");
+    expect(openingSignal?.aborted).toBe(true);
+  });
+
   it("bounds and cleans up a silent control request", async () => {
     vi.useFakeTimers();
     try {
@@ -164,12 +228,20 @@ describe("host-link", () => {
         () => ({ kind: "resolved" as const }),
         (error: unknown) => ({ kind: "rejected" as const, error }),
       );
-      const deadline = new Promise<{ kind: "deadline" }>((resolve) => {
-        setTimeout(() => resolve({ kind: "deadline" }), 60_000);
-      });
+      let settled = false;
+      void opening.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
 
-      await vi.advanceTimersByTimeAsync(60_000);
-      const result = await Promise.race([opening, deadline]);
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await opening;
       expect(result.kind).toBe("rejected");
       if (result.kind === "rejected") expect(result.error).toBeInstanceOf(Error);
       expect(control.port.removeEventListener).toHaveBeenCalledOnce();
@@ -189,7 +261,16 @@ describe("host-link", () => {
           contexts: [{ key: "ctx", appId: "app1", dbName: "db", schema: {} }],
         });
       } else if (message.type === "attach-context") {
-        control.port.dispatch({ id: message.id, type: "result", error: "attach failed" });
+        control.port.dispatch({
+          id: message.id,
+          type: "result",
+          error: {
+            name: "InspectorAttachError",
+            message: "attach failed",
+            code: "context_unavailable",
+            cause: { name: "Error", message: "context disappeared" },
+          },
+        });
       }
     });
     installHost([], async () => control.port);
@@ -205,7 +286,12 @@ describe("host-link", () => {
     });
     try {
       const session = await openInspectorRuntimeSession();
-      await expect(session?.attach("ctx")).rejects.toThrow("attach failed");
+      await expect(session?.attach("ctx")).rejects.toMatchObject({
+        name: "InspectorAttachError",
+        message: "attach failed",
+        code: "context_unavailable",
+        cause: { message: "context disappeared" },
+      });
       expect(attachedPort.port.close).toHaveBeenCalledOnce();
     } finally {
       Object.defineProperty(globalThis, "MessageChannel", {

--- a/packages/inspector/src/contexts/host-link.ts
+++ b/packages/inspector/src/contexts/host-link.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import {
   INSPECTOR_HOST_GLOBAL,
   INSPECTOR_SUBSCRIPTIONS_MESSAGE,
+  deserializeInspectorControlError,
   type InspectorSubscription,
   type InspectorSubscriptionsMessage,
   type JazzInspectorHost,
@@ -64,24 +65,177 @@ export function readInspectorHostSchema(): WasmSchema | null {
   }
 }
 
-export async function openInspectorRuntimeSession(): Promise<InspectorRuntimeSession | null> {
+export interface InspectorRuntimeSessionOptions {
+  /** Cancel opening before the host has returned a control port. */
+  signal?: AbortSignal;
+  /** Absolute epoch deadline shared by opening and the first request. */
+  deadline?: number;
+}
+
+const CONTROL_REQUEST_TIMEOUT_MS = 5_000;
+
+function abortError(): Error {
+  return new Error("Inspector control session opening was cancelled");
+}
+
+function sessionClosedError(): Error {
+  return new Error("Inspector control session is closed");
+}
+
+const closedRemotePorts = new WeakSet<MessagePort>();
+
+function closeRemotePort(port: MessagePort): void {
+  if (closedRemotePorts.has(port)) return;
+  closedRemotePorts.add(port);
+  try {
+    port.postMessage({ type: "close" });
+  } catch {
+    // The remote endpoint may already have torn down its side of the channel.
+  }
+  try {
+    port.close();
+  } catch {
+    // Closing an already unusable local endpoint is best effort.
+  }
+}
+
+export function closeInspectorRuntimePort(port: MessagePort): void {
+  closeRemotePort(port);
+}
+
+export async function openInspectorRuntimeSession(
+  options: InspectorRuntimeSessionOptions = {},
+): Promise<InspectorRuntimeSession | null> {
   const host = readHost();
   if (!host) return null;
-  const control = await host.handle.openControlPort();
+
+  const { signal, deadline } = options;
+  if (signal?.aborted || (deadline !== undefined && deadline <= Date.now())) {
+    throw abortError();
+  }
+
+  const openingController = new AbortController();
+  const opening = Promise.resolve().then(() =>
+    host.handle.openControlPort(openingController.signal),
+  );
+  let openingSettled = false;
+  let openingTimer: ReturnType<typeof setTimeout> | undefined;
+  let removeAbortListener: (() => void) | undefined;
+  const control = await new Promise<MessagePort>((resolve, reject) => {
+    const finish = (error?: unknown, port?: MessagePort) => {
+      if (openingSettled) {
+        if (port) closeRemotePort(port);
+        return;
+      }
+
+      if (error !== undefined) openingController.abort();
+      openingSettled = true;
+      clearTimeout(openingTimer);
+      openingTimer = undefined;
+      removeAbortListener?.();
+      if (error !== undefined) reject(error);
+      else resolve(port!);
+    };
+
+    opening.then(
+      (port) => finish(undefined, port),
+      (error) => finish(error),
+    );
+    const remaining = deadline === undefined ? undefined : deadline - Date.now();
+    if (remaining !== undefined) {
+      openingTimer = setTimeout(() => finish(abortError()), Math.max(0, remaining));
+    }
+    if (signal) {
+      const onAbort = () => finish(abortError());
+      signal.addEventListener("abort", onAbort, { once: true });
+      removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+    }
+  });
+
   control.start();
   let nextId = 1;
+  let closed = false;
+  let requestDeadline = deadline;
+  type PendingRequest = {
+    resolve: (value: unknown) => void;
+    reject: (error: unknown) => void;
+    timer: ReturnType<typeof setTimeout>;
+  };
+  const pending = new Map<number, PendingRequest>();
+  const attachedPorts = new Set<MessagePort>();
+  const onMessage = (event: MessageEvent) => {
+    const message = event.data as { id?: unknown; error?: unknown } | null;
+    if (!message || typeof message.id !== "number") return;
+    const entry = pending.get(message.id);
+    if (!entry) return;
+    pending.delete(message.id);
+    clearTimeout(entry.timer);
+    if (message.error) entry.reject(deserializeInspectorControlError(message.error));
+    else entry.resolve(message);
+  };
 
+  // The control channel has one dispatcher for the lifetime of the session.
+  // Requests only add entries to the pending map, so unrelated responses cannot
+  // accumulate event listeners.
+  let removeSessionAbortListener: (() => void) | undefined;
+  control.addEventListener("message", onMessage);
+
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    removeSessionAbortListener?.();
+    control.removeEventListener("message", onMessage);
+    const error = sessionClosedError();
+    for (const [id, entry] of pending) {
+      pending.delete(id);
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    for (const port of attachedPorts) closeRemotePort(port);
+    attachedPorts.clear();
+    closeRemotePort(control);
+  };
+  if (signal?.aborted) {
+    close();
+  } else if (signal) {
+    const onSessionAbort = () => close();
+    signal.addEventListener("abort", onSessionAbort, { once: true });
+    removeSessionAbortListener = () => signal.removeEventListener("abort", onSessionAbort);
+  }
   const request = <T>(message: Record<string, unknown>, transfer: Transferable[] = []) =>
     new Promise<T>((resolve, reject) => {
+      if (closed) {
+        reject(sessionClosedError());
+        return;
+      }
       const id = nextId++;
-      const onMessage = (event: MessageEvent) => {
-        if (event.data?.id !== id) return;
-        control.removeEventListener("message", onMessage);
-        if (event.data.error) reject(new Error(event.data.error));
-        else resolve(event.data);
-      };
-      control.addEventListener("message", onMessage);
-      control.postMessage({ ...message, id }, transfer);
+      const timer = setTimeout(
+        () => {
+          if (!pending.delete(id)) return;
+          reject(new Error("Inspector control request timed out"));
+        },
+        Math.max(
+          0,
+          Math.min(
+            CONTROL_REQUEST_TIMEOUT_MS,
+            requestDeadline === undefined
+              ? CONTROL_REQUEST_TIMEOUT_MS
+              : requestDeadline - Date.now(),
+          ),
+        ),
+      );
+      pending.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        timer,
+      });
+      try {
+        control.postMessage({ ...message, id }, transfer);
+      } catch (error) {
+        pending.delete(id);
+        clearTimeout(timer);
+        reject(error);
+      }
     });
 
   const listContexts = async () =>
@@ -90,27 +244,48 @@ export async function openInspectorRuntimeSession(): Promise<InspectorRuntimeSes
         type: "list-contexts",
       })
     ).contexts;
-  const contexts = await listContexts();
+
+  let contexts: InspectorRuntimeContext[];
+  try {
+    contexts = await listContexts();
+  } catch (error) {
+    close();
+    throw error;
+  }
+  requestDeadline = undefined;
+  if (closed) throw sessionClosedError();
+  removeSessionAbortListener?.();
+  removeSessionAbortListener = undefined;
   return {
     contexts,
     listContexts,
     async attach(contextKey) {
       const channel = new MessageChannel();
-      await request(
-        {
-          type: "attach-context",
-          contextKey,
-          tabId: crypto.randomUUID(),
-          port: channel.port2,
-        },
-        [channel.port2],
-      );
-      return channel.port1;
+      const attachedPort = channel.port1;
+      attachedPorts.add(attachedPort);
+      try {
+        await request(
+          {
+            type: "attach-context",
+            contextKey,
+            tabId: crypto.randomUUID(),
+            port: channel.port2,
+          },
+          [channel.port2],
+        );
+        attachedPorts.delete(attachedPort);
+        if (closed) {
+          closeRemotePort(attachedPort);
+          throw sessionClosedError();
+        }
+        return attachedPort;
+      } catch (error) {
+        attachedPorts.delete(attachedPort);
+        closeRemotePort(attachedPort);
+        throw error;
+      }
     },
-    close() {
-      control.postMessage({ type: "close" });
-      control.close();
-    },
+    close,
   };
 }
 

--- a/packages/inspector/src/inspector-app.test.ts
+++ b/packages/inspector/src/inspector-app.test.ts
@@ -1,8 +1,28 @@
-import { describe, expect, it } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
 import type { WasmSchema } from "jazz-tools";
 import { defaultRuntimeContextKey } from "./contexts/default-runtime-context";
 import type { InspectorRuntimeContext } from "./contexts/host-link";
+import { InspectorApp } from "./inspector-app";
 
+const { openSessionMock, readHostConfigMock } = vi.hoisted(() => ({
+  openSessionMock: vi.fn(),
+  readHostConfigMock: vi.fn(),
+}));
+
+vi.mock("./contexts/host-link", () => ({
+  openInspectorRuntimeSession: openSessionMock,
+  readInspectorHostConfig: readHostConfigMock,
+}));
+
+vi.mock("./contexts/devtools-context", () => ({
+  DevtoolsProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("./routes", () => ({
+  InspectorRoutes: () => null,
+}));
 const appId = "shared-app";
 const logicalBase = "shared-db";
 const externalPhysicalDbName =

--- a/packages/inspector/src/inspector-app.test.ts
+++ b/packages/inspector/src/inspector-app.test.ts
@@ -6,14 +6,20 @@ import { defaultRuntimeContextKey } from "./contexts/default-runtime-context";
 import type { InspectorRuntimeContext } from "./contexts/host-link";
 import { InspectorApp } from "./inspector-app";
 
-const { openSessionMock, readHostConfigMock } = vi.hoisted(() => ({
+const { closePortMock, openSessionMock, readHostConfigMock } = vi.hoisted(() => ({
+  closePortMock: vi.fn(),
   openSessionMock: vi.fn(),
   readHostConfigMock: vi.fn(),
 }));
 
 vi.mock("./contexts/host-link", () => ({
+  closeInspectorRuntimePort: closePortMock,
   openInspectorRuntimeSession: openSessionMock,
   readInspectorHostConfig: readHostConfigMock,
+}));
+
+vi.mock("jazz-tools/react", () => ({
+  JazzClientProvider: ({ children }: { children: ReactNode }) => children,
 }));
 
 vi.mock("./contexts/devtools-context", () => ({
@@ -63,5 +69,66 @@ describe("defaultRuntimeContextKey", () => {
         runtimeSources: { inspectorHostPhysicalDbName: localFirstPhysicalDbName },
       }),
     ).toBe("external-first");
+  });
+});
+
+describe("InspectorApp", () => {
+  it("retries host discovery until the 15 second deadline", async () => {
+    vi.useFakeTimers();
+    openSessionMock.mockReset();
+    readHostConfigMock.mockReset();
+    openSessionMock.mockResolvedValue(null);
+    readHostConfigMock.mockReturnValue(null);
+    try {
+      const view = render(createElement(InspectorApp));
+      expect(view.getByText("Connecting…")).toBeDefined();
+
+      await act(() => vi.advanceTimersByTimeAsync(14_999));
+      expect(view.queryByText(/no host connection found/)).toBeNull();
+
+      await act(() => vi.advanceTimersByTimeAsync(1));
+      expect(view.getByText(/no host connection found/)).toBeDefined();
+      expect(openSessionMock.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      cleanup();
+      vi.useRealTimers();
+    }
+  });
+
+  it("protocol-closes an attachment acknowledged after unmount", async () => {
+    openSessionMock.mockReset();
+    readHostConfigMock.mockReset();
+    closePortMock.mockReset();
+    let resolveAttach: (port: MessagePort) => void = () => {};
+    const attach = vi.fn(
+      () =>
+        new Promise<MessagePort>((resolve) => {
+          resolveAttach = resolve;
+        }),
+    );
+    const close = vi.fn();
+    const runtimeContext = context("context", localFirstPhysicalDbName);
+    openSessionMock.mockResolvedValue({
+      contexts: [runtimeContext],
+      listContexts: vi.fn(async () => [runtimeContext]),
+      attach,
+      close,
+    });
+    readHostConfigMock.mockReturnValue({
+      appId,
+      runtimeSources: { inspectorHostPhysicalDbName: localFirstPhysicalDbName },
+    });
+    const view = render(createElement(InspectorApp));
+    await vi.waitFor(() => expect(attach).toHaveBeenCalledWith("context"));
+
+    view.unmount();
+    const port = {} as MessagePort;
+    await act(async () => {
+      resolveAttach(port);
+      await Promise.resolve();
+    });
+
+    expect(closePortMock).toHaveBeenCalledWith(port);
+    expect(close).toHaveBeenCalledOnce();
   });
 });

--- a/packages/inspector/src/inspector-app.tsx
+++ b/packages/inspector/src/inspector-app.tsx
@@ -6,6 +6,7 @@ import { JazzClientProvider } from "jazz-tools/react";
 import { DevtoolsProvider } from "./contexts/devtools-context";
 import { defaultRuntimeContextKey } from "./contexts/default-runtime-context";
 import {
+  closeInspectorRuntimePort,
   openInspectorRuntimeSession,
   readInspectorHostConfig,
   type InspectorRuntimeContext,
@@ -18,6 +19,23 @@ import { InspectorRoutes } from "./routes";
 // mounted the loader, or its schema getter keeps throwing).
 const HOST_POLL_INTERVAL_MS = 200;
 const HOST_POLL_TIMEOUT_MS = 15_000;
+const CONTEXT_REFRESH_INTERVAL_MS = 1_000;
+
+function waitForDelay(delay: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, delay);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
 
 function runtimeContextsEqual(
   left: InspectorRuntimeContext[],
@@ -80,13 +98,17 @@ export function InspectorApp() {
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
     let active = true;
     let activeSession: InspectorRuntimeSession | null = null;
     const deadline = Date.now() + HOST_POLL_TIMEOUT_MS;
     const connect = async () => {
       while (active && Date.now() < deadline) {
         try {
-          const next = await openInspectorRuntimeSession();
+          const next = await openInspectorRuntimeSession({
+            signal: controller.signal,
+            deadline,
+          });
           if (next && next.contexts.length > 0) {
             if (!active) {
               next.close();
@@ -100,32 +122,48 @@ export function InspectorApp() {
           }
           next?.close();
         } catch {
+          if (!active) return;
           // The host runtime may still be starting. Retry until the deadline.
         }
-        await new Promise((resolve) => setTimeout(resolve, HOST_POLL_INTERVAL_MS));
+        if (!active) return;
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) break;
+        await waitForDelay(Math.min(HOST_POLL_INTERVAL_MS, remaining), controller.signal);
       }
       if (active) setHostTimedOut(true);
     };
     void connect();
     return () => {
       active = false;
+      controller.abort();
       activeSession?.close();
     };
   }, []);
 
   useEffect(() => {
     if (!session) return;
-    const timer = setInterval(() => {
-      void session.listContexts().then((next) => {
-        setContexts((current) => (runtimeContextsEqual(current, next) ? current : next));
-        setSelectedKey((current) =>
-          current && next.some((context) => context.key === current)
-            ? current
-            : defaultRuntimeContextKey(next, readInspectorHostConfig()),
-        );
-      });
-    }, 1_000);
-    return () => clearInterval(timer);
+    const controller = new AbortController();
+    const refresh = async () => {
+      while (!controller.signal.aborted) {
+        await waitForDelay(CONTEXT_REFRESH_INTERVAL_MS, controller.signal);
+        if (controller.signal.aborted) return;
+        try {
+          const next = await session.listContexts();
+          if (controller.signal.aborted) return;
+          setContexts((current) => (runtimeContextsEqual(current, next) ? current : next));
+          setSelectedKey((current) =>
+            current && next.some((context) => context.key === current)
+              ? current
+              : defaultRuntimeContextKey(next, readInspectorHostConfig()),
+          );
+        } catch {
+          // A transient control-port failure should not create an unhandled
+          // rejection or stop future refreshes.
+        }
+      }
+    };
+    void refresh();
+    return () => controller.abort();
   }, [session]);
 
   useEffect(() => {
@@ -147,7 +185,7 @@ export function InspectorApp() {
       .then(async (browserWorkerPort) => {
         if (!browserWorkerPort) return;
         if (!active) {
-          browserWorkerPort.close();
+          closeInspectorRuntimePort(browserWorkerPort);
           return;
         }
         const client = await createInspectorAttachmentClient(

--- a/packages/jazz-tools/src/dev/inspector-overlay/browser-control-registry.test.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/browser-control-registry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   deserializeBrowserRelayError,
   type BrowserInspectorControlEvent,
@@ -144,5 +144,125 @@ describe("aggregated inspector browser control", () => {
     });
     outer.close();
     channel.port2.close();
+  });
+  it("closes acquired controls when a sibling factory rejects", async () => {
+    const acquired = new MessageChannel();
+    acquired.port2.start();
+    let markOpened: () => void = () => {};
+    const opened = new Promise<void>((resolve) => {
+      markOpened = resolve;
+    });
+    const closed = new Promise<void>((resolve) => {
+      acquired.port2.addEventListener(
+        "message",
+        (event: MessageEvent<BrowserInspectorControlRequest>) => {
+          if (event.data.type === "close") resolve();
+        },
+        { once: true },
+      );
+    });
+    disposers.push(
+      registerBrowserInspectorControl(async () => {
+        markOpened();
+        return acquired.port1;
+      }),
+      registerBrowserInspectorControl(async () => {
+        await opened;
+        await Promise.resolve();
+        throw new Error("factory failed");
+      }),
+    );
+
+    await expect(
+      openAggregatedBrowserInspectorControlPort(async () => {
+        throw new Error("fallback should not be used");
+      }),
+    ).rejects.toThrow("factory failed");
+    await expect(closed).resolves.toBeUndefined();
+    acquired.port2.close();
+  });
+
+  it("closes a control that resolves after a sibling factory rejects", async () => {
+    const late = new MessageChannel();
+    late.port2.start();
+    let resolveLate: (port: MessagePort) => void = () => {};
+    const lateFactory = new Promise<MessagePort>((resolve) => {
+      resolveLate = resolve;
+    });
+    disposers.push(
+      registerBrowserInspectorControl(() => lateFactory),
+      registerBrowserInspectorControl(async () => {
+        throw new Error("factory failed first");
+      }),
+    );
+
+    await expect(
+      openAggregatedBrowserInspectorControlPort(async () => {
+        throw new Error("fallback should not be used");
+      }),
+    ).rejects.toThrow("factory failed first");
+
+    const closed = new Promise<unknown>((resolve) => {
+      late.port2.addEventListener("message", (event) => resolve(event.data), { once: true });
+    });
+    resolveLate(late.port1);
+    await expect(closed).resolves.toEqual({ type: "close" });
+    late.port2.close();
+  });
+
+  it("protocol-closes acquired controls when the aggregate closes", async () => {
+    const inner = new MessageChannel();
+    inner.port2.start();
+    disposers.push(registerBrowserInspectorControl(async () => inner.port1));
+    const outer = await openAggregatedBrowserInspectorControlPort(async () => {
+      throw new Error("fallback should not be used");
+    });
+    const closed = new Promise<unknown>((resolve) => {
+      inner.port2.addEventListener("message", (event) => resolve(event.data), { once: true });
+    });
+
+    outer.postMessage({ type: "close" } satisfies BrowserInspectorControlRequest);
+
+    await expect(closed).resolves.toEqual({ type: "close" });
+    inner.port2.close();
+  });
+
+  it("bounds silent registered control requests", async () => {
+    vi.useFakeTimers();
+    const silent = new MessageChannel();
+    silent.port2.start();
+    const received = new Promise<void>((resolve) => {
+      silent.port2.addEventListener(
+        "message",
+        (event: MessageEvent<BrowserInspectorControlRequest>) => {
+          if (event.data.type === "list-contexts") resolve();
+        },
+        { once: true },
+      );
+    });
+    disposers.push(registerBrowserInspectorControl(async () => silent.port1));
+    try {
+      const outer = await openAggregatedBrowserInspectorControlPort(async () => {
+        throw new Error("fallback should not be used");
+      });
+      const result = waitForEvent(
+        outer,
+        (event): event is Extract<BrowserInspectorControlEvent, { type: "result" }> =>
+          event.type === "result" && event.id === 9,
+      );
+      outer.postMessage({ type: "list-contexts", id: 9 } satisfies BrowserInspectorControlRequest);
+      await received;
+
+      await vi.advanceTimersByTimeAsync(4_500);
+      await expect(result).resolves.toMatchObject({
+        error: expect.objectContaining({
+          message: "Inspector relay control request timed out",
+        }),
+      });
+      outer.close();
+    } finally {
+      silent.port2.close();
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/jazz-tools/src/dev/inspector-overlay/browser-control-registry.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/browser-control-registry.ts
@@ -8,8 +8,14 @@ import {
   deserializeBrowserRelayError,
   serializeBrowserRelayError,
 } from "../../runtime/native-runtime/browser-worker-protocol.js";
+import {
+  closeInspectorControlPort,
+  inspectorControlAbortError,
+} from "../../runtime/native-runtime/inspector-control-lifecycle.js";
 
-type ControlPortFactory = (() => Promise<MessagePort>) & { getConfig?: () => DbConfig };
+type ControlPortFactory = ((signal?: AbortSignal) => Promise<MessagePort>) & {
+  getConfig?: () => DbConfig;
+};
 type ControlRequestWithoutId = BrowserInspectorControlRequest extends infer Request
   ? Request extends { id: number }
     ? Omit<Request, "id">
@@ -23,6 +29,8 @@ function registry(): RegistryState {
   const scope = globalThis as typeof globalThis & { [REGISTRY_KEY]?: RegistryState };
   return (scope[REGISTRY_KEY] ??= { factories: new Map(), nextFactoryId: 1 });
 }
+
+const CONTROL_REQUEST_TIMEOUT_MS = 4_500;
 
 export function registerBrowserInspectorControl(
   factory: ControlPortFactory,
@@ -46,35 +54,111 @@ export function getRegisteredInspectorConfig(contextKey: string): DbConfig {
 
 export async function openAggregatedBrowserInspectorControlPort(
   fallback: ControlPortFactory,
+  signal?: AbortSignal,
 ): Promise<MessagePort> {
+  if (signal?.aborted) throw inspectorControlAbortError();
   const factories = registry().factories;
-  if (factories.size === 0) return fallback();
-  const registrations = [...factories];
-  const controls = await Promise.all(
-    registrations.map(async ([id, factory]) => ({ id, port: await factory(), nextId: 1 })),
-  );
+  if (factories.size === 0) return fallback(signal);
+
+  type Control = { id: number; port: MessagePort; nextId: number };
+  const controls: Control[] = [];
+  let acquisitionCancelled = false;
+  let rejectAcquisition: ((error: Error) => void) | undefined;
+  const closeAcquiredControls = () => {
+    for (const control of controls.splice(0)) closeInspectorControlPort(control.port);
+  };
+  const onAcquisitionAbort = () => {
+    acquisitionCancelled = true;
+    closeAcquiredControls();
+    rejectAcquisition?.(inspectorControlAbortError());
+  };
+  signal?.addEventListener("abort", onAcquisitionAbort, { once: true });
+  try {
+    const acquisition = Promise.all(
+      [...factories].map(async ([id, factory]) => {
+        const port = await factory(signal);
+        if (acquisitionCancelled || signal?.aborted) {
+          closeInspectorControlPort(port);
+          throw inspectorControlAbortError();
+        }
+        controls.push({ id, port, nextId: 1 });
+      }),
+    );
+    await (signal
+      ? Promise.race([
+          acquisition,
+          new Promise<never>((_, reject) => {
+            rejectAcquisition = reject;
+          }),
+        ])
+      : acquisition);
+  } catch (error) {
+    acquisitionCancelled = true;
+    closeAcquiredControls();
+    throw error;
+  } finally {
+    signal?.removeEventListener("abort", onAcquisitionAbort);
+    rejectAcquisition = undefined;
+  }
+
   for (const control of controls) control.port.start();
   const routes = new Map<string, { port: MessagePort; contextKey: string }>();
   const channel = new MessageChannel();
   const port = channel.port1;
+  const pendingCancels = new Set<(error: Error) => void>();
+  let disposed = false;
 
   const request = <T extends BrowserInspectorControlEvent>(
-    control: (typeof controls)[number],
+    control: Control,
     message: ControlRequestWithoutId,
     transfer: Transferable[] = [],
   ) =>
     new Promise<T>((resolve, reject) => {
       const id = control.nextId++;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let settled = false;
+      const finish = (error?: unknown, event?: BrowserInspectorControlEvent) => {
+        if (settled) return;
+        settled = true;
+        control.port.removeEventListener("message", onMessage);
+        clearTimeout(timer);
+        pendingCancels.delete(cancel);
+        if (error !== undefined) reject(error);
+        else resolve(event as T);
+      };
+      const cancel = (error: Error) => finish(error);
       const onMessage = (event: MessageEvent<BrowserInspectorControlEvent>) => {
         if (event.data.id !== id) return;
-        control.port.removeEventListener("message", onMessage);
-        if ("error" in event.data && event.data.error)
-          reject(deserializeBrowserRelayError(event.data.error));
-        else resolve(event.data as T);
+        if ("error" in event.data && event.data.error) {
+          finish(deserializeBrowserRelayError(event.data.error));
+        } else {
+          finish(undefined, event.data);
+        }
       };
+      pendingCancels.add(cancel);
       control.port.addEventListener("message", onMessage);
-      control.port.postMessage({ ...message, id }, transfer);
+      timer = setTimeout(
+        () => finish(new Error("Inspector relay control request timed out")),
+        CONTROL_REQUEST_TIMEOUT_MS,
+      );
+      try {
+        control.port.postMessage({ ...message, id }, transfer);
+      } catch (error) {
+        finish(error);
+      }
     });
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    port.removeEventListener("message", onMessage);
+    for (const cancel of [...pendingCancels]) {
+      cancel(new Error("Inspector aggregate control is closed"));
+    }
+    routes.clear();
+    closeAcquiredControls();
+    port.close();
+  };
 
   const onMessage = async (event: MessageEvent<BrowserInspectorControlRequest>) => {
     const message = event.data;
@@ -130,20 +214,14 @@ export async function openAggregatedBrowserInspectorControlPort(
       );
       port.postMessage({ type: "result", id: message.id });
     } catch (error) {
+      if (message.type === "attach-context") message.port.close();
+      if (disposed) return;
       port.postMessage({
         type: "result",
         id: "id" in message ? message.id : 0,
         error: serializeBrowserRelayError(error),
       });
     }
-  };
-  const dispose = () => {
-    port.removeEventListener("message", onMessage);
-    for (const control of controls) {
-      control.port.postMessage({ type: "close" });
-      control.port.close();
-    }
-    port.close();
   };
   port.addEventListener("message", onMessage);
   port.start();

--- a/packages/jazz-tools/src/dev/inspector-overlay/host-bridge.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/host-bridge.ts
@@ -115,8 +115,11 @@ export function installInspectorHost(
         }),
       );
     },
-    openControlPort() {
-      return openAggregatedBrowserInspectorControlPort(() => db.openInspectorControlPort());
+    openControlPort(signal) {
+      return openAggregatedBrowserInspectorControlPort(
+        (factorySignal) => db.openInspectorControlPort(factorySignal),
+        signal,
+      );
     },
     getWasmSchema() {
       const live = db.getRuntimeSchema();

--- a/packages/jazz-tools/src/dev/inspector-overlay/inspector-host-types.ts
+++ b/packages/jazz-tools/src/dev/inspector-overlay/inspector-host-types.ts
@@ -1,5 +1,9 @@
 import type { WasmSchema } from "../../drivers/types.js";
 import type { ActiveQuerySubscriptionTrace, DbConfig } from "../../runtime/db.js";
+import {
+  deserializeBrowserRelayError,
+  type BrowserRelayError,
+} from "../../runtime/native-runtime/browser-worker-protocol.js";
 
 /** Resolved bearer plus non-secret scope; never a signing root or admin credential. */
 export type InspectorHostConfig = Pick<
@@ -26,7 +30,7 @@ export interface JazzInspectorHost {
    */
   getConnectionConfig(contextKey?: string): InspectorHostConfig;
   /** Open a session-scoped channel for discovering and attaching to worker contexts. */
-  openControlPort(): Promise<MessagePort>;
+  openControlPort(signal?: AbortSignal): Promise<MessagePort>;
   /** The host's runtime schema (plain serializable data — safe across realms). */
   getWasmSchema(): WasmSchema;
   /** Current active subscriptions, without JS stacks. */
@@ -41,6 +45,10 @@ export const INSPECTOR_SUBSCRIPTIONS_MESSAGE = "jazz-inspector:subscriptions" as
 export interface InspectorSubscriptionsMessage {
   type: typeof INSPECTOR_SUBSCRIPTIONS_MESSAGE;
   list: InspectorSubscription[];
+}
+
+export function deserializeInspectorControlError(error: unknown): Error {
+  return deserializeBrowserRelayError(error as BrowserRelayError);
 }
 
 export function serializeActiveSubscriptions(

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -14,6 +14,7 @@ import {
 } from "./types.js";
 import { registerBrowserInspectorControl } from "../../dev/inspector-overlay/browser-control-registry.js";
 import { assertBrowserStorageOwnerUnchanged } from "../browser-worker-config.js";
+import { waitForInspectorOpening } from "../native-runtime/inspector-control-lifecycle.js";
 
 /**
  * Every persistent browser tab is an in-memory client of one SharedWorker
@@ -85,7 +86,7 @@ export class BrowserConnectionManager extends ConnectionManager {
     this.observedConfigurationAdmissionFailure = null;
     this.unregisterInspectorControl?.();
     this.unregisterInspectorControl = registerBrowserInspectorControl(
-      () => connection.openInspectorControlPort(),
+      (signal) => connection.openInspectorControlPort(signal),
       () => this.host.config,
     );
     this.initialExplicitOfflineStateKnown = false;
@@ -276,10 +277,10 @@ export class BrowserConnectionManager extends ConnectionManager {
     await this.storageReset;
   }
 
-  override async openInspectorControlPort(): Promise<MessagePort> {
-    await this.connectionReady;
+  override async openInspectorControlPort(signal?: AbortSignal): Promise<MessagePort> {
+    await waitForInspectorOpening(this.connectionReady ?? Promise.resolve(), signal);
     if (!this.connection) throw new Error("Shared browser runtime is not connected");
-    return this.connection.openInspectorControlPort();
+    return this.connection.openInspectorControlPort(signal);
   }
 
   private beginStorageReset(connection: BrowserWorkerConnection): void {

--- a/packages/jazz-tools/src/runtime/connection-manager/types.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/types.ts
@@ -171,7 +171,7 @@ export abstract class ConnectionManager {
     return null;
   }
 
-  openInspectorControlPort(): Promise<MessagePort> {
+  openInspectorControlPort(_signal?: AbortSignal): Promise<MessagePort> {
     return Promise.reject(new Error("This runtime has no shared browser worker"));
   }
 

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -2030,8 +2030,8 @@ export class Db {
   }
 
   /** @internal Open a control channel for the same-origin embedded inspector. */
-  openInspectorControlPort(): Promise<MessagePort> {
-    return this.connection.openInspectorControlPort();
+  openInspectorControlPort(signal?: AbortSignal): Promise<MessagePort> {
+    return this.connection.openInspectorControlPort(signal);
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.test.ts
@@ -300,4 +300,108 @@ describe("MessagePortBrowserFollowerConnection", () => {
 
     connection.detachForReconnect();
   });
+  it("cancels a silent inspector control opening and protocol-closes its channel", async () => {
+    const port = new TestPort();
+    const transport = {
+      recvWireFrames: () => [],
+      sendWireFrame: () => undefined,
+      tick: () => 0,
+    };
+    const runtime = {
+      connectUpstreamPeer: vi.fn(() => transport),
+      onPeerTransportWork: vi.fn(() => () => undefined),
+      progressPeerTransport: vi.fn(async () => undefined),
+      retirePeerTransport: vi.fn(async () => undefined),
+      clearRemoteServerTransportError: vi.fn(),
+      reportRemoteServerTransportError: vi.fn(),
+      reportRemoteMutationError: vi.fn(),
+    };
+    const connection = new MessagePortBrowserFollowerConnection(
+      runtime as never,
+      port as unknown as MessagePort,
+      {},
+      null,
+      {
+        onAuthFailure: vi.fn(),
+        onAuthRestored: vi.fn(),
+        onFailure: vi.fn(),
+      },
+    );
+    const init = port.sent[0];
+    if (!init || init.type !== "init") throw new Error("follower did not initialize");
+    port.emit({ type: "result", id: init.id });
+    await connection.ready();
+
+    const controller = new AbortController();
+    const opening = connection.openInspectorControlPort(controller.signal);
+    await vi.waitFor(() =>
+      expect(port.sent.some((request) => request.type === "open-inspector-control")).toBe(true),
+    );
+    const request = port.sent.find((candidate) => candidate.type === "open-inspector-control");
+    if (!request || request.type !== "open-inspector-control") {
+      throw new Error("follower did not request an inspector control");
+    }
+    request.port.start();
+    const closed = new Promise<unknown>((resolve) => {
+      request.port.addEventListener("message", (event) => resolve(event.data), { once: true });
+    });
+
+    controller.abort();
+
+    await expect(opening).rejects.toThrow("cancelled");
+    await expect(closed).resolves.toEqual({ type: "close" });
+    request.port.close();
+    connection.detachForReconnect();
+  });
+  it("protocol-closes an inspector channel when follower disposal rejects its opening", async () => {
+    const port = new TestPort();
+    const transport = {
+      recvWireFrames: () => [],
+      sendWireFrame: () => undefined,
+      tick: () => 0,
+    };
+    const runtime = {
+      connectUpstreamPeer: vi.fn(() => transport),
+      onPeerTransportWork: vi.fn(() => () => undefined),
+      progressPeerTransport: vi.fn(async () => undefined),
+      retirePeerTransport: vi.fn(async () => undefined),
+      clearRemoteServerTransportError: vi.fn(),
+      reportRemoteServerTransportError: vi.fn(),
+      reportRemoteMutationError: vi.fn(),
+    };
+    const connection = new MessagePortBrowserFollowerConnection(
+      runtime as never,
+      port as unknown as MessagePort,
+      {},
+      null,
+      {
+        onAuthFailure: vi.fn(),
+        onAuthRestored: vi.fn(),
+        onFailure: vi.fn(),
+      },
+    );
+    const init = port.sent[0];
+    if (!init || init.type !== "init") throw new Error("follower did not initialize");
+    port.emit({ type: "result", id: init.id });
+    await connection.ready();
+
+    const opening = connection.openInspectorControlPort();
+    await vi.waitFor(() =>
+      expect(port.sent.some((request) => request.type === "open-inspector-control")).toBe(true),
+    );
+    const request = port.sent.find((candidate) => candidate.type === "open-inspector-control");
+    if (!request || request.type !== "open-inspector-control") {
+      throw new Error("follower did not request an inspector control");
+    }
+    request.port.start();
+    const closed = new Promise<unknown>((resolve) => {
+      request.port.addEventListener("message", (event) => resolve(event.data), { once: true });
+    });
+
+    connection.detachForReconnect();
+
+    await expect(opening).rejects.toThrow("reconnecting");
+    await expect(closed).resolves.toEqual({ type: "close" });
+    request.port.close();
+  });
 });

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
@@ -12,6 +12,11 @@ import {
 } from "./browser-worker-protocol.js";
 import type { NativeRuntimeAdapter } from "./native-runtime-adapter.js";
 import { IndexedDbPageStore } from "../indexeddb-page-store.js";
+import {
+  closeInspectorControlPort,
+  inspectorControlAbortError,
+  waitForInspectorOpening,
+} from "./inspector-control-lifecycle.js";
 
 type PendingRequest = {
   type: BrowserFollowerPortRpcRequest["type"] | "open-inspector-control";
@@ -160,23 +165,51 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
     await this.request({ type: "finish-storage-reset" });
   }
 
-  async openInspectorControlPort(): Promise<MessagePort> {
-    await this.ready();
+  async openInspectorControlPort(signal?: AbortSignal): Promise<MessagePort> {
+    await waitForInspectorOpening(this.ready(), signal);
+    if (signal?.aborted) throw inspectorControlAbortError();
+
     const channel = new MessageChannel();
     const id = this.nextRequestId++;
+    let rejectPending: (error: Error) => void = () => {};
     const promise = new Promise<void>((resolve, reject) => {
+      rejectPending = reject;
       this.pending.set(id, { type: "open-inspector-control", resolve, reject });
     });
-    this.port.postMessage(
-      {
-        type: "open-inspector-control",
-        id,
-        port: channel.port2,
-      } satisfies BrowserFollowerPortRequest,
-      [channel.port2],
-    );
-    await promise;
-    return channel.port1;
+    let controlClosed = false;
+    const closeControl = () => {
+      if (controlClosed) return;
+      controlClosed = true;
+      closeInspectorControlPort(channel.port1);
+    };
+    const onAbort = () => {
+      if (!this.pending.delete(id)) return;
+      closeControl();
+      rejectPending(inspectorControlAbortError());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    try {
+      this.port.postMessage(
+        {
+          type: "open-inspector-control",
+          id,
+          port: channel.port2,
+        } satisfies BrowserFollowerPortRequest,
+        [channel.port2],
+      );
+      await promise;
+      if (signal?.aborted) {
+        closeControl();
+        throw inspectorControlAbortError();
+      }
+      return channel.port1;
+    } catch (error) {
+      this.pending.delete(id);
+      closeControl();
+      throw error;
+    } finally {
+      signal?.removeEventListener("abort", onAbort);
+    }
   }
 
   async reconnect(authJson: string, sessionClaims: Record<string, unknown>): Promise<void> {

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -21,6 +21,7 @@ import type {
 } from "../runtime-source.js";
 import { MessagePortBrowserFollowerConnection } from "./browser-follower-connection.js";
 import type { NativeRuntimeAdapter } from "./native-runtime-adapter.js";
+import { waitForInspectorOpening } from "./inspector-control-lifecycle.js";
 
 export type BrowserForegroundNodeLeaseOptions = Pick<
   BrowserWorkerInitOptions,
@@ -628,10 +629,10 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
     await this.connection?.deleteStorage();
   }
 
-  async openInspectorControlPort(): Promise<MessagePort> {
-    await this.ready();
+  async openInspectorControlPort(signal?: AbortSignal): Promise<MessagePort> {
+    await waitForInspectorOpening(this.ready(), signal);
     if (!this.connection) throw new Error("Shared browser runtime is not connected");
-    const port = await this.connection.openInspectorControlPort();
+    const port = await this.connection.openInspectorControlPort(signal);
     const generation = this.connectedGeneration;
     if (generation !== null) {
       installWorkerTerminationGenerationHandoff(port, this.workerName, generation);

--- a/packages/jazz-tools/src/runtime/native-runtime/inspector-control-lifecycle.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/inspector-control-lifecycle.ts
@@ -1,0 +1,34 @@
+export function inspectorControlAbortError(): Error {
+  return new Error("Inspector control opening was cancelled");
+}
+
+export function closeInspectorControlPort(port: MessagePort): void {
+  try {
+    port.postMessage({ type: "close" });
+  } catch {
+    // The remote endpoint may already be unavailable or not yet adopted.
+  }
+  port.close();
+}
+
+export function waitForInspectorOpening<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(inspectorControlAbortError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(inspectorControlAbortError());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}

--- a/packages/jazz-tools/src/runtime/runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/runtime-source.ts
@@ -48,7 +48,7 @@ export interface BrowserWorkerConnection {
   deleteStorage(): Promise<void>;
   flushLocal(): Promise<void>;
   waitForPendingWrites(): Promise<void>;
-  openInspectorControlPort(): Promise<MessagePort>;
+  openInspectorControlPort(signal?: AbortSignal): Promise<MessagePort>;
   shutdown(): Promise<void>;
   /** Present only after an authenticated Inspector control-port attachment. */
   getAuthenticatedInspectorAttachmentPhysicalDbName?(): string | null;

--- a/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
@@ -1739,6 +1739,7 @@ function attachInspectorControl(authSessionKey: string, port: MessagePort): void
       context.storageInvalidated ||
       !context.runtime
     ) {
+      message.port.close();
       port.postMessage({
         type: "result",
         id: message.id,

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -8,6 +8,8 @@ import type {
   BrowserForegroundNodeLeaseCancelRequest,
   BrowserForegroundNodeLeasePortRequest,
   BrowserForegroundNodeLeaseProbeRequest,
+  BrowserInspectorControlEvent,
+  BrowserInspectorControlRequest,
   BrowserFollowerPortEvent,
   BrowserFollowerPortRequest,
   BrowserInspectorControlEvent,
@@ -372,6 +374,29 @@ class TestPort {
 
   hasEvent(predicate: (event: TestPortEvent) => boolean): boolean {
     return this.events.some(predicate);
+  }
+}
+
+class InspectorControlTestPort {
+  readonly close = vi.fn();
+  readonly start = vi.fn();
+  readonly messages: BrowserInspectorControlEvent[] = [];
+  private readonly listeners = new Set<(event: MessageEvent) => void>();
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    if (type === "message") this.listeners.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    if (type === "message") this.listeners.delete(listener);
+  }
+
+  postMessage(message: BrowserInspectorControlEvent): void {
+    this.messages.push(message);
+  }
+
+  emitMessage(message: BrowserInspectorControlRequest): void {
+    for (const listener of this.listeners) listener({ data: message } as MessageEvent);
   }
 }
 
@@ -2299,5 +2324,34 @@ describe("broker worker context initialization", () => {
     await owner.port.waitForEvent((event) => event.type === "result" && event.id === 3);
     await Promise.resolve();
     expect(editor.port.hasEvent((event) => event.type === "result" && event.id === 2)).toBe(false);
+  });
+
+  it("closes an attachment port when its context is unavailable", async () => {
+    const owner = await connect(options("inspector-control"), "owner-tab");
+    await initializeFollower(owner.port, 1);
+    const control = new InspectorControlTestPort();
+    const opened = owner.port.waitForEvent((event) => event.type === "result" && event.id === 2);
+    owner.port.emitMessage({
+      type: "open-inspector-control",
+      id: 2,
+      port: control as unknown as MessagePort,
+    });
+    await opened;
+
+    const attachment = new InspectorControlTestPort();
+    control.emitMessage({
+      type: "attach-context",
+      id: 3,
+      contextKey: "missing",
+      tabId: "inspector-tab",
+      port: attachment as unknown as MessagePort,
+    });
+
+    expect(attachment.close).toHaveBeenCalledOnce();
+    expect(control.messages).toContainEqual({
+      type: "result",
+      id: 3,
+      error: "Inspector context is no longer available",
+    });
   });
 });

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -12,8 +12,6 @@ import type {
   BrowserInspectorControlRequest,
   BrowserFollowerPortEvent,
   BrowserFollowerPortRequest,
-  BrowserInspectorControlEvent,
-  BrowserInspectorControlRequest,
   BrowserSharedWorkerConnectRequest,
   BrowserSharedWorkerConnectResponse,
   BrowserWorkerInitOptions,

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -2349,7 +2349,7 @@ describe("broker worker context initialization", () => {
     expect(control.messages).toContainEqual({
       type: "result",
       id: 3,
-      error: "Inspector context is no longer available",
+      error: expect.objectContaining({ message: "Inspector context is no longer available" }),
     });
   });
 });


### PR DESCRIPTION
## Summary
- Bound Inspector control opening and inner relay requests with propagated cancellation.
- Protocol-close acquired, rejected, late, stale, and disposed control ports across follower, worker, aggregate, and React attachment seams.
- Preserve structured relay errors and centralise private control-port lifecycle operations.

## Before
Silent or partially failed control acquisition could retain listeners and worker ports indefinitely; late attachment success could outlive the requesting UI; failure payloads could lose structure.

## After
Every non-success ownership transition deterministically cancels pending work and sends the worker close protocol before local disposal. Aggregate partial and late successes are cleaned up, and errors retain their structured envelope.

## Test plan
- `pnpm --filter jazz-tools check` — passed.
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/dev/inspector-overlay/browser-control-registry.test.ts src/runtime/native-runtime/browser-follower-connection.test.ts` — 12 passed.
- `pnpm --filter inspector exec vitest run --config vitest.config.ts src/contexts/host-link.test.tsx src/inspector-app.test.ts` — 17 passed.