### PR TITLE
Make recursive evaluation failures atomic on current main

### DIFF
--- a/crates/groove/SPEC/4_incremental_maintenance.md
+++ b/crates/groove/SPEC/4_incremental_maintenance.md
@@ -41,7 +41,7 @@ Invariant digest:
 - `INV-TICK-15`: A recursive positive incremental tick MUST emit each newly discovered recursive fact at weight `+1` at most once and MUST collapse duplicate derivations.
 - `INV-TICK-16`: The reference implementation selects recompute for negative table deltas, cached recursive state with table deltas, empty unbound state, or unhydrated step arrangements. This trigger set is broader than the minimum necessary; the contractual result is the minimal diff required by INV-REC-8.
 - `INV-TICK-17`: Recursive recompute and incremental recursion MUST reject non-positive recursive frontier facts instead of assigning bag-recursive semantics.
-- `INV-TICK-18`: Fixpoint recursion MUST stop with `RecursiveIterationLimit` when the frontier remains non-empty after its safety `max_iters`; semantic depth bounds MUST truncate instead.
+- `INV-TICK-18`: Fixpoint recursion MUST stop with `RecursiveIterationLimit` when the frontier remains non-empty after its safety `max_iters`; semantic depth bounds MUST truncate instead. The limit is part of recursive-node identity: equal recursive nodes share one success or failure, while distinct limits remain distinct. Failure aborts that node and its downstream closure, including dependent terminals and staged durable writes; independent graph branches may still publish and valid shared upstream state is not duplicated.
 - `INV-TICK-19`: Hydrating or querying a graph MUST NOT perturb an existing subscription stream's future tick deltas.
 - `INV-TICK-20`: Contextual recursive child state MUST NOT be persisted in `operator_states` after recursive recompute; retained child operator state outside `FrontierSource` context remains root-scoped.
 
@@ -227,7 +227,11 @@ _Further invariants._ `INV-TICK-17` — recursion rejects non-positive frontier
 facts rather than assigning bag-recursive semantics (ch. 6). `INV-TICK-18` —
 fixpoint recursion stops with `RecursiveIterationLimit` when the frontier is
 still non-empty after its safety `max_iters`, while semantic depth bounds
-truncate the out-of-range frontier (ch. 6). `INV-TICK-20` — contextual recursive
+truncate the out-of-range frontier (ch. 6). The limit participates in recursive
+node identity, so equal nodes share success or failure while different limits
+do not alias. Failure aborts the node and its downstream closure, including
+dependent terminals and staged durable writes; independent branches still
+publish and valid shared upstream state is not duplicated. `INV-TICK-20` — contextual recursive
 child state is not persisted in `operator_states` after recompute (ch. 6).
 
 ### 4.6 The unified arrangement model

--- a/crates/groove/src/db/tests/graphs/recursion.rs
+++ b/crates/groove/src/db/tests/graphs/recursion.rs
@@ -1389,9 +1389,14 @@ async fn resident_recursive_limit_discards_staged_closure() {
         .subscribe_one_sink(reachability_graph(1))
         .await
         .unwrap();
+    let mut reopened = subscription.recv().unwrap().to_values().unwrap();
+    reopened.sort_by_key(|(values, _)| format!("{values:?}"));
     assert_eq!(
-        subscription.recv().unwrap().to_values().unwrap(),
-        [(vec![Value::U64(1), Value::U64(2)], 1)],
-        "a fresh resident subscription must not inherit the failed staged closure"
+        reopened,
+        [
+            (vec![Value::U64(1), Value::U64(2)], 1),
+            (vec![Value::U64(3), Value::U64(4)], 1),
+        ],
+        "a fresh resident subscription rebuilds from committed base rows, not the failed closure"
     );
 }

--- a/crates/groove/src/db/tests/graphs/recursion.rs
+++ b/crates/groove/src/db/tests/graphs/recursion.rs
@@ -1308,3 +1308,90 @@ async fn recursive_graphs_fail_when_frontier_exceeds_max_iters() {
         Error::IvmRuntime(IvmRuntimeError::RecursiveIterationLimit { max_iters: 1, .. })
     ));
 }
+
+/// A scoped recursive failure on the resident Database path must not install
+/// the partially evaluated closure. A fresh subscription must rebuild from
+/// the persisted rows without inheriting that failed state.
+#[futures_test::test]
+async fn resident_recursive_limit_discards_staged_closure() {
+    let storage = MemoryStorage::new(&["edges"]).expect("valid memory storage families");
+    let mut database = Database::new(edges_schema(), storage).await.unwrap();
+
+    let mut seed = database.open_batch();
+    insert_edge(&mut seed, 1, 1, 2);
+    database.commit_batch(seed).await.unwrap();
+
+    let failed = database
+        .subscribe_one_sink(reachability_graph(1))
+        .await
+        .unwrap();
+    assert_eq!(
+        failed.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+
+    let before_stats = database.runtime_stats();
+    let mut update = database.open_batch();
+    insert_edge(&mut update, 2, 2, 3);
+    insert_edge(&mut update, 3, 3, 4);
+    database.commit_batch(update).await.unwrap();
+    let after_stats = database.runtime_stats();
+    assert_eq!(
+        after_stats.graph_nodes, before_stats.graph_nodes,
+        "a failed subscription must not alter the installed graph"
+    );
+    assert_eq!(
+        after_stats.active_subscriptions, before_stats.active_subscriptions,
+        "the failed subscription remains observable through its failure channel"
+    );
+    assert_eq!(
+        after_stats.recursive_state_count, 0,
+        "failed subscription teardown must remove recursive operator state"
+    );
+    assert_eq!(
+        after_stats.recursive_accumulated_rows, 0,
+        "failed recursion must not retain a partial closure"
+    );
+    assert_eq!(
+        after_stats.recursive_accumulated_encoded_bytes, 0,
+        "failed recursion must not retain encoded partial closure state"
+    );
+    assert_eq!(
+        after_stats.arrangement_count, before_stats.arrangement_count,
+        "failed recursion must not install or remove committed arrangements"
+    );
+    assert_eq!(
+        after_stats.arrangement_rows, before_stats.arrangement_rows,
+        "failed recursion must not advance committed arrangement rows"
+    );
+    assert_eq!(
+        after_stats.arrangement_encoded_bytes, before_stats.arrangement_encoded_bytes,
+        "failed recursion must not advance encoded arrangement state"
+    );
+    assert!(
+        after_stats.eval_memo_entries <= before_stats.eval_memo_entries,
+        "failed recursion must not install partial evaluator memo entries"
+    );
+    assert!(
+        after_stats.eval_memo_bytes <= before_stats.eval_memo_bytes,
+        "failed recursion must not install partial evaluator memo bytes"
+    );
+    assert!(
+        failed.recv().is_err(),
+        "the scoped failure must fail its subscription"
+    );
+
+    let mut rollback = database.open_batch();
+    rollback.delete("edges", PrimaryKeyValue::U64(2));
+    database.commit_batch(rollback).await.unwrap();
+
+    let subscription = database
+        .subscribe_one_sink(reachability_graph(1))
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)],
+        "a fresh resident subscription must not inherit the failed staged closure"
+    );
+}

--- a/crates/groove/src/db/tests/graphs/recursion.rs
+++ b/crates/groove/src/db/tests/graphs/recursion.rs
@@ -1329,12 +1329,34 @@ async fn resident_recursive_limit_discards_staged_closure() {
         failed.recv().unwrap().to_values().unwrap(),
         [(vec![Value::U64(1), Value::U64(2)], 1)]
     );
+    let healthy = database
+        .subscribe_one_sink(GraphBuilder::table("edges").project(["src", "dst"]))
+        .await
+        .expect("an independent recursive subscription opens");
+    assert_eq!(
+        healthy.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
 
     let before_stats = database.runtime_stats();
     let mut update = database.open_batch();
     insert_edge(&mut update, 2, 2, 3);
     insert_edge(&mut update, 3, 3, 4);
     database.commit_batch(update).await.unwrap();
+    let mut healthy_delta = healthy
+        .try_recv()
+        .expect("the independent subscription receives its commit delta")
+        .to_values()
+        .unwrap();
+    healthy_delta.sort_by_key(|(values, _)| format!("{values:?}"));
+    assert_eq!(
+        healthy_delta,
+        [
+            (vec![Value::U64(2), Value::U64(3)], 1),
+            (vec![Value::U64(3), Value::U64(4)], 1),
+        ],
+        "a failed recursive owner must not suppress an independent owner's publication"
+    );
     let after_stats = database.runtime_stats();
     assert_eq!(
         after_stats.graph_nodes, before_stats.graph_nodes,
@@ -1356,17 +1378,11 @@ async fn resident_recursive_limit_discards_staged_closure() {
         after_stats.recursive_accumulated_encoded_bytes, 0,
         "failed recursion must not retain encoded partial closure state"
     );
-    assert_eq!(
-        after_stats.arrangement_count, before_stats.arrangement_count,
-        "failed recursion must not install or remove committed arrangements"
-    );
-    assert_eq!(
-        after_stats.arrangement_rows, before_stats.arrangement_rows,
-        "failed recursion must not advance committed arrangement rows"
-    );
-    assert_eq!(
-        after_stats.arrangement_encoded_bytes, before_stats.arrangement_encoded_bytes,
-        "failed recursion must not advance encoded arrangement state"
+    assert!(
+        after_stats.arrangement_count >= before_stats.arrangement_count
+            && after_stats.arrangement_rows >= before_stats.arrangement_rows
+            && after_stats.arrangement_encoded_bytes >= before_stats.arrangement_encoded_bytes,
+        "only the healthy owner's arrangement work may be published"
     );
     assert!(
         after_stats.eval_memo_entries <= before_stats.eval_memo_entries,

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -90,14 +90,153 @@ mod collect_by_state_tests {
         prepared.groups.clear();
         assert!(!Rc::ptr_eq(&original.payload, &prepared.payload));
     }
+
+    #[test]
+    fn collect_by_group_stages_only_touched_occurrences() {
+        let first = (Vec::new(), Bytes::from_static(b"first"));
+        let second = (Vec::new(), Bytes::from_static(b"second"));
+        let mut live = CollectByGroup::default();
+        live.set(first.clone(), 1);
+        live.commit_overlay();
+
+        let mut staged = live.clone();
+        staged.set(second.clone(), 1);
+
+        assert_eq!(live.get(&second), None);
+        assert_eq!(staged.get(&first), Some(&1));
+        assert_eq!(staged.get(&second), Some(&1));
+        assert!(Rc::ptr_eq(&live.base, &staged.base));
+
+        // Installation removes the live state first, so folding the staged
+        // overlay updates the shared base without re-materializing it.
+        drop(live);
+        staged.commit_overlay();
+        assert!(staged.overlay.is_empty());
+        assert_eq!(staged.get(&first), Some(&1));
+        assert_eq!(staged.get(&second), Some(&1));
+    }
 }
 
 pub(super) type CollectByOrderKey = (Vec<TopBySortPart>, Bytes);
-type CollectByGroups = BTreeMap<Vec<u8>, BTreeMap<CollectByOrderKey, i64>>;
+type TopByGroups = BTreeMap<Vec<u8>, CollectByGroup>;
+type CollectByGroups = BTreeMap<Vec<u8>, CollectByGroup>;
+
+/// A collector group is copied between a live evaluator and its staged tick.
+/// Keep its long-lived occurrence map immutable and record only touched keys
+/// in the staged overlay.  A single child edit must not clone every child of a
+/// large parent collection merely because the tick later needs atomic commit.
+#[derive(Clone, Debug, Default)]
+pub(super) struct CollectByGroup {
+    base: Rc<BTreeMap<CollectByOrderKey, i64>>,
+    overlay: Rc<BTreeMap<CollectByOrderKey, Option<i64>>>,
+}
+
+impl CollectByGroup {
+    pub(super) fn get(&self, key: &CollectByOrderKey) -> Option<&i64> {
+        self.overlay.get(key).and_then(Option::as_ref).or_else(|| {
+            (!self.overlay.contains_key(key))
+                .then(|| self.base.get(key))
+                .flatten()
+        })
+    }
+
+    pub(super) fn set(&mut self, key: CollectByOrderKey, weight: i64) {
+        Rc::make_mut(&mut self.overlay).insert(key, (weight != 0).then_some(weight));
+    }
+
+    pub(super) fn count_before(&self, key: &CollectByOrderKey) -> usize {
+        self.iter()
+            .take_while(|(candidate, _)| *candidate < key)
+            .filter(|(_, weight)| **weight > 0)
+            .count()
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.iter().next().is_none()
+    }
+
+    pub(super) fn iter(&self) -> CollectByGroupIter<'_> {
+        CollectByGroupIter {
+            base: self.base.iter().peekable(),
+            overlay: self.overlay.iter().peekable(),
+        }
+    }
+
+    /// Fold this tick's sparse mutations only after the old live operator was
+    /// removed, making the common commit path uniquely own the base map.
+    pub(super) fn commit_overlay(&mut self) {
+        if self.overlay.is_empty() {
+            return;
+        }
+        let overlay = std::mem::take(&mut self.overlay);
+        let overlay = Rc::try_unwrap(overlay).unwrap_or_else(|overlay| (*overlay).clone());
+        let base = Rc::make_mut(&mut self.base);
+        for (key, weight) in overlay {
+            if let Some(weight) = weight {
+                base.insert(key, weight);
+            } else {
+                base.remove(&key);
+            }
+        }
+    }
+}
+
+pub(super) struct CollectByGroupIter<'a> {
+    base: std::iter::Peekable<std::collections::btree_map::Iter<'a, CollectByOrderKey, i64>>,
+    overlay:
+        std::iter::Peekable<std::collections::btree_map::Iter<'a, CollectByOrderKey, Option<i64>>>,
+}
+
+impl<'a> Iterator for CollectByGroupIter<'a> {
+    type Item = (&'a CollectByOrderKey, &'a i64);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match (self.base.peek(), self.overlay.peek()) {
+                (Some((base_key, base_weight)), Some((overlay_key, overlay_weight))) => {
+                    match base_key.cmp(overlay_key) {
+                        std::cmp::Ordering::Less => {
+                            let item = (*base_key, *base_weight);
+                            self.base.next();
+                            return Some(item);
+                        }
+                        std::cmp::Ordering::Greater => {
+                            let item = (*overlay_key, *overlay_weight);
+                            self.overlay.next();
+                            if let (key, Some(weight)) = item {
+                                return Some((key, weight));
+                            }
+                        }
+                        std::cmp::Ordering::Equal => {
+                            self.base.next();
+                            let item = self.overlay.next().expect("overlay was peeked");
+                            if let (key, Some(weight)) = item {
+                                return Some((key, weight));
+                            }
+                        }
+                    }
+                }
+                (Some((key, weight)), None) => {
+                    let item = (*key, *weight);
+                    self.base.next();
+                    return Some(item);
+                }
+                (None, Some((key, weight))) => {
+                    let item = (*key, *weight);
+                    self.overlay.next();
+                    if let (key, Some(weight)) = item {
+                        return Some((key, weight));
+                    }
+                }
+                (None, None) => return None,
+            }
+        }
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 pub(super) struct TopByIncrementalState {
-    groups: CollectByGroups,
+    groups: TopByGroups,
 }
 
 impl TopByIncrementalState {
@@ -108,9 +247,19 @@ impl TopByIncrementalState {
         I: IntoIterator<Item = Vec<u8>>,
     {
         for group in groups {
-            if self.groups.get(&group).is_some_and(BTreeMap::is_empty) {
+            if self
+                .groups
+                .get(&group)
+                .is_some_and(CollectByGroup::is_empty)
+            {
                 self.groups.remove(&group);
             }
+        }
+    }
+
+    pub(super) fn commit_overlays(&mut self) {
+        for group in self.groups.values_mut() {
+            group.commit_overlay();
         }
     }
 
@@ -1793,11 +1942,8 @@ impl TickEvaluator<'_> {
                     top_by_sort_key(output_desc, delta.raw(), top_by)?,
                     delta.record.clone(),
                 );
-                let weight = group.entry(order_key.clone()).or_default();
-                *weight += delta.weight;
-                if *weight == 0 {
-                    group.remove(&order_key);
-                }
+                let weight = group.get(&order_key).copied().unwrap_or_default() + delta.weight;
+                group.set(order_key, weight);
             }
         }
         state

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -121,28 +121,43 @@ mod collect_by_state_tests {
         let first = b"first".to_vec();
         let second = b"second".to_vec();
         let order = (Vec::new(), Bytes::from_static(b"record"));
+        let changed_order = (Vec::new(), Bytes::from_static(b"changed-record"));
         let mut live = SparseGroups::default();
         live.get_or_default(first.clone()).set(order.clone(), 1);
+        live.get_or_default(second.clone()).set(order.clone(), 1);
         live.commit_overlay();
+        let first_base = Rc::as_ptr(&live.get(&first).expect("installed first group").base);
 
         let mut staged = live.clone();
-        staged.get_or_default(second.clone()).set(order, 1);
+        staged
+            .get_or_default(first.clone())
+            .set(changed_order.clone(), 1);
 
         // This is the scale canary: a tick changing one group must retain the
         // installed outer map, rather than cloning every unrelated group.
         assert!(Rc::ptr_eq(&live.base, &staged.base));
-        assert_eq!(live.keys(), BTreeSet::from([first.clone()]));
+        assert_eq!(live.keys(), BTreeSet::from([first.clone(), second.clone()]));
         assert_eq!(
             staged.keys(),
             BTreeSet::from([first.clone(), second.clone()])
         );
-        assert!(staged.get(&first).is_some());
+        assert_eq!(
+            staged
+                .get(&first)
+                .and_then(|group| group.get(&changed_order)),
+            Some(&1)
+        );
         assert!(staged.get(&second).is_some());
 
         drop(live);
         staged.commit_overlay();
         assert!(staged.overlay.is_empty());
         assert_eq!(staged.keys(), BTreeSet::from([first, second]));
+        assert_eq!(
+            Rc::as_ptr(&staged.get(b"first").expect("committed first group").base),
+            first_base,
+            "folding a changed group must not copy its untouched occurrences"
+        );
     }
 }
 
@@ -171,11 +186,21 @@ impl SparseGroups {
 
     pub(super) fn get_or_default(&mut self, key: Vec<u8>) -> &mut CollectByGroup {
         let base = &self.base;
-        Rc::make_mut(&mut self.overlay)
-            .entry(key.clone())
-            .or_insert_with(|| Some(base.get(&key).cloned().unwrap_or_default()))
-            .as_mut()
-            .expect("present group is never removed before mutation")
+        let overlay = Rc::make_mut(&mut self.overlay);
+        let group = match overlay.entry(key.clone()) {
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                // A previous retraction can leave a tombstone in the staged
+                // overlay. A later delta in the same tick must revive it.
+                if entry.get().is_none() {
+                    entry.insert(Some(base.get(&key).cloned().unwrap_or_default()));
+                }
+                entry.into_mut()
+            }
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(Some(base.get(&key).cloned().unwrap_or_default()))
+            }
+        };
+        group.as_mut().expect("revived group is present")
     }
 
     pub(super) fn remove_empty_touched_groups<I>(&mut self, keys: I)
@@ -192,6 +217,22 @@ impl SparseGroups {
     pub(super) fn clear(&mut self) {
         self.base = Rc::default();
         self.overlay = Rc::default();
+    }
+
+    /// Rank a present group in the merged ordered map without constructing a
+    /// combined snapshot of all groups.
+    pub(super) fn count_before(&self, key: &[u8]) -> usize {
+        let retained_base = self
+            .base
+            .range(..key.to_vec())
+            .filter(|(candidate, _)| self.overlay.get(*candidate).is_none_or(Option::is_some))
+            .count();
+        let inserted_overlay = self
+            .overlay
+            .range(..key.to_vec())
+            .filter(|(candidate, group)| group.is_some() && !self.base.contains_key(*candidate))
+            .count();
+        retained_base + inserted_overlay
     }
 
     #[cfg(test)]
@@ -212,26 +253,28 @@ impl SparseGroups {
         self.keys().len()
     }
 
-    /// Fold after the installed state was removed, so both outer and inner
-    /// bases are uniquely owned on the normal commit path.
+    /// Fold after the installed state was removed.  Remove a replaced group
+    /// from the uniquely-owned outer map *before* folding its inner overlay:
+    /// the staged group shares that inner base with the old map entry, so
+    /// folding first would make `Rc::make_mut` clone every occurrence.
     pub(super) fn commit_overlay(&mut self) {
         if self.overlay.is_empty() {
             return;
         }
         let overlay = std::mem::take(&mut self.overlay);
         let overlay = Rc::try_unwrap(overlay).unwrap_or_else(|value| (*value).clone());
-        let base = Rc::make_mut(&mut self.base);
+        let mut base =
+            Rc::try_unwrap(std::mem::take(&mut self.base)).unwrap_or_else(|value| (*value).clone());
         for (key, group) in overlay {
-            match group {
-                Some(mut group) => {
-                    group.commit_overlay();
-                    base.insert(key, group);
-                }
-                None => {
-                    base.remove(&key);
-                }
+            // Dropping the pre-image first makes an existing staged group's
+            // occurrence base uniquely owned on the successful install path.
+            base.remove(&key);
+            if let Some(mut group) = group {
+                group.commit_overlay();
+                base.insert(key, group);
             }
         }
+        self.base = Rc::new(base);
     }
 }
 

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -115,11 +115,125 @@ mod collect_by_state_tests {
         assert_eq!(staged.get(&first), Some(&1));
         assert_eq!(staged.get(&second), Some(&1));
     }
+
+    #[test]
+    fn sparse_groups_stage_one_group_without_cloning_the_outer_index() {
+        let first = b"first".to_vec();
+        let second = b"second".to_vec();
+        let order = (Vec::new(), Bytes::from_static(b"record"));
+        let mut live = SparseGroups::default();
+        live.get_or_default(first.clone()).set(order.clone(), 1);
+        live.commit_overlay();
+
+        let mut staged = live.clone();
+        staged.get_or_default(second.clone()).set(order, 1);
+
+        // This is the scale canary: a tick changing one group must retain the
+        // installed outer map, rather than cloning every unrelated group.
+        assert!(Rc::ptr_eq(&live.base, &staged.base));
+        assert_eq!(live.keys(), BTreeSet::from([first.clone()]));
+        assert_eq!(
+            staged.keys(),
+            BTreeSet::from([first.clone(), second.clone()])
+        );
+        assert!(staged.get(&first).is_some());
+        assert!(staged.get(&second).is_some());
+
+        drop(live);
+        staged.commit_overlay();
+        assert!(staged.overlay.is_empty());
+        assert_eq!(staged.keys(), BTreeSet::from([first, second]));
+    }
 }
 
 pub(super) type CollectByOrderKey = (Vec<TopBySortPart>, Bytes);
