### PR TITLE
Invalidate eviction state before body removal on current main

### DIFF
--- a/crates/jazz/src/node/eviction.rs
+++ b/crates/jazz/src/node/eviction.rs
@@ -206,16 +206,39 @@ where
             }
         }
         evictable.sort_by_key(|candidate| candidate.tx_id);
+        if !evictable.is_empty() {
+            // INV-SYNC-27: once local row-version bodies may be removed, no
+            // persisted or in-memory fast known-state cursor may survive.
+            // Clear these facts before publishing any body deletion so a
+            // clearing failure leaves every candidate body intact.
+            self.clear_all_known_state_facts().await?;
+        }
+
+        if low_water_bytes.is_none() {
+            // Manual eviction publishes one batch, so every affected cache
+            // must be invalid before that batch can have an ambiguous outcome.
+            let mut last_invalidated_tx_id = None;
+            for candidate in &evictable {
+                if last_invalidated_tx_id == Some(candidate.tx_id) {
+                    continue;
+                }
+                self.invalidate_tx_version_tables_cache(candidate.tx_id);
+                last_invalidated_tx_id = Some(candidate.tx_id);
+            }
+        }
 
         let mut batch = self.database.open_batch();
         let mut batch_deletes = 0_usize;
-        let mut evicted_tx_ids = BTreeSet::new();
         for candidate in evictable {
             if low_water_bytes.is_some_and(|low_water| remaining_bytes <= low_water) {
                 break;
             }
             report.row_versions_evictable += 1;
-            evicted_tx_ids.insert(candidate.tx_id);
+            if low_water_bytes.is_some() {
+                // A budgeted deletion is persisted per candidate. Invalidate
+                // both transaction-version caches before its fallible commit.
+                self.invalidate_tx_version_tables_cache(candidate.tx_id);
+            }
             let history_table = self.version_storage_table_for_row(&candidate.version)?;
             batch.delete(
                 history_table.as_ref(),
@@ -237,16 +260,6 @@ where
             let applied = self.database.apply_batch(batch).await?;
             let persisted = applied.persist().await;
             self.database.finish_persistence(persisted)?;
-        }
-        for tx_id in evicted_tx_ids {
-            self.invalidate_tx_version_tables_cache(tx_id);
-        }
-        if report.row_versions_evictable > 0 {
-            // INV-SYNC-27: once local row-version bodies are removed, no
-            // persisted fast known-state cursor may survive. This coarse
-            // invalidation is conservative until eviction tracks affected
-            // binding views directly.
-            self.clear_all_known_state_facts().await?;
         }
 
         let after_bytes = self

--- a/crates/jazz/src/node/tests/persistence_contracts.rs
+++ b/crates/jazz/src/node/tests/persistence_contracts.rs
@@ -34,7 +34,6 @@ struct FailWriteManyMemoryStorage {
     fail_on_write_many: std::rc::Rc<std::cell::Cell<Option<usize>>>,
     targeted_write_many_failure:
         std::rc::Rc<std::cell::RefCell<Option<TargetedWriteManyFailure>>>,
-    fail_next_delete: std::rc::Rc<std::cell::Cell<bool>>,
     write_many_calls: std::rc::Rc<std::cell::Cell<usize>>,
 }
 
@@ -44,7 +43,6 @@ impl FailWriteManyMemoryStorage {
             inner: MemoryStorage::new(column_families).expect("valid memory storage families"),
             fail_on_write_many: std::rc::Rc::new(std::cell::Cell::new(None)),
             targeted_write_many_failure: std::rc::Rc::new(std::cell::RefCell::new(None)),
-            fail_next_delete: std::rc::Rc::new(std::cell::Cell::new(false)),
             write_many_calls: std::rc::Rc::new(std::cell::Cell::new(0)),
         }
     }
@@ -76,10 +74,6 @@ impl FailWriteManyMemoryStorage {
             }));
     }
 
-    fn fail_next_delete(&self) {
-        self.fail_next_delete.set(true);
-    }
-
     fn write_many_call_count(&self) -> usize {
         self.write_many_calls.get()
     }
@@ -108,13 +102,6 @@ impl OrderedKvStorage for FailWriteManyMemoryStorage {
     }
 
     fn delete(&self, cf: String, key: Vec<u8>) -> groove::storage::StorageFuture<'_, Result<(), groove::storage::Error>> {
