### PR TITLE
Validate auxiliary envelopes on the current main

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -655,8 +655,6 @@ pub struct Transport {
     inner: NapiTransportInner,
     queues: WireQueues,
     auxiliary_pump: jazz::db::PeerIoPump,
-    protocol_version: u16,
-    features: u64,
 }
 
 #[napi(js_name = "Subscription")]
@@ -970,7 +968,7 @@ impl Transport {
     ) -> napi::Result<Option<Uint8Array>> {
         core_block_on(
             self.auxiliary_pump
-                .route_incoming_wire_frame(frame.to_vec(), self.features),
+                .route_incoming_wire_frame(frame.to_vec()),
         )
         .map(|frame| frame.map(Uint8Array::new))
         .map_err(napi::Error::from_reason)
@@ -981,7 +979,7 @@ impl Transport {
         let mut frames = Vec::new();
         while let Some(frame) = self
             .auxiliary_pump
-            .take_outbound_wire_frame(self.protocol_version, self.features, None)
+            .take_outbound_wire_frame()
             .map_err(napi::Error::from_reason)?
         {
             frames.push(Uint8Array::new(frame));
@@ -4415,10 +4413,6 @@ impl NapiDb {
             inner,
             queues,
             auxiliary_pump,
-            protocol_version: jazz::wire::WIRE_PROTOCOL_VERSION,
-            features: jazz::wire::current_wire_features()
-                & !(jazz::wire::FEATURE_AUTHORIZATION_SCOPE_RECEIPTS
-                    | jazz::wire::FEATURE_AUTHORIZATION_SCOPE_VIEWS),
         })
     }
 
@@ -4502,8 +4496,6 @@ impl NapiDb {
             inner,
             queues,
             auxiliary_pump,
-            protocol_version,
-            features,
         })
     }
 
@@ -5658,7 +5650,7 @@ struct JazzServerLifecycle {
 }
 
 enum JazzServerState {
-    Running(JazzServerInner),
+    Running(Box<JazzServerInner>),
     Stopping,
     Stopped(std::result::Result<(), String>),
 }
