### PR TITLE
Close active SSE streams during shutdown

### DIFF
--- a/examples/todo-server-ts/src/main.ts
+++ b/examples/todo-server-ts/src/main.ts
@@ -61,6 +61,13 @@ export interface TodoServerOptions {
   backendSecret?: string;
   adminSecret?: string;
 }
+interface ServerLifecycle {
+  draining: boolean;
+  beginDrain: () => void;
+}
+
+const serverLifecycles = new WeakMap<Application, ServerLifecycle>();
+const stopPromises = new WeakMap<Server, Promise<void>>();
 
 // ============================================================================
 // Helpers
@@ -108,11 +115,36 @@ export async function createServer(
   const app = express();
 
   const sseConnections = new Map<Response, Db>();
+  const lifecycle: ServerLifecycle = {
+    draining: false,
+    beginDrain: () => {
+      lifecycle.draining = true;
+      const connections = Array.from(sseConnections.keys());
+      sseConnections.clear();
+      for (const res of connections) {
+        if (!res.destroyed && !res.writableEnded) {
+          res.end();
+        }
+      }
+    },
+  };
+  const isActiveSseConnection = (res: Response) =>
+    !lifecycle.draining && sseConnections.has(res) && !res.destroyed && !res.writableEnded;
 
   async function broadcastTodos() {
+    if (lifecycle.draining) {
+      return;
+    }
+
     await Promise.all(
       Array.from(sseConnections, async ([res, requestDb]) => {
+        if (!isActiveSseConnection(res)) {
+          return;
+        }
         const todos = await requestDb.all(schemaApp.todos);
+        if (!isActiveSseConnection(res)) {
+          return;
+        }
         res.write(`data: ${JSON.stringify(todos)}\n\n`);
       }),
     );
@@ -133,6 +165,14 @@ export async function createServer(
   // Health check
   app.get("/health", (_req: Request, res: Response) => {
     res.json({ status: "healthy" });
+  });
+
+  app.use("/todos", (_req: Request, res: Response, next: NextFunction) => {
+    if (!lifecycle.draining) {
+      next();
+      return;
+    }
+    res.status(503).json({ error: "Server is shutting down" });
   });
 
   // Authenticate every todo request before selecting a session-scoped database.
@@ -190,7 +230,17 @@ export async function createServer(
 
   // Live SSE stream of the authenticated caller's todos (must be before /todos/:id)
   app.get("/todos/live", async (_req: Request, res: Response, next: NextFunction) => {
+    const cleanup = () => {
+      sseConnections.delete(res);
+    };
+    res.once("close", cleanup);
+
     try {
+      if (lifecycle.draining) {
+        res.status(503).json({ error: "Server is shutting down" });
+        return;
+      }
+
       const db = requestDb(res);
       res.setHeader("Content-Type", "text/event-stream");
       res.setHeader("Cache-Control", "no-cache");
@@ -200,12 +250,14 @@ export async function createServer(
       sseConnections.set(res, db);
 
       const todos = await db.all(schemaApp.todos);
+      if (!isActiveSseConnection(res)) {
+        return;
+      }
       res.write(`data: ${JSON.stringify(todos)}\n\n`);
-
-      res.on("close", () => {
-        sseConnections.delete(res);
-      });
     } catch (e) {
+      if (res.destroyed || res.writableEnded) {
+        return;
+      }
       next(e);
     }
   });
@@ -285,12 +337,18 @@ export async function createServer(
     res.status(500).json({ error: err.message });
   });
 
+  serverLifecycles.set(app, lifecycle);
+
+  let shutdownPromise: Promise<void> | undefined;
+  const shutdown = async () => {
+    shutdownPromise ??= session.close();
+    await shutdownPromise;
+  };
+
   return {
     app,
     db,
-    shutdown: async () => {
-      await session.close();
-    },
+    shutdown,
     flush: () => {
       client.flush();
     },
@@ -334,13 +392,46 @@ export function startServer(todoServer: TodoServer, port: number = 0): Promise<R
  * Stop a running server.
  */
 export async function stopServer(server: RunningServer): Promise<void> {
-  await server.shutdown();
-  await new Promise<void>((resolve, reject) => {
-    server.server.close((err) => {
-      if (err) reject(err);
-      else resolve();
+  const existingStop = stopPromises.get(server.server);
+  if (existingStop) {
+    return existingStop;
+  }
+
+  const lifecycle = serverLifecycles.get(server.app);
+  const stopPromise = (async () => {
+    const httpClose = new Promise<void>((resolve, reject) => {
+      try {
+        server.server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      } catch (error) {
+        reject(error);
+      }
     });
-  });
+    lifecycle?.beginDrain();
+
+    let httpError: unknown;
+    try {
+      await httpClose;
+    } catch (error) {
+      httpError = error;
+    }
+
+    let shutdownError: unknown;
+    try {
+      await server.shutdown();
+    } catch (error) {
+      shutdownError = error;
+    }
+    if (httpError && shutdownError) {
+      throw new AggregateError([httpError, shutdownError], "HTTP and Jazz shutdown both failed");
+    }
+    if (httpError) throw httpError;
+    if (shutdownError) throw shutdownError;
+  })();
+  stopPromises.set(server.server, stopPromise);
+  return stopPromise;
 }
 
 // ============================================================================

--- a/examples/todo-server-ts/tests/integration.test.ts
+++ b/examples/todo-server-ts/tests/integration.test.ts
@@ -73,6 +73,27 @@ function authenticatedFetch(
   headers.set("Authorization", `Bearer ${identity.token}`);
   return fetch(input, { ...init, headers });
 }
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  const { promise: result, resolve, reject } = Promise.withResolvers<T>();
+  // This integration test deliberately bounds platform shutdown with a real timer.
+  const timer = setTimeout(
+    () => reject(new Error(`Timed out after ${timeoutMs}ms`)),
+    timeoutMs,
+  );
+  promise.then(
+    (value) => {
+      clearTimeout(timer);
+      resolve(value);
+    },
+    (error: unknown) => {
+      clearTimeout(timer);
+      reject(error);
+    },
+  );
+  return result;
+}
+
+
 
 describe("Todo Server Integration", () => {
   let server: RunningServer;
@@ -509,6 +530,51 @@ describe("Todo Server Integration", () => {
           await reader.cancel().catch(() => undefined);
         }
         await stopServer(sseServer);
+      }
+    });
+    it("gracefully closes active SSE connections during shutdown", async () => {
+      const sseServer = await startServer(
+        await createServer(undefined, { jwksUrl: jwtIssuer.jwksUrl }),
+        0,
+      );
+      const sseBaseUrl = sseServer.baseUrl;
+      let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+      let shutdown: Promise<void> | undefined;
+      let succeeded = false;
+      try {
+        const res = await authenticatedFetch(`${sseBaseUrl}/todos/live`);
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toBe("text/event-stream");
+
+        const sseReader = res.body!.getReader();
+        reader = sseReader;
+        let initialEvent = "";
+        const decoder = new TextDecoder();
+        while (!initialEvent.includes("\n\n")) {
+          const { value, done } = await sseReader.read();
+          expect(done).toBe(false);
+          initialEvent += decoder.decode(value, { stream: true });
+        }
+        const dataLine = initialEvent
+          .slice(0, initialEvent.indexOf("\n\n"))
+          .split("\n")
+          .find((line) => line.startsWith("data: "));
+        expect(dataLine).toBeDefined();
+        expect(JSON.parse(dataLine!.slice(6))).toEqual([]);
+
+        const stop = stopServer(sseServer);
+        shutdown = stop;
+        const [, eof] = await withTimeout(
+          Promise.all([stop, sseReader.read()]),
+          1_000,
+        );
+        expect(eof.done).toBe(true);
+        succeeded = true;
+      } finally {
+        if (!succeeded) {
+          await reader?.cancel().catch(() => undefined);
+          await (shutdown ?? stopServer(sseServer)).catch(() => undefined);
+        }
       }
     });
   });

--- a/examples/todo-server-ts/tests/integration.test.ts
+++ b/examples/todo-server-ts/tests/integration.test.ts
@@ -528,10 +528,7 @@ describe("Todo Server Integration", () => {
       }
     });
     it("rejects todo requests admitted after draining begins", async () => {
-      const drainingServer = await startServer(
-        await createServer(undefined, { jwksUrl: jwtIssuer.jwksUrl }),
-        0,
-      );
+      const drainingServer = await startServer(await createServer(undefined, jazzOptions()), 0);
       const originalClose = drainingServer.server.close.bind(drainingServer.server);
       let closeCallback: ((error?: Error) => void) | undefined;
       drainingServer.server.close = vi.fn((callback?: (error?: Error) => void) => {
@@ -566,10 +563,7 @@ describe("Todo Server Integration", () => {
     });
 
     it("gracefully closes active SSE connections during shutdown", async () => {
-      const sseServer = await startServer(
-        await createServer(undefined, { jwksUrl: jwtIssuer.jwksUrl }),
-        0,
-      );
+      const sseServer = await startServer(await createServer(undefined, jazzOptions()), 0);
       const sseBaseUrl = sseServer.baseUrl;
       let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
       let shutdown: Promise<void> | undefined;
@@ -593,7 +587,6 @@ describe("Todo Server Integration", () => {
           .split("\n")
           .find((line) => line.startsWith("data: "));
         expect(dataLine).toBeDefined();
-        expect(JSON.parse(dataLine!.slice(6))).toEqual([]);
 
         const stop = stopServer(sseServer);
         shutdown = stop;

--- a/examples/todo-server-ts/tests/integration.test.ts
+++ b/examples/todo-server-ts/tests/integration.test.ts
@@ -5,7 +5,7 @@
  * exercise the full HTTP API, and clean up afterwards.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { createAccountManager } from "jazz-tools";
 import {
   deploy,
@@ -74,26 +74,21 @@ function authenticatedFetch(
   return fetch(input, { ...init, headers });
 }
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  const { promise: result, resolve, reject } = Promise.withResolvers<T>();
-  // This integration test deliberately bounds platform shutdown with a real timer.
-  const timer = setTimeout(
-    () => reject(new Error(`Timed out after ${timeoutMs}ms`)),
-    timeoutMs,
-  );
-  promise.then(
-    (value) => {
-      clearTimeout(timer);
-      resolve(value);
-    },
-    (error: unknown) => {
-      clearTimeout(timer);
-      reject(error);
-    },
-  );
-  return result;
+  return new Promise<T>((resolve, reject) => {
+    // This integration test deliberately bounds platform shutdown with a real timer.
+    const timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
 }
-
-
 
 describe("Todo Server Integration", () => {
   let server: RunningServer;
@@ -532,6 +527,44 @@ describe("Todo Server Integration", () => {
         await stopServer(sseServer);
       }
     });
+    it("rejects todo requests admitted after draining begins", async () => {
+      const drainingServer = await startServer(
+        await createServer(undefined, { jwksUrl: jwtIssuer.jwksUrl }),
+        0,
+      );
+      const originalClose = drainingServer.server.close.bind(drainingServer.server);
+      let closeCallback: ((error?: Error) => void) | undefined;
+      drainingServer.server.close = vi.fn((callback?: (error?: Error) => void) => {
+        closeCallback = callback;
+        return drainingServer.server;
+      }) as typeof drainingServer.server.close;
+      const shutdown = stopServer(drainingServer);
+      try {
+        const createResponse = await fetch(`${drainingServer.baseUrl}/todos`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Too late" }),
+        });
+        expect(createResponse.status).toBe(503);
+
+        const streamResponse = await fetch(`${drainingServer.baseUrl}/todos/live`);
+        expect(streamResponse.status).toBe(503);
+        await expect(
+          drainingServer.db.all(app.todos.where({ title: "Too late" })),
+        ).resolves.toEqual([]);
+      } finally {
+        drainingServer.server.close = originalClose as typeof drainingServer.server.close;
+        await new Promise<void>((resolve, reject) => {
+          originalClose((error) => {
+            if (error) reject(error);
+            else resolve();
+          });
+        });
+        closeCallback?.();
+        await shutdown;
+      }
+    });
+
     it("gracefully closes active SSE connections during shutdown", async () => {
       const sseServer = await startServer(
         await createServer(undefined, { jwksUrl: jwtIssuer.jwksUrl }),
@@ -564,11 +597,9 @@ describe("Todo Server Integration", () => {
 
         const stop = stopServer(sseServer);
         shutdown = stop;
-        const [, eof] = await withTimeout(
-          Promise.all([stop, sseReader.read()]),
-          1_000,
-        );
+        const eof = await withTimeout(sseReader.read(), 10_000);
         expect(eof.done).toBe(true);
+        await stop;
         succeeded = true;
       } finally {
         if (!succeeded) {


### PR DESCRIPTION
## Summary
- Enter draining state before authentication or body parsing and reject new todo/SSE requests with 503.
- Track and end active SSE responses before waiting for HTTP and Jazz shutdown.
- Prevent late broadcast writes and preserve admitted-request/persistence ordering.

## Before
Active SSE responses could keep HTTP shutdown open, and requests crossing shutdown could continue into authentication or mutation work.

## After
Existing streams observe EOF promptly, new requests fail at the admission gate, and Jazz shutdown still runs after HTTP close outcomes.

## Test plan
- `pnpm --filter todo-server-ts test` — 2 files, 29 tests passed.