### PR TITLE
Honor cancellation of subscriptions waiting to start

### DIFF
--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -729,13 +729,19 @@ where
     }
 }
 
+#[derive(Clone, Debug)]
+struct ParkedSubscription {
+    subscribe: Subscribe,
+    policy_binding: Option<PolicyBindingKey>,
+}
+
 /// Payloads parked until missing schema or catalogue context arrives.
 #[derive(Clone, Debug, Default)]
 struct Parking {
     /// Shape registrations waiting for an unknown schema version.
     parked_shape_registrations: BTreeMap<ShapeId, ShapeAst>,
     /// Subscription attaches waiting for their shape registration to become installable.
-    parked_binding_deltas: BTreeMap<ShapeId, Vec<Subscribe>>,
+    parked_binding_deltas: BTreeMap<ShapeId, Vec<ParkedSubscription>>,
     /// Commit units waiting for parent transactions or schema context.
     parked_commit_units: BTreeMap<TxId, ParkedCommitUnit>,
     /// Catalogue commit units waiting to be applied in dependency order.

--- a/crates/jazz/src/node/query_eval/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/subscriptions.rs
@@ -391,6 +391,10 @@ where
     }
 
     pub(in crate::node) fn apply_subscribe(&mut self, subscribe: Subscribe) -> Result<(), Error> {
+        let policy_binding = subscribe
+            .delegated_session
+            .as_ref()
+            .map(crate::protocol::PolicyBindingKey::from_delegated_session);
         let Some(shape) = self
             .query
             .registered_shapes
@@ -401,10 +405,13 @@ where
                 .parked_binding_deltas
                 .entry(subscribe.shape_id)
                 .or_default()
-                .push(subscribe);
+                .push(super::ParkedSubscription {
+                    subscribe,
+                    policy_binding,
+                });
             return Ok(());
         };
-        self.apply_known_shape_subscribe(&shape, subscribe)
+        self.apply_known_shape_subscribe(&shape, subscribe, policy_binding)
     }
 
     /// Register a server-admitted subscriber usage under the exact immutable
@@ -520,8 +527,8 @@ where
             self.parking.parked_binding_deltas.insert(shape_id, deltas);
             return Ok(());
         };
-        for subscribe in deltas {
-            self.apply_known_shape_subscribe(&shape, subscribe)?;
+        for parked in deltas {
+            self.apply_known_shape_subscribe(&shape, parked.subscribe, parked.policy_binding)?;
         }
         Ok(())
     }
@@ -530,6 +537,7 @@ where
         &mut self,
         shape: &ValidatedQuery,
         subscribe: Subscribe,