-        if self.fail_next_delete.replace(false) {
-            return Box::pin(async {
-                Err(groove::storage::Error::InvalidStorageLayout(
-                    "injected delete failure".to_owned(),
-                ))
-            });
-        }
         self.inner.delete(cf, key)
     }
 
@@ -181,14 +168,12 @@ impl ReopenableStorage for FailWriteManyMemoryStorage {
                 inner,
                 fail_on_write_many,
                 targeted_write_many_failure,
-                fail_next_delete,
                 write_many_calls,
             } = self;
             Ok(Self {
                 inner: inner.reopen(column_families).await?,
                 fail_on_write_many,
                 targeted_write_many_failure,
-                fail_next_delete,
                 write_many_calls,
             })
         })

--- a/crates/jazz/src/node/tests/persistence_contracts.rs
+++ b/crates/jazz/src/node/tests/persistence_contracts.rs
@@ -3,10 +3,38 @@
 // same seam: a failed durable commit is not permission to publish an IVM delta,
 // a view, or a fate acknowledgement.
 
+struct TargetedWriteManyFailure {
+    cf: String,
+    key: Vec<u8>,
+    write_through: bool,
+}
+
+fn jazz_class_v1_history_physical_target(
+    logical_cf: &str,
+    logical_key: &[u8],
+) -> (String, Vec<u8>) {
+    assert!(
+        logical_cf.starts_with("jazz_") && logical_cf.ends_with("_history"),
+        "physical history target requires a Jazz history column family"
+    );
+    let logical_cf_bytes = logical_cf.as_bytes();
+    let logical_cf_len =
+        u32::try_from(logical_cf_bytes.len()).expect("Jazz column-family names fit in u32");
+    let mut physical_key =
+        Vec::with_capacity(4 + logical_cf_bytes.len() + logical_key.len());
+    physical_key.extend_from_slice(&logical_cf_len.to_be_bytes());
+    physical_key.extend_from_slice(logical_cf_bytes);
+    physical_key.extend_from_slice(logical_key);
+    ("__groove_class_history".to_owned(), physical_key)
+}
+
 #[derive(Clone)]
 struct FailWriteManyMemoryStorage {
     inner: MemoryStorage,
     fail_on_write_many: std::rc::Rc<std::cell::Cell<Option<usize>>>,
+    targeted_write_many_failure:
+        std::rc::Rc<std::cell::RefCell<Option<TargetedWriteManyFailure>>>,
+    fail_next_delete: std::rc::Rc<std::cell::Cell<bool>>,
     write_many_calls: std::rc::Rc<std::cell::Cell<usize>>,
 }
 
@@ -15,6 +43,8 @@ impl FailWriteManyMemoryStorage {
         Self {
             inner: MemoryStorage::new(column_families).expect("valid memory storage families"),
             fail_on_write_many: std::rc::Rc::new(std::cell::Cell::new(None)),
+            targeted_write_many_failure: std::rc::Rc::new(std::cell::RefCell::new(None)),
+            fail_next_delete: std::rc::Rc::new(std::cell::Cell::new(false)),
             write_many_calls: std::rc::Rc::new(std::cell::Cell::new(0)),
         }
     }
@@ -26,6 +56,28 @@ impl FailWriteManyMemoryStorage {
         assert!(nth > 0, "write-many failpoint is one-based");
         self.fail_on_write_many
             .set(Some(self.write_many_calls.get() + nth));
+    }
+
+    fn fail_write_many_on_delete(&self, cf: String, key: Vec<u8>) {
+        self.targeted_write_many_failure
+            .replace(Some(TargetedWriteManyFailure {
+                cf,
+                key,
+                write_through: false,
+            }));
+    }
+
+    fn fail_write_many_on_delete_after_write_through(&self, cf: String, key: Vec<u8>) {
+        self.targeted_write_many_failure
+            .replace(Some(TargetedWriteManyFailure {
+                cf,
+                key,
+                write_through: true,
+            }));
+    }
+
+    fn fail_next_delete(&self) {
+        self.fail_next_delete.set(true);
     }
 
     fn write_many_call_count(&self) -> usize {
@@ -56,6 +108,13 @@ impl OrderedKvStorage for FailWriteManyMemoryStorage {
     }
 
     fn delete(&self, cf: String, key: Vec<u8>) -> groove::storage::StorageFuture<'_, Result<(), groove::storage::Error>> {
+        if self.fail_next_delete.replace(false) {
+            return Box::pin(async {
+                Err(groove::storage::Error::InvalidStorageLayout(
+                    "injected delete failure".to_owned(),
+                ))
+            });
+        }
         self.inner.delete(cf, key)
     }
 