-type TopByGroups = BTreeMap<Vec<u8>, CollectByGroup>;
-type CollectByGroups = BTreeMap<Vec<u8>, CollectByGroup>;
+type TopByGroups = SparseGroups;
+type CollectByGroups = SparseGroups;
+
+/// Copy-on-write ordered map for the outer window-group index.  Like
+/// [`CollectByGroup`], a speculative tick owns only its changed entries; the
+/// (potentially very large) untouched group index remains shared with the
+/// installed state until the successful install boundary.
+#[derive(Clone, Debug, Default)]
+pub(super) struct SparseGroups {
+    base: Rc<BTreeMap<Vec<u8>, CollectByGroup>>,
+    overlay: Rc<BTreeMap<Vec<u8>, Option<CollectByGroup>>>,
+}
+
+impl SparseGroups {
+    pub(super) fn get(&self, key: &[u8]) -> Option<&CollectByGroup> {
+        self.overlay.get(key).and_then(Option::as_ref).or_else(|| {
+            (!self.overlay.contains_key(key))
+                .then(|| self.base.get(key))
+                .flatten()
+        })
+    }
+
+    pub(super) fn get_or_default(&mut self, key: Vec<u8>) -> &mut CollectByGroup {
+        let base = &self.base;
+        Rc::make_mut(&mut self.overlay)
+            .entry(key.clone())
+            .or_insert_with(|| Some(base.get(&key).cloned().unwrap_or_default()))
+            .as_mut()
+            .expect("present group is never removed before mutation")
+    }
+
+    pub(super) fn remove_empty_touched_groups<I>(&mut self, keys: I)
+    where
+        I: IntoIterator<Item = Vec<u8>>,
+    {
+        for key in keys {
+            if self.get(&key).is_some_and(CollectByGroup::is_empty) {
+                Rc::make_mut(&mut self.overlay).insert(key, None);
+            }
+        }
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.base = Rc::default();
+        self.overlay = Rc::default();
+    }
+
+    #[cfg(test)]
+    pub(super) fn keys(&self) -> BTreeSet<Vec<u8>> {
+        let mut keys = self.base.keys().cloned().collect::<BTreeSet<_>>();
+        for (key, value) in self.overlay.iter() {
+            if value.is_some() {
+                keys.insert(key.clone());
+            } else {
+                keys.remove(key);
+            }
+        }
+        keys
+    }
+
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.keys().len()
+    }
+
+    /// Fold after the installed state was removed, so both outer and inner
+    /// bases are uniquely owned on the normal commit path.
+    pub(super) fn commit_overlay(&mut self) {
+        if self.overlay.is_empty() {
+            return;
+        }
+        let overlay = std::mem::take(&mut self.overlay);
+        let overlay = Rc::try_unwrap(overlay).unwrap_or_else(|value| (*value).clone());
+        let base = Rc::make_mut(&mut self.base);
+        for (key, group) in overlay {
+            match group {
+                Some(mut group) => {
+                    group.commit_overlay();
+                    base.insert(key, group);
+                }
+                None => {
+                    base.remove(&key);
+                }
+            }
+        }
+    }
+}
 
 /// A collector group is copied between a live evaluator and its staged tick.
 /// Keep its long-lived occurrence map immutable and record only touched keys
@@ -252,15 +366,13 @@ impl TopByIncrementalState {
                 .get(&group)
                 .is_some_and(CollectByGroup::is_empty)
             {
-                self.groups.remove(&group);
+                self.groups.remove_empty_touched_groups([group]);
             }
         }
     }
 
     pub(super) fn commit_overlays(&mut self) {
-        for group in self.groups.values_mut() {
-            group.commit_overlay();
-        }
+        self.groups.commit_overlay();
     }
 
     #[cfg(test)]
@@ -1935,8 +2047,7 @@ impl TickEvaluator<'_> {
             let group = state
                 .value_mut()
                 .groups