@@ -5826,7 +5818,7 @@ impl JazzServer {
         if let Some(server) = shutdown_owner {
             let lifecycle = Arc::clone(&self.lifecycle);
             tokio::spawn(async move {
-                let result = AssertUnwindSafe(shutdown_jazz_server(server))
+                let result = AssertUnwindSafe(shutdown_jazz_server(*server))
                     .catch_unwind()
                     .await
                     .unwrap_or_else(|_| Err("JazzServer shutdown task panicked".to_owned()));
@@ -5870,7 +5862,7 @@ impl JazzServer {
         let (changed, _) = tokio::sync::watch::channel(());
         Self {
             lifecycle: Arc::new(JazzServerLifecycle {
-                state: Mutex::new(JazzServerState::Running(inner)),
+                state: Mutex::new(JazzServerState::Running(Box::new(inner))),
                 changed,
             }),
         }
@@ -5883,7 +5875,7 @@ impl JazzServer {
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
         match &*state {
-            JazzServerState::Running(server) => Ok(f(server)),
+            JazzServerState::Running(server) => Ok(f(server.as_ref())),
             JazzServerState::Stopping => Err(napi::Error::from_reason("JazzServer is stopping")),
             JazzServerState::Stopped(_) => {
                 Err(napi::Error::from_reason("JazzServer has been stopped"))

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -515,8 +515,6 @@ pub struct WasmTransport {
     inner: WasmTransportInner,
     queues: WasmWireQueues,
     auxiliary_pump: jazz::db::PeerIoPump,
-    protocol_version: u16,
-    features: u64,
     subscriber_identity: Option<AuthorSubject>,
 }
 
@@ -2936,10 +2934,6 @@ impl WasmDb {
                 inner,
                 queues,
                 auxiliary_pump,
-                protocol_version: jazz::wire::WIRE_PROTOCOL_VERSION,
-                features: jazz::wire::current_wire_features()
-                    & !(jazz::wire::FEATURE_AUTHORIZATION_SCOPE_RECEIPTS
-                        | jazz::wire::FEATURE_AUTHORIZATION_SCOPE_VIEWS),
                 subscriber_identity: None,
             }
             .into())
@@ -3006,8 +3000,6 @@ impl WasmDb {
                 inner,
                 queues,
                 auxiliary_pump,
-                protocol_version,
-                features: features as u64,
                 subscriber_identity: None,
             }
             .into())
@@ -3084,10 +3076,6 @@ impl WasmDb {
             inner,
             queues,
             auxiliary_pump,
-            protocol_version: jazz::wire::WIRE_PROTOCOL_VERSION,
-            features: jazz::wire::current_wire_features()
-                & !(jazz::wire::FEATURE_AUTHORIZATION_SCOPE_RECEIPTS
-                    | jazz::wire::FEATURE_AUTHORIZATION_SCOPE_VIEWS),
             subscriber_identity: Some(identity),
         })
     }
@@ -3196,10 +3184,9 @@ impl WasmTransport {
     #[wasm_bindgen(js_name = routeAuxiliaryWireFrame)]
     pub fn route_auxiliary_wire_frame(&self, frame: Vec<u8>) -> js_sys::Promise {
         let pump = self.auxiliary_pump.clone();
-        let features = self.features;
         future_to_promise(async move {
             match pump
-                .route_incoming_wire_frame(frame, features)
+                .route_incoming_wire_frame(frame)
                 .await
                 .map_err(|error| JsValue::from_str(&error))?
             {
@@ -3226,13 +3213,7 @@ impl WasmTransport {
         let frames = js_sys::Array::new();
         for frame in self
             .auxiliary_pump
-            .take_outbound_wire_frames(
-                self.protocol_version,
-                self.features,
-                None,
-                max_frames,
-                max_bytes,
-            )
+            .take_outbound_wire_frames(max_frames, max_bytes)
             .map_err(|error| JsValue::from_str(&error))?
         {
             frames.push(&js_sys::Uint8Array::from(frame.as_slice()).into());
@@ -5024,16 +5005,18 @@ mod dynamic_schema_view_tests {
             &serde_json::to_string(&("https://wasm.test", "subscriber")).unwrap(),
         )
         .unwrap();
-        let mut transport = binding
+        let transport = binding
             .accept_subscriber(subscriber.canonical().as_bytes().to_vec(), JsValue::NULL)
             .expect("accept a real wasm subscriber transport");
 
-        // Encode against the exact binding-local negotiation surface. The
-        // subscriber transport intentionally omits authorization-scope
-        // extensions, whose feature-gated enum layout must not leak into this
-        // auxiliary frame.
-        transport.features &= !(jazz::wire::FEATURE_PAYLOAD_LZ4 | jazz::wire::FEATURE_PAYLOAD_ZSTD);
-        let features = transport.features;
+        // Decode against the exact feature set carried by an auxiliary frame.
+        // The pump strips compression bits because each auxiliary payload is an
+        // independently encoded complete envelope.
+        let features = jazz::wire::current_wire_features()
+            & !(jazz::wire::FEATURE_AUTHORIZATION_SCOPE_RECEIPTS
+                | jazz::wire::FEATURE_AUTHORIZATION_SCOPE_VIEWS
+                | jazz::wire::FEATURE_PAYLOAD_LZ4
+                | jazz::wire::FEATURE_PAYLOAD_ZSTD);
         let request = |request_id| jazz::protocol::ChunkRequestEntry {
             request_id,
             locator: jazz::groove::large_values::Locator::random(),

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -699,6 +699,8 @@ pub struct PeerIoPump {
     local_chunks: groove::chunks::LocalChunkReader,
     connection: u64,
     role: PeerIoPumpRole,
+    wire_inbound_context: Option<Rc<crate::wire::WireInboundContext>>,
+    wire_outbound_frame: Option<Rc<RefCell<crate::wire::WireFrame>>>,
 }
 
 /// One encoded auxiliary frame whose source obligation remains owned by this
@@ -740,14 +742,34 @@ impl PeerIoPump {
         local_chunks: groove::chunks::LocalChunkReader,
         connection: u64,
         role: PeerIoPumpRole,
+        wire_inbound_context: Option<Rc<crate::wire::WireInboundContext>>,
     ) -> Self {
         resolver.register_connection(connection, matches!(role, PeerIoPumpRole::Upstream));
+        let wire_outbound_frame = wire_inbound_context.as_ref().map(|context| {
+            let mut envelope = crate::wire::WireEnvelope::new(
+                context.expected_protocol_version(),
+                crate::wire::FEATURE_NONE,
+                Vec::new(),
+            );
+            if let Some(session) = context.expected_session().cloned() {
+                envelope = envelope.with_session(session);
+            }
+            Rc::new(RefCell::new(crate::wire::WireFrame::Message(envelope)))
+        });
         Self {
             resolver,
             local_chunks,
             connection,
             role,
+            wire_inbound_context,
+            wire_outbound_frame,
         }
+    }
+
+    fn wire_inbound_context(&self) -> Result<&crate::wire::WireInboundContext, String> {
+        self.wire_inbound_context.as_deref().ok_or_else(|| {
+            "auxiliary wire framing requires a paired wire transport adapter".to_owned()
+        })
     }
 
     /// Route an auxiliary message received by the binding. Returns `false` for
@@ -891,17 +913,17 @@ impl PeerIoPump {
     pub async fn route_incoming_wire_frame(
         &self,
         frame: Vec<u8>,
-        negotiated_features: crate::wire::WireFeatures,
     ) -> Result<Option<Vec<u8>>, String> {
         let decoded = crate::wire::decode_frame(&frame)
             .map_err(|error| format!("malformed auxiliary wire frame: {error}"))?;
         let crate::wire::WireFrame::Message(envelope) = decoded else {
             return Ok(Some(frame));
         };
-        let payload = crate::wire::decompress_sync_payload(&envelope.payload, envelope.features)
-            .map_err(|error| format!("malformed auxiliary wire payload: {error}"))?;
-        let message = crate::wire::decode_sync_message_for_features(&payload, negotiated_features)
-            .map_err(|error| format!("malformed auxiliary sync payload: {error:?}"))?;
+        let context = self.wire_inbound_context()?;
+        let mut decoder = crate::wire::WireStreamDecoder::new(context.negotiated_features())
+            .map_err(|error| format!("invalid auxiliary wire context: {error}"))?;
+        let message = crate::wire::admit_complete_envelope(context, &mut decoder, envelope)
+            .map_err(|error| format!("malformed auxiliary wire envelope: {error:?}"))?;
         match self.route_incoming(message).await {
             Ok(()) => Ok(None),
             Err(_) => Ok(Some(frame)),
@@ -911,15 +933,8 @@ impl PeerIoPump {
     /// Encode one bounded auxiliary batch as an ordinary complete wire frame.
     /// Bindings request one chunk per frame, keeping the maximum 256 KiB node
     /// response below the non-fragmented wire-frame bound.
-    pub fn take_outbound_wire_frame(
-        &self,
-        protocol_version: u16,
-        negotiated_features: crate::wire::WireFeatures,
-        session: Option<crate::wire::WireSession>,
-    ) -> Result<Option<Vec<u8>>, String> {
-        let Some(mut reservation) =
-            self.reserve_outbound_wire_frame(protocol_version, negotiated_features, session)?
-        else {
+    pub fn take_outbound_wire_frame(&self) -> Result<Option<Vec<u8>>, String> {
+        let Some(mut reservation) = self.reserve_outbound_wire_frame()? else {
             return Ok(None);
         };
         let frame = reservation.take_frame();
@@ -932,19 +947,12 @@ impl PeerIoPump {
     /// it after a rejected send; dropping it also restores the original batch.
     pub(crate) fn reserve_outbound_wire_frame(
         &self,
-        protocol_version: u16,
-        negotiated_features: crate::wire::WireFeatures,
-        session: Option<crate::wire::WireSession>,
     ) -> Result<Option<ReservedOutboundWireFrame>, String> {
+        let context = self.wire_inbound_context()?;
         let Some(message) = self.take_outbound(1) else {
             return Ok(None);
         };
-        let frame = match Self::encode_outbound_wire_frame(
-            message.clone(),
-            protocol_version,
-            negotiated_features,
-            session,
-        ) {
+        let frame = match self.encode_outbound_wire_frame(message.clone(), context) {
             Ok(frame) => frame,
             Err(error) => {
                 self.restore_outbound(message);
@@ -964,27 +972,20 @@ impl PeerIoPump {
     /// transport chooses a smaller batch boundary.
     pub fn take_outbound_wire_frames(
         &self,
-        protocol_version: u16,
-        negotiated_features: crate::wire::WireFeatures,
-        session: Option<crate::wire::WireSession>,
         max_frames: usize,
         max_bytes: usize,
     ) -> Result<Vec<Vec<u8>>, String> {
         if max_frames == 0 || max_bytes == 0 {
             return Ok(Vec::new());
         }
+        let context = self.wire_inbound_context()?;
         let mut frames = Vec::new();
         let mut total_bytes: usize = 0;
         while frames.len() < max_frames {
             let Some(message) = self.take_outbound(1) else {
                 break;
             };
-            let frame = Self::encode_outbound_wire_frame(
-                message.clone(),
-                protocol_version,
-                negotiated_features,
-                session.clone(),
-            );
+            let frame = self.encode_outbound_wire_frame(message.clone(), context);
             let frame = match frame {
                 Ok(frame) => frame,
                 Err(error) => {
@@ -1014,22 +1015,34 @@ impl PeerIoPump {
     }
 
     fn encode_outbound_wire_frame(
+        &self,
         message: SyncMessage,
-        protocol_version: u16,
-        negotiated_features: crate::wire::WireFeatures,
-        session: Option<crate::wire::WireSession>,
+        context: &crate::wire::WireInboundContext,
     ) -> Result<Vec<u8>, String> {
+        let negotiated_features = context.negotiated_features();
         let payload = crate::wire::encode_sync_message_for_features(&message, negotiated_features)
             .map_err(|error| format!("cannot encode auxiliary sync payload: {error:?}"))?;
         let active_features = negotiated_features
             & !(crate::wire::FEATURE_PAYLOAD_LZ4 | crate::wire::FEATURE_PAYLOAD_ZSTD);
-        let mut envelope =
-            crate::wire::WireEnvelope::new(protocol_version, active_features, payload);
-        if let Some(session) = session {
-            envelope = envelope.with_session(session);
+        let wire_outbound_frame = self.wire_outbound_frame.as_ref().ok_or_else(|| {
+            "auxiliary wire framing requires a paired wire transport adapter".to_owned()
+        })?;
+        let mut frame = wire_outbound_frame.borrow_mut();
+        {
+            let crate::wire::WireFrame::Message(envelope) = &mut *frame else {
+                unreachable!("auxiliary outbound template is always a message frame");
+            };
+            envelope.protocol_version = context.expected_protocol_version();
+            envelope.features = active_features;
+            envelope.payload = payload;
         }
-        crate::wire::encode_frame(&crate::wire::WireFrame::Message(envelope))
-            .map_err(|error| format!("cannot encode auxiliary wire frame: {error}"))
+        let encoded = crate::wire::encode_frame(&frame)
+            .map_err(|error| format!("cannot encode auxiliary wire frame: {error}"));
+        let crate::wire::WireFrame::Message(envelope) = &mut *frame else {
+            unreachable!("auxiliary outbound template is always a message frame");
+        };
+        envelope.payload = Vec::new();
+        encoded
     }
 
     /// Drain one bounded auxiliary batch for immediate transmission.

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -1714,6 +1714,7 @@ where
         let confirmation_floor = node.committed_global_time();
         drop(node);
         let session_context = transport.connection_session_context();
+        let wire_inbound_context = transport.wire_inbound_context().map(Rc::new);
         let upstream_upload_destination =
             session_context.map(|context| UpstreamUploadDestination {
                 remote_node: *context.remote.node.as_bytes(),
@@ -1975,6 +1976,7 @@ where
                 self.local_chunk_reader.clone(),
                 connection_epoch,
                 PeerIoPumpRole::Upstream,
+                wire_inbound_context,
             ),
         }));
         self.connections.borrow_mut().push(Rc::clone(&connection));
@@ -2230,6 +2232,7 @@ where
             .connection_session_context()
             .map(|context| context.local.epoch)
             .unwrap_or_else(|| uuid::Uuid::new_v4().as_u128() as u64);
+        let wire_inbound_context = transport.wire_inbound_context().map(Rc::new);
         let downstream_fates = Rc::new(RefCell::new(Vec::new()));
         let scope_mismatch = self
             .node
@@ -2313,6 +2316,7 @@ where
                 self.local_chunk_reader.clone(),
                 connection_epoch,
                 PeerIoPumpRole::Subscriber,
+                wire_inbound_context,
             ),
         }));
         self.connections.borrow_mut().push(Rc::clone(&connection));
@@ -4039,6 +4043,12 @@ pub trait Transport {
     fn send(&mut self, message: SyncMessage) -> Result<(), TransportError>;
     /// Pull the next inbound message the binding has staged, if any.
     fn try_recv(&mut self) -> Option<SyncMessage>;
+
+    /// Return the immutable wire admission context paired with this transport.
+    #[doc(hidden)]
+    fn wire_inbound_context(&self) -> Option<crate::wire::WireInboundContext> {
+        None
+    }
 
     /// Immutable endpoint facts accepted by authenticated session admission.
     /// Semantic messages never self-assert this context.

--- a/crates/jazz/src/db/tests/chunk_io_pump.rs
+++ b/crates/jazz/src/db/tests/chunk_io_pump.rs
@@ -7,7 +7,10 @@ use std::task::{Context, Poll, Waker};
 use groove::chunks::{ChunkKvStorage, ChunkProvider, ChunkStorage, MissingChunkResolver};
 
 use super::super::*;
-use super::{duplex, open_db, schema};
+use super::{
+    FEATURE_SYNC_MESSAGE_PAYLOAD, WIRE_PROTOCOL_VERSION, WireEnvelope, WireFrame, duplex,
+    encode_frame, open_db, schema,
+};
 
 #[derive(Default)]
 struct DeferredChunkStorage {
@@ -77,6 +80,14 @@ fn retained_relay_obligations(state: &ChunkDemandState) -> usize {
     state.relay_chunk_obligations
 }
 
+fn test_wire_inbound_context() -> Option<Rc<crate::wire::WireInboundContext>> {
+    Some(Rc::new(crate::wire::WireInboundContext::new(
+        WIRE_PROTOCOL_VERSION,
+        crate::wire::current_wire_features(),
+        None,
+    )))
+}
+
 #[test]
 fn auxiliary_pump_completes_a_suspended_groove_chunk_read_without_a_semantic_tick() {
     crate::db::block_on(async {
@@ -112,12 +123,14 @@ fn auxiliary_pump_completes_a_suspended_groove_chunk_read_without_a_semantic_tic
             destination_database.local_chunk_reader(),
             1,
             PeerIoPumpRole::Upstream,
+            test_wire_inbound_context(),
         );
         let upstream = PeerIoPump::new(
             resolver.clone(),
             source_database.local_chunk_reader(),
             2,
             PeerIoPumpRole::Subscriber,
+            test_wire_inbound_context(),
         );
         let provider = groove::chunks::StorageChunkProvider::with_resolver(
             destination.clone(),
@@ -135,37 +148,16 @@ fn auxiliary_pump_completes_a_suspended_groove_chunk_read_without_a_semantic_tic
             Poll::Pending
         ));
 
-        let features = crate::wire::current_wire_features();
         assert!(
             upstream
-                .route_incoming_wire_frame(
-                    downstream
-                        .take_outbound_wire_frame(
-                            crate::wire::WIRE_PROTOCOL_VERSION,
-                            features,
-                            None,
-                        )
-                        .unwrap()
-                        .unwrap(),
-                    features,
-                )
+                .route_incoming_wire_frame(downstream.take_outbound_wire_frame().unwrap().unwrap(),)
                 .await
                 .unwrap()
                 .is_none()
         );
         assert!(
             downstream
-                .route_incoming_wire_frame(
-                    upstream
-                        .take_outbound_wire_frame(
-                            crate::wire::WIRE_PROTOCOL_VERSION,
-                            features,
-                            None,
-                        )
-                        .unwrap()
-                        .unwrap(),
-                    features,
-                )
+                .route_incoming_wire_frame(upstream.take_outbound_wire_frame().unwrap().unwrap(),)
                 .await
                 .unwrap()
                 .is_none()
@@ -200,6 +192,7 @@ fn subscriber_auxiliary_responses_are_bounded_to_one_chunk_per_wire_frame() {
         database.local_chunk_reader(),
         23,
         PeerIoPumpRole::Subscriber,
+        test_wire_inbound_context(),
     );
     let response_count = 10;
     let chunk_bytes = vec![0x5a; groove::large_values::LEAF_MAX_BYTES];
@@ -221,7 +214,7 @@ fn subscriber_auxiliary_responses_are_bounded_to_one_chunk_per_wire_frame() {
     let mut observed_request_ids = Vec::new();
     for _ in 0..response_count {
         let frame = subscriber
-            .take_outbound_wire_frame(crate::wire::WIRE_PROTOCOL_VERSION, features, None)
+            .take_outbound_wire_frame()
             .unwrap()
             .expect("each queued response has its own wire frame");
         assert!(
@@ -246,12 +239,7 @@ fn subscriber_auxiliary_responses_are_bounded_to_one_chunk_per_wire_frame() {
         observed_request_ids,
         (0..response_count).collect::<Vec<_>>()
     );
-    assert!(
-        subscriber
-            .take_outbound_wire_frame(crate::wire::WIRE_PROTOCOL_VERSION, features, None)
-            .unwrap()
-            .is_none()
-    );
+    assert!(subscriber.take_outbound_wire_frame().unwrap().is_none());
 }
 
 #[test]
@@ -269,6 +257,7 @@ fn bounded_auxiliary_drain_keeps_large_response_batches_fifo_and_within_bytes() 
         database.local_chunk_reader(),
         24,
         PeerIoPumpRole::Subscriber,
+        test_wire_inbound_context(),
     );
     let response_count = 32_u64;
     let chunk_bytes = vec![0x3c; groove::large_values::LEAF_MAX_BYTES];
@@ -291,13 +280,7 @@ fn bounded_auxiliary_drain_keeps_large_response_batches_fifo_and_within_bytes() 
     let mut observed_request_ids = Vec::new();
     loop {
         let frames = subscriber
-            .take_outbound_wire_frames(
-                crate::wire::WIRE_PROTOCOL_VERSION,
-                features,
-                None,
-                8,
-                byte_budget,
-            )
+            .take_outbound_wire_frames(8, byte_budget)
             .unwrap();
         if frames.is_empty() {
             break;
@@ -349,6 +332,7 @@ fn dropping_the_last_suspended_consumer_cancels_unsent_chunk_demand() {
         database.local_chunk_reader(),
         9,
         PeerIoPumpRole::Upstream,
+        test_wire_inbound_context(),
     );
     let request = groove::chunks::ChunkRequest {
         object_hash: [4; 32],
@@ -380,6 +364,7 @@ fn failed_send_restore_keeps_its_relay_reservation_across_later_admission() {
         database.local_chunk_reader(),
         40,
         PeerIoPumpRole::Subscriber,
+        test_wire_inbound_context(),
     );
     let shared = ChunkRequestEntry {
         request_id: 0,
@@ -451,6 +436,7 @@ fn reserved_wire_chunk_request_retries_after_backpressure_without_changing_its_i
             database.local_chunk_reader(),
             47,
             PeerIoPumpRole::Upstream,
+            test_wire_inbound_context(),
         );
         let mut pending = resolver.resolve(groove::chunks::ChunkRequest {
             object_hash: [47; 32],
@@ -465,14 +451,14 @@ fn reserved_wire_chunk_request_retries_after_backpressure_without_changing_its_i
 
         let features = crate::wire::current_wire_features();
         let mut first = pump
-            .reserve_outbound_wire_frame(crate::wire::WIRE_PROTOCOL_VERSION, features, None)
+            .reserve_outbound_wire_frame()
             .unwrap()
             .expect("chunk request is reserved for the first send");
         let first_frame = first.take_frame();
         drop(first);
 
         let mut retry = pump
-            .reserve_outbound_wire_frame(crate::wire::WIRE_PROTOCOL_VERSION, features, None)
+            .reserve_outbound_wire_frame()
             .unwrap()
             .expect("backpressured request remains reserved for retry");
         let retry_frame = retry.take_frame();
@@ -499,9 +485,7 @@ fn reserved_wire_chunk_request_retries_after_backpressure_without_changing_its_i
             "backpressure retries the exact same chunk request once"
         );
         assert!(
-            pump.reserve_outbound_wire_frame(crate::wire::WIRE_PROTOCOL_VERSION, features, None)
-                .unwrap()
-                .is_none(),
+            pump.reserve_outbound_wire_frame().unwrap().is_none(),
             "committing the retry consumes the request exactly once"
         );
         drop(pending);
@@ -524,6 +508,7 @@ fn reserved_wire_chunk_response_restores_its_relay_obligation_after_backpressure
         database.local_chunk_reader(),
         48,
         PeerIoPumpRole::Subscriber,
+        test_wire_inbound_context(),
     );
     let response = ChunkResponseEntry {
         request_id: 48,
@@ -535,9 +520,8 @@ fn reserved_wire_chunk_response_restores_its_relay_obligation_after_backpressure
         state.relay_chunk_obligations = 1;
     }
 
-    let features = crate::wire::current_wire_features();
     let mut first = pump
-        .reserve_outbound_wire_frame(crate::wire::WIRE_PROTOCOL_VERSION, features, None)
+        .reserve_outbound_wire_frame()
         .unwrap()
         .expect("chunk response is reserved for the first send");
     let first_frame = first.take_frame();
@@ -549,7 +533,7 @@ fn reserved_wire_chunk_response_restores_its_relay_obligation_after_backpressure
     );
 
     let mut retry = pump
-        .reserve_outbound_wire_frame(crate::wire::WIRE_PROTOCOL_VERSION, features, None)
+        .reserve_outbound_wire_frame()
         .unwrap()
         .expect("backpressured response remains reserved for retry");
     let retry_frame = retry.take_frame();
@@ -565,9 +549,7 @@ fn reserved_wire_chunk_response_restores_its_relay_obligation_after_backpressure
         "committing the retry releases the relay claim exactly once"
     );
     assert!(
-        pump.reserve_outbound_wire_frame(crate::wire::WIRE_PROTOCOL_VERSION, features, None)
-            .unwrap()
-            .is_none(),
+        pump.reserve_outbound_wire_frame().unwrap().is_none(),
         "the committed response is not replayed"
     );
 }
@@ -587,12 +569,14 @@ fn partial_drain_then_disconnect_releases_only_that_connections_obligations() {
         database.local_chunk_reader(),
         41,
         PeerIoPumpRole::Subscriber,
+        test_wire_inbound_context(),
     );
     let second = PeerIoPump::new(
         resolver.clone(),
         database.local_chunk_reader(),
         42,
         PeerIoPumpRole::Subscriber,
+        test_wire_inbound_context(),
     );
     for (connection, request_id) in [(41, 1), (41, 2), (42, 3), (42, 4)] {
         resolver.enqueue_relay(
@@ -686,6 +670,7 @@ fn completion_transfers_a_relay_reservation_until_the_response_is_acknowledged()
         database.local_chunk_reader(),
         46,
         PeerIoPumpRole::Subscriber,
+        test_wire_inbound_context(),
     );
     resolver.enqueue_relay(
         46,
@@ -728,6 +713,7 @@ fn disconnect_mid_batch_stops_later_lookup_and_drops_the_resumed_result() {
         local_chunks,
         subscriber.borrow().connection_epoch,
         PeerIoPumpRole::Subscriber,
+        test_wire_inbound_context(),
     );
     subscriber.borrow_mut().auxiliary_pump = pump.clone();
     let requests = [44_u64, 45]
@@ -880,12 +866,14 @@ fn five_concurrent_chunk_demands_are_delivered_in_two_decodable_batches() {
             destination_database.local_chunk_reader(),
             1,
             PeerIoPumpRole::Upstream,
+            test_wire_inbound_context(),
         );
         let upstream = PeerIoPump::new(
             resolver.clone(),
             source_database.local_chunk_reader(),
             2,
             PeerIoPumpRole::Subscriber,
+            test_wire_inbound_context(),
         );
         let provider =
             groove::chunks::StorageChunkProvider::with_resolver(destination, Rc::new(resolver));
@@ -942,6 +930,7 @@ fn retryable_chunk_response_preserves_retry_delay_and_allows_a_later_fulfillment
             database.local_chunk_reader(),
             41,
             PeerIoPumpRole::Upstream,
+            test_wire_inbound_context(),
         );
         let request = groove::chunks::ChunkRequest {
             object_hash: [0x41; 32],
@@ -1007,12 +996,14 @@ fn a_late_response_from_a_disconnected_upstream_cannot_complete_reassigned_deman
             database.local_chunk_reader(),
             10,
             PeerIoPumpRole::Upstream,
+            test_wire_inbound_context(),
         );
         let successor = PeerIoPump::new(
             resolver.clone(),
             database.local_chunk_reader(),
             11,
             PeerIoPumpRole::Upstream,
+            test_wire_inbound_context(),
         );
         let request = groove::chunks::ChunkRequest {
             object_hash: [6; 32],
@@ -1086,6 +1077,7 @@ fn a_later_registered_upstream_retries_demand_drained_by_a_disconnected_predeces
             database.local_chunk_reader(),
             12,
             PeerIoPumpRole::Upstream,
+            test_wire_inbound_context(),
         );
         let request = groove::chunks::ChunkRequest {
             object_hash: [7; 32],
@@ -1109,6 +1101,7 @@ fn a_later_registered_upstream_retries_demand_drained_by_a_disconnected_predeces
             database.local_chunk_reader(),
             13,
             PeerIoPumpRole::Upstream,
+            test_wire_inbound_context(),
         );
         let retried_id = match successor.take_outbound(64).unwrap() {
             SyncMessage::ChunkRequestBatch(batch) => batch.requests[0].request_id,
@@ -1143,5 +1136,145 @@ fn a_later_registered_upstream_retries_demand_drained_by_a_disconnected_predeces
             .await
             .unwrap();
         assert_eq!(pending.await.unwrap().as_ref(), &[2]);
+    });
+}
+
+#[test]
+fn complete_auxiliary_response_with_wrong_protocol_version_is_rejected_without_resolving_pending_chunk()
+ {
+    crate::db::block_on(async {
+        let resolver = PeerChunkResolver::default();
+        let database = groove::db::Database::new(
+            groove::schema::DatabaseSchema::new(Vec::<groove::schema::TableSchema>::new()),
+            groove::storage::MemoryStorage::new(&[groove::db::LARGE_VALUE_METADATA_CF])
+                .expect("valid memory storage families"),
+        )
+        .await
+        .unwrap();
+        let pump = PeerIoPump::new(
+            resolver.clone(),
+            database.local_chunk_reader(),
+            51,
+            PeerIoPumpRole::Upstream,
+            test_wire_inbound_context(),
+        );
+        let mut pending = resolver.resolve(groove::chunks::ChunkRequest {
+            object_hash: [0x51; 32],
+            locator: groove::large_values::Locator::random(),
+        });
+        let request_id = match pump.take_outbound(1).unwrap() {
+            SyncMessage::ChunkRequestBatch(batch) => batch.requests[0].request_id,
+            _ => unreachable!(),
+        };
+        let features = FEATURE_SYNC_MESSAGE_PAYLOAD | crate::wire::FEATURE_AUXILIARY_CHUNKS;
+        let payload = crate::wire::encode_sync_message(&SyncMessage::ChunkResponseBatch(
+            ChunkResponseBatch {
+                responses: vec![ChunkResponseEntry {
+                    request_id,
+                    result: ChunkResponse::Found(vec![0x51]),
+                }],
+            },
+        ))
+        .unwrap();
+        let frame = encode_frame(&WireFrame::Message(WireEnvelope::new(
+            WIRE_PROTOCOL_VERSION + 1,
+            features,
+            payload,
+        )))
+        .unwrap();
+
+        let route = pump.route_incoming_wire_frame(frame).await;
+        let waker = futures::task::noop_waker();
+        let mut context = Context::from_waker(&waker);
+        let pending_is_unchanged =
+            matches!(Pin::new(&mut pending).poll(&mut context), Poll::Pending);
+
+        assert!(
+            route.is_err() && pending_is_unchanged,
+            "a response from another protocol version must be rejected before resolving its chunk"
+        );
+    });
+}
+
+// This stays at the pump seam because bindings clone the connection's pump and
+// route auxiliary frames without re-entering the database's semantic interface.
+#[test]
+fn paired_wire_context_governs_auxiliary_frames_in_both_directions() {
+    crate::db::block_on(async {
+        let author = AuthorSubject::for_test_bytes([0x52; 16]);
+        let database = open_db(0x52, author, &schema());
+        let (client_bytes, _server_bytes) = super::byte_duplex_raw();
+        let features = FEATURE_SYNC_MESSAGE_PAYLOAD
+            | crate::wire::FEATURE_SESSION_FRAME
+            | crate::wire::FEATURE_AUXILIARY_CHUNKS;
+        let session = crate::wire::WireSession {
+            session_id: "auxiliary-context-session".to_owned(),
+            epoch: 7,
+            identity: Some(author),
+        };
+        let connection = database
+            .connect_upstream(Box::new(WireTransportAdapter::new(
+                client_bytes,
+                WIRE_PROTOCOL_VERSION,
+                features,
+                Some(session.clone()),
+            )))
+            .await;
+        let pump = connection.lock().await.io_pump();
+        let resolver = database.node.chunk_resolver.clone();
+        let mut pending = resolver.resolve(groove::chunks::ChunkRequest {
+            object_hash: [0x52; 32],
+            locator: groove::large_values::Locator::random(),
+        });
+
+        let outbound = pump
+            .take_outbound_wire_frame()
+            .unwrap()
+            .expect("pending chunk demand produces an auxiliary frame");
+        let WireFrame::Message(outbound_envelope) = crate::wire::decode_frame(&outbound).unwrap()
+        else {
+            panic!("auxiliary output must use a complete message envelope");
+        };
+        assert_eq!(outbound_envelope.protocol_version, WIRE_PROTOCOL_VERSION);
+        assert_eq!(outbound_envelope.features, features);
+        assert_eq!(outbound_envelope.session.as_ref(), Some(&session));
+        let request_id = match crate::wire::decode_sync_message_for_features(
+            &outbound_envelope.payload,
+            features,
+        )
+        .unwrap()
+        {
+            SyncMessage::ChunkRequestBatch(batch) => batch.requests[0].request_id,
+            message => panic!("expected auxiliary chunk request, got {message:?}"),
+        };
+
+        let payload = crate::wire::encode_sync_message_for_features(
+            &SyncMessage::ChunkResponseBatch(ChunkResponseBatch {
+                responses: vec![ChunkResponseEntry {
+                    request_id,
+                    result: ChunkResponse::Found(vec![0x52]),
+                }],
+            }),
+            features,
+        )
+        .unwrap();
+        let mismatched_session = crate::wire::WireSession {
+            session_id: "different-auxiliary-session".to_owned(),
+            ..session
+        };
+        let inbound = encode_frame(&WireFrame::Message(
+            WireEnvelope::new(WIRE_PROTOCOL_VERSION, features, payload)
+                .with_session(mismatched_session),
+        ))
+        .unwrap();
+
+        let route = pump.route_incoming_wire_frame(inbound).await;
+        let waker = futures::task::noop_waker();
+        let mut context = Context::from_waker(&waker);
+        assert!(route.is_err(), "a mismatched wire session must be rejected");
+        assert!(
+            matches!(Pin::new(&mut pending).poll(&mut context), Poll::Pending),
+            "rejected session metadata must not resolve the pending chunk"
+        );
     });
 }

--- a/crates/jazz/src/db/wire_transport.rs
+++ b/crates/jazz/src/db/wire_transport.rs
@@ -16,9 +16,9 @@ use crate::protocol_limits::{
 };
 use crate::wire::{
     FEATURE_MESSAGE_FRAGMENTATION, TransportError, WIRE_PROTOCOL_VERSION, WireEnvelope, WireError,
-    WireErrorCode, WireFeatures, WireFrame, WireMessageFragment, WireRetry, WireSession,
-    WireStreamDecoder, WireStreamEncoder, WireTransport, current_wire_features, decode_frame,
-    decode_sync_message_for_features, encode_frame, encode_sync_message_for_features,
+    WireErrorCode, WireFeatures, WireFrame, WireInboundContext, WireMessageFragment, WireRetry,
+    WireSession, WireStreamDecoder, WireStreamEncoder, WireTransport, admit_complete_envelope,
+    current_wire_features, decode_frame, encode_frame, encode_sync_message_for_features,
 };
 
 const WIRE_FRAGMENT_PAYLOAD_BYTES: usize = 512 * 1024;
@@ -238,9 +238,7 @@ impl LogicalMessageReassembler {
 /// Converts logical sync messages to negotiated bounded wire frames and back.
 pub struct WireTransportAdapter<T> {
     inner: T,
-    protocol_version: u16,
-    features: WireFeatures,
-    session: Option<WireSession>,
+    inbound_context: WireInboundContext,
     session_context: Option<ConnectionSessionContext>,
     permits_delegated_sessions: bool,
     outbound_stream: WireStreamEncoder,
@@ -305,9 +303,7 @@ where
             .expect("negotiated wire compression must be compiled into this binary");
         Self {
             inner,
-            protocol_version,
-            features,
-            session,
+            inbound_context: WireInboundContext::new(protocol_version, features, session),
             session_context,
             permits_delegated_sessions,
             outbound_stream,
@@ -371,99 +367,11 @@ where
         Ok(())
     }
 
-    fn validate_inbound_session(&self, envelope: &WireEnvelope) -> Result<(), WireError> {
-        let Some(expected) = &self.session else {
-            return Ok(());
-        };
-        let Some(actual) = &envelope.session else {
-            return Err(WireError::new(
-                WireErrorCode::AuthFailed,
-                WireRetry::AfterAuth,
-                "missing wire session metadata",
-            ));
-        };
-        if actual.session_id != expected.session_id {
-            return Err(WireError::new(
-                WireErrorCode::AuthFailed,
-                WireRetry::AfterResume,
-                "wire session id does not match this connection",
-            ));
-        }
-        if actual.identity != expected.identity {
-            return Err(WireError::new(
-                WireErrorCode::AuthFailed,
-                WireRetry::AfterAuth,
-                "wire session identity does not match this connection",
-            ));
-        }
-        if actual.epoch < expected.epoch {
-            return Err(WireError::new(
-                WireErrorCode::AuthFailed,
-                WireRetry::AfterResume,
-                "stale wire session epoch",
-            ));
-        }
-        if actual.epoch != expected.epoch {
-            return Err(WireError::new(
-                WireErrorCode::AuthFailed,
-                WireRetry::AfterResume,
-                "wire session epoch does not match this connection",
-            ));
-        }
-        Ok(())
-    }
-
-    fn validate_inbound_metadata(&self, envelope: &WireEnvelope) -> Result<(), WireError> {
-        if envelope.protocol_version != self.protocol_version {
-            return Err(WireError::new(
-                WireErrorCode::UnsupportedProtocolVersion,
-                WireRetry::AfterResume,
-                format!(
-                    "wire message protocol version {} does not match negotiated {}",
-                    envelope.protocol_version, self.protocol_version
-                ),
-            ));
-        }
-        let unnegotiated = envelope.features & !self.features;
-        if unnegotiated != 0 {
-            return Err(WireError::new(
-                WireErrorCode::UnsupportedFeature,
-                WireRetry::AfterResume,
-                format!("wire message declares unnegotiated features {unnegotiated:#x}"),
-            ));
-        }
-        Ok(())
-    }
-
     fn decode_inbound_envelope(
         &mut self,
         envelope: WireEnvelope,
     ) -> Result<SyncMessage, WireError> {
-        self.validate_inbound_metadata(&envelope)?;
-        self.validate_inbound_session(&envelope)?;
-        let payload = self
-            .inbound_stream
-            .decode_message_borrowed(&envelope.payload, envelope.features)
-            .map_err(|message| {
-                WireError::new(WireErrorCode::MalformedFrame, WireRetry::Never, message)
-            })?;
-        validate_logical_message_len(payload.len()).map_err(|message| {
-            WireError::new(WireErrorCode::MalformedFrame, WireRetry::Never, message)
-        })?;
-        let message =
-            decode_sync_message_for_features(&payload, self.features).map_err(|error| {
-                WireError::new(
-                    error.code,
-                    error.retry,
-                    format!(
-                        "{}; payload_bytes={}; payload_hex={}",
-                        error.message,
-                        payload.len(),
-                        hex_diagnostic(&payload)
-                    ),
-                )
-            })?;
-        Ok(message)
+        admit_complete_envelope(&self.inbound_context, &mut self.inbound_stream, envelope)
     }
 
     /// Strict receive mode for bootstrap-only exchanges. Unlike a live peer,
@@ -493,15 +401,9 @@ where
                 }
                 WireFrame::MessageFragment(fragment) => {
                     let fragment_message_id = fragment.message_id;
-                    let metadata = WireEnvelope {
-                        protocol_version: fragment.protocol_version,
-                        features: fragment.features,
-                        session: fragment.session.clone(),
-                        payload: Vec::new(),
-                    };
-                    self.validate_inbound_metadata(&metadata)?;
-                    self.validate_inbound_session(&metadata)?;
-                    if self.features & FEATURE_MESSAGE_FRAGMENTATION == 0
+                    self.inbound_context.validate_fragment_metadata(&fragment)?;
+                    if self.inbound_context.negotiated_features() & FEATURE_MESSAGE_FRAGMENTATION
+                        == 0
                         || fragment.features & FEATURE_MESSAGE_FRAGMENTATION == 0
                     {
                         return Err(WireError::new(
@@ -552,7 +454,8 @@ where
         // until that bounded backlog flushes: callers retain/retry an
         // `Err(Backpressure)` message at their semantic boundary.
         self.flush_pending_outbound()?;
-        let payload = match encode_sync_message_for_features(&message, self.features) {
+        let negotiated_features = self.inbound_context.negotiated_features();
+        let payload = match encode_sync_message_for_features(&message, negotiated_features) {
             Ok(payload) => payload,
             Err(error) => {
                 self.send_wire_error(error);
@@ -566,18 +469,22 @@ where
             Ok(payload) => payload,
             Err(message) => return Err(TransportError::Failed(message)),
         };
-        let active_features = (self.features
+        let active_features = (negotiated_features
             & !(crate::wire::FEATURE_PAYLOAD_LZ4 | crate::wire::FEATURE_PAYLOAD_ZSTD))
             | self.outbound_stream.active_feature();
-        let mut envelope = WireEnvelope::new(self.protocol_version, active_features, payload);
-        if let Some(session) = self.session.clone() {
+        let mut envelope = WireEnvelope::new(
+            self.inbound_context.expected_protocol_version(),
+            active_features,
+            payload,
+        );
+        if let Some(session) = self.inbound_context.expected_session().cloned() {
             envelope = envelope.with_session(session);
         }
         match encode_frame(&WireFrame::Message(envelope.clone())) {
             Ok(frame) if frame.len() <= WIRE_FRAGMENT_PAYLOAD_BYTES => {
                 self.send_encoded_frames(vec![frame])
             }
-            Ok(_) if self.features & FEATURE_MESSAGE_FRAGMENTATION == 0 => {
+            Ok(_) if negotiated_features & FEATURE_MESSAGE_FRAGMENTATION == 0 => {
                 Err(TransportError::Failed(
                     "peer did not negotiate logical-message fragmentation".to_owned(),
                 ))
@@ -665,21 +572,12 @@ where
                 },
                 WireFrame::MessageFragment(fragment) => {
                     let fragment_message_id = fragment.message_id;
-                    let metadata = WireEnvelope {
-                        protocol_version: fragment.protocol_version,
-                        features: fragment.features,
-                        session: fragment.session.clone(),
-                        payload: Vec::new(),
-                    };
-                    if let Err(error) = self.validate_inbound_metadata(&metadata) {
+                    if let Err(error) = self.inbound_context.validate_fragment_metadata(&fragment) {
                         self.send_wire_error(error);
                         continue;
                     }
-                    if let Err(error) = self.validate_inbound_session(&metadata) {
-                        self.send_wire_error(error);
-                        continue;
-                    }
-                    if self.features & FEATURE_MESSAGE_FRAGMENTATION == 0
+                    if self.inbound_context.negotiated_features() & FEATURE_MESSAGE_FRAGMENTATION
+                        == 0
                         || fragment.features & FEATURE_MESSAGE_FRAGMENTATION == 0
                     {
                         self.send_wire_error(WireError::new(
@@ -717,6 +615,10 @@ where
         None
     }
 
+    fn wire_inbound_context(&self) -> Option<WireInboundContext> {
+        Some(self.inbound_context.clone())
+    }
+
     fn connection_session_context(&self) -> Option<ConnectionSessionContext> {
         self.session_context
     }
@@ -724,20 +626,4 @@ where
     fn permits_delegated_sessions(&self) -> bool {
         self.permits_delegated_sessions
     }
-}
-
-fn hex_diagnostic(bytes: &[u8]) -> String {
-    if bytes.len() <= 128 {
-        return hex_prefix(bytes, bytes.len());
-    }
-    hex_prefix(bytes, 16)
-}
-
-fn hex_prefix(bytes: &[u8], max: usize) -> String {
-    bytes
-        .iter()
-        .take(max)
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<Vec<_>>()
-        .join("")
 }

--- a/crates/jazz/src/serving/mod.rs
+++ b/crates/jazz/src/serving/mod.rs
@@ -284,7 +284,6 @@ struct ServerSessionState {
     connection: ShellPeerConnection,
     transport: SharedWireTransport,
     auxiliary_pump: crate::db::PeerIoPump,
-    negotiated_features: crate::wire::WireFeatures,
     identity: AuthorSubject,
     epoch: u64,
     resume_status: ServerResumeStatus,
@@ -316,8 +315,6 @@ pub(super) struct ServerUpstreamIo {
     pub(super) transport: SharedWireTransport,
     pub(super) pump: crate::db::PeerIoPump,
     pub(super) connection_id: u64,
-    pub(super) protocol_version: u16,
-    pub(super) features: crate::wire::WireFeatures,
 }
 
 impl WireTransport for SharedWireTransport {
@@ -1304,7 +1301,6 @@ impl InMemoryServerShell {
             connection,
             transport,
             auxiliary_pump,
-            negotiated_features,
             identity,
             epoch: 1,
             resume_status: ServerResumeStatus::Fresh,
@@ -1351,8 +1347,6 @@ impl InMemoryServerShell {
             transport,
             pump,
             connection_id,
-            protocol_version,
-            features,
         }
     }
 
@@ -1429,7 +1423,6 @@ impl InMemoryServerShell {
             connection,
             transport,
             auxiliary_pump,
-            negotiated_features: crate::wire::current_wire_features(),
             identity: resume.identity,
             epoch: resume.resume_token.saturating_add(1),
             resume_status: ServerResumeStatus::Resumed,
@@ -1518,12 +1511,9 @@ impl InMemoryServerShell {
             self.metrics.frames_received += 1;
             self.metrics.bytes_received += frame.len() as u64;
             let state = self.session_state(session)?;
-            let canonical = crate::db::block_on(
-                state
-                    .auxiliary_pump
-                    .route_incoming_wire_frame(frame, state.negotiated_features),
-            )
-            .map_err(ShellError::Transport)?;
+            let canonical =
+                crate::db::block_on(state.auxiliary_pump.route_incoming_wire_frame(frame))
+                    .map_err(ShellError::Transport)?;
             if let Some(frame) = canonical {
                 state.transport.queues.borrow_mut().inbound.push_back(frame);
             }
@@ -1545,7 +1535,7 @@ impl InMemoryServerShell {
             let state = self.session_state(session)?;
             let canonical = state
                 .auxiliary_pump
-                .route_incoming_wire_frame(frame, state.negotiated_features)
+                .route_incoming_wire_frame(frame)
                 .await
                 .map_err(ShellError::Transport)?;
             if let Some(frame) = canonical {
@@ -1606,11 +1596,7 @@ impl InMemoryServerShell {
             .collect::<Vec<_>>();
         while let Some(frame) = state
             .auxiliary_pump
-            .take_outbound_wire_frame(
-                crate::wire::WIRE_PROTOCOL_VERSION,
-                state.negotiated_features,
-                None,
-            )
+            .take_outbound_wire_frame()
             .map_err(ShellError::Transport)?
         {
             frames.push(frame);

--- a/crates/jazz/src/serving/server_runtime.rs
+++ b/crates/jazz/src/serving/server_runtime.rs
@@ -416,7 +416,7 @@ async fn drive_upstream_wire(
         loop {
             let mut staged_semantic_input = false;
             while let Some(frame) = wire.try_recv_frame() {
-                match io.pump.route_incoming_wire_frame(frame, io.features).await {
+                match io.pump.route_incoming_wire_frame(frame).await {
                     Ok(Some(canonical)) => {
                         io.transport
                             .queues
@@ -460,11 +460,7 @@ async fn drive_upstream_wire(
             }
             if !transport_backpressured {
                 loop {
-                    let reservation = match io.pump.reserve_outbound_wire_frame(
-                        io.protocol_version,
-                        io.features,
-                        None,
-                    ) {
+                    let reservation = match io.pump.reserve_outbound_wire_frame() {
                         Ok(reservation) => reservation,
                         Err(error) => {
                             return ServerUpstreamTerminalReason::ProtocolFailed(error);
@@ -1327,7 +1323,12 @@ mod tests {
 
     fn encode_message(message: SyncMessage) -> Vec<u8> {
         let payload = encode_sync_message(&message).unwrap();
-        encode_frame(&WireFrame::Message(WireEnvelope::new(0, 0, payload))).unwrap()
+        encode_frame(&WireFrame::Message(WireEnvelope::new(
+            crate::wire::WIRE_PROTOCOL_VERSION,
+            crate::wire::FEATURE_NONE,
+            payload,
+        )))
+        .unwrap()
     }
 
     // This internal test is necessary because the terminal reason crosses the

--- a/crates/jazz/src/wire.rs
+++ b/crates/jazz/src/wire.rs
@@ -288,6 +288,128 @@ impl WireEnvelope {
     }
 }
 
+/// Immutable admission requirements for complete inbound envelopes.
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct WireInboundContext {
+    expected_protocol_version: u16,
+    negotiated_features: WireFeatures,
+    expected_session: Option<WireSession>,
+}
+
+impl WireInboundContext {
+    pub(crate) fn new(
+        expected_protocol_version: u16,
+        negotiated_features: WireFeatures,
+        expected_session: Option<WireSession>,
+    ) -> Self {
+        Self {
+            expected_protocol_version,
+            negotiated_features,
+            expected_session,
+        }
+    }
+
+    pub(crate) fn expected_protocol_version(&self) -> u16 {
+        self.expected_protocol_version
+    }
+
+    pub(crate) fn negotiated_features(&self) -> WireFeatures {
+        self.negotiated_features
+    }
+
+    pub(crate) fn expected_session(&self) -> Option<&WireSession> {
+        self.expected_session.as_ref()
+    }
+
+    pub(crate) fn validate_envelope_metadata(
+        &self,
+        envelope: &WireEnvelope,
+    ) -> Result<(), WireError> {
+        self.validate_metadata(
+            envelope.protocol_version,
+            envelope.features,
+            envelope.session.as_ref(),
+        )
+    }
+
+    pub(crate) fn validate_fragment_metadata(
+        &self,
+        fragment: &WireMessageFragment,
+    ) -> Result<(), WireError> {
+        self.validate_metadata(
+            fragment.protocol_version,
+            fragment.features,
+            fragment.session.as_ref(),
+        )
+    }
+
+    fn validate_metadata(
+        &self,
+        protocol_version: u16,
+        features: WireFeatures,
+        session: Option<&WireSession>,
+    ) -> Result<(), WireError> {
+        if protocol_version != self.expected_protocol_version {
+            return Err(WireError::new(
+                WireErrorCode::UnsupportedProtocolVersion,
+                WireRetry::AfterResume,
+                format!(
+                    "wire message protocol version {protocol_version} does not match negotiated {}",
+                    self.expected_protocol_version
+                ),
+            ));
+        }
+        let unnegotiated = features & !self.negotiated_features;
+        if unnegotiated != 0 {
+            return Err(WireError::new(
+                WireErrorCode::UnsupportedFeature,
+                WireRetry::AfterResume,
+                format!("wire message declares unnegotiated features {unnegotiated:#x}"),
+            ));
+        }
+        let Some(expected) = &self.expected_session else {
+            return Ok(());
+        };
+        let Some(actual) = session else {
+            return Err(WireError::new(
+                WireErrorCode::AuthFailed,
+                WireRetry::AfterAuth,
+                "missing wire session metadata",
+            ));
+        };
+        if actual.session_id != expected.session_id {
+            return Err(WireError::new(
+                WireErrorCode::AuthFailed,
+                WireRetry::AfterResume,
+                "wire session id does not match this connection",
+            ));
+        }
+        if actual.identity != expected.identity {
+            return Err(WireError::new(
+                WireErrorCode::AuthFailed,
+                WireRetry::AfterAuth,
+                "wire session identity does not match this connection",
+            ));
+        }
+        if actual.epoch < expected.epoch {
+            return Err(WireError::new(
+                WireErrorCode::AuthFailed,
+                WireRetry::AfterResume,
+                "stale wire session epoch",
+            ));
+        }
+        if actual.epoch != expected.epoch {
+            return Err(WireError::new(
+                WireErrorCode::AuthFailed,
+                WireRetry::AfterResume,
+                "wire session epoch does not match this connection",
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Structured wire error code.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -344,6 +466,51 @@ impl WireError {
     }
 }
 
+/// Admit one decoded complete envelope through the canonical wire checks.
+pub(crate) fn admit_complete_envelope(
+    context: &WireInboundContext,
+    decoder: &mut WireStreamDecoder,
+    envelope: WireEnvelope,
+) -> Result<SyncMessage, WireError> {
+    context.validate_envelope_metadata(&envelope)?;
+    let payload = decoder
+        .decode_message_borrowed(&envelope.payload, envelope.features)
+        .map_err(|message| {
+            WireError::new(WireErrorCode::MalformedFrame, WireRetry::Never, message)
+        })?;
+    validate_logical_message_len(payload.len()).map_err(|message| {
+        WireError::new(WireErrorCode::MalformedFrame, WireRetry::Never, message)
+    })?;
+    decode_sync_message_for_features(&payload, context.negotiated_features).map_err(|error| {
+        WireError::new(
+            error.code,
+            error.retry,
+            format!(
+                "{}; payload_bytes={}; payload_hex={}",
+                error.message,
+                payload.len(),
+                hex_diagnostic(&payload)
+            ),
+        )
+    })
+}
+
+fn hex_diagnostic(bytes: &[u8]) -> String {
+    if bytes.len() <= 128 {
+        return hex_prefix(bytes, bytes.len());
+    }
+    hex_prefix(bytes, 16)
+}
+
+fn hex_prefix(bytes: &[u8], max: usize) -> String {
+    bytes
+        .iter()
+        .take(max)
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<Vec<_>>()
+        .join("")
+}
+
 /// Serialize a wire frame with the canonical Jazz frame codec.
 pub fn encode_frame(frame: &WireFrame) -> Result<Vec<u8>, postcard::Error> {
     to_allocvec(frame)
@@ -376,21 +543,9 @@ pub fn validate_frame_for_artifact_corpus(
             .map(|_| ())
             .map_err(|error| format!("hello negotiation rejected: {}", error.message)),
         WireFrame::Message(envelope) => {
-            if envelope.protocol_version != WIRE_PROTOCOL_VERSION {
-                return Err(format!(
-                    "message protocol version {} does not match v{}",
-                    envelope.protocol_version, WIRE_PROTOCOL_VERSION
-                ));
-            }
-            let unnegotiated = envelope.features & !negotiated_features;
-            if unnegotiated != 0 {
-                return Err(format!(
-                    "message declares unnegotiated features {unnegotiated:#x}"
-                ));
-            }
+            let context = WireInboundContext::new(WIRE_PROTOCOL_VERSION, negotiated_features, None);
             let mut decoder = WireStreamDecoder::new(negotiated_features)?;
-            let payload = decoder.decode_message(&envelope.payload, envelope.features)?;
-            decode_sync_message_for_features(&payload, negotiated_features)
+            admit_complete_envelope(&context, &mut decoder, envelope)
                 .map(|_| ())
                 .map_err(|error| format!("semantic payload rejected: {}", error.message))
         }


### PR DESCRIPTION
🤖 Adapts #2487 to the newly merged main, preserving Joe's admission fix and the newer async WASM connection path. Independent review found no correctness blocker; this remains a draft pending full CI and Anselm's review.

## Before / after

Previously an auxiliary chunk response could affect pending chunk work before the regular transport adapter checked its negotiated protocol, features, and session metadata. Both paths now use the same canonical complete-envelope admission checks before routing effects.

For example, a response carrying the correct chunk request ID but the wrong protocol version must not resolve that request. A correctly admitted response still resolves it. Fragments remain byte-exact for the adapter's existing reassembly path.

The adapter and auxiliary pump share immutable connection metadata, also used for outbound auxiliary frames. Low-level Rust `PeerIoPump` methods therefore no longer accept independently supplied protocol/features/session arguments. This is an intentional Rust signature change under the new-core no-backcompat policy; the user-facing TS/NAPI/WASM API is unchanged. No new storage or wire encoding is introduced.

## Verification so far

- Wrong-protocol pending-chunk regression: passed.
- Paired-context incoming/outgoing regression: passed.
- Existing auxiliary completion regression: passed.
- `cargo check -p jazz-wasm -p jazz-napi`: passed.
- Independent review: no correctness blocker. Fragment admission and compressed-backpressure tests passed; a planted metadata-validation bypass made the new regression fail, then was restored.
- Coordinator reran the wrong-protocol regression successfully on the clean committed tree.
- Full CI remains pending.

Source work: `f61076e96f` and `7dd64846b0` from #2487; adapted commit `cdf3b2a815`. The original published branch has not been rewritten.
