### PR TITLE
Keep example backend credentials server-only on current main

### DIFF
--- a/.changeset/quiet-secrets-hide.md
+++ b/.changeset/quiet-secrets-hide.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Keep managed development backend credentials in the server process instead of returned Next.js configuration. Applications using `jazz-tools/dev/next` should read `BACKEND_SECRET` from the server environment.

--- a/examples/nextjs-csr-ssr/.env
+++ b/examples/nextjs-csr-ssr/.env
@@ -1,3 +1,0 @@
-NEXT_PUBLIC_JAZZ_APP_ID=c22be49e-c119-4553-a5dd-17c4a8e0ad3f
-NEXT_PUBLIC_JAZZ_SERVER_URL=https://v2.sync.jazz.tools
-BACKEND_SECRET=nextjs-csr-ssr-example-backend-secret

--- a/examples/nextjs-csr-ssr/README.md
+++ b/examples/nextjs-csr-ssr/README.md
@@ -2,11 +2,12 @@
 
 The canonical Next.js server-side rendering / RSC story for Jazz: a Server Component reading the database via `jazz-tools/backend` alongside a Client Component using the standard `jazz-tools/react` hooks. The `next-*` starters under `starters/` are pure client-side; this example is where SSR + Server Actions + `BACKEND_SECRET` live.
 
-- `pnpm run sync-server`
-- `pnpm run dev`
+- `pnpm dev`
+
+`withJazz` starts a local Jazz server for development and keeps its generated backend credential in the Next server process. No tracked `.env` file or manually configured backend credential is needed. Set `JAZZ_E2E_IN_MEMORY=1` only for isolated browser tests.
 
 ## Hot points
 
 - `next.config.ts` uses `withJazz(...)` from `jazz-tools/dev/next`
 - Public Jazz connection vars are `NEXT_PUBLIC_JAZZ_APP_ID` and `NEXT_PUBLIC_JAZZ_SERVER_URL`
-- The SSR example still keeps `BACKEND_SECRET` explicit because backend access is server-only
+- Server-side database access uses `getBackendDb()` from `lib/jazz-server.ts`

--- a/examples/nextjs-csr-ssr/app/ServerTodo.tsx
+++ b/examples/nextjs-csr-ssr/app/ServerTodo.tsx
@@ -1,6 +1,6 @@
 import { revalidatePath } from "next/cache";
 import { app } from "../schema";
-import { db } from "@/lib/jazz-server";
+import { getBackendDb } from "@/lib/jazz-server";
 
 export default function ServerTodo() {
   return (
@@ -12,8 +12,7 @@ export default function ServerTodo() {
 }
 
 async function TodoList() {
-  const todos = await db.all(app.todos);
-
+  const todos = await getBackendDb().all(app.todos);
   return (
     <ul className="mt-4 space-y-1">
       {todos.length === 0 && <li className="text-sm text-foreground/30 italic">No todos yet.</li>}
@@ -31,7 +30,7 @@ function TodoForm() {
     "use server";
     const title = formData.get("titleField");
     if (typeof title !== "string" || !title.trim()) return;
-    db.insert(app.todos, { title: title.trim(), done: false });
+    getBackendDb().insert(app.todos, { title: title.trim(), done: false });
     revalidatePath("/");
   }
 

--- a/examples/nextjs-csr-ssr/e2e/config-security.spec.ts
+++ b/examples/nextjs-csr-ssr/e2e/config-security.spec.ts
@@ -62,7 +62,8 @@ function findNonEmptyPrivilegedLiterals(source: string): string[] {
         (ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value)) &&
         value.text.length > 0
       ) {
-        violations.push(`${name}=${value.text}`);
+        const position = file.getLineAndCharacter(node.getStart(file));
+        violations.push(`${name} at ${position.line + 1}:${position.character + 1}`);
       }
     }
     ts.forEachChild(node, visit);

--- a/examples/nextjs-csr-ssr/e2e/config-security.spec.ts
+++ b/examples/nextjs-csr-ssr/e2e/config-security.spec.ts
@@ -62,7 +62,7 @@ function findNonEmptyPrivilegedLiterals(source: string): string[] {
         (ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value)) &&
         value.text.length > 0
       ) {
-        const position = file.getLineAndCharacter(node.getStart(file));
+        const position = file.getLineAndCharacterOfPosition(node.getStart(file));
         violations.push(`${name} at ${position.line + 1}:${position.character + 1}`);
       }
     }