-                .entry(group_prefix.clone())
-                .or_default();
+                .get_or_default(group_prefix.clone());
             for delta in group_deltas {
                 let order_key = (
                     top_by_sort_key(output_desc, delta.raw(), top_by)?,

--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -63,9 +63,28 @@ pub(super) struct SemiJoinState {
 
 #[derive(Clone, Debug, Default)]
 pub(super) struct ArrangementState {
-    /// key -> record multiset. Records are kept as encoded bytes so probing can
-    /// build output records without rehydrating whole tables.
+    /// Immutable base buckets are shared between evaluator snapshots. Updates
+    /// retain only touched buckets in the overlay, rather than cloning the
+    /// complete join index.
     index: Rc<JoinIndex>,
+    overlay: Rc<HashMap<JoinKey, Option<JoinBucket>>>,
+}
+
+enum JoinLookup<'a> {
+    Arrangement(&'a ArrangementState),
+    Index(&'a JoinIndex),
+}
+
+impl JoinLookup<'_> {
+    fn bucket(&self, key: &JoinKey) -> Option<&JoinBucket> {
+        match self {
+            Self::Arrangement(arrangement) => match arrangement.overlay.get(key) {
+                Some(bucket) => bucket.as_ref(),
+                None => arrangement.index.get(key),
+            },
+            Self::Index(index) => index.get(key),
+        }
+    }
 }
 
 impl JoinState {
@@ -185,7 +204,7 @@ impl JoinState {
                 &mut output,
                 &context,
                 &keyed_left_delta,
-                &right_arrangement.value().index,
+                &JoinLookup::Arrangement(right_arrangement.value()),
                 JoinProbeSide::LeftDelta,
                 1,
             )?;
@@ -206,7 +225,7 @@ impl JoinState {
             &mut output,
             &context,
             &keyed_left_delta,
-            &right_arrangement.value().index,
+            &JoinLookup::Arrangement(right_arrangement.value()),
             JoinProbeSide::LeftDelta,
             1,
         )?;
@@ -214,7 +233,7 @@ impl JoinState {
             &mut output,
             &context,
             &keyed_right_delta,
-            &left_arrangement.value().index,
+            &JoinLookup::Arrangement(left_arrangement.value()),
             JoinProbeSide::RightDelta,
             1,
         )?;
@@ -226,7 +245,7 @@ impl JoinState {
             &mut output,
             &context,
             &keyed_right_delta,
-            &left_delta_index,
+            &JoinLookup::Index(&left_delta_index),
             JoinProbeSide::RightDelta,
             -1,
         )?;
@@ -417,43 +436,50 @@ impl ArrangementState {
         let mut index = HashMap::default();
         for key in keys {
             let key = JoinKey::from_slice(key);
-            if let Some(bucket) = self.index.get(&key) {
+            if let Some(bucket) = self.bucket(&key) {
                 index.insert(key, bucket.clone());
             }
         }
         Self {
             index: Rc::new(index),
+            overlay: Rc::default(),
         }
     }
 
     pub(super) fn replace_keys<'a>(
         &mut self,
         keys: impl IntoIterator<Item = &'a Vec<u8>>,
-        mut replacement: Self,
+        replacement: Self,
     ) {
+        let overlay = Rc::make_mut(&mut self.overlay);
         for key in keys {
             let key = JoinKey::from_slice(key);
-            if let Some(bucket) = Rc::make_mut(&mut replacement.index).remove(&key) {
-                Rc::make_mut(&mut self.index).insert(key, bucket);
-            } else {
-                Rc::make_mut(&mut self.index).remove(&key);
-            }
+            overlay.insert(key.clone(), replacement.bucket(&key).cloned());
         }
     }
 
     pub(super) fn row_count(&self) -> usize {
-        self.index
-            .values()
+        let mut keys = self.index.keys().cloned().collect::<HashSet<_>>();
+        keys.extend(self.overlay.keys().cloned());
+        keys.into_iter()
+            .filter_map(|key| self.bucket(&key))
             .map(|bucket| bucket.values().filter(|weight| **weight != 0).count())
             .sum()
     }
 
     pub(super) fn encoded_bytes(&self) -> usize {
-        self.index
-            .iter()
-            .map(|(key, bucket)| {
-                key.len() + bucket.keys().map(|record| record.len()).sum::<usize>()
+        let mut keys = self.index.keys().cloned().collect::<HashSet<_>>();
+        keys.extend(self.overlay.keys().cloned());
+        keys.into_iter()
+            .filter_map(|key| {
+                self.bucket(&key).map(|bucket| {
+                    (
+                        key.len(),
+                        bucket.keys().map(|record| record.len()).sum::<usize>(),
+                    )
+                })
             })
+            .map(|(key_len, record_bytes)| key_len + record_bytes)
             .sum()
     }
 
@@ -464,23 +490,43 @@ impl ArrangementState {
     ) {
         match update_mode {
             ArrangementUpdateMode::Accumulate => {
-                apply_join_delta_to_index(Rc::make_mut(&mut self.index), deltas);
+                let mut buckets = HashMap::<JoinKey, JoinBucket>::default();
+                for delta in deltas {
+                    let bucket = buckets
+                        .entry(delta.key.clone())
+                        .or_insert_with(|| self.bucket(&delta.key).cloned().unwrap_or_default());
+                    let next_weight = bucket.get(&delta.delta.record).copied().unwrap_or_default()
+                        + delta.delta.weight;
+                    if next_weight == 0 {
+                        bucket.remove(&delta.delta.record);
+                    } else {
+                        bucket.insert(delta.delta.record.clone(), next_weight);
+                    }
+                }
+                let overlay = Rc::make_mut(&mut self.overlay);
+                for (key, bucket) in buckets {
+                    overlay.insert(key, (!bucket.is_empty()).then_some(bucket));
+                }
             }
             ArrangementUpdateMode::Replace => {
                 self.index = Rc::new(build_join_delta_index(deltas));
+                self.overlay = Rc::default();
             }
         }
     }
 
     fn key_count(&self, key: &[u8]) -> i64 {
-        self.index
-            .get(key)
+        self.bucket(key)
             .map(|bucket| bucket.values().sum())
             .unwrap_or_default()
     }
 
     fn bucket(&self, key: &[u8]) -> Option<&JoinBucket> {
-        self.index.get(key)
+        let key = JoinKey::from_slice(key);
+        match self.overlay.get(&key) {
+            Some(bucket) => bucket.as_ref(),
+            None => self.index.get(&key),
+        }
     }
 
     pub(super) fn apply_record_deltas(
@@ -496,8 +542,7 @@ impl ArrangementState {
     }
 
     pub(super) fn records_for_key(&self, key: &[u8]) -> Vec<(Bytes, i64)> {
-        self.index
-            .get(key)
+        self.bucket(key)
             .into_iter()
             .flat_map(|bucket| bucket.iter())
             .filter_map(|(record, weight)| (*weight > 0).then_some((record.clone(), *weight)))
@@ -562,16 +607,11 @@ struct JoinChangeContext<'a> {
 struct JoinOutputBuffer {
     /// All encoded joined rows, stored one after another.
     bytes: BytesMut,
+    deltas: Vec<(Range<usize>, i64)>,
     /// Where each row is inside `bytes`, together with its weight.
     ///
     /// For example, `(0..20, 1)` means “the row in bytes `0..20` has weight
     /// `+1`.”
-    deltas: Vec<(Range<usize>, i64)>,
-    /// Temporary work area for fields such as strings, bytes, and arrays.
-    ///
-    /// Each item stores which input row owns the field (`0` for left, `1` for
-    /// right) and where the field's bytes are in that row. The encoder clears
-    /// and reuses this vector for every joined row.
     variable_scratch: Vec<(usize, Range<usize>)>,
 }
 
@@ -589,7 +629,7 @@ fn append_join_deltas(
     output: &mut JoinOutputBuffer,
     context: &JoinChangeContext<'_>,
     delta_records: &[KeyedRecordDelta<'_>],
-    stored: &JoinIndex,
+    stored: &JoinLookup<'_>,
     side: JoinProbeSide,
     sign: i64,
 ) -> Result<(), IvmRuntimeError> {
@@ -597,7 +637,7 @@ fn append_join_deltas(
         if delta.delta.weight == 0 {
             continue;
         }
-        let Some(bucket) = stored.get(&delta.key) else {
+        let Some(bucket) = stored.bucket(&delta.key) else {
             continue;
         };
         for (stored_record, right_weight) in bucket {
@@ -1240,6 +1280,7 @@ mod tests {
         index.insert(JoinKey::from_slice(b"one"), bucket);
         let original = ArrangementState {
             index: Rc::new(index),
+            overlay: Rc::default(),
         };
 
         let mut prepared = original.clone();
@@ -1250,8 +1291,10 @@ mod tests {
 
         let mut second_bucket = HashMap::default();
         second_bucket.insert(Bytes::from_static(b"row-two"), 1);
-        Rc::make_mut(&mut prepared.index).insert(JoinKey::from_slice(b"two"), second_bucket);
-        assert!(!Rc::ptr_eq(&original.index, &prepared.index));
+        Rc::make_mut(&mut prepared.overlay)
+            .insert(JoinKey::from_slice(b"two"), Some(second_bucket));
+        assert!(Rc::ptr_eq(&original.index, &prepared.index));
+        assert!(!Rc::ptr_eq(&original.overlay, &prepared.overlay));
         assert_eq!(original.row_count(), 1);
         assert_eq!(prepared.row_count(), 2);
     }

--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -24,7 +24,69 @@ use super::{
 };
 
 pub(super) type JoinKey = SmallVec<[u8; 64]>;
-type JoinBucket = HashMap<Bytes, i64>;
+#[derive(Clone, Debug, Default)]
+struct JoinBucket {
+    base: Rc<HashMap<Bytes, i64>>,
+    overlay: Rc<HashMap<Bytes, Option<i64>>>,
+}
+
+impl JoinBucket {
+    fn get(&self, record: &Bytes) -> Option<&i64> {
+        self.overlay
+            .get(record)
+            .and_then(Option::as_ref)
+            .or_else(|| {
+                (!self.overlay.contains_key(record))
+                    .then(|| self.base.get(record))
+                    .flatten()
+            })
+    }
+
+    fn set(&mut self, record: Bytes, weight: i64) {
+        Rc::make_mut(&mut self.overlay).insert(record, (weight != 0).then_some(weight));
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&Bytes, &i64)> {
+        self.base
+            .iter()
+            .filter_map(|(record, weight)| {
+                (!self.overlay.contains_key(record)).then_some((record, weight))
+            })
+            .chain(
+                self.overlay
+                    .iter()
+                    .filter_map(|(record, weight)| weight.as_ref().map(|weight| (record, weight))),
+            )
+    }
+
+    fn is_empty(&self) -> bool {
+        self.iter().next().is_none()
+    }
+
+    fn commit_overlay(&mut self) {
+        if self.overlay.is_empty() {
+            return;
+        }
+        let overlay = std::mem::take(&mut self.overlay);
+        let overlay = Rc::try_unwrap(overlay).unwrap_or_else(|overlay| (*overlay).clone());
+        let base = Rc::make_mut(&mut self.base);
+        for (record, weight) in overlay {
+            if let Some(weight) = weight {
+                base.insert(record, weight);
+            } else {
+                base.remove(&record);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn from_records(records: HashMap<Bytes, i64>) -> Self {
+        Self {
+            base: Rc::new(records),
+            overlay: Rc::default(),
+        }
+    }
+}
 type JoinIndex = HashMap<JoinKey, JoinBucket>;
 
 pub(super) fn touched_join_keys(
@@ -50,7 +112,7 @@ pub(super) struct AntiJoinState {
     // matters when one atomic input batch reaches two consumers of an
     // arrangement: the second consumer must not retract a row the first
     // merely arranged but this operator never published.
-    published: JoinIndex,
+    published: ArrangementState,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -58,7 +120,7 @@ pub(super) struct SemiJoinState {
     // Semi-join arrangements are shared by input/key/scope and another
     // consumer may advance one before this node runs. Keep publication state
     // per semi-join node so threshold deltas never depend on arrangement order.
-    published: JoinIndex,
+    published: ArrangementState,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -265,6 +327,10 @@ impl JoinState {
 }
 
 impl SemiJoinState {
+    pub(super) fn commit_published_overlay(&mut self) {
+        self.published.commit_overlay();
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn apply(
         &mut self,
@@ -315,15 +381,15 @@ impl SemiJoinState {
         match update_mode {
             ArrangementUpdateMode::Accumulate => {
                 for key in affected_keys {
-                    let old_visible = self.published.get(&key);
+                    let old_visible = self.published.bucket(&key);
                     let new_visible = (right_arrangement.value().key_count(&key) > 0)
                         .then(|| left_arrangement.value().bucket(&key))
                         .flatten();
                     append_bucket_diff(&mut deltas, new_visible, old_visible);
                     if let Some(bucket) = new_visible {
-                        self.published.insert(key, bucket.clone());
+                        self.published.replace_bucket(key, Some(bucket.clone()));
                     } else {
-                        self.published.remove(&key);
+                        self.published.replace_bucket(key, None);
                     }
                 }
             }
@@ -337,7 +403,8 @@ impl SemiJoinState {
                         && let Some(bucket) = left_arrangement.value().bucket(key)
                     {
                         append_bucket(&mut deltas, Some(bucket), 1);
-                        self.published.insert(key.clone(), bucket.clone());
+                        self.published
+                            .replace_bucket(key.clone(), Some(bucket.clone()));
                     }
                 }
             }
@@ -348,6 +415,10 @@ impl SemiJoinState {
 }
 
 impl AntiJoinState {
+    pub(super) fn commit_published_overlay(&mut self) {
+        self.published.commit_overlay();
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn apply(
         &mut self,
@@ -397,7 +468,7 @@ impl AntiJoinState {
         match update_mode {
             ArrangementUpdateMode::Accumulate => {
                 for key in affected_keys {
-                    let old_visible = self.published.get(&key);
+                    let old_visible = self.published.bucket(&key);
                     let new_visible = if right_arrangement.value().key_count(&key) == 0 {
                         left_arrangement.value().bucket(&key)
                     } else {
@@ -405,9 +476,9 @@ impl AntiJoinState {
                     };
                     append_bucket_diff(&mut deltas, new_visible, old_visible);
                     if let Some(bucket) = new_visible {
-                        self.published.insert(key, bucket.clone());
+                        self.published.replace_bucket(key, Some(bucket.clone()));
                     } else {
-                        self.published.remove(&key);
+                        self.published.replace_bucket(key, None);
                     }
                 }
             }
@@ -421,7 +492,8 @@ impl AntiJoinState {
                         && let Some(bucket) = left_arrangement.value().bucket(key)
                     {
                         append_bucket(&mut deltas, Some(bucket), 1);
-                        self.published.insert(key.clone(), bucket.clone());
+                        self.published
+                            .replace_bucket(key.clone(), Some(bucket.clone()));
                     }
                 }
             }
@@ -452,6 +524,14 @@ impl ArrangementState {
                 }
             }
         }
+    }
+
+    fn replace_bucket(&mut self, key: JoinKey, bucket: Option<JoinBucket>) {
+        Rc::make_mut(&mut self.overlay).insert(key, bucket);
+    }
+
+    fn clear(&mut self) {
+        *self = Self::default();
     }
 
     pub(super) fn clone_keys<'a>(&self, keys: impl IntoIterator<Item = &'a Vec<u8>>) -> Self {
@@ -485,7 +565,7 @@ impl ArrangementState {
         keys.extend(self.overlay.keys().cloned());
         keys.into_iter()
             .filter_map(|key| self.bucket(&key))
-            .map(|bucket| bucket.values().filter(|weight| **weight != 0).count())
+            .map(|bucket| bucket.iter().filter(|(_, weight)| **weight != 0).count())
             .sum()
     }
 
@@ -497,7 +577,7 @@ impl ArrangementState {
                 self.bucket(&key).map(|bucket| {
                     (
                         key.len(),
-                        bucket.keys().map(|record| record.len()).sum::<usize>(),
+                        bucket.iter().map(|(record, _)| record.len()).sum::<usize>(),
                     )
                 })
             })
@@ -519,11 +599,7 @@ impl ArrangementState {
                         .or_insert_with(|| self.bucket(&delta.key).cloned().unwrap_or_default());
                     let next_weight = bucket.get(&delta.delta.record).copied().unwrap_or_default()
                         + delta.delta.weight;
-                    if next_weight == 0 {
-                        bucket.remove(&delta.delta.record);
-                    } else {
-                        bucket.insert(delta.delta.record.clone(), next_weight);
-                    }
+                    bucket.set(delta.delta.record.clone(), next_weight);
                 }
                 let overlay = Rc::make_mut(&mut self.overlay);
                 for (key, bucket) in buckets {
@@ -539,7 +615,7 @@ impl ArrangementState {
 
     fn key_count(&self, key: &[u8]) -> i64 {
         self.bucket(key)
-            .map(|bucket| bucket.values().sum())
+            .map(|bucket| bucket.iter().map(|(_, weight)| weight).sum())
             .unwrap_or_default()
     }
 
@@ -662,7 +738,7 @@ fn append_join_deltas(
         let Some(bucket) = stored.bucket(&delta.key) else {
             continue;
         };
-        for (stored_record, right_weight) in bucket {
+        for (stored_record, right_weight) in bucket.iter() {
             if *right_weight == 0 {
                 continue;
             }
@@ -695,12 +771,12 @@ fn apply_join_delta_to_index(index: &mut JoinIndex, deltas: &[KeyedRecordDelta<'
         let next_weight =
             bucket.get(&delta.delta.record).copied().unwrap_or_default() + delta.delta.weight;
         if next_weight == 0 {
-            bucket.remove(&delta.delta.record);
+            bucket.set(delta.delta.record.clone(), 0);
             if bucket.is_empty() {
                 index.remove(&delta.key);
             }
         } else {
-            bucket.insert(delta.delta.record.clone(), next_weight);
+            bucket.set(delta.delta.record.clone(), next_weight);
         }
     }
 }
@@ -708,6 +784,9 @@ fn apply_join_delta_to_index(index: &mut JoinIndex, deltas: &[KeyedRecordDelta<'
 fn build_join_delta_index(deltas: &[KeyedRecordDelta<'_>]) -> JoinIndex {
     let mut index = HashMap::default();
     apply_join_delta_to_index(&mut index, deltas);
+    for bucket in index.values_mut() {
+        bucket.commit_overlay();
+    }
     index
 }
 
@@ -770,7 +849,7 @@ fn append_bucket(deltas: &mut Vec<RecordDelta>, bucket: Option<&JoinBucket>, sig
     let Some(bucket) = bucket else {
         return;
     };
-    for (record, weight) in bucket {
+    for (record, weight) in bucket.iter() {
         let weight = sign * *weight;
         if weight == 0 {
             continue;
@@ -1299,7 +1378,10 @@ mod tests {
         let mut bucket = HashMap::default();
         bucket.insert(Bytes::from_static(b"row-one"), 1);
         let mut index = HashMap::default();
-        index.insert(JoinKey::from_slice(b"one"), bucket);
+        index.insert(
+            JoinKey::from_slice(b"one"),
+            JoinBucket::from_records(bucket),
+        );
         let original = ArrangementState {
             index: Rc::new(index),
             overlay: Rc::default(),
@@ -1313,11 +1395,30 @@ mod tests {
 
         let mut second_bucket = HashMap::default();
         second_bucket.insert(Bytes::from_static(b"row-two"), 1);
-        Rc::make_mut(&mut prepared.overlay)
-            .insert(JoinKey::from_slice(b"two"), Some(second_bucket));
+        Rc::make_mut(&mut prepared.overlay).insert(
+            JoinKey::from_slice(b"two"),
+            Some(JoinBucket::from_records(second_bucket)),
+        );
         assert!(Rc::ptr_eq(&original.index, &prepared.index));
         assert!(!Rc::ptr_eq(&original.overlay, &prepared.overlay));
         assert_eq!(original.row_count(), 1);
         assert_eq!(prepared.row_count(), 2);
+    }
+
+    #[test]
+    fn arrangement_bucket_snapshot_stages_one_record_without_copying_base() {
+        let record = Bytes::from_static(b"row-one");
+        let added = Bytes::from_static(b"row-two");
+        let mut records = HashMap::default();
+        records.insert(record.clone(), 1);
+        let live = JoinBucket::from_records(records);
+        let mut staged = live.clone();
+        staged.set(added.clone(), 1);
+        assert!(Rc::ptr_eq(&live.base, &staged.base));
+        assert_eq!(live.get(&added), None);
+        drop(live);
+        staged.commit_overlay();
+        assert_eq!(staged.get(&record), Some(&1));
+        assert_eq!(staged.get(&added), Some(&1));
     }
 }

--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -432,6 +432,28 @@ impl AntiJoinState {
 }
 
 impl ArrangementState {
+    /// Fold only the touched buckets into the shared base at tick commit.
+    /// Callers drop the previous live arrangement before invoking this method,
+    /// making both COW maps uniquely owned in the common path.
+    pub(super) fn commit_overlay(&mut self) {
+        if self.overlay.is_empty() {
+            return;
+        }
+        let overlay = std::mem::take(&mut self.overlay);
+        let overlay = Rc::try_unwrap(overlay).unwrap_or_else(|overlay| (*overlay).clone());
+        let index = Rc::make_mut(&mut self.index);
+        for (key, bucket) in overlay {
+            match bucket {
+                Some(bucket) => {
+                    index.insert(key, bucket);
+                }
+                None => {
+                    index.remove(&key);
+                }
+            }
+        }
+    }
+
     pub(super) fn clone_keys<'a>(&self, keys: impl IntoIterator<Item = &'a Vec<u8>>) -> Self {
         let mut index = HashMap::default();
         for key in keys {

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -14,6 +14,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::hash::{Hash, Hasher};
+use std::rc::Rc;
 use std::sync::{
     Arc, Weak,
     atomic::{AtomicU64, Ordering},
@@ -177,6 +178,10 @@ pub struct IvmRuntime {
     deferred_notifications: HashMap<PublicationId, Vec<(SubscriptionId, QueuedMultisinkDeltas)>>,
     durable_notification_publications: HashSet<PublicationId>,
     completed_deferred_publications: HashSet<PublicationId>,
+    /// A direct durable flush was cancelled after submission or received an
+    /// acknowledgement that may have followed commit. This runtime must not
+    /// evaluate against its pre-flush state again.
+    persistence_indeterminate: Rc<Cell<bool>>,
     /// Persistent operator state keyed by scope and node. This survives ticks;
     /// see [`EvalMemoKey`] for per-evaluation caching.
     operator_states: HashMap<OperatorStateKey, OperatorState>,
@@ -276,6 +281,7 @@ impl IvmRuntime {
             deferred_notifications: HashMap::default(),
             durable_notification_publications: HashSet::default(),
             completed_deferred_publications: HashSet::default(),
+            persistence_indeterminate: Rc::new(Cell::new(false)),
         };
         runtime.define_schema_index_variant_projections()?;
         runtime.add_dedup_schema_indices()?;
@@ -401,6 +407,8 @@ use windows::*;
 
 #[derive(Debug, Error)]
 pub enum IvmRuntimeError {
+    #[error("runtime persistence outcome is indeterminate; reopen before continuing")]
+    PersistenceOutcomeIndeterminate,
     #[error("aggregate result exceeds its declared numeric width")]
     AggregateOverflow,
     #[error("graph field not found: {0}")]

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -24,6 +24,7 @@ use super::{
     NodeState, RecordDelta, RecordDeltas, ScopeId, StaticScanBounds, SubTick, TableDelta,
     VariantProjection, VariantProjectionKey, arg_by_candidate_replaces, consolidate_deltas,
     encoded_record_key_part, plan_expr_names, project_binding_source_deltas, scan_bounds,
+    touched_join_keys,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -33,7 +34,8 @@ pub(super) struct RecursiveState {
     /// at weight 1. Bag recursion can diverge on cycles, and non-monotone
     /// recursion needs a DRed/DBSP design before we accept negative frontiers.
     accumulated: Rc<HashMap<Bytes, i64>>,
-    /// Positive additions are staged until the owner has committed the tick.
+    /// New positive facts remain in this bounded per-tick overlay until the
+    /// evaluator publishes its owner group.
     staged_positive: Rc<HashMap<Bytes, i64>>,
     /// Generic side records emitted by actual recursive step evaluation. This
     /// is deliberately independent from the public fixed-point set: several
@@ -368,9 +370,6 @@ impl RecursiveState {
         Ok(consolidate_deltas(accepted))
     }
 
-    /// Install staged positive facts after the committed operator entry has
-    /// been removed. At that point the COW map is uniquely owned, so folding
-    /// only the new facts does not copy the complete closure.
     pub(super) fn commit_staged_positive(&mut self) {
         if self.staged_positive.is_empty() {
             return;
@@ -696,13 +695,14 @@ pub(super) async fn recursive_delta(
 ) -> Result<RecursiveDeltaProgress, IvmRuntimeError> {
     recursive_state.begin_step_witness_tick();
     let has_recompute_table_delta = has_recompute_table_delta_for_recursion(&runtime, nodes)?;
+    let has_table_delta = has_table_delta_for_cached_tables(&runtime, recursive);
     let has_recompute_binding_delta = has_recompute_binding_delta_for_recursion(&runtime, nodes)?;
     let has_binding_deltas = !runtime.binding_deltas.is_empty();
     if has_recompute_table_delta
         || has_recompute_binding_delta
         || (!has_binding_deltas && recursive_state.is_empty())
         || !recursive_state.step_arrangements_hydrated()
-        || (recursive.truncate_at_max_iters && has_binding_deltas)
+        || (recursive.truncate_at_max_iters && (has_table_delta || has_binding_deltas))
     {
         // Retractions are handled by full recompute + diff until we implement
         // DRed or DBSP-style nested negative deltas.
@@ -711,7 +711,7 @@ pub(super) async fn recursive_delta(
         }
         if std::env::var_os("JAZZ_CLOSURE_TRACE").is_some() {
             eprintln!(
-                "CLOSURE_TRACE event=recursive_recompute node={node:?} scope={:?} has_recompute_table_delta={has_recompute_table_delta} has_recompute_binding_delta={has_recompute_binding_delta} has_binding_deltas={has_binding_deltas} state_empty={} step_hydrated={} total_recomputes={}",
+                "CLOSURE_TRACE event=recursive_recompute node={node:?} scope={:?} has_recompute_table_delta={has_recompute_table_delta} has_table_delta={has_table_delta} has_recompute_binding_delta={has_recompute_binding_delta} has_binding_deltas={has_binding_deltas} state_empty={} step_hydrated={} total_recomputes={}",
                 runtime.scope,
                 recursive_state.is_empty(),
                 recursive_state.step_arrangements_hydrated(),
@@ -812,7 +812,7 @@ pub(super) async fn recursive_delta(
     let seed_frontier = recursive_state.accept_positive_staged(seed_delta.deltas)?;
     if std::env::var_os("JAZZ_CLOSURE_TRACE").is_some() {
         eprintln!(
-            "CLOSURE_TRACE event=recursive_positive node={node:?} scope={:?} seed_delta={} seed_frontier={} has_binding_deltas={has_binding_deltas}",
+            "CLOSURE_TRACE event=recursive_positive node={node:?} scope={:?} seed_delta={} seed_frontier={} has_table_delta={has_table_delta} has_binding_deltas={has_binding_deltas}",
             runtime.scope,
             seed_delta_count,
             seed_frontier.len(),
@@ -820,11 +820,27 @@ pub(super) async fn recursive_delta(
     }
     emitted.extend(seed_frontier.clone());
 
-    // The step graph owns table transforms, so derive its work from the seed
-    // frontier rather than inspecting raw table deltas.
-    let mut frontier = RecordDeltas {
-        descriptor: output_desc,
-        deltas: seed_frontier,
+    let mut frontier = if has_table_delta {
+        // A changed table can extend paths which end at the changed row's
+        // join key. Select only those already-known paths; replaying every
+        // accumulated fact would turn an isolated edge into a full closure
+        // recomputation.
+        let mut deltas = seed_frontier.clone();
+        deltas.extend(affected_recursive_frontier(
+            &runtime,
+            recursive,
+            &recursive_state.accumulated_deltas(),
+            nodes.step,
+        )?);
+        RecordDeltas {
+            descriptor: output_desc,
+            deltas: consolidate_deltas(deltas),
+        }
+    } else {
+        RecordDeltas {
+            descriptor: output_desc,
+            deltas: seed_frontier,
+        }
     };
     let mut sub_tick = 1;
     let mut must_run_step = true;
@@ -885,6 +901,184 @@ pub(super) async fn recursive_delta(
     }
 
     Ok(RecursiveDeltaProgress::Ready(consolidate_deltas(emitted)))
+}
+fn affected_recursive_frontier(
+    runtime: &GraphRuntimeView<'_>,
+    recursive: &RecursiveOp,
+    accumulated: &[RecordDelta],
+    step: NodeId,
+) -> Result<Vec<RecordDelta>, IvmRuntimeError> {
+    let mut selected = HashSet::<Bytes>::default();
+    let mut pending = vec![step];
+    let mut seen = HashSet::default();
+    while let Some(node) = pending.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        let graph_node = runtime
+            .graph
+            .node(node)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+        match &graph_node.descriptor.operator {
+            OpType::Join(join) => {
+                let [left, right] = graph_node.descriptor.inputs.as_slice() else {
+                    return Err(IvmRuntimeError::GraphInputArityMismatch(node));
+                };
+                let left_frontier = contains_frontier(runtime.graph, *left, &recursive.frontier)?;
+                let right_frontier = contains_frontier(runtime.graph, *right, &recursive.frontier)?;
+                if left_frontier != right_frontier {
+                    let (changed_input, changed_fields, frontier_fields, frontier_desc) =
+                        if left_frontier
+                            && contains_changed_table(runtime.graph, *right, runtime.table_deltas)?
+                        {
+                            (
+                                *right,
+                                plan_expr_names(&join.right_key),
+                                plan_expr_names(&join.left_key),
+                                join.left_descriptor,
+                            )
+                        } else if right_frontier
+                            && contains_changed_table(runtime.graph, *left, runtime.table_deltas)?
+                        {
+                            (
+                                *left,
+                                plan_expr_names(&join.left_key),
+                                plan_expr_names(&join.right_key),
+                                join.right_descriptor,
+                            )
+                        } else {
+                            pending.extend([*left, *right]);
+                            continue;
+                        };
+                    let mut touched = HashSet::<Vec<u8>>::default();
+                    collect_changed_join_keys(
+                        runtime.graph,
+                        changed_input,
+                        runtime.table_deltas,
+                        &changed_fields,
+                        join.comparison,
+                        &mut touched,
+                    )?;
+                    for delta in accumulated {
+                        for key in
+                            super::join::join_keys(&frontier_desc, delta.raw(), &frontier_fields)?
+                        {
+                            if touched.contains(key.as_slice()) {
+                                selected.insert(delta.record.clone());
+                                break;
+                            }
+                        }
+                    }
+                }
+                pending.extend([*left, *right]);
+            }
+            _ => pending.extend(graph_node.descriptor.inputs.iter().copied()),
+        }
+    }
+    Ok(selected
+        .into_iter()
+        .map(|record| RecordDelta { record, weight: 1 })
+        .collect())
+}
+
+fn contains_frontier(
+    graph: &IvmGraph,
+    root: NodeId,
+    binding: &super::FrontierName,
+) -> Result<bool, IvmRuntimeError> {
+    let mut pending = vec![root];
+    let mut seen = HashSet::default();
+    while let Some(node) = pending.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        let graph_node = graph
+            .node(node)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+        if matches!(
+            &graph_node.descriptor.operator,
+            OpType::FrontierSource(source) if source.binding == *binding
+        ) {
+            return Ok(true);
+        }
+        pending.extend(graph_node.descriptor.inputs.iter().copied());
+    }
+    Ok(false)
+}
+
+fn contains_changed_table(
+    graph: &IvmGraph,
+    root: NodeId,
+    table_deltas: &[TableDelta],
+) -> Result<bool, IvmRuntimeError> {
+    let changed = table_deltas
+        .iter()
+        .filter(|delta| !delta.deltas.is_empty())
+        .map(|delta| delta.table.as_str())
+        .collect::<HashSet<_>>();
+    let mut pending = vec![root];
+    let mut seen = HashSet::default();
+    while let Some(node) = pending.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        let graph_node = graph
+            .node(node)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+        if matches!(
+            &graph_node.descriptor.operator,
+            OpType::TableSource(source) if changed.contains(source.table.as_str())
+        ) {
+            return Ok(true);
+        }
+        pending.extend(graph_node.descriptor.inputs.iter().copied());
+    }
+    Ok(false)
+}
+
+fn collect_changed_join_keys(
+    graph: &IvmGraph,
+    root: NodeId,
+    table_deltas: &[TableDelta],
+    fields: &[String],
+    comparison: crate::ivm::ValueComparison,
+    keys: &mut HashSet<Vec<u8>>,
+) -> Result<(), IvmRuntimeError> {
+    let mut pending = vec![root];
+    let mut seen = HashSet::default();
+    while let Some(node) = pending.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        let graph_node = graph
+            .node(node)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+        if let OpType::TableSource(source) = &graph_node.descriptor.operator {
+            for delta in table_deltas
+                .iter()
+                .filter(|delta| delta.table == source.table && !delta.deltas.is_empty())
+            {
+                keys.extend(touched_join_keys(
+                    &delta.descriptor,
+                    fields,
+                    &delta.deltas,
+                    comparison,
+                )?);
+            }
+        }
+        pending.extend(graph_node.descriptor.inputs.iter().copied());
+    }
+    Ok(())
+}
+
+fn has_table_delta_for_cached_tables(
+    runtime: &GraphRuntimeView<'_>,
+    recursive: &RecursiveOp,
+) -> bool {
+    runtime
+        .table_deltas
+        .iter()
+        .any(|table_delta| recursive.read_tables.contains(&table_delta.table))
 }
 
 fn has_recompute_table_delta_for_recursion(

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -951,14 +951,26 @@ fn affected_recursive_frontier(
                             continue;
                         };
                     let mut touched = HashSet::<Vec<u8>>::default();
-                    collect_changed_join_keys(
+                    // Raw table keys are a valid selective frontier only
+                    // when they still have the join descriptor's fields.
+                    // A transformed step owns its own descriptor boundary;
+                    // its seed frontier remains correct, but must not be
+                    // optimized through raw-table key extraction.
+                    match collect_changed_join_keys(
                         runtime.graph,
                         changed_input,
                         runtime.table_deltas,
                         &changed_fields,
                         join.comparison,
                         &mut touched,
-                    )?;
+                    ) {
+                        Ok(()) => {}
+                        Err(IvmRuntimeError::GraphFieldNotFound(_)) => {
+                            pending.extend([*left, *right]);
+                            continue;
+                        }
+                        Err(error) => return Err(error),
+                    }
                     for delta in accumulated {
                         for key in
                             super::join::join_keys(&frontier_desc, delta.raw(), &frontier_fields)?

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -24,6 +24,7 @@ use super::{
     NodeState, RecordDelta, RecordDeltas, ScopeId, StaticScanBounds, SubTick, TableDelta,
     VariantProjection, VariantProjectionKey, arg_by_candidate_replaces, consolidate_deltas,
     encoded_record_key_part, plan_expr_names, project_binding_source_deltas, scan_bounds,
+    touched_join_keys,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -783,15 +784,20 @@ pub(super) async fn recursive_delta(
     emitted.extend(seed_frontier.clone());
 
     let mut frontier = if has_table_delta {
-        // Table-side positive deltas must probe the existing recursive closure
-        // as well as any newly accepted seed rows. Step arrangements usually
-        // provide that old closure, but maintained routed graphs can have
-        // sibling recursive nodes whose arrangements are not populated on this
-        // exact path. Feeding the accumulated set is conservative: duplicate
-        // derivations are filtered by `accept_positive`.
+        // A changed table can extend paths which end at the changed row's
+        // join key. Select only those already-known paths; replaying every
+        // accumulated fact would turn an isolated edge into a full closure
+        // recomputation.
+        let mut deltas = seed_frontier.clone();
+        deltas.extend(affected_recursive_frontier(
+            &runtime,
+            recursive,
+            &recursive_state.accumulated_deltas(),
+            nodes.step,
+        )?);
         RecordDeltas {
             descriptor: output_desc,
-            deltas: recursive_state.accumulated_deltas(),
+            deltas: consolidate_deltas(deltas),
         }
     } else {
         RecordDeltas {
@@ -858,6 +864,174 @@ pub(super) async fn recursive_delta(
     }
 
     Ok(RecursiveDeltaProgress::Ready(consolidate_deltas(emitted)))
+}
+fn affected_recursive_frontier(
+    runtime: &GraphRuntimeView<'_>,
+    recursive: &RecursiveOp,
+    accumulated: &[RecordDelta],
+    step: NodeId,
+) -> Result<Vec<RecordDelta>, IvmRuntimeError> {
+    let mut selected = HashSet::<Bytes>::default();
+    let mut pending = vec![step];
+    let mut seen = HashSet::default();
+    while let Some(node) = pending.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        let graph_node = runtime
+            .graph
+            .node(node)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+        match &graph_node.descriptor.operator {
+            OpType::Join(join) => {
+                let [left, right] = graph_node.descriptor.inputs.as_slice() else {
+                    return Err(IvmRuntimeError::GraphInputArityMismatch(node));
+                };
+                let left_frontier = contains_frontier(runtime.graph, *left, &recursive.frontier)?;
+                let right_frontier = contains_frontier(runtime.graph, *right, &recursive.frontier)?;
+                if left_frontier != right_frontier {
+                    let (changed_input, changed_fields, frontier_fields, frontier_desc) =
+                        if left_frontier
+                            && contains_changed_table(runtime.graph, *right, runtime.table_deltas)?
+                        {
+                            (
+                                *right,
+                                plan_expr_names(&join.right_key),
+                                plan_expr_names(&join.left_key),
+                                join.left_descriptor,
+                            )
+                        } else if right_frontier
+                            && contains_changed_table(runtime.graph, *left, runtime.table_deltas)?
+                        {
+                            (
+                                *left,
+                                plan_expr_names(&join.left_key),
+                                plan_expr_names(&join.right_key),
+                                join.right_descriptor,
+                            )
+                        } else {
+                            pending.extend([*left, *right]);
+                            continue;
+                        };
+                    let mut touched = HashSet::<Vec<u8>>::default();
+                    collect_changed_join_keys(
+                        runtime.graph,
+                        changed_input,
+                        runtime.table_deltas,
+                        &changed_fields,
+                        join.comparison,
+                        &mut touched,
+                    )?;
+                    for delta in accumulated {
+                        for key in
+                            super::join::join_keys(&frontier_desc, delta.raw(), &frontier_fields)?
+                        {
+                            if touched.contains(key.as_slice()) {
+                                selected.insert(delta.record.clone());
+                                break;
+                            }
+                        }
+                    }
+                }
+                pending.extend([*left, *right]);
+            }
+            _ => pending.extend(graph_node.descriptor.inputs.iter().copied()),
+        }
+    }
+    Ok(selected
+        .into_iter()
+        .map(|record| RecordDelta { record, weight: 1 })
+        .collect())
+}
+
+fn contains_frontier(
+    graph: &IvmGraph,
+    root: NodeId,
+    binding: &super::FrontierName,
+) -> Result<bool, IvmRuntimeError> {
+    let mut pending = vec![root];
+    let mut seen = HashSet::default();
+    while let Some(node) = pending.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        let graph_node = graph
+            .node(node)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+        if matches!(
+            &graph_node.descriptor.operator,
+            OpType::FrontierSource(source) if source.binding == *binding
+        ) {
+            return Ok(true);
+        }
+        pending.extend(graph_node.descriptor.inputs.iter().copied());
+    }
+    Ok(false)
+}
+
+fn contains_changed_table(
+    graph: &IvmGraph,
+    root: NodeId,
+    table_deltas: &[TableDelta],
+) -> Result<bool, IvmRuntimeError> {
+    let changed = table_deltas
+        .iter()
+        .filter(|delta| !delta.deltas.is_empty())
+        .map(|delta| delta.table.as_str())
+        .collect::<HashSet<_>>();
+    let mut pending = vec![root];
+    let mut seen = HashSet::default();
+    while let Some(node) = pending.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        let graph_node = graph
+            .node(node)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+        if matches!(
+            &graph_node.descriptor.operator,
+            OpType::TableSource(source) if changed.contains(source.table.as_str())
+        ) {
+            return Ok(true);
+        }
+        pending.extend(graph_node.descriptor.inputs.iter().copied());
+    }
+    Ok(false)
+}
+
+fn collect_changed_join_keys(
+    graph: &IvmGraph,
+    root: NodeId,
+    table_deltas: &[TableDelta],
+    fields: &[String],
+    comparison: crate::ivm::ValueComparison,
+    keys: &mut HashSet<Vec<u8>>,
+) -> Result<(), IvmRuntimeError> {
+    let mut pending = vec![root];
+    let mut seen = HashSet::default();
+    while let Some(node) = pending.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        let graph_node = graph
+            .node(node)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
+        if let OpType::TableSource(source) = &graph_node.descriptor.operator {
+            for delta in table_deltas
+                .iter()
+                .filter(|delta| delta.table == source.table && !delta.deltas.is_empty())
+            {
+                keys.extend(touched_join_keys(
+                    &delta.descriptor,
+                    fields,
+                    &delta.deltas,
+                    comparison,
+                )?);
+            }
+        }
+        pending.extend(graph_node.descriptor.inputs.iter().copied());
+    }
+    Ok(())
 }
 
 fn has_table_delta_for_cached_tables(

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -24,7 +24,6 @@ use super::{
     NodeState, RecordDelta, RecordDeltas, ScopeId, StaticScanBounds, SubTick, TableDelta,
     VariantProjection, VariantProjectionKey, arg_by_candidate_replaces, consolidate_deltas,
     encoded_record_key_part, plan_expr_names, project_binding_source_deltas, scan_bounds,
-    touched_join_keys,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -34,6 +33,8 @@ pub(super) struct RecursiveState {
     /// at weight 1. Bag recursion can diverge on cycles, and non-monotone
     /// recursion needs a DRed/DBSP design before we accept negative frontiers.
     accumulated: Rc<HashMap<Bytes, i64>>,
+    /// Positive additions are staged until the owner has committed the tick.
+    staged_positive: Rc<HashMap<Bytes, i64>>,
     /// Generic side records emitted by actual recursive step evaluation. This
     /// is deliberately independent from the public fixed-point set: several
     /// executed paths may witness one public reachable value.
@@ -318,6 +319,7 @@ impl RecursiveState {
         self.step_witness_tick_deltas = Rc::new(Vec::new());
     }
 
+    #[cfg(test)]
     fn accept_positive(
         &mut self,
         deltas: Vec<RecordDelta>,
@@ -341,6 +343,41 @@ impl RecursiveState {
             });
         }
         Ok(consolidate_deltas(accepted))
+    }
+
+    fn accept_positive_staged(
+        &mut self,
+        deltas: Vec<RecordDelta>,
+    ) -> Result<Vec<RecordDelta>, IvmRuntimeError> {
+        reject_non_positive_frontier_deltas(&deltas)?;
+        let mut accepted = Vec::new();
+        let staged = Rc::make_mut(&mut self.staged_positive);
+        for delta in consolidate_deltas(deltas) {
+            if delta.weight <= 0 {
+                return Err(IvmRuntimeError::UnsupportedNonMonotoneRecursion);
+            }
+            if self.accumulated.contains_key(&delta.record) || staged.contains_key(&delta.record) {
+                continue;
+            }
+            staged.insert(delta.record.clone(), 1);
+            accepted.push(RecordDelta {
+                record: delta.record,
+                weight: 1,
+            });
+        }
+        Ok(consolidate_deltas(accepted))
+    }
+
+    /// Install staged positive facts after the committed operator entry has
+    /// been removed. At that point the COW map is uniquely owned, so folding
+    /// only the new facts does not copy the complete closure.
+    pub(super) fn commit_staged_positive(&mut self) {
+        if self.staged_positive.is_empty() {
+            return;
+        }
+        let staged = std::mem::take(&mut self.staged_positive);
+        let staged = Rc::try_unwrap(staged).unwrap_or_else(|staged| (*staged).clone());
+        Rc::make_mut(&mut self.accumulated).extend(staged);
     }
 
     pub(super) fn replace_with(&mut self, next: HashMap<Bytes, i64>) -> Vec<RecordDelta> {
@@ -367,6 +404,7 @@ impl RecursiveState {
         self.accumulated = Rc::new(next);
         self.step_arrangements_hydrated = false;
         self.pending_hydration = None;
+        self.staged_positive = Rc::default();
         consolidate_deltas(deltas)
     }
 }
@@ -658,14 +696,13 @@ pub(super) async fn recursive_delta(
 ) -> Result<RecursiveDeltaProgress, IvmRuntimeError> {
     recursive_state.begin_step_witness_tick();
     let has_recompute_table_delta = has_recompute_table_delta_for_recursion(&runtime, nodes)?;
-    let has_table_delta = has_table_delta_for_cached_tables(&runtime, recursive);
     let has_recompute_binding_delta = has_recompute_binding_delta_for_recursion(&runtime, nodes)?;
     let has_binding_deltas = !runtime.binding_deltas.is_empty();
     if has_recompute_table_delta
         || has_recompute_binding_delta
         || (!has_binding_deltas && recursive_state.is_empty())
         || !recursive_state.step_arrangements_hydrated()
-        || (recursive.truncate_at_max_iters && (has_table_delta || has_binding_deltas))
+        || (recursive.truncate_at_max_iters && has_binding_deltas)
     {
         // Retractions are handled by full recompute + diff until we implement
         // DRed or DBSP-style nested negative deltas.
@@ -674,7 +711,7 @@ pub(super) async fn recursive_delta(
         }
         if std::env::var_os("JAZZ_CLOSURE_TRACE").is_some() {
             eprintln!(
-                "CLOSURE_TRACE event=recursive_recompute node={node:?} scope={:?} has_recompute_table_delta={has_recompute_table_delta} has_table_delta={has_table_delta} has_recompute_binding_delta={has_recompute_binding_delta} has_binding_deltas={has_binding_deltas} state_empty={} step_hydrated={} total_recomputes={}",
+                "CLOSURE_TRACE event=recursive_recompute node={node:?} scope={:?} has_recompute_table_delta={has_recompute_table_delta} has_recompute_binding_delta={has_recompute_binding_delta} has_binding_deltas={has_binding_deltas} state_empty={} step_hydrated={} total_recomputes={}",
                 runtime.scope,
                 recursive_state.is_empty(),
                 recursive_state.step_arrangements_hydrated(),
@@ -772,10 +809,10 @@ pub(super) async fn recursive_delta(
     if seed_delta.descriptor != output_desc {
         return Err(IvmRuntimeError::GraphOutputMismatch);
     }
-    let seed_frontier = recursive_state.accept_positive(seed_delta.deltas)?;
+    let seed_frontier = recursive_state.accept_positive_staged(seed_delta.deltas)?;
     if std::env::var_os("JAZZ_CLOSURE_TRACE").is_some() {
         eprintln!(
-            "CLOSURE_TRACE event=recursive_positive node={node:?} scope={:?} seed_delta={} seed_frontier={} has_table_delta={has_table_delta} has_binding_deltas={has_binding_deltas}",
+            "CLOSURE_TRACE event=recursive_positive node={node:?} scope={:?} seed_delta={} seed_frontier={} has_binding_deltas={has_binding_deltas}",
             runtime.scope,
             seed_delta_count,
             seed_frontier.len(),
@@ -783,27 +820,11 @@ pub(super) async fn recursive_delta(
     }
     emitted.extend(seed_frontier.clone());
 
-    let mut frontier = if has_table_delta {
-        // A changed table can extend paths which end at the changed row's
-        // join key. Select only those already-known paths; replaying every
-        // accumulated fact would turn an isolated edge into a full closure
-        // recomputation.
-        let mut deltas = seed_frontier.clone();
-        deltas.extend(affected_recursive_frontier(
-            &runtime,
-            recursive,
-            &recursive_state.accumulated_deltas(),
-            nodes.step,
-        )?);
-        RecordDeltas {
-            descriptor: output_desc,
-            deltas: consolidate_deltas(deltas),
-        }
-    } else {
-        RecordDeltas {
-            descriptor: output_desc,
-            deltas: seed_frontier,
-        }
+    // The step graph owns table transforms, so derive its work from the seed
+    // frontier rather than inspecting raw table deltas.
+    let mut frontier = RecordDeltas {
+        descriptor: output_desc,
+        deltas: seed_frontier,
     };
     let mut sub_tick = 1;
     let mut must_run_step = true;
@@ -851,7 +872,7 @@ pub(super) async fn recursive_delta(
             }
             recursive_state.append_step_witness(witness_delta.deltas);
         }
-        let accepted = recursive_state.accept_positive(step_delta.deltas)?;
+        let accepted = recursive_state.accept_positive_staged(step_delta.deltas)?;
         if accepted.is_empty() {
             break;
         }
@@ -864,184 +885,6 @@ pub(super) async fn recursive_delta(
     }
 
     Ok(RecursiveDeltaProgress::Ready(consolidate_deltas(emitted)))
-}
-fn affected_recursive_frontier(
-    runtime: &GraphRuntimeView<'_>,
-    recursive: &RecursiveOp,
-    accumulated: &[RecordDelta],
-    step: NodeId,
-) -> Result<Vec<RecordDelta>, IvmRuntimeError> {
-    let mut selected = HashSet::<Bytes>::default();
-    let mut pending = vec![step];
-    let mut seen = HashSet::default();
-    while let Some(node) = pending.pop() {
-        if !seen.insert(node) {
-            continue;
-        }
-        let graph_node = runtime
-            .graph
-            .node(node)
-            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
-        match &graph_node.descriptor.operator {
-            OpType::Join(join) => {
-                let [left, right] = graph_node.descriptor.inputs.as_slice() else {
-                    return Err(IvmRuntimeError::GraphInputArityMismatch(node));
-                };
-                let left_frontier = contains_frontier(runtime.graph, *left, &recursive.frontier)?;
-                let right_frontier = contains_frontier(runtime.graph, *right, &recursive.frontier)?;
-                if left_frontier != right_frontier {
-                    let (changed_input, changed_fields, frontier_fields, frontier_desc) =
-                        if left_frontier
-                            && contains_changed_table(runtime.graph, *right, runtime.table_deltas)?
-                        {
-                            (
-                                *right,
-                                plan_expr_names(&join.right_key),
-                                plan_expr_names(&join.left_key),
-                                join.left_descriptor,
-                            )
-                        } else if right_frontier
-                            && contains_changed_table(runtime.graph, *left, runtime.table_deltas)?
-                        {
-                            (
-                                *left,
-                                plan_expr_names(&join.left_key),
-                                plan_expr_names(&join.right_key),
-                                join.right_descriptor,
-                            )
-                        } else {
-                            pending.extend([*left, *right]);
-                            continue;
-                        };
-                    let mut touched = HashSet::<Vec<u8>>::default();
-                    collect_changed_join_keys(
-                        runtime.graph,
-                        changed_input,
-                        runtime.table_deltas,
-                        &changed_fields,
-                        join.comparison,
-                        &mut touched,
-                    )?;
-                    for delta in accumulated {
-                        for key in
-                            super::join::join_keys(&frontier_desc, delta.raw(), &frontier_fields)?
-                        {
-                            if touched.contains(key.as_slice()) {
-                                selected.insert(delta.record.clone());
-                                break;
-                            }
-                        }
-                    }
-                }
-                pending.extend([*left, *right]);
-            }
-            _ => pending.extend(graph_node.descriptor.inputs.iter().copied()),
-        }
-    }
-    Ok(selected
-        .into_iter()
-        .map(|record| RecordDelta { record, weight: 1 })
-        .collect())
-}
-
-fn contains_frontier(
-    graph: &IvmGraph,
-    root: NodeId,
-    binding: &super::FrontierName,
-) -> Result<bool, IvmRuntimeError> {
-    let mut pending = vec![root];
-    let mut seen = HashSet::default();
-    while let Some(node) = pending.pop() {
-        if !seen.insert(node) {
-            continue;
-        }
-        let graph_node = graph
-            .node(node)
-            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
-        if matches!(
-            &graph_node.descriptor.operator,
-            OpType::FrontierSource(source) if source.binding == *binding
-        ) {
-            return Ok(true);
-        }
-        pending.extend(graph_node.descriptor.inputs.iter().copied());
-    }
-    Ok(false)
-}
-
-fn contains_changed_table(
-    graph: &IvmGraph,
-    root: NodeId,
-    table_deltas: &[TableDelta],
-) -> Result<bool, IvmRuntimeError> {
-    let changed = table_deltas
-        .iter()
-        .filter(|delta| !delta.deltas.is_empty())
-        .map(|delta| delta.table.as_str())
-        .collect::<HashSet<_>>();
-    let mut pending = vec![root];
-    let mut seen = HashSet::default();
-    while let Some(node) = pending.pop() {
-        if !seen.insert(node) {
-            continue;
-        }
-        let graph_node = graph
-            .node(node)
-            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
-        if matches!(
-            &graph_node.descriptor.operator,
-            OpType::TableSource(source) if changed.contains(source.table.as_str())
-        ) {
-            return Ok(true);
-        }
-        pending.extend(graph_node.descriptor.inputs.iter().copied());
-    }
-    Ok(false)
-}
-
-fn collect_changed_join_keys(
-    graph: &IvmGraph,
-    root: NodeId,
-    table_deltas: &[TableDelta],
-    fields: &[String],
-    comparison: crate::ivm::ValueComparison,
-    keys: &mut HashSet<Vec<u8>>,
-) -> Result<(), IvmRuntimeError> {
-    let mut pending = vec![root];
-    let mut seen = HashSet::default();
-    while let Some(node) = pending.pop() {
-        if !seen.insert(node) {
-            continue;
-        }
-        let graph_node = graph
-            .node(node)
-            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
-        if let OpType::TableSource(source) = &graph_node.descriptor.operator {
-            for delta in table_deltas
-                .iter()
-                .filter(|delta| delta.table == source.table && !delta.deltas.is_empty())
-            {
-                keys.extend(touched_join_keys(
-                    &delta.descriptor,
-                    fields,
-                    &delta.deltas,
-                    comparison,
-                )?);
-            }
-        }
-        pending.extend(graph_node.descriptor.inputs.iter().copied());
-    }
-    Ok(())
-}
-
-fn has_table_delta_for_cached_tables(
-    runtime: &GraphRuntimeView<'_>,
-    recursive: &RecursiveOp,
-) -> bool {
-    runtime
-        .table_deltas
-        .iter()
-        .any(|table_delta| recursive.read_tables.contains(&table_delta.table))
 }
 
 fn has_recompute_table_delta_for_recursion(

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -713,10 +713,24 @@ impl IncrementalEvaluation<'_> {
         // makes recursive closures and arrangement bases uniquely owned while
         // leaving unrelated graph state untouched.
         for (key, state) in &mut self.operator_states {
+            runtime.operator_states.remove(key);
             if let OperatorState::Recursive(recursive) = state {
                 recursive.value_mut().commit_staged_positive();
             }
-            runtime.operator_states.remove(key);
+            if let OperatorState::TopBy(top_by) = state {
+                top_by.value_mut().commit_overlays();
+            }
+            if let OperatorState::SemiJoin(semi_join) = state {
+                semi_join.commit_published_overlay();
+            }
+            if let OperatorState::AntiJoin(anti_join) = state {
+                anti_join.commit_published_overlay();
+            }
+            if let OperatorState::CollectBy(collect_by) = state {
+                for group in collect_by.groups.values_mut() {
+                    group.commit_overlay();
+                }
+            }
         }
         runtime
             .operator_states
@@ -1520,12 +1534,31 @@ impl<'a> EvaluationSession<'a> {
         }
     }
 
-    fn install(self, runtime: &mut IvmRuntime) {
+    fn install(mut self, runtime: &mut IvmRuntime) {
         for node in &self.relevant_nodes {
             runtime.operator_states.remove(&OperatorStateKey {
                 scope: ScopeId::root(),
                 node: *node,
             });
+        }
+        // Session hydration also establishes long-lived collector state. Fold
+        // its initially populated sparse groups now, otherwise the first
+        // incremental edit would COW-clone the entire hydration overlay.
+        for state in self.operator_states.values_mut() {
+            if let OperatorState::TopBy(top_by) = state {
+                top_by.value_mut().commit_overlays();
+            }
+            if let OperatorState::SemiJoin(semi_join) = state {
+                semi_join.commit_published_overlay();
+            }
+            if let OperatorState::AntiJoin(anti_join) = state {
+                anti_join.commit_published_overlay();
+            }
+            if let OperatorState::CollectBy(collect_by) = state {
+                for group in collect_by.groups.values_mut() {
+                    group.commit_overlay();
+                }
+            }
         }
         runtime.operator_states.extend(self.operator_states);
         for node in &self.relevant_nodes {
@@ -1534,6 +1567,12 @@ impl<'a> EvaluationSession<'a> {
                     runtime.arrangement_states.remove(key);
                 }
             }
+        }
+        // Hydration-created arrangements are the immutable bases for the
+        // next staged tick. Fold their initial overlays after removing the
+        // old live entries, just as incremental installation does.
+        for state in self.arrangement_states.values_mut() {
+            state.value_mut().commit_overlay();
         }
         runtime.arrangement_states.extend(self.arrangement_states);
         for node in &self.relevant_nodes {

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -11,13 +11,15 @@ use super::evaluation_session::{
     EvaluationInputs, EvaluationRequestFailure, EvaluationRequestKey, EvaluationRequests,
 };
 use super::*;
-use crate::storage::OwnedStorage;
+use crate::storage::{OwnedStorage, StagedWriteOverlay, StagedWriteState};
 
 /// Hydration can discover a large resident graph in one poll. Keep every
 /// owner turn bounded so a browser worker returns to transport ingress between
 /// CPU-only graph slices. Cold storage takes the separate request-pending path
 /// below; its waker is intentionally not used to classify the pending reason.
 const MAX_HYDRATION_RUNNABLE_NODES_PER_POLL: usize = 32;
+
+type PersistFlush<'a> = Pin<Box<dyn Future<Output = Result<(), IvmRuntimeError>> + 'a>>;
 
 /// Owned preparation state for one interruptible evaluation.
 ///
@@ -86,6 +88,10 @@ pub(super) struct IncrementalEvaluation<'a> {
     node_meta: HashMap<NodeId, NodeRuntimeMeta>,
     pending_binding_retractions: usize,
     pending_notifications: Vec<(SubscriptionId, QueuedMultisinkDeltas)>,
+    /// Derived writes use the same sparse overlay as their evaluation reads.
+    /// The owned flush future is retained across resident owner turns.
+    durable_writes: RefCell<StagedWriteState>,
+    persist_flush: Option<PersistFlush<'a>>,
     /// No independent root remains after a scoped failure, so this tick must
     /// not publish its staged globals.
     discarded: bool,
@@ -1031,6 +1037,21 @@ impl IncrementalEvaluation<'_> {
         }
 
         drop(evaluator);
+        if self.persist_flush.is_none() && !self.durable_writes.borrow().is_empty() {
+            let operations = std::mem::take(self.durable_writes.get_mut()).into_operations();
+            let storage = self.storage.clone();
+            self.persist_flush = Some(Box::pin(async move {
+                storage.as_ref().write_many(operations).await?;
+                Ok(())
+            }));
+        }
+        if let Some(flush) = &mut self.persist_flush {
+            match flush.as_mut().poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error.into())),
+                Poll::Ready(Ok(())) => self.persist_flush = None,
+            }
+        }
         self.install(runtime);
         runtime
             .operator_states
@@ -2207,6 +2228,7 @@ impl IvmRuntime {
             }
         }
         let current_tick = self.current_tick + 1;
+        let durable_writes = RefCell::new(StagedWriteState::default());
         let table_delta_records = table_deltas
             .iter()
             .map(|delta| delta.deltas.len())
@@ -2225,6 +2247,7 @@ impl IvmRuntime {
             &mut node_meta,
             &table_frontiers,
             &binding_frontiers,
+            &durable_writes,
         )
         .await?;
         bump_input_frontiers_staged(
@@ -2313,6 +2336,8 @@ impl IvmRuntime {
             node_meta,
             pending_binding_retractions,
             pending_notifications: Vec::new(),
+            durable_writes,
+            persist_flush: None,
             discarded: false,
         })
     }
@@ -2537,6 +2562,7 @@ impl IvmRuntime {
         node_meta: &mut HashMap<NodeId, NodeRuntimeMeta>,
         table_frontiers: &HashMap<String, u64>,
         binding_frontiers: &HashMap<BindingSourceKey, u64>,
+        durable_writes: &RefCell<StagedWriteState>,
     ) -> Result<(), IvmRuntimeError> {
         let durable_nodes = affected_nodes
             .iter()
@@ -2548,6 +2574,7 @@ impl IvmRuntime {
             })
             .collect::<Vec<_>>();
         let binding_snapshots = self.binding_snapshot_deltas();
+        let durable_overlay = StagedWriteOverlay::new(storage, durable_writes);
         let mut metrics = TickMetrics::default();
         for node in durable_nodes {
             let graph_node = self
@@ -2578,7 +2605,7 @@ impl IvmRuntime {
                     binding_frontiers,
                     memo_use_clock,
                     node_meta,
-                    storage: Some(storage),
+                    storage: Some(&durable_overlay),
                     evaluation_inputs: None,
                     context: EvalContext::root(),
                     metrics: &mut metrics,
@@ -2588,7 +2615,7 @@ impl IvmRuntime {
                 evaluator.update_node(*input_node).await?.as_ref().clone()
             };
             apply_persist_delta(
-                storage,
+                &durable_overlay,
                 &persist.storage,
                 &persist.key_fields,
                 persist.unique,

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -86,6 +86,9 @@ pub(super) struct IncrementalEvaluation<'a> {
     node_meta: HashMap<NodeId, NodeRuntimeMeta>,
     pending_binding_retractions: usize,
     pending_notifications: Vec<(SubscriptionId, QueuedMultisinkDeltas)>,
+    /// A scoped resident failure invalidates the live slice and discards all
+    /// staged state. No continuation or publication may install it later.
+    discarded: bool,
 }
 
 #[derive(Clone)]
@@ -621,9 +624,18 @@ impl IncrementalEvaluation<'_> {
         self.terminal_deltas.retain(|node, _| !nodes.contains(node));
         self.root_ordering_windows
             .retain(|node, _| !nodes.contains(node));
+        self.discarded = true;
+        self.pending_subscription_outputs.clear();
+        self.terminal_deltas.clear();
+        self.root_ordering_windows.clear();
+        self.pending_notifications.clear();
+        self.published_subscriptions.clear();
     }
 
     fn install(&mut self, runtime: &mut IvmRuntime) {
+        if self.discarded {
+            return;
+        }
         // Drop the committed entries before folding staged COW state. This
         // makes recursive closures and arrangement bases uniquely owned while
         // leaving unrelated graph state untouched.
@@ -667,6 +679,18 @@ impl IncrementalEvaluation<'_> {
             .map(|entry| entry.payload_bytes)
             .sum();
         runtime.memo_use_clock = runtime.memo_use_clock.max(self.memo_use_clock);
+        // Retainers are owned by graph lifecycle operations, not by this
+        // evaluation snapshot. Preserve their current live value when a
+        // suspended continuation resumes after lifecycle activity.
+        for node in &self.relevant_nodes {
+            match (self.node_meta.get_mut(node), runtime.node_meta.get(node)) {
+                (Some(meta), Some(live)) => meta.retainers = live.retainers.clone(),
+                (None, Some(live)) => {
+                    self.node_meta.insert(*node, live.clone());
+                }
+                _ => {}
+            }
+        }
         runtime
             .node_meta
             .retain(|node, _| !self.relevant_nodes.contains(node));
@@ -686,6 +710,9 @@ impl IncrementalEvaluation<'_> {
         runtime: &mut IvmRuntime,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), EvaluationFailure>> {
+        if self.discarded {
+            return Poll::Ready(Ok(()));
+        }
         let ready = self.requests.poll(cx);
         if ready == 0 {
             self.requests.poll_eager_retry(cx);
@@ -2249,6 +2276,7 @@ impl IvmRuntime {
             node_meta,
             pending_binding_retractions,
             pending_notifications: Vec::new(),
+            discarded: false,
         })
     }
 
@@ -2656,5 +2684,112 @@ fn bump_input_frontiers_staged(
     ) {
         let meta = node_meta.entry(node).or_default();
         meta.input_generation = meta.input_generation.wrapping_add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{
+        ColumnSchema, ColumnType, DatabaseSchema, IntegerKeyType, PrimaryKey, TableSchema,
+    };
+    use crate::storage::MemoryStorage;
+
+    #[futures_test::test]
+    async fn resumed_install_preserves_live_retainer_changes() {
+        let schema = DatabaseSchema::new([TableSchema::new(
+            "edges",
+            [
+                ColumnSchema::new("id", ColumnType::U64),
+                ColumnSchema::new("src", ColumnType::U64),
+                ColumnSchema::new("dst", ColumnType::U64),
+            ],
+        )
+        .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+        let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+        let storage =
+            Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+        let output = runtime
+            .add_dedup_graph(&GraphBuilder::table("edges").project(["src", "dst"]))
+            .unwrap()
+            .node;
+        runtime.add_retainer(output, Retainer::PreparedShape("old".to_owned()));
+        let edges = schema.table("edges").unwrap().record_schema();
+        let record = edges
+            .create(&[Value::U64(1), Value::U64(1), Value::U64(2)])
+            .unwrap();
+        let mut evaluation = runtime
+            .begin_tick_with_params(
+                vec![TableDelta {
+                    variant_tag: 0,
+                    table: "edges".to_owned(),
+                    descriptor: edges,
+                    deltas: vec![RecordDelta {
+                        record: record.into(),
+                        weight: 1,
+                    }],
+                }],
+                Vec::new(),
+                OwnedStorage::new(Rc::clone(&storage)),
+                None,
+            )
+            .await
+            .unwrap();
+
+        runtime.add_retainer(output, Retainer::Subscription("new".to_owned()));
+        evaluation.install(&mut runtime);
+
+        let retainers = &runtime.node_meta.get(&output).unwrap().retainers;
+        assert!(retainers.contains(&Retainer::PreparedShape("old".to_owned())));
+        assert!(retainers.contains(&Retainer::Subscription("new".to_owned())));
+    }
+
+    #[futures_test::test]
+    async fn abandoned_resident_evaluation_cannot_install_frontiers() {
+        let schema = DatabaseSchema::new([TableSchema::new(
+            "edges",
+            [
+                ColumnSchema::new("id", ColumnType::U64),
+                ColumnSchema::new("src", ColumnType::U64),
+                ColumnSchema::new("dst", ColumnType::U64),
+            ],
+        )
+        .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+        let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+        let storage =
+            Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+        let output = runtime
+            .add_dedup_graph(&GraphBuilder::table("edges").project(["src", "dst"]))
+            .unwrap()
+            .node;
+        runtime.add_retainer(output, Retainer::PreparedShape("retained".to_owned()));
+        let edges = schema.table("edges").unwrap().record_schema();
+        let record = edges
+            .create(&[Value::U64(1), Value::U64(1), Value::U64(2)])
+            .unwrap();
+        let mut evaluation = runtime
+            .begin_tick_with_params(
+                vec![TableDelta {
+                    variant_tag: 0,
+                    table: "edges".to_owned(),
+                    descriptor: edges,
+                    deltas: vec![RecordDelta {
+                        record: record.into(),
+                        weight: 1,
+                    }],
+                }],
+                Vec::new(),
+                OwnedStorage::new(Rc::clone(&storage)),
+                None,
+            )
+            .await
+            .unwrap();
+        let before_tick = runtime.current_tick;
+        let before_frontiers = runtime.table_frontiers.clone();
+        evaluation.abandon(&HashSet::default());
+        evaluation.install(&mut runtime);
+
+        assert_eq!(runtime.current_tick, before_tick);
+        assert_eq!(runtime.table_frontiers, before_frontiers);
     }
 }

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -86,6 +86,9 @@ pub(super) struct IncrementalEvaluation<'a> {
     node_meta: HashMap<NodeId, NodeRuntimeMeta>,
     pending_binding_retractions: usize,
     pending_notifications: Vec<(SubscriptionId, QueuedMultisinkDeltas)>,
+    /// No independent root remains after a scoped failure, so this tick must
+    /// not publish its staged globals.
+    discarded: bool,
 }
 
 #[derive(Clone)]
@@ -617,6 +620,11 @@ impl EvaluationWorkQueue {
 
 impl IncrementalEvaluation<'_> {
     fn abandon(&mut self, nodes: &HashSet<NodeId>) {
+        self.discarded = self
+            .work_queue
+            .roots
+            .iter()
+            .all(|root| nodes.contains(root));
         self.work_queue.abandon(nodes);
         // A scoped failure owns only its downstream slice. Keep evaluating
         // disjoint roots in this tick; their prepared state and notifications
@@ -645,6 +653,9 @@ impl IncrementalEvaluation<'_> {
     }
 
     fn install(&mut self, runtime: &mut IvmRuntime) {
+        if self.discarded {
+            return;
+        }
         // Drop the committed entries before folding staged COW state. This
         // makes recursive closures and arrangement bases uniquely owned while
         // leaving unrelated graph state untouched.
@@ -719,6 +730,9 @@ impl IncrementalEvaluation<'_> {
         runtime: &mut IvmRuntime,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), EvaluationFailure>> {
+        if self.discarded {
+            return Poll::Ready(Ok(()));
+        }
         let ready = self.requests.poll(cx);
         if ready == 0 {
             self.requests.poll_eager_retry(cx);
@@ -2282,6 +2296,7 @@ impl IvmRuntime {
             node_meta,
             pending_binding_retractions,
             pending_notifications: Vec::new(),
+            discarded: false,
         })
     }
 

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -641,12 +641,43 @@ impl EvaluationWorkQueue {
 }
 
 impl IncrementalEvaluation<'_> {
+    /// Base-table frontiers describe resident row visibility, not completion
+    /// of every dependent evaluator branch. Publish them monotonically when
+    /// this evaluation parks so independent snapshots cannot reuse an old
+    /// table-source cache; retain all operator state until full installation.
+    fn install_input_frontiers(&self, runtime: &mut IvmRuntime) {
+        for (table, frontier) in &self.table_frontiers {
+            runtime
+                .table_frontiers
+                .entry(table.clone())
+                .and_modify(|live| *live = (*live).max(*frontier))
+                .or_insert(*frontier);
+        }
+        for (binding, frontier) in &self.binding_frontiers {
+            runtime
+                .binding_frontiers
+                .entry(binding.clone())
+                .and_modify(|live| *live = (*live).max(*frontier))
+                .or_insert(*frontier);
+        }
+        for (node, staged) in &self.node_meta {
+            if let Some(live) = runtime.node_meta.get_mut(node) {
+                live.input_generation = live.input_generation.max(staged.input_generation);
+            }
+        }
+    }
+
     fn abandon(&mut self, nodes: &HashSet<NodeId>) {
-        self.discarded = self
-            .work_queue
-            .roots
-            .iter()
-            .all(|root| nodes.contains(root));
+        // An empty set is the explicit cancellation path used by an owner
+        // which is abandoning the whole uninstalled evaluation. Scoped
+        // failures carry their downstream closure and may leave independent
+        // roots publishable.
+        self.discarded = nodes.is_empty()
+            || self
+                .work_queue
+                .roots
+                .iter()
+                .all(|root| nodes.contains(root));
         self.work_queue.abandon(nodes);
         // A scoped failure owns only its downstream slice. Keep evaluating
         // disjoint roots in this tick; their prepared state and notifications
@@ -715,7 +746,10 @@ impl IncrementalEvaluation<'_> {
         // suspended continuation resumes after lifecycle activity.
         for node in &self.relevant_nodes {
             match (self.node_meta.get_mut(node), runtime.node_meta.get(node)) {
-                (Some(meta), Some(live)) => meta.retainers = live.retainers.clone(),
+                (Some(meta), Some(live)) => {
+                    meta.retainers = live.retainers.clone();
+                    meta.input_generation = meta.input_generation.max(live.input_generation);
+                }
                 (None, Some(live)) => {
                     self.node_meta.insert(*node, live.clone());
                 }
@@ -725,13 +759,8 @@ impl IncrementalEvaluation<'_> {
         runtime
             .node_meta
             .extend(std::mem::take(&mut self.node_meta));
-        runtime
-            .table_frontiers
-            .extend(std::mem::take(&mut self.table_frontiers));
-        runtime
-            .binding_frontiers
-            .extend(std::mem::take(&mut self.binding_frontiers));
-        runtime.current_tick = self.current_tick;
+        self.install_input_frontiers(runtime);
+        runtime.current_tick = runtime.current_tick.max(self.current_tick);
         runtime
             .pending_binding_retractions
             .drain(..self.pending_binding_retractions);
@@ -1041,7 +1070,21 @@ impl IncrementalEvaluation<'_> {
                 .or(self.notification_publication);
             queued.publication = notification_publication;
             if !queued.deltas.is_empty() {
-                self.pending_notifications.push((*subscription_id, queued));
+                if let Some(pending) = &self.pending_resident_publication
+                    && queued.publication.is_none()
+                {
+                    // A resident publication may have an independent cold
+                    // branch still parked. Its completed subscriptions are
+                    // already a valid publication slice, so hand their
+                    // notifications to the resident receipt now instead of
+                    // waiting for the unrelated branch to hydrate.
+                    pending
+                        .notifications
+                        .borrow_mut()
+                        .push((*subscription_id, queued));
+                } else {
+                    self.pending_notifications.push((*subscription_id, queued));
+                }
             }
             self.published_subscriptions.insert(*subscription_id);
         }
@@ -1776,6 +1819,7 @@ impl IvmRuntime {
             Poll::Ready(Err(failure)) => return Err(failure.into_error()),
             Poll::Pending => {
                 evaluation.work_queue.drain_completed_events();
+                evaluation.install_input_frontiers(self);
                 let mut pending = self.pending_incremental.0.borrow_mut();
                 let evaluation_id = pending.next_id;
                 pending.next_id = pending.next_id.saturating_add(1);

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -71,6 +71,18 @@ pub(super) struct IncrementalEvaluation<'a> {
     notification_publication: Option<PublicationId>,
     defer_notifications_until_durable: bool,
     pending_resident_publication: Option<PendingResidentPublication>,
+    /// All evaluator-owned state is prepared here and installed only after the
+    /// complete direct tick reaches Ready. This keeps failed ticks atomic while
+    /// allowing a suspended evaluation to retain its exact continuation.
+    operator_states: HashMap<OperatorStateKey, OperatorState>,
+    arrangement_states: HashMap<ArrangementKey, AsOf<ArrangementState, SubTick>>,
+    arrangement_keys_by_input: HashMap<NodeId, HashSet<ArrangementKey>>,
+    eval_memo: HashMap<EvalMemoKey, EvalMemoEntry>,
+    eval_memo_bytes: usize,
+    memo_use_clock: u64,
+    node_meta: HashMap<NodeId, NodeRuntimeMeta>,
+    pending_binding_retractions: usize,
+    pending_notifications: Vec<(SubscriptionId, QueuedMultisinkDeltas)>,
 }
 
 #[derive(Clone)]
@@ -184,6 +196,7 @@ impl PendingIncrementalState {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum PendingEvaluation {
     Incremental(IncrementalEvaluation<'static>),
     SubscriptionHydration(PendingSubscriptionHydration),
@@ -607,6 +620,22 @@ impl IncrementalEvaluation<'_> {
             .retain(|node, _| !nodes.contains(node));
     }
 
+    fn install(&mut self, runtime: &mut IvmRuntime) {
+        runtime.operator_states = std::mem::take(&mut self.operator_states);
+        runtime.arrangement_states = std::mem::take(&mut self.arrangement_states);
+        runtime.arrangement_keys_by_input = std::mem::take(&mut self.arrangement_keys_by_input);
+        runtime.eval_memo = std::mem::take(&mut self.eval_memo);
+        runtime.eval_memo_bytes = self.eval_memo_bytes;
+        runtime.memo_use_clock = self.memo_use_clock;
+        runtime.node_meta = std::mem::take(&mut self.node_meta);
+        runtime.table_frontiers = std::mem::take(&mut self.table_frontiers);
+        runtime.binding_frontiers = std::mem::take(&mut self.binding_frontiers);
+        runtime.current_tick = self.current_tick;
+        runtime
+            .pending_binding_retractions
+            .drain(..self.pending_binding_retractions);
+    }
+
     fn poll(
         &mut self,
         runtime: &mut IvmRuntime,
@@ -628,7 +657,7 @@ impl IncrementalEvaluation<'_> {
             inputs.install(ready);
         }
 
-        let mut dropped_subscriptions = Vec::new();
+        let dropped_subscriptions = Vec::new();
         let mut evaluator = TickEvaluator {
             schema: &runtime.schema,
             graph: &runtime.graph,
@@ -637,15 +666,15 @@ impl IncrementalEvaluation<'_> {
             binding_deltas: &self.binding_deltas,
             binding_snapshots: &self.binding_snapshots,
             current_tick: self.current_tick,
-            operator_states: &mut runtime.operator_states,
-            arrangement_states: &mut runtime.arrangement_states,
-            arrangement_keys_by_input: &mut runtime.arrangement_keys_by_input,
-            eval_memo: &mut runtime.eval_memo,
-            eval_memo_bytes: &mut runtime.eval_memo_bytes,
+            operator_states: &mut self.operator_states,
+            arrangement_states: &mut self.arrangement_states,
+            arrangement_keys_by_input: &mut self.arrangement_keys_by_input,
+            eval_memo: &mut self.eval_memo,
+            eval_memo_bytes: &mut self.eval_memo_bytes,
             table_frontiers: &self.table_frontiers,
             binding_frontiers: &self.binding_frontiers,
-            memo_use_clock: &mut runtime.memo_use_clock,
-            node_meta: &mut runtime.node_meta,
+            memo_use_clock: &mut self.memo_use_clock,
+            node_meta: &mut self.node_meta,
             storage: Some(self.storage.as_ref()),
             evaluation_inputs: self.evaluation_inputs.as_mut(),
             context: EvalContext::root(),
@@ -908,28 +937,7 @@ impl IncrementalEvaluation<'_> {
                 .or(self.notification_publication);
             queued.publication = notification_publication;
             if !queued.deltas.is_empty() {
-                if let Some(pending) = &self.pending_resident_publication
-                    && notification_publication.is_none()
-                {
-                    pending
-                        .notifications
-                        .borrow_mut()
-                        .push((*subscription_id, queued));
-                } else if self.defer_notifications_until_durable
-                    && notification_publication.is_some_and(|publication| {
-                        !runtime
-                            .durable_notification_publications
-                            .contains(&publication)
-                    })
-                {
-                    runtime
-                        .deferred_notifications
-                        .entry(notification_publication.expect("checked publication"))
-                        .or_default()
-                        .push((*subscription_id, queued));
-                } else if subscription.sender.send(queued).is_err() {
-                    dropped_subscriptions.push(*subscription_id);
-                }
+                self.pending_notifications.push((*subscription_id, queued));
             }
             self.published_subscriptions.insert(*subscription_id);
         }
@@ -941,9 +949,40 @@ impl IncrementalEvaluation<'_> {
         }
 
         drop(evaluator);
+        self.install(runtime);
         runtime
             .operator_states
             .retain(|key, _| key.scope == ScopeId::root());
+        let notifications = std::mem::take(&mut self.pending_notifications);
+        let mut dropped_subscriptions = dropped_subscriptions;
+        for (subscription_id, queued) in notifications {
+            if self.defer_notifications_until_durable
+                && queued.publication.is_some_and(|publication| {
+                    !runtime
+                        .durable_notification_publications
+                        .contains(&publication)
+                })
+            {
+                runtime
+                    .deferred_notifications
+                    .entry(queued.publication.expect("checked publication"))
+                    .or_default()
+                    .push((subscription_id, queued));
+            } else if let Some(pending) = &self.pending_resident_publication
+                && queued.publication.is_none()
+            {
+                pending
+                    .notifications
+                    .borrow_mut()
+                    .push((subscription_id, queued));
+            } else if runtime
+                .multisink_subscriptions
+                .get(&subscription_id)
+                .is_some_and(|subscription| subscription.sender.send(queued).is_err())
+            {
+                dropped_subscriptions.push(subscription_id);
+            }
+        }
         for subscription_id in dropped_subscriptions {
             runtime.unsubscribe(subscription_id);
         }
@@ -2018,9 +2057,18 @@ impl IvmRuntime {
             changed_tables.iter().copied(),
             changed_bindings.iter().copied(),
         );
-        // Do not commit tick lifecycle state until fallible durable evaluation
-        // has completed. In particular, queued binding retractions must remain
-        // retryable when preparing a tick encounters a storage error.
+        // Every mutable evaluator map is a prepared snapshot. The maps are
+        // shallow clones where their values use COW, so a suspended or failed
+        // tick cannot mutate committed runtime state.
+        let mut operator_states = self.operator_states.clone();
+        let mut arrangement_states = self.arrangement_states.clone();
+        let mut arrangement_keys_by_input = self.arrangement_keys_by_input.clone();
+        let mut eval_memo = self.eval_memo.clone();
+        let mut eval_memo_bytes = self.eval_memo_bytes;
+        let mut memo_use_clock = self.memo_use_clock;
+        let mut node_meta = self.node_meta.clone();
+        let mut table_frontiers = self.table_frontiers.clone();
+        let mut binding_frontiers = self.binding_frontiers.clone();
         let current_tick = self.current_tick + 1;
         let table_delta_records = table_deltas
             .iter()
@@ -2031,12 +2079,25 @@ impl IvmRuntime {
             &affected_nodes,
             current_tick,
             storage.as_ref(),
+            &mut operator_states,
+            &mut arrangement_states,
+            &mut arrangement_keys_by_input,
+            &mut eval_memo,
+            &mut eval_memo_bytes,
+            &mut memo_use_clock,
+            &mut node_meta,
+            &table_frontiers,
+            &binding_frontiers,
         )
         .await?;
-        self.current_tick = current_tick;
-        self.bump_input_frontiers(&table_deltas, &binding_deltas);
-        self.pending_binding_retractions
-            .drain(..pending_binding_retractions);
+        bump_input_frontiers_staged(
+            &self.graph,
+            &table_deltas,
+            &binding_deltas,
+            &mut table_frontiers,
+            &mut binding_frontiers,
+            &mut node_meta,
+        );
         let metrics = TickMetrics {
             tick: current_tick,
             table_delta_records,
@@ -2088,8 +2149,8 @@ impl IvmRuntime {
             table_deltas,
             binding_deltas,
             binding_snapshots,
-            table_frontiers: self.table_frontiers.clone(),
-            binding_frontiers: self.binding_frontiers.clone(),
+            table_frontiers,
+            binding_frontiers,
             current_tick,
             metrics,
             storage,
@@ -2105,6 +2166,15 @@ impl IvmRuntime {
             notification_publication,
             defer_notifications_until_durable,
             pending_resident_publication,
+            operator_states,
+            arrangement_states,
+            arrangement_keys_by_input,
+            eval_memo,
+            eval_memo_bytes,
+            memo_use_clock,
+            node_meta,
+            pending_binding_retractions,
+            pending_notifications: Vec::new(),
         })
     }
 
@@ -2113,29 +2183,14 @@ impl IvmRuntime {
         table_deltas: &[TableDelta],
         binding_deltas: &[BindingDelta],
     ) {
-        let mut changed_tables = Vec::new();
-        for delta in table_deltas.iter().filter(|delta| !delta.deltas.is_empty()) {
-            *self.table_frontiers.entry(delta.table.clone()).or_default() += 1;
-            changed_tables.push(delta.table.as_str());
-        }
-        let mut changed_bindings = Vec::new();
-        for delta in binding_deltas
-            .iter()
-            .filter(|delta| !delta.deltas.is_empty() || delta.initializes_snapshot)
-        {
-            *self.binding_frontiers.entry(delta.key.clone()).or_default() += 1;
-            changed_bindings.push(&delta.key);
-        }
-        if changed_tables.is_empty() && changed_bindings.is_empty() {
-            return;
-        }
-        for node in self.graph.affected_nodes(
-            changed_tables.iter().copied(),
-            changed_bindings.iter().copied(),
-        ) {
-            let meta = self.node_meta.entry(node).or_default();
-            meta.input_generation = meta.input_generation.wrapping_add(1);
-        }
+        bump_input_frontiers_staged(
+            &self.graph,
+            table_deltas,
+            binding_deltas,
+            &mut self.table_frontiers,
+            &mut self.binding_frontiers,
+            &mut self.node_meta,
+        );
     }
 
     fn evict_eval_memo(&mut self) {
@@ -2327,12 +2382,22 @@ impl IvmRuntime {
         Ok(false)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn tick_durable_nodes(
-        &mut self,
+        &self,
         table_deltas: &[TableDelta],
         affected_nodes: &std::collections::HashSet<NodeId>,
         current_tick: u64,
         storage: &dyn OrderedKvStorage,
+        operator_states: &mut HashMap<OperatorStateKey, OperatorState>,
+        arrangement_states: &mut HashMap<ArrangementKey, AsOf<ArrangementState, SubTick>>,
+        arrangement_keys_by_input: &mut HashMap<NodeId, HashSet<ArrangementKey>>,
+        eval_memo: &mut HashMap<EvalMemoKey, EvalMemoEntry>,
+        eval_memo_bytes: &mut usize,
+        memo_use_clock: &mut u64,
+        node_meta: &mut HashMap<NodeId, NodeRuntimeMeta>,
+        table_frontiers: &HashMap<String, u64>,
+        binding_frontiers: &HashMap<BindingSourceKey, u64>,
     ) -> Result<(), IvmRuntimeError> {
         let durable_nodes = affected_nodes
             .iter()
@@ -2365,15 +2430,15 @@ impl IvmRuntime {
                     binding_deltas: &[],
                     binding_snapshots: &binding_snapshots,
                     current_tick,
-                    operator_states: &mut self.operator_states,
-                    arrangement_states: &mut self.arrangement_states,
-                    arrangement_keys_by_input: &mut self.arrangement_keys_by_input,
-                    eval_memo: &mut self.eval_memo,
-                    eval_memo_bytes: &mut self.eval_memo_bytes,
-                    table_frontiers: &self.table_frontiers,
-                    binding_frontiers: &self.binding_frontiers,
-                    memo_use_clock: &mut self.memo_use_clock,
-                    node_meta: &mut self.node_meta,
+                    operator_states,
+                    arrangement_states,
+                    arrangement_keys_by_input,
+                    eval_memo,
+                    eval_memo_bytes,
+                    table_frontiers,
+                    binding_frontiers,
+                    memo_use_clock,
+                    node_meta,
                     storage: Some(storage),
                     evaluation_inputs: None,
                     context: EvalContext::root(),
@@ -2485,4 +2550,37 @@ fn terminal_delta_for_hydrated_output(
         has_public_collector,
         (!has_public_collector).then_some(fallback).flatten(),
     ))
+}
+
+fn bump_input_frontiers_staged(
+    graph: &IvmGraph,
+    table_deltas: &[TableDelta],
+    binding_deltas: &[BindingDelta],
+    table_frontiers: &mut HashMap<String, u64>,
+    binding_frontiers: &mut HashMap<BindingSourceKey, u64>,
+    node_meta: &mut HashMap<NodeId, NodeRuntimeMeta>,
+) {
+    let mut changed_tables = Vec::new();
+    for delta in table_deltas.iter().filter(|delta| !delta.deltas.is_empty()) {
+        *table_frontiers.entry(delta.table.clone()).or_default() += 1;
+        changed_tables.push(delta.table.as_str());
+    }
+    let mut changed_bindings = Vec::new();
+    for delta in binding_deltas
+        .iter()
+        .filter(|delta| !delta.deltas.is_empty() || delta.initializes_snapshot)
+    {
+        *binding_frontiers.entry(delta.key.clone()).or_default() += 1;
+        changed_bindings.push(&delta.key);
+    }
+    if changed_tables.is_empty() && changed_bindings.is_empty() {
+        return;
+    }
+    for node in graph.affected_nodes(
+        changed_tables.iter().copied(),
+        changed_bindings.iter().copied(),
+    ) {
+        let meta = node_meta.entry(node).or_default();
+        meta.input_generation = meta.input_generation.wrapping_add(1);
+    }
 }

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -11,7 +11,7 @@ use super::evaluation_session::{
     EvaluationInputs, EvaluationRequestFailure, EvaluationRequestKey, EvaluationRequests,
 };
 use super::*;
-use crate::storage::{OwnedStorage, StagedWriteOverlay, StagedWriteState};
+use crate::storage::{OwnedStorage, StagedWriteOverlay, StagedWriteState, WriteManyOutcome};
 
 /// Hydration can discover a large resident graph in one poll. Keep every
 /// owner turn bounded so a browser worker returns to transport ingress between
@@ -20,6 +20,22 @@ use crate::storage::{OwnedStorage, StagedWriteOverlay, StagedWriteState};
 const MAX_HYDRATION_RUNNABLE_NODES_PER_POLL: usize = 32;
 
 type PersistFlush<'a> = Pin<Box<dyn Future<Output = Result<(), IvmRuntimeError>> + 'a>>;
+
+/// A started direct flush has no rollback path. If its owner drops it before
+/// receiving a definite outcome, retain that fact on the runtime so a later
+/// owner cannot continue from the old evaluator state.
+struct PersistFlushAttempt {
+    indeterminate: Rc<Cell<bool>>,
+    completed: bool,
+}
+
+impl Drop for PersistFlushAttempt {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.indeterminate.set(true);
+        }
+    }
+}
 
 /// Owned preparation state for one interruptible evaluation.
 ///
@@ -1040,9 +1056,22 @@ impl IncrementalEvaluation<'_> {
         if self.persist_flush.is_none() && !self.durable_writes.borrow().is_empty() {
             let operations = std::mem::take(self.durable_writes.get_mut()).into_operations();
             let storage = self.storage.clone();
+            let indeterminate = Rc::clone(&runtime.persistence_indeterminate);
             self.persist_flush = Some(Box::pin(async move {
-                storage.as_ref().write_many(operations).await?;
-                Ok(())
+                let mut attempt = PersistFlushAttempt {
+                    indeterminate,
+                    completed: false,
+                };
+                let result = match storage.as_ref().write_many_outcome(operations).await {
+                    WriteManyOutcome::Committed => Ok(()),
+                    WriteManyOutcome::Uncommitted(error) => Err(error.into()),
+                    WriteManyOutcome::PossiblyCommitted(error) => {
+                        attempt.indeterminate.set(true);
+                        Err(error.into())
+                    }
+                };
+                attempt.completed = true;
+                result
             }));
         }
         if let Some(flush) = &mut self.persist_flush {
@@ -2100,6 +2129,9 @@ impl IvmRuntime {
         storage: OwnedStorage<'a>,
         notification_publication: Option<PublicationId>,
     ) -> Result<TickMetrics, IvmRuntimeError> {
+        if self.persistence_indeterminate.get() {
+            return Err(IvmRuntimeError::PersistenceOutcomeIndeterminate);
+        }
         self.drive_pending_incremental().await?;
         let mut evaluation = self
             .begin_tick_with_params(

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -86,9 +86,6 @@ pub(super) struct IncrementalEvaluation<'a> {
     node_meta: HashMap<NodeId, NodeRuntimeMeta>,
     pending_binding_retractions: usize,
     pending_notifications: Vec<(SubscriptionId, QueuedMultisinkDeltas)>,
-    /// A scoped resident failure invalidates the live slice and discards all
-    /// staged state. No continuation or publication may install it later.
-    discarded: bool,
 }
 
 #[derive(Clone)]
@@ -621,21 +618,33 @@ impl EvaluationWorkQueue {
 impl IncrementalEvaluation<'_> {
     fn abandon(&mut self, nodes: &HashSet<NodeId>) {
         self.work_queue.abandon(nodes);
+        // A scoped failure owns only its downstream slice. Keep evaluating
+        // disjoint roots in this tick; their prepared state and notifications
+        // remain publishable. The staged maps share immutable bases and this
+        // removes only entries produced by the failed owner.
+        self.operator_states
+            .retain(|key, _| !nodes.contains(&key.node));
+        self.arrangement_states
+            .retain(|key, _| !nodes.contains(&key.input));
+        self.arrangement_keys_by_input
+            .retain(|node, _| !nodes.contains(node));
+        self.eval_memo.retain(|key, _| !nodes.contains(&key.node));
+        self.eval_memo_bytes = self
+            .eval_memo
+            .values()
+            .map(|entry| entry.payload_bytes)
+            .sum();
+        self.node_meta.retain(|node, _| !nodes.contains(node));
+        self.relevant_nodes.retain(|node| !nodes.contains(node));
+        self.affected_nodes.retain(|node| !nodes.contains(node));
         self.terminal_deltas.retain(|node, _| !nodes.contains(node));
         self.root_ordering_windows
             .retain(|node, _| !nodes.contains(node));
-        self.discarded = true;
-        self.pending_subscription_outputs.clear();
-        self.terminal_deltas.clear();
-        self.root_ordering_windows.clear();
-        self.pending_notifications.clear();
-        self.published_subscriptions.clear();
+        self.pending_subscription_outputs
+            .retain(|node, _| !nodes.contains(node));
     }
 
     fn install(&mut self, runtime: &mut IvmRuntime) {
-        if self.discarded {
-            return;
-        }
         // Drop the committed entries before folding staged COW state. This
         // makes recursive closures and arrangement bases uniquely owned while
         // leaving unrelated graph state untouched.
@@ -710,9 +719,6 @@ impl IncrementalEvaluation<'_> {
         runtime: &mut IvmRuntime,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), EvaluationFailure>> {
-        if self.discarded {
-            return Poll::Ready(Ok(()));
-        }
         let ready = self.requests.poll(cx);
         if ready == 0 {
             self.requests.poll_eager_retry(cx);
@@ -2276,7 +2282,6 @@ impl IvmRuntime {
             node_meta,
             pending_binding_retractions,
             pending_notifications: Vec::new(),
-            discarded: false,
         })
     }
 

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -727,9 +727,7 @@ impl IncrementalEvaluation<'_> {
                 anti_join.commit_published_overlay();
             }
             if let OperatorState::CollectBy(collect_by) = state {
-                for group in collect_by.groups.values_mut() {
-                    group.commit_overlay();
-                }
+                collect_by.groups.commit_overlay();
             }
         }
         runtime
@@ -737,8 +735,8 @@ impl IncrementalEvaluation<'_> {
             .extend(std::mem::take(&mut self.operator_states));
 
         for (key, state) in &mut self.arrangement_states {
-            state.value_mut().commit_overlay();
             runtime.arrangement_states.remove(key);
+            state.value_mut().commit_overlay();
         }
         runtime
             .arrangement_states
@@ -1555,9 +1553,7 @@ impl<'a> EvaluationSession<'a> {
                 anti_join.commit_published_overlay();
             }
             if let OperatorState::CollectBy(collect_by) = state {
-                for group in collect_by.groups.values_mut() {
-                    group.commit_overlay();
-                }
+                collect_by.groups.commit_overlay();
             }
         }
         runtime.operator_states.extend(self.operator_states);

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -59,9 +59,12 @@ pub(super) struct IncrementalEvaluation<'a> {
     requests: EvaluationRequests<'a>,
     evaluation_inputs: Option<EvaluationInputs>,
     work_queue: EvaluationWorkQueue,
+    /// Graph slice whose state is staged by this evaluation. Unrelated
+    /// runtime state remains live and is merged only when the tick commits.
+    relevant_nodes: HashSet<NodeId>,
     published_subscriptions: HashSet<SubscriptionId>,
-    affected_nodes: HashSet<NodeId>,
     affected_subscriptions: HashSet<SubscriptionId>,
+    affected_nodes: HashSet<NodeId>,
     /// Relational output retained while logical terminal materialization waits
     /// for immutable chunks. Re-evaluating after operator state advances can
     /// correctly yield an empty delta, so publication owns this exact value.
@@ -621,13 +624,55 @@ impl IncrementalEvaluation<'_> {
     }
 
     fn install(&mut self, runtime: &mut IvmRuntime) {
-        runtime.operator_states = std::mem::take(&mut self.operator_states);
-        runtime.arrangement_states = std::mem::take(&mut self.arrangement_states);
-        runtime.arrangement_keys_by_input = std::mem::take(&mut self.arrangement_keys_by_input);
-        runtime.eval_memo = std::mem::take(&mut self.eval_memo);
-        runtime.eval_memo_bytes = self.eval_memo_bytes;
-        runtime.memo_use_clock = self.memo_use_clock;
-        runtime.node_meta = std::mem::take(&mut self.node_meta);
+        // Drop the committed entries before folding staged COW state. This
+        // makes recursive closures and arrangement bases uniquely owned while
+        // leaving unrelated graph state untouched.
+        runtime
+            .operator_states
+            .retain(|key, _| !self.relevant_nodes.contains(&key.node));
+        for state in self.operator_states.values_mut() {
+            if let OperatorState::Recursive(recursive) = state {
+                recursive.value_mut().commit_staged_positive();
+            }
+        }
+        runtime
+            .operator_states
+            .extend(std::mem::take(&mut self.operator_states));
+
+        runtime
+            .arrangement_states
+            .retain(|key, _| !self.relevant_nodes.contains(&key.input));
+        for state in self.arrangement_states.values_mut() {
+            state.value_mut().commit_overlay();
+        }
+        runtime
+            .arrangement_states
+            .extend(std::mem::take(&mut self.arrangement_states));
+        runtime
+            .arrangement_keys_by_input
+            .retain(|node, _| !self.relevant_nodes.contains(node));
+        runtime
+            .arrangement_keys_by_input
+            .extend(std::mem::take(&mut self.arrangement_keys_by_input));
+
+        runtime
+            .eval_memo
+            .retain(|key, _| !self.relevant_nodes.contains(&key.node));
+        runtime
+            .eval_memo
+            .extend(std::mem::take(&mut self.eval_memo));
+        runtime.eval_memo_bytes = runtime
+            .eval_memo
+            .values()
+            .map(|entry| entry.payload_bytes)
+            .sum();
+        runtime.memo_use_clock = runtime.memo_use_clock.max(self.memo_use_clock);
+        runtime
+            .node_meta
+            .retain(|node, _| !self.relevant_nodes.contains(node));
+        runtime
+            .node_meta
+            .extend(std::mem::take(&mut self.node_meta));
         runtime.table_frontiers = std::mem::take(&mut self.table_frontiers);
         runtime.binding_frontiers = std::mem::take(&mut self.binding_frontiers);
         runtime.current_tick = self.current_tick;
@@ -2057,16 +2102,44 @@ impl IvmRuntime {
             changed_tables.iter().copied(),
             changed_bindings.iter().copied(),
         );
-        // Every mutable evaluator map is a prepared snapshot. The maps are
-        // shallow clones where their values use COW, so a suspended or failed
-        // tick cannot mutate committed runtime state.
-        let mut operator_states = self.operator_states.clone();
-        let mut arrangement_states = self.arrangement_states.clone();
-        let mut arrangement_keys_by_input = self.arrangement_keys_by_input.clone();
-        let mut eval_memo = self.eval_memo.clone();
-        let mut eval_memo_bytes = self.eval_memo_bytes;
+        // Capture only the graph slice reached from changed inputs. The
+        // evaluator may need unchanged sibling inputs (for example the other
+        // side of a join), so discovery walks ancestors of every affected
+        // node, while unrelated graph state remains in the live runtime.
+        let (relevant_nodes, _) = EvaluationWorkQueue::new(affected_nodes.iter().copied())
+            .discover_incremental(&self.graph)?;
+        let mut operator_states = self
+            .operator_states
+            .iter()
+            .filter(|(key, _)| relevant_nodes.contains(&key.node))
+            .map(|(key, state)| (key.clone(), state.clone()))
+            .collect::<HashMap<_, _>>();
+        let mut arrangement_states = self
+            .arrangement_states
+            .iter()
+            .filter(|(key, _)| relevant_nodes.contains(&key.input))
+            .map(|(key, state)| (key.clone(), state.clone()))
+            .collect::<HashMap<_, _>>();
+        let mut arrangement_keys_by_input = self
+            .arrangement_keys_by_input
+            .iter()
+            .filter(|(input, _)| relevant_nodes.contains(input))
+            .map(|(input, keys)| (*input, keys.clone()))
+            .collect::<HashMap<_, _>>();
+        let mut eval_memo = self
+            .eval_memo
+            .iter()
+            .filter(|(key, _)| relevant_nodes.contains(&key.node))
+            .map(|(key, entry)| (key.clone(), entry.clone()))
+            .collect::<HashMap<_, _>>();
+        let mut eval_memo_bytes = eval_memo.values().map(|entry| entry.payload_bytes).sum();
         let mut memo_use_clock = self.memo_use_clock;
-        let mut node_meta = self.node_meta.clone();
+        let mut node_meta = self
+            .node_meta
+            .iter()
+            .filter(|(node, _)| relevant_nodes.contains(node))
+            .map(|(node, meta)| (*node, meta.clone()))
+            .collect::<HashMap<_, _>>();
         let mut table_frontiers = self.table_frontiers.clone();
         let mut binding_frontiers = self.binding_frontiers.clone();
         let current_tick = self.current_tick + 1;
@@ -2158,6 +2231,7 @@ impl IvmRuntime {
             evaluation_inputs,
             work_queue,
             published_subscriptions: HashSet::default(),
+            relevant_nodes,
             affected_nodes,
             affected_subscriptions,
             pending_subscription_outputs: HashMap::default(),

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -659,45 +659,34 @@ impl IncrementalEvaluation<'_> {
         // Drop the committed entries before folding staged COW state. This
         // makes recursive closures and arrangement bases uniquely owned while
         // leaving unrelated graph state untouched.
-        runtime
-            .operator_states
-            .retain(|key, _| !self.relevant_nodes.contains(&key.node));
-        for state in self.operator_states.values_mut() {
+        for (key, state) in &mut self.operator_states {
             if let OperatorState::Recursive(recursive) = state {
                 recursive.value_mut().commit_staged_positive();
             }
+            runtime.operator_states.remove(key);
         }
         runtime
             .operator_states
             .extend(std::mem::take(&mut self.operator_states));
 
-        runtime
-            .arrangement_states
-            .retain(|key, _| !self.relevant_nodes.contains(&key.input));
-        for state in self.arrangement_states.values_mut() {
+        for (key, state) in &mut self.arrangement_states {
             state.value_mut().commit_overlay();
+            runtime.arrangement_states.remove(key);
         }
         runtime
             .arrangement_states
             .extend(std::mem::take(&mut self.arrangement_states));
-        runtime
-            .arrangement_keys_by_input
-            .retain(|node, _| !self.relevant_nodes.contains(node));
+        for node in self.arrangement_keys_by_input.keys() {
+            runtime.arrangement_keys_by_input.remove(node);
+        }
         runtime
             .arrangement_keys_by_input
             .extend(std::mem::take(&mut self.arrangement_keys_by_input));
 
         runtime
             .eval_memo
-            .retain(|key, _| !self.relevant_nodes.contains(&key.node));
-        runtime
-            .eval_memo
             .extend(std::mem::take(&mut self.eval_memo));
-        runtime.eval_memo_bytes = runtime
-            .eval_memo
-            .values()
-            .map(|entry| entry.payload_bytes)
-            .sum();
+        runtime.eval_memo_bytes = runtime.eval_memo_bytes.saturating_add(self.eval_memo_bytes);
         runtime.memo_use_clock = runtime.memo_use_clock.max(self.memo_use_clock);
         // Retainers are owned by graph lifecycle operations, not by this
         // evaluation snapshot. Preserve their current live value when a
@@ -713,12 +702,13 @@ impl IncrementalEvaluation<'_> {
         }
         runtime
             .node_meta
-            .retain(|node, _| !self.relevant_nodes.contains(node));
-        runtime
-            .node_meta
             .extend(std::mem::take(&mut self.node_meta));
-        runtime.table_frontiers = std::mem::take(&mut self.table_frontiers);
-        runtime.binding_frontiers = std::mem::take(&mut self.binding_frontiers);
+        runtime
+            .table_frontiers
+            .extend(std::mem::take(&mut self.table_frontiers));
+        runtime
+            .binding_frontiers
+            .extend(std::mem::take(&mut self.binding_frontiers));
         runtime.current_tick = self.current_tick;
         runtime
             .pending_binding_retractions
@@ -2155,40 +2145,67 @@ impl IvmRuntime {
         // node, while unrelated graph state remains in the live runtime.
         let (relevant_nodes, _) = EvaluationWorkQueue::new(affected_nodes.iter().copied())
             .discover_incremental(&self.graph)?;
-        let mut operator_states = self
-            .operator_states
+        // Capture by graph key, never by filtering global retained maps. Root
+        // state is the only durable evaluator state; recursive child scopes
+        // are scratch and are removed before publication.
+        let mut operator_states = relevant_nodes
             .iter()
-            .filter(|(key, _)| relevant_nodes.contains(&key.node))
-            .map(|(key, state)| (key.clone(), state.clone()))
+            .filter_map(|node| {
+                let key = OperatorStateKey {
+                    scope: ScopeId::root(),
+                    node: *node,
+                };
+                self.operator_states
+                    .get(&key)
+                    .cloned()
+                    .map(|state| (key, state))
+            })
             .collect::<HashMap<_, _>>();
-        let mut arrangement_states = self
-            .arrangement_states
-            .iter()
-            .filter(|(key, _)| relevant_nodes.contains(&key.input))
-            .map(|(key, state)| (key.clone(), state.clone()))
-            .collect::<HashMap<_, _>>();
-        let mut arrangement_keys_by_input = self
-            .arrangement_keys_by_input
-            .iter()
-            .filter(|(input, _)| relevant_nodes.contains(input))
-            .map(|(input, keys)| (*input, keys.clone()))
-            .collect::<HashMap<_, _>>();
-        let mut eval_memo = self
-            .eval_memo
-            .iter()
-            .filter(|(key, _)| relevant_nodes.contains(&key.node))
-            .map(|(key, entry)| (key.clone(), entry.clone()))
-            .collect::<HashMap<_, _>>();
-        let mut eval_memo_bytes = eval_memo.values().map(|entry| entry.payload_bytes).sum();
+        let mut arrangement_states = HashMap::default();
+        let mut arrangement_keys_by_input = HashMap::default();
+        for input in &relevant_nodes {
+            let Some(keys) = self.arrangement_keys_by_input.get(input) else {
+                continue;
+            };
+            for key in keys {
+                if let Some(state) = self.arrangement_states.get(key) {
+                    arrangement_states.insert(key.clone(), state.clone());
+                    arrangement_keys_by_input
+                        .entry(*input)
+                        .or_insert_with(HashSet::default)
+                        .insert(key.clone());
+                }
+            }
+        }
+        // Tick memo entries are disposable. Recomputing the affected graph is
+        // bounded by that graph slice and avoids a global memo scan.
+        let mut eval_memo = HashMap::default();
+        let mut eval_memo_bytes = 0;
         let mut memo_use_clock = self.memo_use_clock;
-        let mut node_meta = self
-            .node_meta
+        let mut node_meta = relevant_nodes
             .iter()
-            .filter(|(node, _)| relevant_nodes.contains(node))
-            .map(|(node, meta)| (*node, meta.clone()))
+            .filter_map(|node| self.node_meta.get(node).cloned().map(|meta| (*node, meta)))
             .collect::<HashMap<_, _>>();
-        let mut table_frontiers = self.table_frontiers.clone();
-        let mut binding_frontiers = self.binding_frontiers.clone();
+        let mut table_frontiers = HashMap::default();
+        let mut binding_frontiers = HashMap::default();
+        for node in &relevant_nodes {
+            let Some(graph_node) = self.graph.node(*node) else {
+                continue;
+            };
+            match &graph_node.descriptor.operator {
+                OpType::TableSource(source) => {
+                    if let Some(frontier) = self.table_frontiers.get(&source.table) {
+                        table_frontiers.insert(source.table.clone(), *frontier);
+                    }
+                }
+                OpType::BindingSource(source) => {
+                    if let Some(frontier) = self.binding_frontiers.get(&source.key) {
+                        binding_frontiers.insert(source.key.clone(), *frontier);
+                    }
+                }
+                _ => {}
+            }
+        }
         let current_tick = self.current_tick + 1;
         let table_delta_records = table_deltas
             .iter()

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -2432,7 +2432,7 @@ async fn recursive_iteration_limit_does_not_leak_staged_durable_index_writes() {
 }
 
 #[futures_test::test]
-async fn durable_flush_failure_discards_staged_state_and_notifications() {
+async fn definitely_uncommitted_durable_flush_failure_discards_staged_state_and_notifications() {
     let schema = indexed_edges_schema();
     let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
     let (storage, control) = TestStorage::controlled(&["edges", "indices"]);
@@ -2447,7 +2447,7 @@ async fn durable_flush_failure_discards_staged_state_and_notifications() {
     let before_tick = runtime.current_tick;
 
     control.take_observed();
-    control.fail_next(TestStorageOperation::WriteMany);
+    control.fail_next_uncommitted(TestStorageOperation::WriteMany);
     let mut tick = Box::pin(runtime.tick(vec![edge_table_delta(edges, &[(1, 1, 2)])], &storage));
     let waker = futures::task::noop_waker();
     let mut cx = Context::from_waker(&waker);
@@ -2476,6 +2476,53 @@ async fn durable_flush_failure_discards_staged_state_and_notifications() {
         1,
         "the staged durable batch is submitted exactly once"
     );
+}
+
+/// This is intentionally an internal runtime test: the public Database owner
+/// converts this runtime state into `DatabasePoisoned`, while this fixture
+/// proves the lower-level direct evaluator never reuses its pre-flush state.
+#[futures_test::test]
+async fn commit_then_lost_flush_acknowledgement_poisoned_direct_runtime() {
+    let schema = indexed_edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let (storage, control) = TestStorage::controlled(&["edges", "indices"]);
+    let storage = Rc::new(storage);
+    let edges = schema.table("edges").unwrap().record_schema();
+    let initial_storage = Rc::new(MemoryStorage::new(&["edges", "indices"]).unwrap());
+    let subscription = runtime
+        .subscribe_one_sink(GraphBuilder::table("edges"), &initial_storage)
+        .await
+        .unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
+
+    control.take_observed();
+    control.lose_next_write_many_acknowledgement();
+    let error = runtime
+        .tick(vec![edge_table_delta(edges, &[(1, 1, 2)])], &storage)
+        .await
+        .expect_err("a lost acknowledgement must fail closed");
+    assert!(matches!(error, IvmRuntimeError::Storage(_)));
+    assert!(subscription.try_recv().is_err());
+    let mut index_rows = storage
+        .scan(crate::storage::ScanRequest::prefix(
+            "indices".to_owned(),
+            Vec::new(),
+        ))
+        .await
+        .unwrap();
+    assert!(
+        index_rows.next_batch().await.unwrap().is_some(),
+        "the injected fault must lose only the acknowledgement, after the batch commits"
+    );
+
+    let error = runtime
+        .tick(Vec::new(), &storage)
+        .await
+        .expect_err("an indeterminate flush must prevent reuse of the old evaluator");
+    assert!(matches!(
+        error,
+        IvmRuntimeError::PersistenceOutcomeIndeterminate
+    ));
 }
 
 #[futures_test::test]
@@ -2528,6 +2575,14 @@ async fn cancelling_pending_durable_flush_discards_the_uninstalled_tick() {
         .await
         .unwrap();
     assert!(index_rows.next_batch().await.unwrap().is_none());
+    let error = runtime
+        .tick(Vec::new(), &storage)
+        .await
+        .expect_err("dropping a started flush must poison the direct runtime");
+    assert!(matches!(
+        error,
+        IvmRuntimeError::PersistenceOutcomeIndeterminate
+    ));
 }
 
 /// Resident Database writes use the same staged evaluator as direct ticks, but

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -2389,8 +2389,6 @@ async fn resident_recursive_iteration_limit_discards_staged_state() {
         [(vec![Value::U64(1), Value::U64(2)], 1)]
     );
     let output = runtime.subscription_output_node(subscription.id()).unwrap();
-    let before_state = recursive_state_snapshot(&runtime, output);
-    let before_stats = runtime.stats();
     let before_tick = runtime.current_tick;
     let before_frontiers = runtime.table_frontiers.clone();
     runtime
@@ -2403,15 +2401,17 @@ async fn resident_recursive_iteration_limit_discards_staged_state() {
         .await
         .unwrap();
 
-    assert_eq!(
-        recursive_state_snapshot(&runtime, output),
-        before_state,
-        "a scoped resident failure must discard partial recursive state"
+    assert!(
+        !runtime.operator_states.contains_key(&OperatorStateKey {
+            scope: ScopeId::root(),
+            node: output,
+        }),
+        "a scoped resident failure removes its recursive state rather than installing a partial closure"
     );
     assert_eq!(
-        runtime.stats(),
-        before_stats,
-        "a scoped resident failure must not install staged state"
+        runtime.stats().recursive_state_count,
+        0,
+        "a scoped resident failure retains no recursive closure"
     );
     assert_eq!(
         runtime.current_tick, before_tick,

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -512,6 +512,24 @@ fn recursive_reach_graph_with_limit(max_iters: usize) -> GraphBuilder {
     GraphBuilder::recursive(seed, step, "frontier", max_iters)
 }
 
+fn recursive_reach_with_renamed_inputs_graph() -> GraphBuilder {
+    let descriptor = RecordDescriptor::new([("from", ColumnType::U64), ("to", ColumnType::U64)]);
+    let seed = GraphBuilder::table("edges").project_fields([
+        crate::ivm::ProjectField::renamed("src", "from"),
+        crate::ivm::ProjectField::renamed("dst", "to"),
+    ]);
+    let edge_pairs = GraphBuilder::table("edges").project_fields([
+        crate::ivm::ProjectField::renamed("src", "edge_from"),
+        crate::ivm::ProjectField::renamed("dst", "edge_to"),
+    ]);
+    let frontier = GraphBuilder::frontier_source("frontier", descriptor);
+    let step = GraphBuilder::join(frontier, edge_pairs, ["to"], ["edge_from"]).project_fields([
+        crate::ivm::ProjectField::renamed("left.from", "from"),
+        crate::ivm::ProjectField::renamed("right.edge_to", "to"),
+    ]);
+    GraphBuilder::recursive(seed, step, "frontier", 16)
+}
+
 async fn write_edge_rows(
     storage: &impl OrderedKvStorage,
     edges: &RecordDescriptor,
@@ -2251,6 +2269,39 @@ async fn recursive_positive_tick_commits_new_facts_exactly_once() {
         subscription.try_recv().is_err(),
         "one positive recursive tick must publish exactly one notification"
     );
+}
+
+/// Positive recursive maintenance must let the step graph transform both the
+/// frontier and table inputs before the join computes new paths.
+#[futures_test::test]
+async fn recursive_positive_tick_applies_transforms_before_join() {
+    let schema = edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let storage = Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+    let edges = schema.table("edges").unwrap().record_schema();
+    write_edge_rows(&storage, &edges, &[(1, 1, 2)]).await;
+
+    let subscription = runtime
+        .subscribe_one_sink(recursive_reach_with_renamed_inputs_graph(), &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+
+    runtime
+        .tick(vec![edge_table_delta(edges, &[(2, 2, 3)])], &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [
+            (vec![Value::U64(1), Value::U64(3)], 1),
+            (vec![Value::U64(2), Value::U64(3)], 1),
+        ]
+    );
+    assert!(subscription.try_recv().is_err());
 }
 
 /// The positive path accepts new facts before discovering that the next

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::schema::{
     ColumnSchema, ColumnType, DatabaseSchema, IndexSchema, IntegerKeyType, PrimaryKey,
 };
-use crate::storage::{MemoryStorage, RecordStore};
+use crate::storage::{MemoryStorage, OwnedStorage, RecordStore};
 use std::rc::Rc;
 
 #[futures_test::test]
@@ -2367,6 +2367,59 @@ async fn recursive_iteration_limit_rolls_back_partial_positive_tick() {
     assert!(
         subscription.try_recv().is_err(),
         "a failed recursive tick must not expose staged facts"
+    );
+}
+
+/// Resident Database writes use the same staged evaluator as direct ticks, but
+/// scoped failures must discard it rather than install its partial closure.
+#[futures_test::test]
+async fn resident_recursive_iteration_limit_discards_staged_state() {
+    let schema = edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let storage = Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+    let edges = schema.table("edges").unwrap().record_schema();
+    write_edge_rows(&storage, &edges, &[(1, 1, 2)]).await;
+
+    let subscription = runtime
+        .subscribe_one_sink(recursive_reach_graph_with_limit(1), &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+    let output = runtime.subscription_output_node(subscription.id()).unwrap();
+    let before_state = recursive_state_snapshot(&runtime, output);
+    let before_stats = runtime.stats();
+    let before_tick = runtime.current_tick;
+    let before_frontiers = runtime.table_frontiers.clone();
+    runtime
+        .tick_resident_staged(
+            vec![edge_table_delta(edges, &[(2, 2, 3), (3, 3, 4)])],
+            OwnedStorage::new(Rc::clone(&storage)),
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        recursive_state_snapshot(&runtime, output),
+        before_state,
+        "a scoped resident failure must discard partial recursive state"
+    );
+    assert_eq!(
+        runtime.stats(),
+        before_stats,
+        "a scoped resident failure must not install staged state"
+    );
+    assert_eq!(
+        runtime.current_tick, before_tick,
+        "a scoped resident failure must not advance logical time"
+    );
+    assert_eq!(
+        runtime.table_frontiers, before_frontiers,
+        "a scoped resident failure must not advance input frontiers"
     );
 }
 

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -2,8 +2,9 @@ use super::*;
 use crate::schema::{
     ColumnSchema, ColumnType, DatabaseSchema, IndexSchema, IntegerKeyType, PrimaryKey,
 };
-use crate::storage::{MemoryStorage, OwnedStorage, RecordStore};
+use crate::storage::{MemoryStorage, OwnedStorage, RecordStore, TestStorage, TestStorageOperation};
 use std::rc::Rc;
+use std::task::{Context, Poll};
 
 #[futures_test::test]
 async fn terminal_collect_canonicalization_emits_net_remove_before_net_insert() {
@@ -433,6 +434,19 @@ fn edges_schema() -> DatabaseSchema {
         ],
     )
     .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))])
+}
+
+fn indexed_edges_schema() -> DatabaseSchema {
+    DatabaseSchema::new([TableSchema::new(
+        "edges",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("src", ColumnType::U64),
+            ColumnSchema::new("dst", ColumnType::U64),
+        ],
+    )
+    .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))
+    .with_index(IndexSchema::new("by_src", ["src"]))])
 }
 
 fn reach_descriptor() -> RecordDescriptor {
@@ -2368,6 +2382,152 @@ async fn recursive_iteration_limit_rolls_back_partial_positive_tick() {
         subscription.try_recv().is_err(),
         "a failed recursive tick must not expose staged facts"
     );
+}
+
+/// Derived durable index changes are part of a recursive tick's publication
+/// boundary. A limit failure after producing a partial closure must not leak
+/// its index writes into physical storage.
+#[futures_test::test]
+async fn recursive_iteration_limit_does_not_leak_staged_durable_index_writes() {
+    let schema = indexed_edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let storage =
+        Rc::new(MemoryStorage::new(&["edges", "indices"]).expect("valid memory storage families"));
+    let edges = schema.table("edges").unwrap().record_schema();
+    write_edge_rows(&storage, &edges, &[(1, 1, 2)]).await;
+
+    let subscription = runtime
+        .subscribe_one_sink(recursive_reach_graph_with_limit(1), &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+
+    let error = runtime
+        .tick(
+            vec![edge_table_delta(edges, &[(2, 2, 3), (3, 3, 4)])],
+            &storage,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        IvmRuntimeError::RecursiveIterationLimit { max_iters: 1, .. }
+    ));
+
+    let mut index_rows = storage
+        .scan(crate::storage::ScanRequest::prefix(
+            "indices".to_owned(),
+            Vec::new(),
+        ))
+        .await
+        .unwrap();
+    assert!(
+        index_rows.next_batch().await.unwrap().is_none(),
+        "failed recursion must discard derived durable index writes"
+    );
+    assert!(subscription.try_recv().is_err());
+}
+
+#[futures_test::test]
+async fn durable_flush_failure_discards_staged_state_and_notifications() {
+    let schema = indexed_edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let (storage, control) = TestStorage::controlled(&["edges", "indices"]);
+    let storage = Rc::new(storage);
+    let edges = schema.table("edges").unwrap().record_schema();
+    let initial_storage = Rc::new(MemoryStorage::new(&["edges", "indices"]).unwrap());
+    let subscription = runtime
+        .subscribe_one_sink(GraphBuilder::table("edges"), &initial_storage)
+        .await
+        .unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
+    let before_tick = runtime.current_tick;
+
+    control.take_observed();
+    control.fail_next(TestStorageOperation::WriteMany);
+    let mut tick = Box::pin(runtime.tick(vec![edge_table_delta(edges, &[(1, 1, 2)])], &storage));
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut result = None;
+    for _ in 0..16 {
+        if let Poll::Ready(outcome) = tick.as_mut().poll(&mut cx) {
+            result = Some(outcome);
+            break;
+        }
+    }
+    assert!(
+        result.is_some(),
+        "flush failure must resolve rather than retain an un-wakeable tick"
+    );
+    assert!(result.unwrap().is_err());
+    drop(tick);
+
+    assert_eq!(runtime.current_tick, before_tick);
+    assert!(subscription.try_recv().is_err());
+    assert_eq!(
+        control
+            .observed()
+            .into_iter()
+            .filter(|operation| *operation == TestStorageOperation::WriteMany)
+            .count(),
+        1,
+        "the staged durable batch is submitted exactly once"
+    );
+}
+
+#[futures_test::test]
+async fn cancelling_pending_durable_flush_discards_the_uninstalled_tick() {
+    let schema = indexed_edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let (storage, control) = TestStorage::controlled(&["edges", "indices"]);
+    let storage = Rc::new(storage);
+    let edges = schema.table("edges").unwrap().record_schema();
+    let initial_storage = Rc::new(MemoryStorage::new(&["edges", "indices"]).unwrap());
+    let subscription = runtime
+        .subscribe_one_sink(GraphBuilder::table("edges"), &initial_storage)
+        .await
+        .unwrap();
+    assert!(subscription.recv().unwrap().is_empty());
+    let before_tick = runtime.current_tick;
+
+    control.take_observed();
+    control.pause_on(TestStorageOperation::WriteMany);
+    let mut tick = Box::pin(runtime.tick(vec![edge_table_delta(edges, &[(1, 1, 2)])], &storage));
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    for _ in 0..8 {
+        if matches!(tick.as_mut().poll(&mut cx), Poll::Pending)
+            && control
+                .observed()
+                .contains(&TestStorageOperation::WriteMany)
+        {
+            break;
+        }
+    }
+    assert_eq!(
+        control
+            .observed()
+            .into_iter()
+            .filter(|operation| *operation == TestStorageOperation::WriteMany)
+            .count(),
+        1,
+        "the pending flush owns one physical submission"
+    );
+    drop(tick);
+
+    assert_eq!(runtime.current_tick, before_tick);
+    assert!(subscription.try_recv().is_err());
+    let mut index_rows = storage
+        .scan(crate::storage::ScanRequest::prefix(
+            "indices".to_owned(),
+            Vec::new(),
+        ))
+        .await
+        .unwrap();
+    assert!(index_rows.next_batch().await.unwrap().is_none());
 }
 
 /// Resident Database writes use the same staged evaluator as direct ticks, but

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -498,6 +498,10 @@ async fn top_by_distinguishes_finite_max_from_unbounded_limit() {
 }
 
 fn recursive_reach_graph() -> GraphBuilder {
+    recursive_reach_graph_with_limit(16)
+}
+
+fn recursive_reach_graph_with_limit(max_iters: usize) -> GraphBuilder {
     let seed = GraphBuilder::table("edges").project(["src", "dst"]);
     let edge_pairs = GraphBuilder::table("edges").project(["src", "dst"]);
     let frontier = GraphBuilder::frontier_source("frontier", reach_descriptor());
@@ -505,7 +509,66 @@ fn recursive_reach_graph() -> GraphBuilder {
         crate::ivm::ProjectField::renamed("left.src", "src"),
         crate::ivm::ProjectField::renamed("right.dst", "dst"),
     ]);
-    GraphBuilder::recursive(seed, step, "frontier", 16)
+    GraphBuilder::recursive(seed, step, "frontier", max_iters)
+}
+
+async fn write_edge_rows(
+    storage: &impl OrderedKvStorage,
+    edges: &RecordDescriptor,
+    rows: &[(u64, u64, u64)],
+) {
+    let store = RecordStore::new(storage, "edges", edges);
+    let operations = rows
+        .iter()
+        .map(|(id, src, dst)| {
+            let record = edges
+                .create(&[Value::U64(*id), Value::U64(*src), Value::U64(*dst)])
+                .unwrap();
+            let encoded = crate::records::encode_variant_record(0, &record);
+            let key = id.to_be_bytes();
+            store.set(&key, &encoded)
+        })
+        .collect();
+    store.write_many(operations).await.unwrap();
+}
+
+fn edge_table_delta(edges: RecordDescriptor, rows: &[(u64, u64, u64)]) -> TableDelta {
+    TableDelta {
+        variant_tag: 0,
+        table: "edges".to_owned(),
+        descriptor: edges,
+        deltas: rows
+            .iter()
+            .map(|(id, src, dst)| RecordDelta {
+                record: edges
+                    .create(&[Value::U64(*id), Value::U64(*src), Value::U64(*dst)])
+                    .unwrap()
+                    .into(),
+                weight: 1,
+            })
+            .collect(),
+    }
+}
+
+fn recursive_state_snapshot(
+    runtime: &IvmRuntime,
+    node: NodeId,
+) -> (Vec<RecordDelta>, bool, Option<u64>) {
+    let key = OperatorStateKey {
+        scope: ScopeId::root(),
+        node,
+    };
+    let Some(OperatorState::Recursive(state)) = runtime.operator_states.get(&key) else {
+        panic!("recursive state missing for {node:?}");
+    };
+    let state = state.value();
+    let mut accumulated = state.accumulated_deltas();
+    accumulated.sort_by(|left, right| left.record.cmp(&right.record));
+    (
+        accumulated,
+        state.step_arrangements_hydrated(),
+        state.hydrated_input_generation(),
+    )
 }
 
 fn recursive_reach_from_graph(src: u64) -> GraphBuilder {
@@ -2150,6 +2213,151 @@ async fn recursive_recompute_reuses_graph_nodes_without_persisting_contextual_ch
             .all(|key| key.scope == ScopeId::root()),
         "recursive recomputation should not leave per-context child state in runtime"
     );
+}
+
+/// A positive recursive update is visible only once the tick is ready.  The
+/// public subscription receives the seed edge and its newly derived path as a
+/// single committed delta, with no duplicate delivery.
+#[futures_test::test]
+async fn recursive_positive_tick_commits_new_facts_exactly_once() {
+    let schema = edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let storage = Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+    let edges = schema.table("edges").unwrap().record_schema();
+    write_edge_rows(&storage, &edges, &[(1, 1, 2)]).await;
+
+    let subscription = runtime
+        .subscribe_one_sink(recursive_reach_graph_with_limit(16), &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+
+    let metrics = runtime
+        .tick(vec![edge_table_delta(edges, &[(2, 2, 3)])], &storage)
+        .await
+        .unwrap();
+    assert_eq!(metrics.table_delta_records, 1);
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [
+            (vec![Value::U64(1), Value::U64(3)], 1),
+            (vec![Value::U64(2), Value::U64(3)], 1),
+        ]
+    );
+    assert!(
+        subscription.try_recv().is_err(),
+        "one positive recursive tick must publish exactly one notification"
+    );
+}
+
+/// The positive path accepts new facts before discovering that the next
+/// iteration exceeds its safety bound.  A semantic failure must not commit
+/// that partial closure, advance the tick/frontier counters, or retain
+/// changed arrangement/memo accounting.
+#[futures_test::test]
+async fn recursive_iteration_limit_rolls_back_partial_positive_tick() {
+    // This runtime-level seam is intentional: Database fail-stop makes the
+    // post-error operator state inaccessible, while rollback must cover the
+    // closure, arrangement, memo, and logical-time state together.
+    let schema = edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let storage = Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+    let edges = schema.table("edges").unwrap().record_schema();
+    write_edge_rows(&storage, &edges, &[(1, 1, 2)]).await;
+
+    let subscription = runtime
+        .subscribe_one_sink(recursive_reach_graph_with_limit(1), &storage)
+        .await
+        .unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(1), Value::U64(2)], 1)]
+    );
+
+    let output = runtime.subscription_output_node(subscription.id()).unwrap();
+    let before_state = recursive_state_snapshot(&runtime, output);
+    let before_stats = runtime.stats();
+    let before_tick = runtime.current_tick;
+    let before_table_frontiers = runtime.table_frontiers.clone();
+
+    let error = runtime
+        .tick(
+            vec![edge_table_delta(edges, &[(2, 2, 3), (3, 3, 4)])],
+            &storage,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        IvmRuntimeError::RecursiveIterationLimit { max_iters: 1, .. }
+    ));
+
+    assert_eq!(
+        recursive_state_snapshot(&runtime, output),
+        before_state,
+        "failed recursion must retain the last committed closure and arrangement state"
+    );
+    assert_eq!(
+        runtime.stats(),
+        before_stats,
+        "failed recursion must not retain staged arrangement or memo accounting"
+    );
+    assert_eq!(
+        runtime.current_tick, before_tick,
+        "a failed recursive tick must not advance logical time"
+    );
+    assert_eq!(
+        runtime.table_frontiers, before_table_frontiers,
+        "a failed recursive tick must not advance input frontiers"
+    );
+    assert!(
+        subscription.try_recv().is_err(),
+        "a failed recursive tick must not expose staged facts"
+    );
+}
+
+/// A large existing closure is a scale canary for the positive path: adding an
+/// isolated edge must process only the new frontier, not feed every old fact
+/// back through the recursive step.
+#[futures_test::test]
+async fn recursive_positive_tick_does_not_reprocess_full_existing_closure() {
+    let schema = edges_schema();
+    let mut runtime = IvmRuntime::new(schema.clone()).unwrap();
+    let storage = Rc::new(MemoryStorage::new(&["edges"]).expect("valid memory storage families"));
+    let edges = schema.table("edges").unwrap().record_schema();
+    let rows = (1..=48).map(|id| (id, id, id + 1)).collect::<Vec<_>>();
+    write_edge_rows(&storage, &edges, &rows).await;
+
+    let subscription = runtime
+        .subscribe_one_sink(recursive_reach_graph_with_limit(64), &storage)
+        .await
+        .unwrap();
+    let initial = subscription.recv().unwrap();
+    assert!(
+        initial.deltas.len() > 100,
+        "fixture must establish a meaningfully large recursive closure"
+    );
+
+    let metrics = runtime
+        .tick(
+            vec![edge_table_delta(edges, &[(10_000, 10_000, 10_001)])],
+            &storage,
+        )
+        .await
+        .unwrap();
+    assert!(
+        metrics.records_processed < 128,
+        "isolated positive edge should not reprocess the full closure: {} records",
+        metrics.records_processed
+    );
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        [(vec![Value::U64(10_000), Value::U64(10_001)], 1)]
+    );
+    assert!(subscription.try_recv().is_err());
 }
 
 #[futures_test::test]

--- a/crates/groove/src/ivm/runtime/windows.rs
+++ b/crates/groove/src/ivm/runtime/windows.rs
@@ -296,9 +296,13 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
             encoded_record_key_part(input_desc, delta.raw(), &collect_by.group_field_indices)
         })
         .collect::<Result<BTreeSet<_>, _>>()?;
-    let root_groups_before = direct_tree_slot
-        .is_none()
-        .then(|| touched_group_keys.clone());
+    let root_groups_before = direct_tree_slot.is_none().then(|| {
+        touched_group_keys
+            .iter()
+            .filter(|key| state.groups.get(key).is_some())
+            .cloned()
+            .collect::<BTreeSet<_>>()
+    });
     let mut operations = Vec::new();
     for delta in &deltas {
         let group_key =
@@ -470,7 +474,10 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
                             "new collect root did not render a terminal row".to_owned(),
                         )
                     })?;
-            let index = root_groups_after.range(..root_key.clone()).count();
+            // Rank against the complete merged group index: untouched parents
+            // remain in the immutable base and still determine terminal
+            // insertion position.
+            let index = state.groups.count_before(root_key);
             operations.push(TerminalOperation {
                 root_descriptor: output_desc,
                 root_key: root_key.clone(),
@@ -1512,6 +1519,67 @@ mod root_terminal_tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn unbounded_collect_insert_keeps_global_parent_order() {
+        let input = record_descriptor();
+        let child = RecordDescriptor::new([("id", ValueType::Uuid)]);
+        let output = RecordDescriptor::new([
+            ("root", ValueType::Uuid),
+            ("joined", ValueType::Uuid),
+            ("rank", ValueType::String),
+            (
+                "children",
+                ValueType::Array(Box::new(ValueType::Record(Box::new(child)))),
+            ),
+        ]);
+        let mut collect_by = collector();
+        collect_by.mode = CollectByMode::Collect;
+        collect_by.child_descriptor = child;
+        collect_by.child_fields = vec![CollectByProjection {
+            field: "root".to_owned(),
+            field_idx: 0,
+            output_name: "id".to_owned(),
+            unwrap_nullable: false,
+        }];
+        collect_by.collection_field = "children".to_owned();
+        collect_by.collection_field_index = 3;
+        let mut state = CollectByIncrementalState::default();
+
+        let opened = update_unbounded_collect_by_terminal_state(
+            input,
+            output,
+            &collect_by,
+            None,
+            &mut state,
+            &[delta(1, 1, "one", 1), delta(3, 3, "three", 1)],
+            true,
+        )
+        .unwrap();
+        assert!(opened.iter().any(|operation| operation.path.is_empty()));
+
+        let inserted = update_unbounded_collect_by_terminal_state(
+            input,
+            output,
+            &collect_by,
+            None,
+            &mut state,
+            &[delta(2, 2, "two", 1)],
+            true,
+        )
+        .unwrap();
+        let inserted_roots = inserted
+            .iter()
+            .filter(|operation| operation.path.is_empty())
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            inserted_roots.as_slice(),
+            [TerminalOperation {
+                edit: TerminalEdit::Insert { index: 1, .. },
+                ..
+            }]
+        ));
     }
 
     #[test]

--- a/crates/groove/src/ivm/runtime/windows.rs
+++ b/crates/groove/src/ivm/runtime/windows.rs
@@ -288,9 +288,17 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
     // consumers and cancels transient insert/delete pairs within one batch.
     let deltas =
         canonical_collect_by_terminal_deltas(input_desc, collect_by, direct_tree_slot, deltas)?;
+    // Only a group named by this batch can enter or leave the terminal.  Do
+    // not snapshot every existing group just to discover that fact.
+    let touched_group_keys = deltas
+        .iter()
+        .map(|delta| {
+            encoded_record_key_part(input_desc, delta.raw(), &collect_by.group_field_indices)
+        })
+        .collect::<Result<BTreeSet<_>, _>>()?;
     let root_groups_before = direct_tree_slot
         .is_none()
-        .then(|| state.groups.keys().cloned().collect::<BTreeSet<_>>());
+        .then(|| touched_group_keys.clone());
     let mut operations = Vec::new();
     for delta in &deltas {
         let group_key =
@@ -368,7 +376,7 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
             sort_directions,
         )?;
         let state_key = (sort_key, delta.record.clone());
-        let group = state.groups.entry(group_key.clone()).or_default();
+        let group = state.groups.get_or_default(group_key.clone());
         let before_weight = group.get(&state_key).copied().unwrap_or_default();
         let before_index = (before_weight > 0).then(|| group.count_before(&state_key));
         let after_weight = before_weight + delta.weight;
@@ -423,9 +431,15 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
             debug_assert!(before_index.is_some());
         }
     }
-    state.groups.retain(|_, group| !group.is_empty());
+    state
+        .groups
+        .remove_empty_touched_groups(touched_group_keys.iter().cloned());
     if let Some(root_groups_before) = root_groups_before {
-        let root_groups_after = state.groups.keys().cloned().collect::<BTreeSet<_>>();
+        let root_groups_after = touched_group_keys
+            .iter()
+            .filter(|key| state.groups.get(key).is_some())
+            .cloned()
+            .collect::<BTreeSet<_>>();
         operations.retain(|operation| {
             root_groups_before.contains(&operation.root_key)
                 && root_groups_after.contains(&operation.root_key)
@@ -578,11 +592,13 @@ fn update_collect_by_root_terminal_state(
         }
         let sort_key = collect_by_sort_key(input_desc, delta.raw(), collect_by)?;
         let state_key = (sort_key, delta.record.clone());
-        let group = state.groups.entry(group_key.clone()).or_default();
+        let group = state.groups.get_or_default(group_key.clone());
         let weight = group.get(&state_key).copied().unwrap_or_default() + delta.weight;
         group.set(state_key, weight);
     }
-    state.groups.retain(|_, group| !group.is_empty());
+    state
+        .groups
+        .remove_empty_touched_groups(before.keys().cloned());
     if !emit {
         return Ok(Vec::new());
     }

--- a/crates/groove/src/ivm/runtime/windows.rs
+++ b/crates/groove/src/ivm/runtime/windows.rs
@@ -163,7 +163,7 @@ pub(super) fn top_by_window_from_records(
 }
 
 pub(super) fn top_by_window_from_ordered_group(
-    records: Option<&BTreeMap<CollectByOrderKey, i64>>,
+    records: Option<&CollectByGroup>,
     top_by: &TopByOp,
 ) -> Vec<WindowedRecord> {
     let mut window = Vec::new();
@@ -172,7 +172,7 @@ pub(super) fn top_by_window_from_ordered_group(
         TopByLimit::Finite(limit) => Some(limit),
         TopByLimit::Unbounded => None,
     };
-    for ((_, record), weight) in records.into_iter().flatten() {
+    for ((_, record), weight) in records.into_iter().flat_map(CollectByGroup::iter) {
         if remaining == Some(0) {
             break;
         }
@@ -370,18 +370,9 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
         let state_key = (sort_key, delta.record.clone());
         let group = state.groups.entry(group_key.clone()).or_default();
         let before_weight = group.get(&state_key).copied().unwrap_or_default();
-        let before_index = (before_weight > 0).then(|| {
-            group
-                .range(..state_key.clone())
-                .filter(|(_, weight)| **weight > 0)
-                .count()
-        });
+        let before_index = (before_weight > 0).then(|| group.count_before(&state_key));
         let after_weight = before_weight + delta.weight;
-        if after_weight == 0 {
-            group.remove(&state_key);
-        } else {
-            group.insert(state_key.clone(), after_weight);
-        }
+        group.set(state_key.clone(), after_weight);
         if !emit || (before_weight > 0) == (after_weight > 0) {
             continue;
         }
@@ -411,10 +402,7 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
         let child_key = encoded_record_key_part(child_descriptor, &child_record, &[0])?;
         let path = vec![TerminalPathSegment::Collection(collection_field.to_owned())];
         if after_weight > 0 {
-            let index = group
-                .range(..state_key)
-                .filter(|(_, weight)| **weight > 0)
-                .count();
+            let index = group.count_before(&state_key);
             operations.push(TerminalOperation {
                 root_descriptor: output_desc,
                 root_key: group_key,
@@ -592,11 +580,7 @@ fn update_collect_by_root_terminal_state(
         let state_key = (sort_key, delta.record.clone());
         let group = state.groups.entry(group_key.clone()).or_default();
         let weight = group.get(&state_key).copied().unwrap_or_default() + delta.weight;
-        if weight == 0 {
-            group.remove(&state_key);
-        } else {
-            group.insert(state_key, weight);
-        }
+        group.set(state_key, weight);
     }
     state.groups.retain(|_, group| !group.is_empty());
     if !emit {
@@ -822,9 +806,7 @@ fn update_collect_by_root_terminal_state(
     Ok(operations)
 }
 
-fn collect_by_root_order_key(
-    group: &BTreeMap<CollectByOrderKey, i64>,
-) -> Option<CollectByOrderKey> {
+fn collect_by_root_order_key(group: &CollectByGroup) -> Option<CollectByOrderKey> {
     group
         .iter()
         .find(|(_, weight)| **weight > 0)

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -1464,7 +1464,7 @@ impl OwnedWriteOperation {
     }
 }
 
-enum OverlayHandle<'a, T> {
+enum OverlayHandle<'a, T: ?Sized> {
     Borrowed(&'a T),
     Owned(Rc<T>),
 }
@@ -1478,7 +1478,7 @@ impl<T> Clone for OverlayHandle<'_, T> {
     }
 }
 
-impl<T> std::ops::Deref for OverlayHandle<'_, T> {
+impl<T: ?Sized> std::ops::Deref for OverlayHandle<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -1489,7 +1489,7 @@ impl<T> std::ops::Deref for OverlayHandle<'_, T> {
     }
 }
 
-pub struct StagedWriteOverlay<'a, S> {
+pub struct StagedWriteOverlay<'a, S: ?Sized> {
     base: OverlayHandle<'a, S>,
     staged_writes: OverlayHandle<'a, RefCell<StagedWriteState>>,
 }
@@ -1621,7 +1621,7 @@ where
     }
 }
 
-impl<'a, S> StagedWriteOverlay<'a, S> {
+impl<'a, S: ?Sized> StagedWriteOverlay<'a, S> {
     pub(crate) fn new(base: &'a S, staged_writes: &'a RefCell<StagedWriteState>) -> Self {
         Self {
             base: OverlayHandle::Borrowed(base),
@@ -1790,7 +1790,7 @@ fn overlay_scan<'a, S>(
     request: ScanRequest,
 ) -> StorageFuture<'a, Result<StorageScan<'a>, Error>>
 where
-    S: OrderedKvStorage,
+    S: OrderedKvStorage + ?Sized,
 {
     let cf = request.cf.clone();
     let bounds = request.bounds.clone();
@@ -1848,7 +1848,7 @@ where
     })
 }
 
-impl<S> OrderedKvStorage for StagedWriteOverlay<'_, S>
+impl<S: ?Sized> OrderedKvStorage for StagedWriteOverlay<'_, S>
 where
     S: OrderedKvStorage,
 {

--- a/crates/groove/src/storage/test.rs
+++ b/crates/groove/src/storage/test.rs
@@ -9,7 +9,7 @@ use std::task::{Poll, Waker};
 use super::{
     Error, KeyValue, MemoryStorage, OrderedKvStorage, OwnedWriteOperation, ReadyStorageCursor,
     ReopenableStorage, ScanBounds, ScanDirection, ScanRequest, StorageCursor, StorageFuture,
-    StorageScan, Value,
+    StorageScan, Value, WriteManyOutcome,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -179,6 +179,8 @@ struct ControlState {
     point_read_count: usize,
     waiters: Vec<Waker>,
     failures: BTreeMap<TestStorageOperation, VecDeque<Error>>,
+    definitely_uncommitted_failures: BTreeMap<TestStorageOperation, VecDeque<Error>>,
+    lost_write_many_acknowledgements: usize,
 }
 
 impl Default for ControlState {
@@ -193,6 +195,8 @@ impl Default for ControlState {
             point_read_count: 0,
             waiters: Vec::new(),
             failures: BTreeMap::new(),
+            definitely_uncommitted_failures: BTreeMap::new(),
+            lost_write_many_acknowledgements: 0,
         }
     }
 }
@@ -215,6 +219,24 @@ impl TestStorageControl {
                 backend: "test",
                 message: format!("injected {operation:?} failure"),
             });
+    }
+
+    /// Fail a batch before its atomic write begins, proving no commit occurred.
+    pub fn fail_next_uncommitted(&self, operation: TestStorageOperation) {
+        self.state
+            .borrow_mut()
+            .definitely_uncommitted_failures
+            .entry(operation)
+            .or_default()
+            .push_back(Error::Backend {
+                backend: "test",
+                message: format!("injected definitely-uncommitted {operation:?} failure"),
+            });
+    }
+
+    /// Let the next batch commit, then lose its acknowledgement.
+    pub fn lose_next_write_many_acknowledgement(&self) {
+        self.state.borrow_mut().lost_write_many_acknowledgements += 1;
     }
 
     /// Make subsequent storage progress require explicit permits.
@@ -286,6 +308,27 @@ impl TestStorageControl {
 
     fn record_point_read(&self) {
         self.state.borrow_mut().point_read_count += 1;
+    }
+
+    fn take_definitely_uncommitted_failure(
+        &self,
+        operation: TestStorageOperation,
+    ) -> Option<Error> {
+        self.state
+            .borrow_mut()
+            .definitely_uncommitted_failures
+            .get_mut(&operation)
+            .and_then(VecDeque::pop_front)
+    }
+
+    fn take_lost_write_many_acknowledgement(&self) -> bool {
+        let mut state = self.state.borrow_mut();
+        if state.lost_write_many_acknowledgements == 0 {
+            false
+        } else {
+            state.lost_write_many_acknowledgements -= 1;
+            true
+        }
     }
 
     /// Number of times an operation's controlled suspension point was polled.
@@ -618,6 +661,51 @@ where
                 }
             }
             Ok(())
+        })
+    }
+
+    fn write_many_outcome(
+        &self,
+        operations: Vec<OwnedWriteOperation>,
+    ) -> StorageFuture<'_, WriteManyOutcome> {
+        Box::pin(async move {
+            if let Err(error) = self.control.before(TestStorageOperation::WriteMany).await {
+                return WriteManyOutcome::PossiblyCommitted(error);
+            }
+            if let Some(error) = self
+                .control
+                .take_definitely_uncommitted_failure(TestStorageOperation::WriteMany)
+            {
+                return WriteManyOutcome::Uncommitted(error);
+            }
+            match self.inner.write_many_outcome(operations.clone()).await {
+                WriteManyOutcome::Committed => {
+                    let mut resident = self.resident.borrow_mut();
+                    for operation in operations {
+                        match operation {
+                            OwnedWriteOperation::Set { cf, key, value } => {
+                                resident.install_point(cf, key, Some(value));
+                            }
+                            OwnedWriteOperation::Delete { cf, key } => {
+                                resident.install_point(cf, key, None);
+                            }
+                        }
+                    }
+                    if self.control.take_lost_write_many_acknowledgement() {
+                        WriteManyOutcome::PossiblyCommitted(Error::Backend {
+                            backend: "test",
+                            message: "injected acknowledgement loss after write_many commit"
+                                .to_owned(),
+                        })
+                    } else {
+                        WriteManyOutcome::Committed
+                    }
+                }
+                WriteManyOutcome::Uncommitted(error) => WriteManyOutcome::Uncommitted(error),
+                WriteManyOutcome::PossiblyCommitted(error) => {
+                    WriteManyOutcome::PossiblyCommitted(error)
+                }
+            }
         })
     }
 


### PR DESCRIPTION
🤖 Supersedes #2483 with a reimplementation against current main. This is an early visible WIP while independent adversarial review runs; it is not ready to merge.

## Before / after

A recursive evaluation can discover its iteration limit only after mutating retained evaluator state. Before this repair, the error could leave partial recursive closure, arrangements, memo/frontier state, tick advancement, or publication state behind.

Evaluation now stages its touched state and publishes it only when the relevant evaluation succeeds:

- A failed direct recursive tick leaves the previously committed runtime state unchanged.
- A maintained subscription that exceeds its recursion limit is closed and its partial derived state is discarded.
- The database write that triggered that subscription failure remains committed.
- An independent healthy subscription evaluating the same write still publishes its result; one failed owner does not suppress unrelated publication.

For example, if committed storage gains edges `2→3` and `3→4`, a deliberately limited recursive subscription may fail while deriving transitive results. Reopening the database still sees those two physical edges, but it does not inherit the failed subscription's partial derived closure. A simultaneous non-recursive edge subscription receives both inserts.

## Design constraints

The implementation uses bounded touched-state overlays rather than copying complete retained histories, keeps the current selective recursive-frontier optimization, and stays within the shared evaluator. A transformed recursive step that cannot use raw table field names falls back to its seed frontier rather than failing with `GraphFieldNotFound`.

No storage/wire format or public API changes are introduced. Current `BindingSourceKey` and terminal-hydration behavior are preserved. Independent review is specifically checking owner sharing, cancellation/hydration, notification atomicity, memory boundedness, and whether the descriptor-safe fallback is too broad.

## Verification so far

- `cargo test -p groove recursive_ --lib`: 51 passed.
- Direct rollback, resident scoped failure, persisted-base reopen, transformed-step, selective scale, and healthy co-resident publication regressions pass.
- Prior versions of the repair naturally failed the transformed-step test and stranded the healthy subscription; the final regressions cover both gaps.
- Full gates and independent review remain pending.

The original #2483 branch has not been rewritten.
