### PR TITLE
Cancel stale Inspector connection submissions

### DIFF
--- a/packages/inspector/src/App.test.tsx
+++ b/packages/inspector/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import App from "./App";
@@ -266,6 +266,59 @@ describe("App", () => {
     expect(preview).toBeDefined();
     expect(stored.activeConnectionId).toBe(preview?.id);
   });
+
+  it("keeps connections open when an edit submission is cancelled while schema hashes load", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 2,
+        activeConnectionId: "local",
+        connections: [
+          {
+            id: "local",
+            name: "Local dev",
+            serverUrl: "http://localhost:19879",
+            appId: "local-app-id",
+            adminSecret: "local-admin-secret",
+            env: "dev",
+            branch: "main",
+            schemaHash: "hash-a",
+          },
+        ],
+      }),
+    );
+
+    render(<App />);
+
+    expect(await screen.findByText("Inspector ready")).not.toBeNull();
+    const storedBeforeEdit = localStorage.getItem(STORAGE_KEY);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open connections" }));
+    expect(await screen.findByRole("heading", { name: "Connections" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Edit Local dev" }));
+    expect(await screen.findByRole("heading", { name: "Edit connection" })).not.toBeNull();
+
+    let resolveSchemaHashes!: (result: { hashes: string[] }) => void;
+    const pendingSchemaHashes = new Promise<{ hashes: string[] }>((resolve) => {
+      resolveSchemaHashes = resolve;
+    });
+    fetchSchemaHashesMock.mockImplementationOnce(() => pendingSchemaHashes);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(await screen.findByRole("heading", { name: "Connections" })).not.toBeNull();
+
+    await act(async () => {
+      resolveSchemaHashes({ hashes: ["hash-c"] });
+      await pendingSchemaHashes;
+    });
+
+    expect(screen.getByRole("heading", { name: "Connections" })).not.toBeNull();
+    expect(screen.queryByRole("heading", { name: "Select schema" })).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(storedBeforeEdit);
+  });
+
 
   it("prefills the connection form from partial hash params", async () => {
     localStorage.setItem(

--- a/packages/inspector/src/App.test.tsx
+++ b/packages/inspector/src/App.test.tsx
@@ -319,7 +319,6 @@ describe("App", () => {
     expect(localStorage.getItem(STORAGE_KEY)).toBe(storedBeforeEdit);
   });
 
-
   it("prefills the connection form from partial hash params", async () => {
     localStorage.setItem(
       STORAGE_KEY,

--- a/packages/inspector/src/components/db-config-form/DbConfigForm.tsx
+++ b/packages/inspector/src/components/db-config-form/DbConfigForm.tsx
@@ -1,5 +1,5 @@
 import { fetchSchemaHashes } from "jazz-tools";
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type FormEvent } from "react";
 import {
   normalizeSchemaHashInfos,
   type SchemaHashInfo,
@@ -33,26 +33,41 @@ export function DbConfigForm({
   title,
   onCancel,
 }: DbConfigFormProps) {
-  const [name, setName] = useState(initialValues?.name ?? "");
-  const [serverUrl, setServerUrl] = useState(initialValues?.serverUrl ?? "");
-  const [appId, setAppId] = useState(initialValues?.appId ?? "");
-  const [adminSecret, setAdminSecret] = useState(initialValues?.adminSecret ?? "");
-  const [env, setEnv] = useState(initialValues?.env ?? "dev");
+  const initialName = initialValues?.name ?? "";
+  const initialServerUrl = initialValues?.serverUrl ?? "";
+  const initialAppId = initialValues?.appId ?? "";
+  const initialAdminSecret = initialValues?.adminSecret ?? "";
+  const initialEnv = initialValues?.env ?? "dev";
+  const submissionGeneration = useRef(0);
+  const [name, setName] = useState(initialName);
+  const [serverUrl, setServerUrl] = useState(initialServerUrl);
+  const [appId, setAppId] = useState(initialAppId);
+  const [adminSecret, setAdminSecret] = useState(initialAdminSecret);
+  const [env, setEnv] = useState(initialEnv);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
+  useLayoutEffect(() => {
+    submissionGeneration.current += 1;
+    return () => {
+      submissionGeneration.current += 1;
+    };
+  }, [initialName, initialServerUrl, initialAppId, initialAdminSecret, initialEnv, mode]);
+
   useEffect(() => {
-    setName(initialValues?.name ?? "");
-    setServerUrl(initialValues?.serverUrl ?? "");
-    setAppId(initialValues?.appId ?? "");
-    setAdminSecret(initialValues?.adminSecret ?? "");
-    setEnv(initialValues?.env ?? "dev");
+    setName(initialName);
+    setServerUrl(initialServerUrl);
+    setAppId(initialAppId);
+    setAdminSecret(initialAdminSecret);
+    setEnv(initialEnv);
     setIsSubmitting(false);
     setErrorMessage(null);
-  }, [initialValues]);
+  }, [initialName, initialServerUrl, initialAppId, initialAdminSecret, initialEnv, mode]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    const submissionId = ++submissionGeneration.current;
+
     setErrorMessage(null);
     setIsSubmitting(true);
 
@@ -69,13 +84,22 @@ export function DbConfigForm({
         appId: values.appId,
         adminSecret: values.adminSecret,
       })) as SchemaHashesResult;
+      if (submissionGeneration.current !== submissionId) return;
       onSubmit(values, normalizeSchemaHashInfos(hashes, schemas));
     } catch (error) {
+      if (submissionGeneration.current !== submissionId) return;
       const message = error instanceof Error ? error.message : String(error);
       setErrorMessage(message);
     } finally {
-      setIsSubmitting(false);
+      if (submissionGeneration.current === submissionId) {
+        setIsSubmitting(false);
+      }
     }
+  };
+
+  const handleCancel = () => {
+    submissionGeneration.current += 1;
+    onCancel?.();
   };
 
   return (
@@ -144,7 +168,7 @@ export function DbConfigForm({
           {isSubmitting ? "Fetching schemas…" : mode === "edit" ? "Save changes" : "Connect"}
         </button>
         {onCancel ? (
-          <button type="button" onClick={onCancel} className={styles.resetButton}>
+          <button type="button" onClick={handleCancel} className={styles.resetButton}>
             Cancel
           </button>
         ) : null}


### PR DESCRIPTION
## Summary
- Associate each connection-form submission with its own cancellation lifetime.
- Ignore schema-hash completion from a superseded or unmounted submission.
- Keep an already-open connection stable while the cancelled edit unwinds.

## Before
A slow schema-hash lookup could complete after cancellation and replace or close connection state that belonged to a newer UI lifetime.

## After
Only the current live submission may publish connection state; stale asynchronous completions are inert.

## Test plan
- `pnpm --filter inspector exec vitest run --config vitest.config.ts src/App.test.tsx` — 5 passed.