### PR TITLE
Resolve create-jazz app names after option values

### DIFF
--- a/.changeset/create-app-name-options.md
+++ b/.changeset/create-app-name-options.md
@@ -1,0 +1,5 @@
+---
+"create-jazz": patch
+---
+
+Ignore option values when resolving the generated application name.

--- a/packages/create-jazz/src/cli.integration.test.ts
+++ b/packages/create-jazz/src/cli.integration.test.ts
@@ -120,9 +120,9 @@ describe("create-jazz CLI end-to-end", () => {
       expect(fs.existsSync(appDir), "scaffolded directory should use the positional name").toBe(
         true,
       );
-      expect(
-        JSON.parse(fs.readFileSync(path.join(appDir, "package.json"), "utf-8")).name,
-      ).toBe("starter-before-name");
+      expect(JSON.parse(fs.readFileSync(path.join(appDir, "package.json"), "utf-8")).name).toBe(
+        "starter-before-name",
+      );
     },
   );
 
@@ -170,9 +170,9 @@ describe("create-jazz CLI end-to-end", () => {
       expect(fs.existsSync(appDir), "scaffolded directory should use the positional name").toBe(
         true,
       );
-      expect(
-        JSON.parse(fs.readFileSync(path.join(appDir, "package.json"), "utf-8")).name,
-      ).toBe("hosting-before-name");
+      expect(JSON.parse(fs.readFileSync(path.join(appDir, "package.json"), "utf-8")).name).toBe(
+        "hosting-before-name",
+      );
       expect(fs.existsSync(path.join(appDir, ".git")), "--no-git should be preserved").toBe(false);
     },
   );

--- a/packages/create-jazz/src/cli.integration.test.ts
+++ b/packages/create-jazz/src/cli.integration.test.ts
@@ -77,6 +77,105 @@ describe("create-jazz CLI end-to-end", () => {
       }
     },
   );
+  it(
+    "uses the first positional app name after a separate --starter value",
+    { timeout: 60_000 },
+    () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "create-jazz-cli-starter-before-name-"));
+
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        JAZZ_STARTER_PATH: path.join(repoRoot, "starters/next-betterauth"),
+        GIT_AUTHOR_NAME: "create-jazz tests",
+        GIT_AUTHOR_EMAIL: "tests@create-jazz.invalid",
+        GIT_COMMITTER_NAME: "create-jazz tests",
+        GIT_COMMITTER_EMAIL: "tests@create-jazz.invalid",
+      };
+      delete env.npm_config_user_agent;
+
+      const result = spawnSync(
+        tsxBin,
+        [
+          cliEntry,
+          "--starter",
+          "next-betterauth",
+          "starter-before-name",
+          "--starter=next-betterauth",
+          "--hosting=selfhosted",
+        ],
+        {
+          cwd: tmpDir,
+          env,
+          encoding: "utf-8",
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+
+      expect(
+        result.status,
+        `CLI exited non-zero. stdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+      ).toBe(0);
+
+      const appDir = path.join(tmpDir, "starter-before-name");
+      expect(fs.existsSync(appDir), "scaffolded directory should use the positional name").toBe(
+        true,
+      );
+      expect(
+        JSON.parse(fs.readFileSync(path.join(appDir, "package.json"), "utf-8")).name,
+      ).toBe("starter-before-name");
+    },
+  );
+
+  it(
+    "uses the first positional app name after a separate --hosting value",
+    { timeout: 60_000 },
+    () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "create-jazz-cli-hosting-before-name-"));
+
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        JAZZ_STARTER_PATH: path.join(repoRoot, "starters/next-betterauth"),
+        GIT_AUTHOR_NAME: "create-jazz tests",
+        GIT_AUTHOR_EMAIL: "tests@create-jazz.invalid",
+        GIT_COMMITTER_NAME: "create-jazz tests",
+        GIT_COMMITTER_EMAIL: "tests@create-jazz.invalid",
+      };
+      delete env.npm_config_user_agent;
+
+      const result = spawnSync(
+        tsxBin,
+        [
+          cliEntry,
+          "--hosting",
+          "selfhosted",
+          "hosting-before-name",
+          "--starter=next-betterauth",
+          "--hosting=selfhosted",
+          "--no-git",
+        ],
+        {
+          cwd: tmpDir,
+          env,
+          encoding: "utf-8",
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+
+      expect(
+        result.status,
+        `CLI exited non-zero. stdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+      ).toBe(0);
+
+      const appDir = path.join(tmpDir, "hosting-before-name");
+      expect(fs.existsSync(appDir), "scaffolded directory should use the positional name").toBe(
+        true,
+      );
+      expect(
+        JSON.parse(fs.readFileSync(path.join(appDir, "package.json"), "utf-8")).name,
+      ).toBe("hosting-before-name");
+      expect(fs.existsSync(path.join(appDir, ".git")), "--no-git should be preserved").toBe(false);
+    },
+  );
 
   hostedIt(
     "scaffolds a hosted project and provisions Jazz Cloud when CREATE_JAZZ_HOSTED_E2E=1",

--- a/packages/create-jazz/src/index.ts
+++ b/packages/create-jazz/src/index.ts
@@ -90,6 +90,18 @@ function readFlagValue(args: string[], name: string): string | undefined {
   return undefined;
 }
 
+function readAppName(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--starter" || arg === "--hosting") {
+      i++;
+      continue;
+    }
+    if (!arg.startsWith("-")) return arg;
+  }
+  return undefined;
+}
+
 async function main() {
   const args = process.argv.slice(2);
 
@@ -102,8 +114,8 @@ async function main() {
 
   const gitOptOut = args.includes("--no-git");
 
-  // App name is the first non-flag argument
-  const argvName = args.find((a) => !a.startsWith("-"));
+  // App name is the first non-flag argument after recognized flag values.
+  const argvName = readAppName(args);
 
   // #146aff brand blue via 24-bit ANSI escape
   const blue = (s: string) => `\x1b[38;2;20;106;255m${s}\x1b[39m`;


### PR DESCRIPTION
## Summary
- parse the application name after consuming option values
- prevent option arguments from becoming the generated directory name

## Testing
- red `eed9c33609`: 2 failed
- green CLI integration: 4 passed, 1 skipped

Changeset: `.changeset/create-app-name-options.md`