+        policy_binding: Option<crate::protocol::PolicyBindingKey>,
     ) -> Result<(), Error> {
         if subscribe.values.len() != shape.params().len() {
             return Err(Error::InvalidStoredValue("binding arity mismatch"));
@@ -546,10 +554,7 @@ where
             binding_id: binding.binding_id(),
             read_view: subscribe.subscription.read_view,
         };
-        let authority_result_key = subscribe
-            .delegated_session
-            .as_ref()
-            .map(crate::protocol::PolicyBindingKey::from_delegated_session)
+        let authority_result_key = policy_binding
             .map(|policy| AuthorityResultKey::policy_scoped(binding_view_key, policy))
             .unwrap_or_else(|| AuthorityResultKey::unscoped(binding_view_key));
         self.apply_known_shape_subscribe_with_authority_result_key(
@@ -666,6 +671,32 @@ where
     }
 
     pub(crate) fn apply_unsubscribe(&mut self, subscription: SubscriptionKey) {
+        let mut parked_policy_binding = None;
+        if let Some(parked) = self
+            .parking
+            .parked_binding_deltas
+            .get(&subscription.shape_id)
+        {
+            for parked in parked
+                .iter()
+                .filter(|parked| parked.subscribe.subscription == subscription)
+            {
+                let policy_binding = &parked.policy_binding;
+                if let Some(existing) = &parked_policy_binding {
+                    if existing != policy_binding {
+                        // A bare wire handle must not choose between policy
+                        // scopes that share the same usage-site key.
+                        return;
+                    }
+                } else {
+                    parked_policy_binding = Some(policy_binding.clone());
+                }
+            }
+        }
+        if let Some(policy_binding) = parked_policy_binding {
+            self.remove_parked_binding_usage(subscription, policy_binding.as_ref());
+        }
+
         let Some(registered_key) = self.unique_registered_binding_usage_key(subscription) else {
             // A bare wire handle is deliberately insufficient to retire an
             // ambiguous multiplexed policy scope. Authenticated serving paths
@@ -683,10 +714,35 @@ where
         subscription: SubscriptionKey,
         policy_binding: crate::protocol::PolicyBindingKey,
     ) {
+        self.remove_parked_binding_usage(subscription, Some(&policy_binding));
         self.apply_unsubscribe_registered_binding(
             subscription,
             registered_binding_usage_key(subscription, Some(policy_binding)),
         );
+    }
+
+    fn remove_parked_binding_usage(
+        &mut self,
+        subscription: SubscriptionKey,
+        policy_binding: Option<&crate::protocol::PolicyBindingKey>,
+    ) {
+        let remove_bucket = self
+            .parking
+            .parked_binding_deltas
+            .get_mut(&subscription.shape_id)
+            .map(|parked| {
+                parked.retain(|parked| {
+                    parked.subscribe.subscription != subscription
+                        || parked.policy_binding.as_ref() != policy_binding
+                });
+                parked.is_empty()
+            })
+            .unwrap_or(false);
+        if remove_bucket {
+            self.parking
+                .parked_binding_deltas
+                .remove(&subscription.shape_id);
+        }
     }
 
     fn apply_unsubscribe_registered_binding(

--- a/crates/jazz/src/node/tests/queries.rs
+++ b/crates/jazz/src/node/tests/queries.rs
@@ -1651,6 +1651,160 @@ fn binding_delta_validates_shape_arity_and_cleans_up_binding_usage() {
 }
 
 #[test]
+fn parked_subscription_unsubscribe_matches_usage_and_cleans_bucket() {
+    let (_temp_dir, mut node) = open_node();
+    let shape = Query::from("todos")
+        .filter(eq(col("title"), param("wanted")))
+        .validate(&schema())
+        .unwrap();
+    let values = vec![Value::String("match".to_owned())];
+    // These usage-site handles share one canonical binding (the same values)
+    // but must remain independently cancellable while the shape is parked.
+    let first_subscription = SubscriptionKey {
+        shape_id: shape.shape_id(),
+        binding_id: BindingId(uuid::Uuid::from_bytes([0x77; 16])),
+        read_view: Default::default(),
+    };
+    let second_subscription = SubscriptionKey {
+        shape_id: shape.shape_id(),
+        binding_id: BindingId(uuid::Uuid::from_bytes([0x88; 16])),
+        read_view: Default::default(),
+    };
+    let subscribe = |subscription| crate::protocol::Subscribe {
+        shape_id: shape.shape_id(),
+        subscription,
+        values: values.clone(),
+        known_state: None,
+        delegated_session: None,
+    };
+
+    // This internal sync-state seam is needed because the public facade always
+    // registers a shape before it can create a subscription.
+    node.apply_sync_message_settled(SyncMessage::Subscribe(subscribe(first_subscription)))
+        .unwrap();
+    node.apply_sync_message_settled(SyncMessage::Subscribe(subscribe(second_subscription)))
+        .unwrap();
+    assert_eq!(
+        node.parking
+            .parked_binding_deltas
+            .get(&shape.shape_id())
+            .unwrap()
+            .len(),
+        2
+    );
+
+    node.apply_sync_message_settled(SyncMessage::Unsubscribe {
+        subscription: first_subscription,
+    })
+    .unwrap();
+    let parked = node
+        .parking
+        .parked_binding_deltas
+        .get(&shape.shape_id())
+        .unwrap();
+    assert_eq!(parked.len(), 1);
+    assert_eq!(parked[0].subscribe.subscription, second_subscription);
+
+    node.apply_sync_message_settled(SyncMessage::Unsubscribe {
+        subscription: second_subscription,
+    })
+    .unwrap();
+    assert!(!node
+        .parking
+        .parked_binding_deltas
+        .contains_key(&shape.shape_id()));
+
+    node.apply_sync_message_settled(SyncMessage::RegisterShape {
+        shape_id: shape.shape_id(),
+        ast: crate::protocol::ShapeAst::from_validated(&shape),
+        opts: crate::protocol::RegisterShapeOptions::default(),
+    })
+    .unwrap();
+    assert!(!node
+        .query
+        .registered_bindings
+        .contains_key(&shape.shape_id()));
+}
+
+#[test]
+fn parked_subscription_unsubscribe_preserves_other_policy_scopes() {
+    let (_temp_dir, mut node) = open_node();
+    let shape = Query::from("todos")
+        .filter(eq(col("title"), param("wanted")))
+        .validate(&schema())
+        .unwrap();
+    let subscription = SubscriptionKey {
+        shape_id: shape.shape_id(),
+        binding_id: BindingId(uuid::Uuid::from_bytes([0x77; 16])),
+        read_view: Default::default(),
+    };
+    let first_session = crate::protocol::DelegatedSessionBinding {
+        identity: user(0xa1),
+        claims: BTreeMap::from([("role".to_owned(), Value::String("first".to_owned()))]),
+    };
+    let second_session = crate::protocol::DelegatedSessionBinding {
+        identity: first_session.identity.clone(),
+        claims: BTreeMap::from([("role".to_owned(), Value::String("second".to_owned()))]),
+    };
+    let subscribe = |delegated_session| crate::protocol::Subscribe {
+        shape_id: shape.shape_id(),
+        subscription,
+        values: vec![Value::String("match".to_owned())],
+        known_state: None,
+        delegated_session: Some(delegated_session),
+    };
+
+    node.apply_sync_message_settled(SyncMessage::Subscribe(subscribe(first_session.clone())))
+        .unwrap();
+    node.apply_sync_message_settled(SyncMessage::Subscribe(subscribe(second_session.clone())))
+        .unwrap();
+
+    // As above, only the internal protocol seam can deliver Subscribe before
+    // RegisterShape. Same-subject sessions must still isolate different claims.
+    node.apply_unsubscribe(subscription);
+    assert_eq!(
+        node.parking
+            .parked_binding_deltas
+            .get(&shape.shape_id())
+            .unwrap()
+            .len(),
+        2,
+        "a bare handle must fail closed across policy scopes"
+    );
+
+    let first_policy =
+        crate::protocol::PolicyBindingKey::from_delegated_session(&first_session);
+    node.apply_unsubscribe_with_admitted_policy_binding(subscription, first_policy);
+    let parked = node
+        .parking
+        .parked_binding_deltas
+        .get(&shape.shape_id())
+        .unwrap();
+    assert_eq!(parked.len(), 1);
+    assert_eq!(
+        parked[0].subscribe.delegated_session.as_ref().unwrap().identity,
+        second_session.identity
+    );
+
+    node.apply_sync_message_settled(SyncMessage::RegisterShape {
+        shape_id: shape.shape_id(),
+        ast: crate::protocol::ShapeAst::from_validated(&shape),
+        opts: crate::protocol::RegisterShapeOptions::default(),
+    })
+    .unwrap();
+    assert_eq!(node.registered_query_binding_count_for_test(), 1);
+    let survivor = node.query.registered_bindings[&shape.shape_id()]
+        .values()
+        .next()
+        .expect("the uncancelled policy scope must activate");
+    assert_eq!(
+        survivor.authority_result_key.policy_binding,
+        Some(crate::protocol::PolicyBindingKey::from_delegated_session(&second_session)),
+        "shape installation must preserve the surviving immutable claims"
+    );
+}
+
+#[test]
 fn binding_delta_cleanup_distinguishes_canonical_read_view() {
     let schema = branch_view_schema();
     let (_temp_dir, mut node) = open_node_with_schema(node(0x44), schema.clone());


### PR DESCRIPTION
🤖 Make cancellation work while a subscription is waiting to start.

A subscription is parked when its query definition cannot yet be installed, for example because required schema/catalogue information has not arrived. If the caller cancels during that wait, it must be removed from the queue. Previously it could remain parked and unexpectedly start when the missing information arrived. This PR makes that cancellation take effect and prevents later resurrection.

Before, an unsubscribe could leave a parked usage behind and later shape registration could activate that cancelled subscription. The parked record now retains its immutable policy binding; cancellation removes only the matching usage and policy, and draining carries that same binding into registration.

For example, cancelling scope A cannot remove scope B even when both have the same subject and subscription handle but different claims. A bare handle shared by distinct policies remains ambiguous and does not select a scope. Registered subscription behavior is preserved. This changes runtime ownership only, with no storage or wire encoding change.

Current-main selective port: 7332bc8024 on c0863c80b3, limited to three Rust files. Independent adversarial review found no introduced issues; four exact review tests passed. Both omitted cancellation and policy-blind cancellation mutations fail the regressions. Coordinator independently reran both new tests: one passed in each run. Internal tests are necessary because the public facade registers shapes before subscribing and cannot construct this parked state.

Canonical core: 2015 passed, 0 failed, 5 ignored across library, integration targets and doctests. Fresh base also passes with the same 4 MiB stack and file-descriptor limit 65536. Earlier EMFILE failures under the shell default were infrastructure failures. Clippy, formatting, sensitive-data, invariant and ignored-test gates passed. Fresh GitHub CI remains required on this published head.