--- a/examples/nextjs-csr-ssr/e2e/config-security.spec.ts
+++ b/examples/nextjs-csr-ssr/e2e/config-security.spec.ts
@@ -1,0 +1,123 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import dotenv from "dotenv";
+import ts from "typescript";
+
+const EXAMPLE_PATH = "examples/nextjs-csr-ssr";
+const PRIVILEGED_KEYS: Record<string, true> = {
+  BACKEND_SECRET: true,
+  JAZZ_BACKEND_SECRET: true,
+  ADMIN_SECRET: true,
+  JAZZ_ADMIN_SECRET: true,
+};
+
+function trackedExampleFiles(): { root: string; files: string[] } {
+  const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+  }).trim();
+  const output = execFileSync(
+    "git",
+    ["-C", root, "ls-files", "-z", "--", `:(top)${EXAMPLE_PATH}`],
+    { encoding: "utf8" },
+  );
+  const files = output.split("\0").filter(Boolean);
+  assert.notEqual(root, "", "repository root must be discovered");
+  assert.ok(files.length > 0, "tracked example selection must not be empty");
+  assert.ok(
+    files.includes(`${EXAMPLE_PATH}/next.config.ts`),
+    "tracked example selection must include next.config.ts sentinel",
+  );
+  assert.ok(
+    files.includes(`${EXAMPLE_PATH}/lib/jazz-server.ts`),
+    "tracked example selection must include jazz-server.ts sentinel",
+  );
+  return { root, files };
+}
+
+function propertyName(property: ts.PropertyName): string | undefined {
+  if (ts.isIdentifier(property) || ts.isStringLiteral(property) || ts.isNumericLiteral(property)) {
+    return property.text;
+  }
+  return undefined;
+}
+
+function findNonEmptyPrivilegedLiterals(source: string): string[] {
+  const file = ts.createSourceFile(
+    "next.config.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const violations: string[] = [];
+  function visit(node: ts.Node): void {
+    if (ts.isPropertyAssignment(node)) {
+      const name = propertyName(node.name);
+      const value = node.initializer;
+      if (
+        (name === "backendSecret" || PRIVILEGED_KEYS[name ?? ""] === true) &&
+        (ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value)) &&
+        value.text.length > 0
+      ) {
+        violations.push(`${name}=${value.text}`);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(file);
+  return violations;
+}
+
+test("tracked configuration contains no privileged admission material", () => {
+  const { root, files } = trackedExampleFiles();
+  assert.ok(
+    !files.includes(`${EXAMPLE_PATH}/.env`),
+    "tracked .env must be absent because it can contain live credentials",
+  );
+
+  const exampleRoot = join(root, EXAMPLE_PATH);
+  const envExample = `${EXAMPLE_PATH}/.env.example`;
+  if (files.includes(envExample)) {
+    const parsed = dotenv.parse(readFileSync(join(root, envExample), "utf8"));
+    for (const key of [
+      ...Object.keys(PRIVILEGED_KEYS),
+      "NEXT_PUBLIC_JAZZ_APP_ID",
+      "NEXT_PUBLIC_JAZZ_SERVER_URL",
+    ]) {
+      assert.ok(
+        parsed[key] === undefined || parsed[key] === "",
+        `${envExample} must keep ${key} absent or empty`,
+      );
+    }
+  }
+
+  const nextConfig = readFileSync(join(exampleRoot, "next.config.ts"), "utf8");
+  assert.deepEqual(
+    findNonEmptyPrivilegedLiterals(nextConfig),
+    [],
+    "next.config.ts must not contain fixed privileged values",
+  );
+
+  const serverModule = ts.createSourceFile(
+    "lib/jazz-server.ts",
+    readFileSync(join(exampleRoot, "lib/jazz-server.ts"), "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const hasSideEffectServerOnlyImport = serverModule.statements.some(
+    (statement) =>
+      ts.isImportDeclaration(statement) &&
+      statement.importClause === undefined &&
+      ts.isStringLiteral(statement.moduleSpecifier) &&
+      statement.moduleSpecifier.text === "server-only",
+  );
+  assert.equal(
+    hasSideEffectServerOnlyImport,
+    true,
+    "jazz-server.ts must use a side-effect server-only import",
+  );
+});

--- a/examples/nextjs-csr-ssr/e2e/csr-ssr.spec.ts
+++ b/examples/nextjs-csr-ssr/e2e/csr-ssr.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
 function todoSection(page: Page, label: string): Locator {
@@ -30,12 +31,13 @@ async function reloadUntilSectionContains(page: Page, label: string, title: stri
 test.describe("Next.js CSR / SSR todos", () => {
   test("client and server panes round-trip todos through the shared Jazz backend", async ({
     page,
-  }) => {
+  }, testInfo) => {
     // Flow:
     // browser client submit -> sync server -> reload -> Next RSC render
     // Next server action submit -> sync server -> live client subscription update
-    const clientTitle = `alice books train tickets ${Date.now()}`;
-    const serverTitle = `bob files travel reimbursement ${Date.now()}`;
+    const identity = `${testInfo.retry}-${randomUUID()}`;
+    const clientTitle = `alice books train tickets ${identity}`;
+    const serverTitle = `bob files travel reimbursement ${identity}`;
 
     await page.goto("/");
 
@@ -43,8 +45,6 @@ test.describe("Next.js CSR / SSR todos", () => {
     const serverPane = todoSection(page, "Server-side (RSC)");
 
     await expect(page.getByRole("heading", { name: "jazz — nextjs CSR / SSR" })).toBeVisible();
-    await expect(clientPane).toContainText("No todos yet.");
-    await expect(serverPane).toContainText("No todos yet.");
 
     await addTodo(clientPane, clientTitle);
     await expect(clientPane).toContainText(clientTitle);

--- a/examples/nextjs-csr-ssr/lib/jazz-server.ts
+++ b/examples/nextjs-csr-ssr/lib/jazz-server.ts
@@ -1,7 +1,8 @@
-"server-only";
+import "server-only";
 
 import { app as schemaApp } from "../schema";
 import permissions from "../permissions";
+import type { BackendContextConfig, Db, JazzContext } from "jazz-tools/backend";
 
 // This is a workaround to resolve correctly NAPI modules in the monorepo
 // Real-world apps should just `import { createJazzContext } from "jazz-tools/backend"`
@@ -9,17 +10,51 @@ import { createRequire as createRequireFromModule } from "node:module";
 const createRequire =
   process.getBuiltinModule?.("module")?.createRequire ?? createRequireFromModule;
 const nodeRequire = createRequire(import.meta.url);
-const { createJazzContext } = nodeRequire(
-  "jazz-tools/backend",
-) as typeof import("jazz-tools/backend");
 
-const context = createJazzContext({
-  appId: process.env.NEXT_PUBLIC_JAZZ_APP_ID!,
-  app: schemaApp,
-  permissions,
-  driver: { type: "memory" },
-  serverUrl: process.env.NEXT_PUBLIC_JAZZ_SERVER_URL!,
-  backendSecret: process.env.BACKEND_SECRET!,
-});
+type BackendState = { context: JazzContext; db: Db };
+type BackendModule = {
+  createJazzContext: (config: BackendContextConfig) => JazzContext;
+};
+type GlobalBackendState = typeof globalThis & {
+  __jazzNextCsrSsrBackend?: BackendState;
+};
 
-export const db = context.asBackend();
+const globalState = globalThis as GlobalBackendState;
+
+function readBackendConfig(): {
+  appId: string;
+  serverUrl: string;
+  backendSecret: string;
+} {
+  const appId = process.env.NEXT_PUBLIC_JAZZ_APP_ID;
+  const serverUrl = process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
+  const backendSecret = process.env.BACKEND_SECRET;
+  const missingKeys = [
+    appId ? undefined : "NEXT_PUBLIC_JAZZ_APP_ID",
+    serverUrl ? undefined : "NEXT_PUBLIC_JAZZ_SERVER_URL",
+    backendSecret ? undefined : "BACKEND_SECRET",
+  ].filter((key): key is string => key !== undefined);
+  if (missingKeys.length > 0) {
+    throw new Error(`Missing server backend configuration: ${missingKeys.join(", ")}`);
+  }
+  return { appId: appId!, serverUrl: serverUrl!, backendSecret: backendSecret! };
+}
+
+export function getBackendDb(): Db {
+  const existing = globalState.__jazzNextCsrSsrBackend;
+  if (existing) return existing.db;
+
+  const config = readBackendConfig();
+  const { createJazzContext } = nodeRequire("jazz-tools/backend") as BackendModule;
+  const context = createJazzContext({
+    appId: config.appId,
+    app: schemaApp,
+    permissions,
+    driver: { type: "memory" },
+    serverUrl: config.serverUrl,
+    backendSecret: config.backendSecret,
+  });
+  const db = context.asBackend();
+  globalState.__jazzNextCsrSsrBackend = { context, db };
+  return db;
+}

--- a/examples/nextjs-csr-ssr/next.config.ts
+++ b/examples/nextjs-csr-ssr/next.config.ts
@@ -1,10 +1,5 @@
 import { withJazz } from "jazz-tools/dev/next";
 
-export default withJazz(
-  {},
-  {
-    server: {
-      backendSecret: "dev-backend-secret",
-    },
-  },
-);
+const inMemoryE2E = process.env.JAZZ_E2E_IN_MEMORY === "1";
+
+export default withJazz({}, inMemoryE2E ? { server: { inMemory: true } } : {});

--- a/examples/nextjs-csr-ssr/package.json
+++ b/examples/nextjs-csr-ssr/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev",
     "build": "node ../../packages/jazz-tools/dist/cli.js validate && next build",
     "start": "next start",
+    "test": "pnpm test:config-security && pnpm test:e2e",
     "test:e2e": "playwright test",
     "test:config-security": "tsx --test e2e/config-security.spec.ts"
   },

--- a/examples/nextjs-csr-ssr/package.json
+++ b/examples/nextjs-csr-ssr/package.json
@@ -15,7 +15,8 @@
     "jazz-tools": "workspace:*",
     "next": "catalog:default",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "server-only": "0.0.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/examples/nextjs-csr-ssr/package.json
+++ b/examples/nextjs-csr-ssr/package.json
@@ -7,8 +7,8 @@
     "dev": "next dev",
     "build": "node ../../packages/jazz-tools/dist/cli.js validate && next build",
     "start": "next start",
-    "sync-server": "tsx --env-file=.env scripts/sync-server.ts",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:config-security": "tsx --test e2e/config-security.spec.ts"
   },
   "dependencies": {
     "jazz-napi": "workspace:*",

--- a/examples/nextjs-csr-ssr/playwright.config.ts
+++ b/examples/nextjs-csr-ssr/playwright.config.ts
@@ -3,6 +3,9 @@ import { defineConfig, devices } from "@playwright/test";
 
 const WEB_PORT = Number(process.env.WEB_PORT ?? "3000");
 const testAppId = randomUUID();
+// Keep each test server independent of ambient credentials. An explicitly empty
+// backend secret is invalid; this fresh credential stays in the server process.
+const testBackendSecret = randomUUID();
 
 export default defineConfig({
   testDir: "./e2e",
@@ -29,8 +32,8 @@ export default defineConfig({
     env: {
       NEXT_PUBLIC_JAZZ_APP_ID: testAppId,
       NEXT_PUBLIC_JAZZ_SERVER_URL: "",
-      BACKEND_SECRET: "",
-      JAZZ_BACKEND_SECRET: "",
+      BACKEND_SECRET: testBackendSecret,
+      JAZZ_BACKEND_SECRET: testBackendSecret,
       ADMIN_SECRET: "",
       JAZZ_ADMIN_SECRET: "",
       JAZZ_E2E_IN_MEMORY: "1",

--- a/examples/nextjs-csr-ssr/playwright.config.ts
+++ b/examples/nextjs-csr-ssr/playwright.config.ts
@@ -1,23 +1,19 @@
+import { randomUUID } from "node:crypto";
 import { defineConfig, devices } from "@playwright/test";
-import dotenv from "dotenv";
 
-dotenv.config();
-
-const SERVER_URL = process.env.NEXT_PUBLIC_JAZZ_SERVER_URL!;
-const APP_ID = process.env.NEXT_PUBLIC_JAZZ_APP_ID!;
-const BACKEND_SECRET = process.env.BACKEND_SECRET!;
-const ADMIN_SECRET = process.env.ADMIN_SECRET!;
 const WEB_PORT = Number(process.env.WEB_PORT ?? "3000");
+const testAppId = randomUUID();
 
 export default defineConfig({
   testDir: "./e2e",
   testMatch: "**/*.spec.ts",
   timeout: 90_000,
+  testIgnore: "**/config-security.spec.ts",
   fullyParallel: false,
   workers: 1,
   retries: process.env.CI ? 2 : 0,
   use: {
-    baseURL: `http://localhost:${WEB_PORT}`,
+    baseURL: `http://127.0.0.1:${WEB_PORT}`,
     trace: "on-first-retry",
   },
   projects: [
@@ -26,30 +22,18 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: [
-    {
-      command: "pnpm run sync-server",
-      url: `${SERVER_URL}/health`,
-      reuseExistingServer: !process.env.CI,
-      timeout: 60_000,
-      env: {
-        NEXT_PUBLIC_JAZZ_APP_ID: APP_ID,
-        BACKEND_SECRET,
-        ADMIN_SECRET,
-        JAZZ_SERVER_PORT: String(new URL(SERVER_URL).port),
-      },
+  webServer: {
+    url: `http://127.0.0.1:${WEB_PORT}`,
+    command: `pnpm dev --hostname 127.0.0.1 --port ${WEB_PORT}`,
+    timeout: 60_000,
+    env: {
+      NEXT_PUBLIC_JAZZ_APP_ID: testAppId,
+      NEXT_PUBLIC_JAZZ_SERVER_URL: "",
+      BACKEND_SECRET: "",
+      JAZZ_BACKEND_SECRET: "",
+      ADMIN_SECRET: "",
+      JAZZ_ADMIN_SECRET: "",
+      JAZZ_E2E_IN_MEMORY: "1",
     },
-    {
-      command: `pnpm dev --hostname 127.0.0.1 --port ${WEB_PORT}`,
-      url: `http://localhost:${WEB_PORT}`,
-      reuseExistingServer: !process.env.CI,
-      timeout: 60_000,
-      env: {
-        NEXT_PUBLIC_JAZZ_SERVER_URL: SERVER_URL,
-        NEXT_PUBLIC_JAZZ_APP_ID: APP_ID,
-        BACKEND_SECRET,
-        ADMIN_SECRET,
-      },
-    },
-  ],
+  },
 });

--- a/packages/jazz-tools/src/dev/managed-runtime.test.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.test.ts
@@ -27,6 +27,7 @@ const tempRoots = createTempRootTracker();
 const originalJazzAppId = process.env.VITE_JAZZ_APP_ID;
 const originalJazzServerUrl = process.env.VITE_JAZZ_SERVER_URL;
 const originalAdminSecret = process.env.JAZZ_ADMIN_SECRET;
+const originalBackendSecret = process.env.BACKEND_SECRET;
 const originalStdoutIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 
 function makeRuntime(): ManagedDevRuntime {
@@ -64,6 +65,7 @@ beforeEach(() => {
   delete process.env.VITE_JAZZ_APP_ID;
   delete process.env.VITE_JAZZ_SERVER_URL;
   delete process.env.JAZZ_ADMIN_SECRET;
+  delete process.env.BACKEND_SECRET;
 });
 
 afterEach(async () => {
@@ -92,6 +94,12 @@ afterEach(async () => {
     delete process.env.JAZZ_ADMIN_SECRET;
   } else {
     process.env.JAZZ_ADMIN_SECRET = originalAdminSecret;
+  }
+
+  if (originalBackendSecret === undefined) {
+    delete process.env.BACKEND_SECRET;
+  } else {
+    process.env.BACKEND_SECRET = originalBackendSecret;
   }
 });
 
@@ -129,6 +137,53 @@ describe("ManagedDevRuntime", () => {
     } finally {
       await runtime.dispose();
     }
+  });
+
+  it("restores the backend secret after stop failure and permits retry", async () => {
+    const firstSchemaDir = await tempRoots.create("jazz-managed-stop-failure-first-");
+    const secondSchemaDir = await tempRoots.create("jazz-managed-stop-failure-second-");
+    await writeFile(join(firstSchemaDir, "schema.ts"), todoSchema());
+    await writeFile(join(secondSchemaDir, "schema.ts"), todoSchema());
+    const stopError = new Error("server stop failed");
+
+    vi.spyOn(devServer, "startLocalJazzServer")
+      .mockResolvedValueOnce({
+        appId: "00000000-0000-0000-0000-000000000128",
+        port: 19888,
+        url: "http://127.0.0.1:19888",
+        dataDir: undefined as unknown as string,
+        adminSecret: "stop-failure-admin-1",
+        backendSecret: "stop-failure-backend-1",
+        stop: vi.fn().mockRejectedValue(stopError),
+      })
+      .mockResolvedValueOnce({
+        appId: "00000000-0000-0000-0000-000000000129",
+        port: 19889,
+        url: "http://127.0.0.1:19889",
+        dataDir: undefined as unknown as string,
+        adminSecret: "stop-failure-admin-2",
+        backendSecret: "stop-failure-backend-2",
+        stop: vi.fn().mockResolvedValue(undefined),
+      });
+    vi.spyOn(catalogueProject, "deploy").mockResolvedValue(deployed());
+    vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
+
+    const runtime = makeRuntime();
+    await runtime.initialize({
+      schemaDir: firstSchemaDir,
+      server: { port: 19888, adminSecret: "stop-failure-admin-1" },
+    });
+    expect(process.env.BACKEND_SECRET).toBe("stop-failure-backend-1");
+
+    await expect(runtime.dispose()).rejects.toBe(stopError);
+    expect(process.env.BACKEND_SECRET).toBeUndefined();
+
+    await runtime.initialize({
+      schemaDir: secondSchemaDir,
+      server: { port: 19889, adminSecret: "stop-failure-admin-2" },
+    });
+    expect(process.env.BACKEND_SECRET).toBe("stop-failure-backend-2");
+    await runtime.dispose();
   });
 
   it("separates a generated app ID from a final unterminated env line", async () => {

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -389,7 +389,9 @@ export class ManagedDevRuntime {
   private watcher: { close: () => void } | null = null;
   private shutdownHooksInstalled = false;
   private cleanupHandler: (() => void) | null = null;
-
+  private previousBackendSecret: string | undefined;
+  private hadPreviousBackendSecret = false;
+  private injectedBackendSecret: string | undefined;
   constructor(private envKeys: ManagedRuntimeEnvKeys) {}
 
   prepareEnv(options: InitializeOptions): string | null {
@@ -445,12 +447,24 @@ export class ManagedDevRuntime {
       await this.serverHandle.stop();
       this.serverHandle = null;
     }
+    if (
+      this.injectedBackendSecret !== undefined &&
+      process.env.BACKEND_SECRET === this.injectedBackendSecret
+    ) {
+      if (this.hadPreviousBackendSecret) {
+        process.env.BACKEND_SECRET = this.previousBackendSecret;
+      } else {
+        delete process.env.BACKEND_SECRET;
+      }
+    }
+    this.previousBackendSecret = undefined;
+    this.hadPreviousBackendSecret = false;
+    this.injectedBackendSecret = undefined;
     this.runtime = null;
     this.initPromise = null;
     this.initConfigSignature = null;
     this.runtimeConfigSignature = null;
   }
-
   private installShutdownHooks(): void {
     if (this.shutdownHooksInstalled) return;
 
@@ -633,13 +647,17 @@ export class ManagedDevRuntime {
 
         const backendSecret = this.serverHandle?.backendSecret;
 
+        this.previousBackendSecret = process.env.BACKEND_SECRET;
+        this.hadPreviousBackendSecret = Object.hasOwn(process.env, "BACKEND_SECRET");
+        if (backendSecret) {
+          process.env.BACKEND_SECRET = backendSecret;
+          this.injectedBackendSecret = backendSecret;
+        }
+
         process.env[this.envKeys.appId] = appId;
         process.env[this.envKeys.serverUrl] = serverUrl;
         if (telemetryCollectorUrl) {
           process.env[this.envKeys.telemetryCollectorUrl] = telemetryCollectorUrl;
-        }
-        if (backendSecret) {
-          process.env.BACKEND_SECRET = backendSecret;
         }
 
         this.runtime = { appId, serverUrl, adminSecret, backendSecret, telemetryCollectorUrl };

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -441,29 +441,52 @@ export class ManagedDevRuntime {
   }
 
   async dispose(): Promise<void> {
-    this.watcher?.close();
-    this.watcher = null;
-    if (this.serverHandle) {
-      await this.serverHandle.stop();
+    let cleanupError: unknown;
+    let stopError: unknown;
+
+    try {
+      this.watcher?.close();
+    } catch (error) {
+      cleanupError = error;
+    } finally {
+      this.watcher = null;
+    }
+
+    try {
+      if (this.serverHandle) {
+        await this.serverHandle.stop();
+      }
+    } catch (error) {
+      stopError = error;
+    } finally {
       this.serverHandle = null;
     }
-    if (
-      this.injectedBackendSecret !== undefined &&
-      process.env.BACKEND_SECRET === this.injectedBackendSecret
-    ) {
-      if (this.hadPreviousBackendSecret) {
-        process.env.BACKEND_SECRET = this.previousBackendSecret;
-      } else {
-        delete process.env.BACKEND_SECRET;
+
+    try {
+      if (
+        this.injectedBackendSecret !== undefined &&
+        process.env.BACKEND_SECRET === this.injectedBackendSecret
+      ) {
+        if (this.hadPreviousBackendSecret) {
+          process.env.BACKEND_SECRET = this.previousBackendSecret;
+        } else {
+          delete process.env.BACKEND_SECRET;
+        }
       }
+    } catch (error) {
+      cleanupError ??= error;
+    } finally {
+      this.previousBackendSecret = undefined;
+      this.hadPreviousBackendSecret = false;
+      this.injectedBackendSecret = undefined;
+      this.runtime = null;
+      this.initPromise = null;
+      this.initConfigSignature = null;
+      this.runtimeConfigSignature = null;
     }
-    this.previousBackendSecret = undefined;
-    this.hadPreviousBackendSecret = false;
-    this.injectedBackendSecret = undefined;
-    this.runtime = null;
-    this.initPromise = null;
-    this.initConfigSignature = null;
-    this.runtimeConfigSignature = null;
+
+    if (stopError !== undefined) throw stopError;
+    if (cleanupError !== undefined) throw cleanupError;
   }
   private installShutdownHooks(): void {
     if (this.shutdownHooksInstalled) return;

--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -17,7 +17,8 @@ const originalJazzServerUrl = process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
 const originalJazzAppId = process.env.NEXT_PUBLIC_JAZZ_APP_ID;
 const originalCorrectnessRun = process.env.JAZZ_CORRECTNESS_ARTIFACT_RUN;
 const originalCorrectnessWasmPackage = process.env.JAZZ_CORRECTNESS_WASM_PACKAGE;
-
+const originalBackendSecret = process.env.BACKEND_SECRET;
+const originalJazzAdminSecret = process.env.JAZZ_ADMIN_SECRET;
 async function resolveWrappedConfig(
   wrapped: ReturnType<typeof withJazz>,
   phase: string,
@@ -71,6 +72,17 @@ afterEach(async () => {
   if (originalCorrectnessWasmPackage === undefined)
     delete process.env.JAZZ_CORRECTNESS_WASM_PACKAGE;
   else process.env.JAZZ_CORRECTNESS_WASM_PACKAGE = originalCorrectnessWasmPackage;
+  if (originalBackendSecret === undefined) {
+    delete process.env.BACKEND_SECRET;
+  } else {
+    process.env.BACKEND_SECRET = originalBackendSecret;
+  }
+
+  if (originalJazzAdminSecret === undefined) {
+    delete process.env.JAZZ_ADMIN_SECRET;
+  } else {
+    process.env.JAZZ_ADMIN_SECRET = originalJazzAdminSecret;
+  }
 });
 
 describe("withJazz", () => {
@@ -189,6 +201,57 @@ describe("withJazz", () => {
         )}&appId=${encodeURIComponent(resolved.env?.NEXT_PUBLIC_JAZZ_APP_ID!)}&adminSecret=next-test-admin`,
       ),
     );
+  }, 30_000);
+
+  it("keeps a generated backend secret in the server process and out of returned Next config", async () => {
+    vi.spyOn(devServer, "startLocalJazzServer")
+      .mockResolvedValueOnce({
+        appId: "00000000-0000-0000-0000-000000000181",
+        port: 19881,
+        url: "http://127.0.0.1:19881",
+        dataDir: undefined as unknown as string,
+        adminSecret: "next-secret-policy-admin-1",
+        backendSecret: "generated-backend-canary-1",
+        stop: vi.fn().mockResolvedValue(undefined),
+      })
+      .mockResolvedValueOnce({
+        appId: "00000000-0000-0000-0000-000000000182",
+        port: 19882,
+        url: "http://127.0.0.1:19882",
+        dataDir: undefined as unknown as string,
+        adminSecret: "next-secret-policy-admin-2",
+        backendSecret: "generated-backend-canary-2",
+        stop: vi.fn().mockResolvedValue(undefined),
+      });
+    vi.spyOn(catalogueProject, "deploy").mockResolvedValue(deployed());
+    vi.spyOn(schemaWatcher, "watchSchema").mockReturnValue({ close: vi.fn() });
+
+    const first = await resolveWrappedConfig(
+      withJazz({}, { server: { adminSecret: "next-secret-policy-admin-1" } }),
+      DEVELOPMENT_PHASE,
+    );
+
+    expect(process.env.BACKEND_SECRET).toBe("generated-backend-canary-1");
+    expect(Object.hasOwn(first.env ?? {}, "BACKEND_SECRET")).toBe(false);
+    expect(Object.values(first.env ?? {})).not.toContain("generated-backend-canary-1");
+    expect(first.env?.NEXT_PUBLIC_JAZZ_APP_ID).toBeTruthy();
+    expect(first.env?.NEXT_PUBLIC_JAZZ_SERVER_URL).toBe("http://127.0.0.1:19881");
+
+    await __resetJazzNextPluginForTests();
+    expect(process.env.BACKEND_SECRET).toBeUndefined();
+
+    process.env.BACKEND_SECRET = "caller-owned-backend-secret";
+    const second = await resolveWrappedConfig(
+      withJazz({}, { server: { adminSecret: "next-secret-policy-admin-2" } }),
+      DEVELOPMENT_PHASE,
+    );
+
+    expect(process.env.BACKEND_SECRET).toBe("generated-backend-canary-2");
+    expect(Object.hasOwn(second.env ?? {}, "BACKEND_SECRET")).toBe(false);
+    expect(Object.values(second.env ?? {})).not.toContain("generated-backend-canary-2");
+
+    await __resetJazzNextPluginForTests();
+    expect(process.env.BACKEND_SECRET).toBe("caller-owned-backend-secret");
   }, 30_000);
 
   it("releases a failed startup before retrying the same port after the schema is fixed", async () => {

--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -257,7 +257,7 @@ describe("withJazz", () => {
   it("preserves an explicit empty backend secret instead of falling back to the environment", async () => {
     process.env.BACKEND_SECRET = "ambient-backend-secret";
     vi.spyOn(devServer, "startLocalJazzServer").mockImplementation(async (options) => {
-      expect(options.backendSecret).toBe("");
+      expect(options?.backendSecret).toBe("");
       throw new Error("backend secret must not be blank");
     });
 

--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -254,6 +254,21 @@ describe("withJazz", () => {
     expect(process.env.BACKEND_SECRET).toBe("caller-owned-backend-secret");
   }, 30_000);
 
+  it("preserves an explicit empty backend secret instead of falling back to the environment", async () => {
+    process.env.BACKEND_SECRET = "ambient-backend-secret";
+    vi.spyOn(devServer, "startLocalJazzServer").mockImplementation(async (options) => {
+      expect(options.backendSecret).toBe("");
+      throw new Error("backend secret must not be blank");
+    });
+
+    await expect(
+      resolveWrappedConfig(
+        withJazz({}, { server: { adminSecret: "next-empty-backend-secret", backendSecret: "" } }),
+        DEVELOPMENT_PHASE,
+      ),
+    ).rejects.toThrow("backend secret must not be blank");
+  });
+
   it("releases a failed startup before retrying the same port after the schema is fixed", async () => {
     const port = await getAvailablePort();
     const schemaDir = await tempRoots.create("jazz-next-retry-");

--- a/packages/jazz-tools/src/dev/next.ts
+++ b/packages/jazz-tools/src/dev/next.ts
@@ -144,7 +144,7 @@ export function withJazz(
       typeof serverOpt === "object" && serverOpt !== null && "backendSecret" in serverOpt
         ? serverOpt.backendSecret
         : undefined;
-    const backendSecret = explicitBackendSecret || process.env.BACKEND_SECRET || undefined;
+    const backendSecret = explicitBackendSecret ?? process.env.BACKEND_SECRET;
 
     const resolvedAppRoot = options.appRoot ?? process.cwd();
     const managed = await runtime.initialize({

--- a/packages/jazz-tools/src/dev/next.ts
+++ b/packages/jazz-tools/src/dev/next.ts
@@ -144,7 +144,7 @@ export function withJazz(
       typeof serverOpt === "object" && serverOpt !== null && "backendSecret" in serverOpt
         ? serverOpt.backendSecret
         : undefined;
-    const backendSecret = explicitBackendSecret ?? process.env.BACKEND_SECRET;
+    const backendSecret = explicitBackendSecret || process.env.BACKEND_SECRET || undefined;
 
     const resolvedAppRoot = options.appRoot ?? process.cwd();
     const managed = await runtime.initialize({
@@ -177,7 +177,6 @@ export function withJazz(
         ...(managed.telemetryCollectorUrl
           ? { [PUBLIC_TELEMETRY_COLLECTOR_URL_ENV]: managed.telemetryCollectorUrl }
           : {}),
-        ...(managed.backendSecret ? { BACKEND_SECRET: managed.backendSecret } : {}),
       },
       turbopack: {
         ...previousTurbopack,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1091,6 +1091,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      server-only:
+        specifier: 0.0.1
+        version: 0.0.1
     devDependencies:
       '@playwright/test':
         specifier: ^1.58.2
@@ -12122,6 +12125,9 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -25297,6 +25303,8 @@ snapshots:
       send: 0.19.2
     transitivePeerDependencies:
       - supports-color
+
+  server-only@0.0.1: {}
 
   set-blocking@2.0.0: {}
 


### PR DESCRIPTION
🤖 Keeps privileged backend credentials server-only in the Next integration and example, with retry-safe managed-runtime cleanup. Supersedes #2515.

Previously, returned Next env configuration could expose backend credentials to client bundling. The example now obtains trusted credentials through its server-only module; client configuration contains public connection settings only. Explicitly supplying an empty backend secret remains invalid rather than silently selecting an ambient or generated secret.

Failed managed-runtime cleanup resets retained handles/configuration and restores an injected environment secret only while it still owns that value, allowing later startup to retry. Normal successful startup and authentication semantics are preserved.

The E2E fixture generates a fresh per-run backend secret in the web-server environment. Its previous empty values correctly triggered the newly preserved blank-secret rejection and prevented startup; the fixture now exercises valid server setup without weakening validation.

Validation: 39 focused Next/managed-runtime tests, configuration-security test, actual admitted Next E2E, example typecheck, and sealed artifact/Tools builds passed. Independent prior review included planted credential exposure, blank fallback and cleanup regressions. Fresh full CI is running at c77f935bc1.