@@ -66,11 +125,48 @@ impl OrderedKvStorage for FailWriteManyMemoryStorage {
     fn write_many(&self, operations: Vec<groove::storage::OwnedWriteOperation>) -> groove::storage::StorageFuture<'_, Result<(), groove::storage::Error>> {
         let call = self.write_many_calls.get() + 1;
         self.write_many_calls.set(call);
+        let matches_target = self
+            .targeted_write_many_failure
+            .borrow()
+            .as_ref()
+            .is_some_and(|target| {
+                operations.iter().any(|operation| {
+                    matches!(
+                        operation,
+                        groove::storage::OwnedWriteOperation::Delete { cf, key }
+                            if cf == &target.cf && key == &target.key
+                    )
+                })
+            });
+        if matches_target {
+            let target = self
+                .targeted_write_many_failure
+                .borrow_mut()
+                .take()
+                .expect("matching targeted write-many failure must remain armed");
+            if target.write_through {
+                let persisted = self.inner.write_many(operations);
+                return Box::pin(async move {
+                    persisted.await?;
+                    Err(groove::storage::Error::InvalidStorageLayout(
+                        "injected post-write failure".to_owned(),
+                    ))
+                });
+            }
+            return Box::pin(async { Err(groove::storage::Error::InvalidStorageLayout("injected durable commit failure".to_owned())) });
+        }
         if self.fail_on_write_many.get() == Some(call) {
             self.fail_on_write_many.set(None);
             return Box::pin(async { Err(groove::storage::Error::InvalidStorageLayout("injected durable commit failure".to_owned())) });
         }
         self.inner.write_many(operations)
+    }
+
+    fn approximate_class_bytes(
+        &self,
+        cf: String,
+    ) -> groove::storage::StorageFuture<'_, Result<Option<u64>, groove::storage::Error>> {
+        self.inner.approximate_class_bytes(cf)
     }
 
     fn column_family_names(&self) -> Option<Vec<String>> {
@@ -81,10 +177,18 @@ impl OrderedKvStorage for FailWriteManyMemoryStorage {
 impl ReopenableStorage for FailWriteManyMemoryStorage {
     fn reopen(self, column_families: Vec<String>) -> groove::storage::StorageFuture<'static, Result<Self, groove::storage::Error>> {
         Box::pin(async move {
-            let Self { inner, fail_on_write_many, write_many_calls } = self;
+            let Self {
+                inner,
+                fail_on_write_many,
+                targeted_write_many_failure,
+                fail_next_delete,
+                write_many_calls,
+            } = self;
             Ok(Self {
                 inner: inner.reopen(column_families).await?,
                 fail_on_write_many,
+                targeted_write_many_failure,
+                fail_next_delete,
                 write_many_calls,
             })
         })

--- a/crates/jazz/src/node/tests/sync/known_state.rs
+++ b/crates/jazz/src/node/tests/sync/known_state.rs
@@ -1463,6 +1463,61 @@ fn budgeted_eviction_write_through_error_removes_body_and_clears_fast_known_stat
 }
 
 #[test]
+fn failed_known_state_clear_leaves_eviction_bodies_and_transaction_caches_intact() {
+    // Internal persistence-boundary coverage: public recovery only observes
+    // the eventual refetch. This direct failpoint proves clearing the fast
+    // declaration is the barrier before eviction can publish any body delete.
+    let (_writer_dir, mut writer) = open_node_with_uuid(node(1));
+    let (_core_dir, mut core) = open_node_with_uuid(node(9));
+    let (shape, binding) = core.whole_table_shape_binding("todos").unwrap();
+    let subscription = core.whole_table_subscription_key("todos").unwrap();
+    let row_uuid = row(0x7c);
+    let tx_id = commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("todos", row_uuid, 18).cells(title_cells("clear failure")),
+    );
+    let column_families = schema().column_families();
+    let refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let storage = FailWriteManyMemoryStorage::new(&refs);
+    let mut reader = NodeState::new(node(3), schema(), storage.clone()).unwrap();
+    let update = PeerState::relay()
+        .rehydrate_query_for_subscription_with_opts(
+            &mut core,
+            subscription,
+            &shape,
+            &binding,
+            RegisterShapeOptions::default(),
+        )
+        .unwrap()
+        .expect("expected view update");
+    reader.apply_sync_message_settled(update).unwrap();
+    let persisted_history = reader.row_history("todos", row_uuid).unwrap();
+    let persisted_versions = reader.query_versions_for_tx(tx_id).unwrap();
+    reader.cache_tx_versions(tx_id, persisted_versions);
+    let binding_view_key = reader
+        .binding_view_key_for_subscription(subscription)
+        .unwrap();
+    assert!(reader.load_known_state_fact(binding_view_key).unwrap().is_some());
+    assert!(reader.cached_tx_versions(tx_id).is_some());
+    assert!(reader.cached_tx_version_tables(tx_id).is_some());
+
+    storage.fail_next_delete();
+    reader
+        .evict_cold(&PeerEvictionPins::default())
+        .resolve()
+        .expect_err("known-state clearing failure must stop eviction before body removal");
+
+    assert_eq!(reader.row_history("todos", row_uuid).unwrap(), persisted_history);
+    assert!(reader.load_known_state_fact(binding_view_key).unwrap().is_some());
+    assert!(reader.cached_tx_versions(tx_id).is_some());
+    assert!(reader.cached_tx_version_tables(tx_id).is_some());
+}
+
+#[test]
 fn storage_reopen_does_not_promote_a_durable_fast_cursor_to_live_settlement() {
     let (_writer_dir, mut writer) = open_node_with_uuid(node(1));
     let (_core_dir, mut core) = open_node_with_uuid(node(9));

--- a/crates/jazz/src/node/tests/sync/known_state.rs
+++ b/crates/jazz/src/node/tests/sync/known_state.rs
@@ -1319,7 +1319,8 @@ fn assert_eviction_failure_contract(
         .collect::<Vec<_>>();
     let storage = FailWriteManyMemoryStorage::new(&refs);
     let mut reader = NodeState::new(node(3), schema(), storage.clone()).unwrap();
-    let update = PeerState::relay()
+    register_shape_binding(&mut reader, &shape, &binding);
+    let update = relay_with_system_binding(subscription)
         .rehydrate_query_for_subscription_with_opts(
             &mut core,
             subscription,
@@ -1348,13 +1349,19 @@ fn assert_eviction_failure_contract(
     assert!(reader.cached_tx_version_tables(tx_id).is_some());
     reader.cache_tx_versions(tx_id, persisted_versions.clone());
     assert!(reader.cached_tx_versions(tx_id).is_some());
-    let binding_view_key = reader
-        .binding_view_key_for_subscription(subscription)
-        .unwrap();
-    assert_eq!(
-        reader.load_known_state_fact(binding_view_key).unwrap(),
-        Some(GlobalTime::new(global_time, 0).unwrap())
-    );
+    assert!(matches!(
+        reader
+            .known_state_declaration_for_subscription(
+                &shape,
+                &binding,
+                subscription,
+                &[],
+                AuthorSubject::SYSTEM,
+                None,
+            )
+            .unwrap(),
+        Some(crate::protocol::KnownStateDeclaration::Fast { .. })
+    ));
 
     match outcome {
         EvictionPersistenceOutcome::FailBeforeDelegation => {
@@ -1484,7 +1491,8 @@ fn failed_known_state_clear_leaves_eviction_bodies_and_transaction_caches_intact
         .collect::<Vec<_>>();
     let storage = FailWriteManyMemoryStorage::new(&refs);
     let mut reader = NodeState::new(node(3), schema(), storage.clone()).unwrap();
-    let update = PeerState::relay()
+    register_shape_binding(&mut reader, &shape, &binding);
+    let update = relay_with_system_binding(subscription)
         .rehydrate_query_for_subscription_with_opts(
             &mut core,
             subscription,
@@ -1498,21 +1506,42 @@ fn failed_known_state_clear_leaves_eviction_bodies_and_transaction_caches_intact
     let persisted_history = reader.row_history("todos", row_uuid).unwrap();
     let persisted_versions = reader.query_versions_for_tx(tx_id).unwrap();
     reader.cache_tx_versions(tx_id, persisted_versions);
-    let binding_view_key = reader
-        .binding_view_key_for_subscription(subscription)
-        .unwrap();
-    assert!(reader.load_known_state_fact(binding_view_key).unwrap().is_some());
+    assert!(matches!(
+        reader
+            .known_state_declaration_for_subscription(
+                &shape,
+                &binding,
+                subscription,
+                &[],
+                AuthorSubject::SYSTEM,
+                None,
+            )
+            .unwrap(),
+        Some(crate::protocol::KnownStateDeclaration::Fast { .. })
+    ));
     assert!(reader.cached_tx_versions(tx_id).is_some());
     assert!(reader.cached_tx_version_tables(tx_id).is_some());
 
-    storage.fail_next_delete();
+    storage.fail_nth_following_write_many(1);
     reader
         .evict_cold(&PeerEvictionPins::default())
         .resolve()
         .expect_err("known-state clearing failure must stop eviction before body removal");
 
     assert_eq!(reader.row_history("todos", row_uuid).unwrap(), persisted_history);
-    assert!(reader.load_known_state_fact(binding_view_key).unwrap().is_some());
+    assert!(matches!(
+        reader
+            .known_state_declaration_for_subscription(
+                &shape,
+                &binding,
+                subscription,
+                &[],
+                AuthorSubject::SYSTEM,
+                None,
+            )
+            .unwrap(),
+        Some(crate::protocol::KnownStateDeclaration::Fast { .. })
+    ));
     assert!(reader.cached_tx_versions(tx_id).is_some());
     assert!(reader.cached_tx_version_tables(tx_id).is_some());
 }

--- a/crates/jazz/src/node/tests/sync/known_state.rs
+++ b/crates/jazz/src/node/tests/sync/known_state.rs
@@ -1284,6 +1284,183 @@ fn fast_known_state_requires_a_live_receipt_after_reopen_and_eviction() {
     assert_eq!(declaration, None);
 }
 
+#[derive(Clone, Copy)]
+enum EvictionFailurePath {
+    ManualBatch,
+    BudgetedPerCandidate,
+}
+
+#[derive(Clone, Copy)]
+enum EvictionPersistenceOutcome {
+    FailBeforeDelegation,
+    WriteThroughThenError,
+}
+
+fn assert_eviction_failure_contract(
+    path: EvictionFailurePath,
+    outcome: EvictionPersistenceOutcome,
+    row_uuid: RowUuid,
+    global_time: u64,
+    title: &'static str,
+) {
+    let (_writer_dir, mut writer) = open_node_with_uuid(node(1));
+    let (_core_dir, mut core) = open_node_with_uuid(node(9));
+    let (shape, binding) = core.whole_table_shape_binding("todos").unwrap();
+    let subscription = core.whole_table_subscription_key("todos").unwrap();
+    let tx_id = commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("todos", row_uuid, global_time).cells(title_cells(title)),
+    );
+    let column_families = schema().column_families();
+    let refs = column_families
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let storage = FailWriteManyMemoryStorage::new(&refs);
+    let mut reader = NodeState::new(node(3), schema(), storage.clone()).unwrap();
+    let update = PeerState::relay()
+        .rehydrate_query_for_subscription_with_opts(
+            &mut core,
+            subscription,
+            &shape,
+            &binding,
+            RegisterShapeOptions::default(),
+        )
+        .unwrap()
+        .expect("expected view update");
+    reader.apply_sync_message_settled(update).unwrap();
+    let persisted_history = reader.row_history("todos", row_uuid).unwrap();
+    let persisted_versions = reader.query_versions_for_tx(tx_id).unwrap();
+    assert_eq!(persisted_versions.len(), 1);
+    let persisted_version = persisted_versions
+        .first()
+        .expect("persisted version count was checked above");
+    let logical_history_table = reader
+        .version_storage_table_for_row(persisted_version)
+        .unwrap()
+        .to_string();
+    let logical_history_key = history_primary_key(persisted_version).into_bytes();
+    let (history_table, history_key) = jazz_class_v1_history_physical_target(
+        &logical_history_table,
+        &logical_history_key,
+    );
+    assert!(reader.cached_tx_version_tables(tx_id).is_some());
+    reader.cache_tx_versions(tx_id, persisted_versions.clone());
+    assert!(reader.cached_tx_versions(tx_id).is_some());
+    let binding_view_key = reader
+        .binding_view_key_for_subscription(subscription)
+        .unwrap();
+    assert_eq!(
+        reader.load_known_state_fact(binding_view_key).unwrap(),
+        Some(GlobalTime::new(global_time, 0).unwrap())
+    );
+
+    match outcome {
+        EvictionPersistenceOutcome::FailBeforeDelegation => {
+            storage.fail_write_many_on_delete(history_table, history_key);
+        }
+        EvictionPersistenceOutcome::WriteThroughThenError => {
+            storage
+                .fail_write_many_on_delete_after_write_through(history_table, history_key);
+        }
+    }
+    match path {
+        EvictionFailurePath::ManualBatch => {
+            reader
+                .evict_cold(&PeerEvictionPins::default())
+                .resolve()
+                .expect_err("manual eviction must reach the injected persistence failure");
+        }
+        EvictionFailurePath::BudgetedPerCandidate => {
+            reader
+                .enforce_edge_cache_budget(
+                    &PeerEvictionPins::default(),
+                    EdgeCacheBudget::new(0),
+                )
+                .resolve()
+                .expect_err("budgeted eviction must reach the injected persistence failure");
+        }
+    }
+    // Public recovery proves durable body and known-state behaviour, but only
+    // this private receipt can observe cache removal without querying a
+    // persistence-poisoned live node.
+    assert!(reader.cached_tx_versions(tx_id).is_none());
+    assert!(reader.cached_tx_version_tables(tx_id).is_none());
+    drop(reader);
+
+    let mut reopened = NodeState::new(node(3), schema(), storage).unwrap();
+    let reopened_history = reopened.row_history("todos", row_uuid).unwrap();
+    match outcome {
+        EvictionPersistenceOutcome::FailBeforeDelegation => {
+            assert_eq!(reopened_history, persisted_history);
+        }
+        EvictionPersistenceOutcome::WriteThroughThenError => {
+            assert!(reopened_history.is_empty());
+        }
+    }
+    let declaration = reopened
+        .known_state_declaration_for_subscription(
+            &shape,
+            &binding,
+            subscription,
+            &[],
+            AuthorSubject::SYSTEM,
+        )
+        .unwrap();
+    assert!(!matches!(
+        declaration,
+        Some(crate::protocol::KnownStateDeclaration::Fast { .. })
+    ));
+}
+
+#[test]
+fn manual_eviction_fail_before_error_preserves_body_and_clears_fast_known_state_and_transaction_cache()
+{
+    assert_eviction_failure_contract(
+        EvictionFailurePath::ManualBatch,
+        EvictionPersistenceOutcome::FailBeforeDelegation,
+        row(0x78),
+        14,
+        "fail before",
+    );
+}
+
+#[test]
+fn manual_eviction_write_through_error_clears_fast_known_state_and_transaction_cache() {
+    assert_eviction_failure_contract(
+        EvictionFailurePath::ManualBatch,
+        EvictionPersistenceOutcome::WriteThroughThenError,
+        row(0x79),
+        15,
+        "write-through",
+    );
+}
+
+#[test]
+fn budgeted_eviction_fail_before_error_preserves_body_and_clears_fast_known_state_and_transaction_cache()
+{
+    assert_eviction_failure_contract(
+        EvictionFailurePath::BudgetedPerCandidate,
+        EvictionPersistenceOutcome::FailBeforeDelegation,
+        row(0x7a),
+        16,
+        "budget fail before",
+    );
+}
+
+#[test]
+fn budgeted_eviction_write_through_error_removes_body_and_clears_fast_known_state_and_transaction_cache()
+{
+    assert_eviction_failure_contract(
+        EvictionFailurePath::BudgetedPerCandidate,
+        EvictionPersistenceOutcome::WriteThroughThenError,
+        row(0x7b),
+        17,
+        "budget write-through",
+    );
+}
+
 #[test]
 fn storage_reopen_does_not_promote_a_durable_fast_cursor_to_live_settlement() {
     let (_writer_dir, mut writer) = open_node_with_uuid(node(1));

--- a/crates/jazz/src/node/tests/sync/known_state.rs
+++ b/crates/jazz/src/node/tests/sync/known_state.rs
@@ -1406,6 +1406,7 @@ fn assert_eviction_failure_contract(
             subscription,
             &[],
             AuthorSubject::SYSTEM,
+            None,
         )
         .unwrap();
     assert!(!matches!(

--- a/crates/jazz/src/node/tests/sync/known_state.rs
+++ b/crates/jazz/src/node/tests/sync/known_state.rs
@@ -1252,7 +1252,6 @@ fn fast_known_state_requires_a_live_receipt_after_reopen_and_eviction() {
             .unwrap(),
         Some(crate::protocol::KnownStateDeclaration::Fast { .. })
     ));
-
     let mut reopened = reader.reopen_in_place().unwrap();
     let declaration = reopened
         .known_state_declaration_for_subscription(
@@ -1349,6 +1348,21 @@ fn assert_eviction_failure_contract(
     assert!(reader.cached_tx_version_tables(tx_id).is_some());
     reader.cache_tx_versions(tx_id, persisted_versions.clone());
     assert!(reader.cached_tx_versions(tx_id).is_some());
+    // Internal durable-boundary receipt: a reopened node intentionally lacks
+    // the live authority handoff needed to declare Fast, so that public API
+    // result alone cannot distinguish an evicted durable fact from a stale
+    // one. This isolated store has exactly this subscription's fact.
+    let known_state_facts = reader
+        .database
+        .direct_record_store(crate::schema::KNOWN_STATE_FACTS_STORE)
+        .unwrap();
+    assert_eq!(
+        futures::executor::block_on(known_state_facts.prefix_entries(&[]))
+            .unwrap()
+            .len(),
+        1,
+        "the settled update must persist its fast known-state fact before eviction"
+    );
     assert!(matches!(
         reader
             .known_state_declaration_for_subscription(
@@ -1397,6 +1411,16 @@ fn assert_eviction_failure_contract(
     drop(reader);
 
     let mut reopened = NodeState::new(node(3), schema(), storage).unwrap();
+    let known_state_facts = reopened
+        .database
+        .direct_record_store(crate::schema::KNOWN_STATE_FACTS_STORE)
+        .unwrap();
+    assert!(
+        futures::executor::block_on(known_state_facts.prefix_entries(&[]))
+            .unwrap()
+            .is_empty(),
+        "eviction must durably remove every fast known-state fact even when body persistence fails"
+    );
     let reopened_history = reopened.row_history("todos", row_uuid).unwrap();
     match outcome {
         EvictionPersistenceOutcome::FailBeforeDelegation => {


### PR DESCRIPTION
🤖 Supersedes #2489 with its eviction repair adapted to current main and a review-driven test correction. Independent adversarial review found no blocker; CI and Anselm's review remain pending.

## Before / after

Eviction previously removed row-version bodies before clearing durable and in-memory declarations that said those bodies were available. A storage error during deletion could therefore leave a node claiming it possessed data that was already missing.

Eviction now crosses the safety boundary in this order:

1. Clear durable and in-memory fast known-state facts before any body deletion.
2. Invalidate both transaction-version caches before the corresponding deletion can have a fallible or ambiguous persistence outcome.
3. Delete the selected bodies.

Manual eviction invalidates all affected transaction caches before its batch. Budgeted eviction invalidates each candidate before that candidate's persistence attempt. Candidate selection and byte-budget policy are unchanged. If candidates exist but the node is already below its low-water target, the known-state clear can conservatively force a refetch without deleting a body; it never produces a false possession claim.

## Failure examples

- If known-state clearing fails, no body is deleted and existing caches remain intact.
- If body persistence definitely fails before writing, the body remains but its fast declaration and caches are already gone.
- If persistence writes through and then returns an error, the body may be absent and its declaration/caches are still safely absent.

## Verification

- Five focused regressions pass independently: manual and budgeted fail-before/write-through outcomes, plus failure of the initial known-state clear.
- Review found the initial reopen assertion was vacuous because a reopened node lacks a live authority receipt. The tests now inspect the durable known-state store directly.
- Removing the production clear call makes the durable assertion fail; the mutation was restored.
- Diff checks pass; full CI pending.

Original #2489 commits are retained in this adaptation, followed by the review-driven durable receipt at `b1371d1c76`. The original branch has not been rewritten.
