### PR TITLE
Observe native transport terminal outcomes on current main

### DIFF
--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 use std::cell::Cell;
 use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::future::Future;
 use std::ops::Deref;
 use std::pin::Pin;
@@ -32,7 +32,10 @@ use crate::protocol::ReadViewSpec as CoreReadViewSpec;
 use crate::query::{Aggregate as CoreAggregate, AggregateFunction as CoreAggregateFunction, Query};
 use crate::storage_codec_profile::epoch_1_storage_codec_profile;
 use crate::tools::OpenTransactionId;
-use crate::tools::native_transport_connector::{NativeTransportConnector, NativeTransportRequest};
+use crate::tools::native_transport_connector::{
+    ConnectedNativeTransport, NativeTransportConnector, NativeTransportRequest,
+    NativeTransportTerminal, NativeTransportTerminalFuture,
+};
 use crate::tools::public_api::types::{
     OrderedAdded, OrderedRemoved, OrderedUpdated, QueryResultField,
 };
@@ -162,6 +165,10 @@ struct ClientDbInner {
     connect_config: Option<ConnectConfig>,
     scheduler: Rc<TickSchedulerImpl>,
     upstream: Option<BackendConnection>,
+    upstream_generation: u64,
+    native_terminal_events: VecDeque<(u64, NativeTransportTerminal)>,
+    upstream_recovery_generation: Option<u64>,
+    upstream_state_notify: Arc<tokio::sync::Notify>,
     write_map: HashMap<TransactionId, CoreTxId>,
     row_tables: HashMap<ObjectId, String>,
     transactions: HashMap<OpenTransactionId, ExclusiveTransactionState>,
@@ -172,6 +179,12 @@ struct ClientDbInner {
     next_subscription_forwarder: u64,
     shutdown_state: ShutdownState,
     shutdown_notify: Arc<tokio::sync::Notify>,
+}
+
+impl Drop for ClientDbInner {
+    fn drop(&mut self) {
+        self.upstream_state_notify.notify_waiters();
+    }
 }
 
 /// A public subscription admission or forwarding task owned by the facade.
@@ -288,10 +301,9 @@ fn tick_driver_retry_delay(attempt: u32) -> Duration {
         .min(TICK_DRIVER_RETRY_MAX_DELAY)
 }
 
-async fn recover_tick_driver_error(
+async fn recover_tick_driver_backpressure(
     inner: &Rc<RefCell<ClientDbInner>>,
     scheduler: &TickSchedulerImpl,
-    class: TickDriverErrorClass,
     error: &CoreDbError,
     attempts: &mut u32,
 ) -> bool {
@@ -305,18 +317,41 @@ async fn recover_tick_driver_error(
 
     #[cfg(feature = "sync-autopsy")]
     crate::db::sync_autopsy::record(format!(
-        "client tick driver retrying {class:?} error attempt {attempts}: {error}"
+        "client tick driver retrying backpressure error attempt {attempts}: {error}"
     ));
     tokio::time::sleep(tick_driver_retry_delay(*attempts)).await;
+    scheduler.wake(TickUrgency::Immediate);
+    true
+}
 
-    if class == TickDriverErrorClass::Reconnect {
-        inner.borrow_mut().disconnect_upstream();
-        if let Err(_reconnect_error) = ClientDbInner::reconnect_upstream(inner).await {
-            #[cfg(feature = "sync-autopsy")]
-            crate::db::sync_autopsy::record(format!(
-                "client tick driver reconnect attempt {attempts} failed: {_reconnect_error}"
+#[cfg(test)]
+async fn recover_tick_driver_error(
+    inner: &Rc<RefCell<ClientDbInner>>,
+    scheduler: &TickSchedulerImpl,
+    class: TickDriverErrorClass,
+    error: &CoreDbError,
+    attempts: &mut u32,
+) -> bool {
+    let expected_generation = inner.borrow().upstream_generation;
+    *attempts = attempts.saturating_add(1);
+    if *attempts > MAX_TICK_DRIVER_RECOVERY_ATTEMPTS {
+        let mut inner_state = inner.borrow_mut();
+        if matches!(inner_state.shutdown_state, ShutdownState::Open)
+            && inner_state.upstream_generation == expected_generation
+            && inner_state.upstream.is_none()
+        {
+            inner_state.record_tick_driver_failure(format!(
+                "recovery exhausted after {MAX_TICK_DRIVER_RECOVERY_ATTEMPTS} attempts for {error}"
             ));
         }
+        return false;
+    }
+
+    tokio::time::sleep(tick_driver_retry_delay(*attempts)).await;
+    if class == TickDriverErrorClass::Reconnect
+        && ClientDbInner::is_current_disconnected_generation(inner, expected_generation)
+    {
+        ClientDbInner::start_upstream_recovery(inner, error.to_string());
     }
     scheduler.wake(TickUrgency::Immediate);
     true
@@ -328,6 +363,23 @@ struct ConnectConfig {
     app_id: crate::tools::AppId,
     auth: WsAuthConfig,
     connector: Arc<dyn NativeTransportConnector>,
+}
+struct UpstreamRecoveryOwner {
+    inner: Weak<RefCell<ClientDbInner>>,
+    generation: u64,
+}
+
+impl Drop for UpstreamRecoveryOwner {
+    fn drop(&mut self) {
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        let mut inner_state = inner.borrow_mut();
+        if inner_state.upstream_recovery_generation == Some(self.generation) {
+            inner_state.upstream_recovery_generation = None;
+            inner_state.upstream_state_notify.notify_waiters();
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -800,6 +852,7 @@ impl ClientDb {
         .await?;
         let inner = Rc::new(RefCell::new(inner));
         if has_upstream {
+            ClientDbInner::connect_upstream_transport(&inner).await?;
             Self::spawn_local_tick_driver(Rc::downgrade(&inner), Rc::clone(&scheduler));
         }
         Ok(Rc::new(Self {
@@ -1261,19 +1314,82 @@ impl ClientDb {
         self.inner.borrow().ensure_tick_driver_running()
     }
 
+    fn spawn_native_terminal_watcher(
+        inner: Weak<RefCell<ClientDbInner>>,
+        scheduler: Rc<TickSchedulerImpl>,
+        generation: u64,
+        terminal: NativeTransportTerminalFuture,
+    ) {
+        tokio::task::spawn_local(async move {
+            let terminal = terminal.await;
+            let Some(inner) = inner.upgrade() else {
+                return;
+            };
+            inner
+                .borrow_mut()
+                .native_terminal_events
+                .push_back((generation, terminal));
+            scheduler.wake(TickUrgency::Immediate);
+        });
+    }
+
+    async fn handle_native_terminal(
+        inner: &Rc<RefCell<ClientDbInner>>,
+        generation: u64,
+        terminal: NativeTransportTerminal,
+    ) {
+        let recovery_error = {
+            let mut inner_state = inner.borrow_mut();
+            if generation != inner_state.upstream_generation
+                || !matches!(inner_state.shutdown_state, ShutdownState::Open)
+            {
+                return;
+            }
+            match terminal {
+                NativeTransportTerminal::OwnerDropped => {
+                    inner_state.disconnect_upstream();
+                    None
+                }
+                NativeTransportTerminal::PeerClosed(reason) => {
+                    Some(format!("native transport peer closed: {reason}"))
+                }
+                NativeTransportTerminal::Failed(error) => {
+                    Some(format!("native transport failed: {error}"))
+                }
+            }
+        };
+        if let Some(error) = recovery_error {
+            ClientDbInner::start_upstream_recovery(inner, error);
+        }
+    }
+
     fn spawn_local_tick_driver(
         inner: Weak<RefCell<ClientDbInner>>,
         scheduler: Rc<TickSchedulerImpl>,
     ) {
         let state = scheduler.wake_handle();
         tokio::task::spawn_local(async move {
-            let mut recovery_attempts = 0;
+            let mut backpressure_attempts = 0;
             loop {
                 state.notify.notified().await;
                 while let Some(urgency) = scheduler.take() {
                     let Some(inner) = inner.upgrade() else {
                         return;
                     };
+                    if inner.borrow().tick_driver_error.is_some() {
+                        return;
+                    }
+                    loop {
+                        let event = { inner.borrow_mut().native_terminal_events.pop_front() };
+                        let Some((generation, terminal)) = event else {
+                            break;
+                        };
+                        ClientDb::handle_native_terminal(&inner, generation, terminal).await;
+                    }
+                    if inner.borrow().tick_driver_error.is_some() {
+                        return;
+                    }
+
                     if urgency == TickUrgency::Deferred {
                         tokio::time::sleep(Duration::from_millis(1)).await;
                     } else if urgency == TickUrgency::AfterCurrentTurn {
@@ -1284,24 +1400,37 @@ impl ClientDb {
                         Err(_) => return,
                     };
                     let tick_result = backend.tick().await;
+                    if inner.borrow().tick_driver_error.is_some() {
+                        return;
+                    }
                     match tick_result {
-                        Ok(()) => recovery_attempts = 0,
+                        Ok(()) => backpressure_attempts = 0,
                         Err(error) => {
                             let class = classify_tick_driver_error(&error);
-                            let should_exit = if class == TickDriverErrorClass::Fatal {
-                                inner
-                                    .borrow_mut()
-                                    .record_tick_driver_failure(error.to_string());
-                                true
-                            } else {
-                                !recover_tick_driver_error(
-                                    &inner,
-                                    &scheduler,
-                                    class,
-                                    &error,
-                                    &mut recovery_attempts,
-                                )
-                                .await
+                            let should_exit = match class {
+                                TickDriverErrorClass::Fatal => {
+                                    inner
+                                        .borrow_mut()
+                                        .record_tick_driver_failure(error.to_string());
+                                    true
+                                }
+                                TickDriverErrorClass::Retry => {
+                                    !recover_tick_driver_backpressure(
+                                        &inner,
+                                        &scheduler,
+                                        &error,
+                                        &mut backpressure_attempts,
+                                    )
+                                    .await
+                                }
+                                TickDriverErrorClass::Reconnect => {
+                                    backpressure_attempts = 0;
+                                    ClientDbInner::start_upstream_recovery(
+                                        &inner,
+                                        error.to_string(),
+                                    );
+                                    false
+                                }
                             };
                             if should_exit {
                                 #[cfg(feature = "sync-autopsy")]
@@ -1332,6 +1461,9 @@ impl ClientDbInner {
     }
 
     fn disconnect_upstream(&mut self) -> bool {
+        self.upstream_generation = self.upstream_generation.wrapping_add(1);
+        self.upstream_recovery_generation = None;
+        self.upstream_state_notify.notify_waiters();
         let Some(connection) = self.upstream.take() else {
             return false;
         };
@@ -1380,6 +1512,8 @@ impl ClientDbInner {
     }
 
     fn record_tick_driver_failure(&mut self, error: String) {
+        self.upstream_recovery_generation = None;
+        self.upstream_state_notify.notify_waiters();
         self.tick_driver_error = Some(error);
         self.tick_driver_error_notify.notify_waiters();
     }
@@ -1413,12 +1547,16 @@ impl ClientDbInner {
         } else {
             None
         };
-        let mut inner = Self {
+        let inner = Self {
             db: Some(db),
             identity,
             connect_config,
             scheduler,
             upstream: None,
+            upstream_generation: 0,
+            native_terminal_events: VecDeque::new(),
+            upstream_recovery_generation: None,
+            upstream_state_notify: Arc::new(tokio::sync::Notify::new()),
             write_map: HashMap::new(),
             row_tables: HashMap::new(),
             transactions: HashMap::new(),
@@ -1430,91 +1568,268 @@ impl ClientDbInner {
             shutdown_state: ShutdownState::Open,
             shutdown_notify: Arc::new(tokio::sync::Notify::new()),
         };
-        inner.connect_upstream_transport().await?;
         Ok(inner)
     }
 
+    fn is_current_disconnected_generation(inner: &Rc<RefCell<Self>>, generation: u64) -> bool {
+        let inner_state = inner.borrow();
+        matches!(inner_state.shutdown_state, ShutdownState::Open)
+            && inner_state.tick_driver_error.is_none()
+            && inner_state.upstream_generation == generation
+            && inner_state.upstream.is_none()
+    }
+
+    fn is_current_disconnected_generation_weak(
+        inner: &Weak<RefCell<Self>>,
+        generation: u64,
+    ) -> bool {
+        inner
+            .upgrade()
+            .is_some_and(|inner| Self::is_current_disconnected_generation(&inner, generation))
+    }
+
+    fn is_current_recovery(inner: &Weak<RefCell<Self>>, generation: u64) -> bool {
+        let Some(inner) = inner.upgrade() else {
+            return false;
+        };
+        let inner_state = inner.borrow();
+        matches!(inner_state.shutdown_state, ShutdownState::Open)
+            && inner_state.tick_driver_error.is_none()
+            && inner_state.upstream_generation == generation
+            && inner_state.upstream.is_none()
+            && inner_state.upstream_recovery_generation == Some(generation)
+    }
+
+    fn start_upstream_recovery(inner: &Rc<RefCell<Self>>, initial_error: String) {
+        let (generation, scheduler) = {
+            let mut inner_state = inner.borrow_mut();
+            if !matches!(inner_state.shutdown_state, ShutdownState::Open)
+                || inner_state.tick_driver_error.is_some()
+                || inner_state.connect_config.is_none()
+            {
+                return;
+            }
+            if inner_state.upstream.is_none()
+                && inner_state.upstream_recovery_generation == Some(inner_state.upstream_generation)
+            {
+                return;
+            }
+            inner_state.disconnect_upstream();
+            let generation = inner_state.upstream_generation;
+            inner_state.upstream_recovery_generation = Some(generation);
+            (generation, Rc::clone(&inner_state.scheduler))
+        };
+        scheduler.wake(TickUrgency::Immediate);
+        tokio::task::spawn_local(Self::run_upstream_recovery(
+            Rc::downgrade(inner),
+            generation,
+            initial_error,
+        ));
+    }
+
+    async fn run_upstream_recovery(
+        inner: Weak<RefCell<Self>>,
+        generation: u64,
+        initial_error: String,
+    ) {
+        let _owner = UpstreamRecoveryOwner {
+            inner: inner.clone(),
+            generation,
+        };
+        let mut last_error = initial_error;
+        for attempt in 1..=MAX_TICK_DRIVER_RECOVERY_ATTEMPTS {
+            if attempt > 1 {
+                tokio::time::sleep(tick_driver_retry_delay(attempt - 1)).await;
+                if !Self::is_current_recovery(&inner, generation) {
+                    return;
+                }
+            }
+
+            match Self::connect_upstream_for_generation(&inner, generation).await {
+                Ok(true) | Ok(false) => return,
+                Err(error) => {
+                    last_error = error.to_string();
+                    #[cfg(feature = "sync-autopsy")]
+                    crate::db::sync_autopsy::record(format!(
+                        "client native upstream recovery attempt {attempt} failed: {error}"
+                    ));
+                }
+            }
+        }
+
+        let Some(inner) = inner.upgrade() else {
+            return;
+        };
+        let scheduler = {
+            let mut inner_state = inner.borrow_mut();
+            if !matches!(inner_state.shutdown_state, ShutdownState::Open)
+                || inner_state.upstream_generation != generation
+                || inner_state.upstream.is_some()
+                || inner_state.upstream_recovery_generation != Some(generation)
+            {
+                return;
+            }
+            inner_state.upstream_recovery_generation = None;
+            inner_state.record_tick_driver_failure(format!(
+                "native upstream recovery exhausted after \
+                 {MAX_TICK_DRIVER_RECOVERY_ATTEMPTS} attempts: {last_error}"
+            ));
+            Rc::clone(&inner_state.scheduler)
+        };
+        scheduler.wake(TickUrgency::Immediate);
+    }
+
     async fn reconnect_upstream(inner: &Rc<RefCell<Self>>) -> Result<bool> {
-        let (db, identity, scheduler, config) = {
-            let inner = inner.borrow();
-            if !matches!(inner.shutdown_state, ShutdownState::Open) {
+        let generation = {
+            let inner_state = inner.borrow();
+            if !matches!(inner_state.shutdown_state, ShutdownState::Open) {
                 return Err(Self::shutdown_error());
             }
-            if inner.upstream.is_some() {
+            inner_state.upstream_generation
+        };
+        Self::connect_upstream_for_generation(&Rc::downgrade(inner), generation).await
+    }
+
+    async fn connect_upstream_transport(inner: &Rc<RefCell<Self>>) -> Result<bool> {
+        Self::reconnect_upstream(inner).await
+    }
+
+    async fn connect_upstream_for_generation(
+        inner: &Weak<RefCell<Self>>,
+        expected_generation: u64,
+    ) -> Result<bool> {
+        let (db, identity, scheduler, config, state_notify) = {
+            let Some(inner) = inner.upgrade() else {
+                return Ok(false);
+            };
+            let inner_state = inner.borrow();
+            if !matches!(inner_state.shutdown_state, ShutdownState::Open)
+                || inner_state.tick_driver_error.is_some()
+                || inner_state.upstream_generation != expected_generation
+                || inner_state.upstream.is_some()
+            {
                 return Ok(false);
             }
-            let Some(config) = inner.connect_config.clone() else {
+            let Some(config) = inner_state.connect_config.clone() else {
                 return Ok(false);
             };
             (
-                inner.backend_clone()?,
-                inner.identity,
-                Rc::clone(&inner.scheduler),
+                inner_state.backend_clone()?,
+                inner_state.identity,
+                Rc::clone(&inner_state.scheduler),
                 config,
+                Arc::clone(&inner_state.upstream_state_notify),
             )
         };
-        let connection = Self::connect_with_config(&db, identity, scheduler, config).await?;
-        let mut inner = inner.borrow_mut();
-        if !matches!(inner.shutdown_state, ShutdownState::Open) || inner.upstream.is_some() {
-            db.detach_connection(&connection);
+
+        let connected = Self::await_native_admission(
+            inner,
+            expected_generation,
+            identity,
+            Rc::clone(&scheduler),
+            config,
+            state_notify,
+        )
+        .await?;
+        let Some(connected) = connected else {
+            return Ok(false);
+        };
+        if !Self::is_current_disconnected_generation_weak(inner, expected_generation) {
             return Ok(false);
         }
-        inner.upstream = Some(connection);
+
+        let ConnectedNativeTransport {
+            transport,
+            protocol_version,
+            features,
+            session_context,
+            permits_delegated_sessions,
+            terminal,
+        } = connected;
+        let connection = db
+            .connect_upstream(Box::new(
+                WireTransportAdapter::new_with_session_context_and_delegated_sessions(
+                    transport,
+                    protocol_version,
+                    features,
+                    None,
+                    session_context,
+                    permits_delegated_sessions,
+                ),
+            ))
+            .await;
+
+        let Some(inner) = inner.upgrade() else {
+            db.detach_connection(&connection);
+            return Ok(false);
+        };
+        let generation = {
+            let mut inner_state = inner.borrow_mut();
+            if !matches!(inner_state.shutdown_state, ShutdownState::Open)
+                || inner_state.tick_driver_error.is_some()
+                || inner_state.upstream_generation != expected_generation
+                || inner_state.upstream.is_some()
+            {
+                drop(inner_state);
+                db.detach_connection(&connection);
+                return Ok(false);
+            }
+            inner_state.upstream_generation = inner_state.upstream_generation.wrapping_add(1);
+            inner_state.upstream = Some(connection);
+            if inner_state.upstream_recovery_generation == Some(expected_generation) {
+                inner_state.upstream_recovery_generation = None;
+            }
+            inner_state.upstream_state_notify.notify_waiters();
+            inner_state.upstream_generation
+        };
+        ClientDb::spawn_native_terminal_watcher(
+            Rc::downgrade(&inner),
+            scheduler,
+            generation,
+            terminal,
+        );
         Ok(true)
     }
 
-    async fn connect_upstream_transport(&mut self) -> Result<()> {
-        if self.upstream.is_some() {
-            return Ok(());
-        }
-        let Some(config) = self.connect_config.clone() else {
-            return Ok(());
-        };
-        self.upstream = Some(
-            Self::connect_with_config(
-                self.backend()?,
-                self.identity,
-                Rc::clone(&self.scheduler),
-                config,
-            )
-            .await?,
-        );
-        Ok(())
-    }
-
-    async fn connect_with_config(
-        db: &Backend,
+    async fn await_native_admission(
+        inner: &Weak<RefCell<Self>>,
+        expected_generation: u64,
         identity: CoreDbIdentity,
         scheduler: Rc<TickSchedulerImpl>,
         config: ConnectConfig,
-    ) -> Result<BackendConnection> {
+        state_notify: Arc<tokio::sync::Notify>,
+    ) -> Result<Option<ConnectedNativeTransport>> {
         let wake = scheduler.wake_handle();
-        let connected = config
-            .connector
-            .connect(NativeTransportRequest {
-                server_url: config.server_url,
-                app_id: config.app_id,
-                peer_identity: identity.author,
-                auth: config.auth,
-                wake: Arc::new(move || {
-                    wake.immediate.store(true, Ordering::Release);
-                    wake.notify.notify_one();
-                }),
-            })
-            .await
-            .map_err(|error| JazzError::Connection(error.to_string()))?;
-        Ok(db
-            .connect_upstream(Box::new(
-                WireTransportAdapter::new_with_session_context_and_delegated_sessions(
-                    connected.transport,
-                    connected.protocol_version,
-                    connected.features,
-                    None,
-                    connected.session_context,
-                    connected.permits_delegated_sessions,
-                ),
-            ))
-            .await)
+        let admission = config.connector.connect(NativeTransportRequest {
+            server_url: config.server_url,
+            app_id: config.app_id,
+            peer_identity: identity.author,
+            auth: config.auth,
+            wake: Arc::new(move || {
+                wake.immediate.store(true, Ordering::Release);
+                wake.notify.notify_one();
+            }),
+        });
+        tokio::pin!(admission);
+        loop {
+            let state_changed = state_notify.notified();
+            tokio::pin!(state_changed);
+            state_changed.as_mut().enable();
+            if !Self::is_current_disconnected_generation_weak(inner, expected_generation) {
+                return Ok(None);
+            }
+            tokio::select! {
+                result = &mut admission => {
+                    if !Self::is_current_disconnected_generation_weak(inner, expected_generation) {
+                        return Ok(None);
+                    }
+                    return result
+                        .map(Some)
+                        .map_err(|error| JazzError::Connection(error.to_string()));
+                }
+                _ = &mut state_changed => {}
+            }
+        }
     }
 
     fn ensure_transaction_open(&self, transaction_id: OpenTransactionId) -> Result<()> {
@@ -3588,10 +3903,231 @@ mod tests {
     use crate::groove::storage::{Error as StorageError, StorageFactory, StorageFuture};
     use crate::ids::NodeUuid;
     use crate::tools::AppId;
+    use crate::tools::native_transport_connector::{
+        ConnectedNativeTransport, NativeCatalogueBootstrapFuture, NativeTransportError,
+        NativeTransportFuture, NativeTransportTerminal, NativeTransportTerminalFuture,
+    };
     use crate::tools::public_schema::Schema;
     use crate::tools::{ClientStorage, ColumnType, SchemaBuilder, TableSchema};
+    use crate::wire::{TransportError, WireTransport};
     use serde_json::json;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicUsize;
     use tempfile::TempDir;
+
+    struct ControlledNativeWireTransport;
+
+    impl WireTransport for ControlledNativeWireTransport {
+        fn send_frame(&mut self, _frame: Vec<u8>) -> std::result::Result<(), TransportError> {
+            Ok(())
+        }
+
+        fn try_recv_frame(&mut self) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
+    struct ControlledTerminal {
+        sender: Option<oneshot::Sender<NativeTransportTerminal>>,
+        observed: Arc<AtomicBool>,
+    }
+
+    impl ControlledTerminal {
+        fn send(&mut self, terminal: NativeTransportTerminal) {
+            let _ = self
+                .sender
+                .take()
+                .expect("controlled terminal sender is used once")
+                .send(terminal);
+        }
+    }
+
+    enum ControlledAdmissionResult {
+        Connected {
+            terminal: oneshot::Receiver<NativeTransportTerminal>,
+            terminal_observed: Arc<AtomicBool>,
+        },
+        Refused(String),
+    }
+
+    struct ControlledAdmission {
+        sender: Option<oneshot::Sender<ControlledAdmissionResult>>,
+    }
+
+    impl ControlledAdmission {
+        fn succeed(&mut self) -> ControlledTerminal {
+            let (terminal, terminal_receiver) = controlled_terminal();
+            let terminal_observed = Arc::clone(&terminal.observed);
+            let _ = self
+                .sender
+                .take()
+                .expect("controlled admission completes once")
+                .send(ControlledAdmissionResult::Connected {
+                    terminal: terminal_receiver,
+                    terminal_observed,
+                });
+            terminal
+        }
+
+        fn refuse(&mut self, error: impl Into<String>) {
+            let _ = self
+                .sender
+                .take()
+                .expect("controlled admission completes once")
+                .send(ControlledAdmissionResult::Refused(error.into()));
+        }
+    }
+
+    type ControlledAdmissionReceiver = oneshot::Receiver<ControlledAdmissionResult>;
+
+    struct ControlledNativeConnector {
+        connect_count: AtomicUsize,
+        admissions: Mutex<VecDeque<ControlledAdmissionReceiver>>,
+    }
+
+    impl ControlledNativeConnector {
+        fn new(admissions: Vec<ControlledAdmissionReceiver>) -> Self {
+            Self {
+                connect_count: AtomicUsize::new(0),
+                admissions: Mutex::new(admissions.into()),
+            }
+        }
+
+        fn connect_count(&self) -> usize {
+            self.connect_count.load(Ordering::Acquire)
+        }
+    }
+
+    impl NativeTransportConnector for ControlledNativeConnector {
+        fn connect(&self, _request: NativeTransportRequest) -> NativeTransportFuture {
+            self.connect_count.fetch_add(1, Ordering::AcqRel);
+            let admission = self
+                .admissions
+                .lock()
+                .expect("take controlled admission")
+                .pop_front()
+                .expect("test connector has an admission for every connection");
+            Box::pin(async move {
+                match admission
+                    .await
+                    .expect("controlled admission sender remains alive")
+                {
+                    ControlledAdmissionResult::Connected {
+                        terminal,
+                        terminal_observed,
+                    } => {
+                        let terminal: NativeTransportTerminalFuture = Box::pin(async move {
+                            terminal_observed.store(true, Ordering::Release);
+                            terminal
+                                .await
+                                .expect("controlled terminal sender remains alive")
+                        });
+                        Ok(ConnectedNativeTransport {
+                            transport: Box::new(ControlledNativeWireTransport),
+                            protocol_version: crate::wire::WIRE_PROTOCOL_VERSION,
+                            features: crate::wire::FEATURE_NONE,
+                            session_context: None,
+                            permits_delegated_sessions: false,
+                            terminal,
+                        })
+                    }
+                    ControlledAdmissionResult::Refused(error) => Err(NativeTransportError(error)),
+                }
+            })
+        }
+
+        fn bootstrap_catalogue(
+            &self,
+            _request: NativeTransportRequest,
+        ) -> NativeCatalogueBootstrapFuture {
+            Box::pin(async {
+                Err(NativeTransportError(
+                    "catalogue bootstrap is not used by client lifecycle tests".to_owned(),
+                ))
+            })
+        }
+    }
+
+    fn controlled_terminal() -> (
+        ControlledTerminal,
+        oneshot::Receiver<NativeTransportTerminal>,
+    ) {
+        let (sender, receiver) = oneshot::channel();
+        let observed = Arc::new(AtomicBool::new(false));
+        (
+            ControlledTerminal {
+                sender: Some(sender),
+                observed,
+            },
+            receiver,
+        )
+    }
+
+    fn controlled_admission() -> (ControlledAdmission, ControlledAdmissionReceiver) {
+        let (sender, receiver) = oneshot::channel();
+        (
+            ControlledAdmission {
+                sender: Some(sender),
+            },
+            receiver,
+        )
+    }
+
+    fn successful_controlled_admission() -> (ControlledTerminal, ControlledAdmissionReceiver) {
+        let (mut admission, receiver) = controlled_admission();
+        let terminal = admission.succeed();
+        (terminal, receiver)
+    }
+
+    fn refused_controlled_admission(error: impl Into<String>) -> ControlledAdmissionReceiver {
+        let (mut admission, receiver) = controlled_admission();
+        admission.refuse(error);
+        receiver
+    }
+
+    async fn yield_until(mut predicate: impl FnMut() -> bool, failure: &str) {
+        for _ in 0..256 {
+            if predicate() {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(predicate(), "{failure}");
+    }
+
+    async fn wait_for_connect_count(connector: &ControlledNativeConnector, expected: usize) {
+        yield_until(
+            || connector.connect_count() >= expected,
+            "connection replacement must not deadlock",
+        )
+        .await;
+    }
+
+    async fn wait_for_terminal_observation(observed: &AtomicBool) {
+        yield_until(
+            || observed.load(Ordering::Acquire),
+            "terminal watcher must poll the controlled terminal future",
+        )
+        .await;
+    }
+
+    fn tick_reconnect_error() -> CoreDbError {
+        CoreDbError {
+            code: CoreDbErrorCode::Protocol,
+            message: "websocket pump is closed".to_owned(),
+        }
+    }
+
+    fn make_native_context(name: &str) -> AppContext {
+        let mut context = make_offline_context(
+            AppId::from_name(name),
+            std::path::PathBuf::new(),
+            declared_todo_schema(),
+        );
+        context.server_url = "ws://native-transport.test".to_owned();
+        context
+    }
 
     #[derive(Debug)]
     struct YieldingStorageFactory;
@@ -4528,6 +5064,449 @@ mod tests {
                     .shutdown()
                     .await
                     .expect("close reopened persistent client");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn idle_peer_closed_terminal_reconnects_without_semantic_traffic() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (mut first, first_admission) = successful_controlled_admission();
+                let first_observed = Arc::clone(&first.observed);
+                let (_replacement, replacement_admission) = successful_controlled_admission();
+                let connector = Arc::new(ControlledNativeConnector::new(vec![
+                    first_admission,
+                    replacement_admission,
+                ]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("idle-peer-closed-reconnect"),
+                    connector.clone(),
+                )
+                .await
+                .expect("connect native client");
+
+                assert_eq!(connector.connect_count(), 1);
+                first.send(NativeTransportTerminal::PeerClosed(
+                    "idle peer closed".to_owned(),
+                ));
+                wait_for_terminal_observation(&first_observed).await;
+                wait_for_connect_count(&connector, 2).await;
+
+                client.shutdown().await.expect("shutdown native client");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn owner_dropped_terminal_does_not_reconnect() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (mut terminal, admission) = successful_controlled_admission();
+                let observed = Arc::clone(&terminal.observed);
+                let connector = Arc::new(ControlledNativeConnector::new(vec![admission]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("owner-dropped-no-reconnect"),
+                    connector.clone(),
+                )
+                .await
+                .expect("connect native client");
+
+                terminal.send(NativeTransportTerminal::OwnerDropped);
+                wait_for_terminal_observation(&observed).await;
+                tokio::task::yield_now().await;
+                assert_eq!(
+                    connector.connect_count(),
+                    1,
+                    "deliberately dropped transport must not reconnect"
+                );
+
+                client.shutdown().await.expect("shutdown native client");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_does_not_reconnect_after_terminal() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (mut terminal, admission) = successful_controlled_admission();
+                let connector = Arc::new(ControlledNativeConnector::new(vec![admission]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("shutdown-no-reconnect"),
+                    connector.clone(),
+                )
+                .await
+                .expect("connect native client");
+
+                client.shutdown().await.expect("shutdown native client");
+                terminal.send(NativeTransportTerminal::PeerClosed(
+                    "terminal raced shutdown".to_owned(),
+                ));
+                tokio::task::yield_now().await;
+                assert_eq!(
+                    connector.connect_count(),
+                    1,
+                    "shutdown must prevent terminal-triggered reconnection"
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn recoverable_native_terminals_retry_refused_replacement() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                for (name, outcome) in [
+                    (
+                        "peer-closed",
+                        NativeTransportTerminal::PeerClosed("closed".to_owned()),
+                    ),
+                    (
+                        "failed",
+                        NativeTransportTerminal::Failed(NativeTransportError("failed".to_owned())),
+                    ),
+                ] {
+                    let (mut first, first_admission) = successful_controlled_admission();
+                    let observed = Arc::clone(&first.observed);
+                    let refused = refused_controlled_admission("refused");
+                    let (replacement_terminal, replacement) = successful_controlled_admission();
+                    let replacement_observed = Arc::clone(&replacement_terminal.observed);
+                    let connector = Arc::new(ControlledNativeConnector::new(vec![
+                        first_admission,
+                        refused,
+                        replacement,
+                    ]));
+                    let client = JazzClient::connect_with_native_transport(
+                        make_native_context(&format!("{name}-retry")),
+                        connector.clone(),
+                    )
+                    .await
+                    .expect("connect");
+
+                    first.send(outcome);
+                    wait_for_terminal_observation(&observed).await;
+                    wait_for_connect_count(&connector, 2).await;
+                    tokio::time::advance(TICK_DRIVER_RETRY_BASE_DELAY).await;
+                    wait_for_connect_count(&connector, 3).await;
+                    wait_for_terminal_observation(&replacement_observed).await;
+                    client.shutdown().await.expect("shutdown");
+                }
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn tick_error_and_terminal_coalesce_to_one_recovery_owner() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (mut first, first_admission) = successful_controlled_admission();
+                let observed = Arc::clone(&first.observed);
+                let (_replacement, replacement) = controlled_admission();
+                let (_duplicate, duplicate) = controlled_admission();
+                let connector = Arc::new(ControlledNativeConnector::new(vec![
+                    first_admission,
+                    replacement,
+                    duplicate,
+                ]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("coalesced-recovery"),
+                    connector.clone(),
+                )
+                .await
+                .expect("connect");
+                let inner = Rc::clone(&client.db.inner);
+                let scheduler = Rc::clone(&inner.borrow().scheduler);
+                let recovery = tokio::task::spawn_local(async move {
+                    let mut attempts = 0;
+                    recover_tick_driver_error(
+                        &inner,
+                        &scheduler,
+                        TickDriverErrorClass::Reconnect,
+                        &tick_reconnect_error(),
+                        &mut attempts,
+                    )
+                    .await
+                });
+                tokio::task::yield_now().await;
+
+                first.send(NativeTransportTerminal::PeerClosed("closed".to_owned()));
+                wait_for_terminal_observation(&observed).await;
+                wait_for_connect_count(&connector, 2).await;
+                tokio::time::advance(TICK_DRIVER_RETRY_BASE_DELAY).await;
+                for _ in 0..64 {
+                    tokio::task::yield_now().await;
+                }
+                assert_eq!(
+                    connector.connect_count(),
+                    2,
+                    "one generation may own only one replacement admission"
+                );
+                recovery.abort();
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn stale_admission_completion_cannot_install_after_newer_generation() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (_first, first) = successful_controlled_admission();
+                let (mut stale, stale_receiver) = controlled_admission();
+                let (mut newer, newer_receiver) = controlled_admission();
+                let connector = Arc::new(ControlledNativeConnector::new(vec![
+                    first,
+                    stale_receiver,
+                    newer_receiver,
+                ]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("stale-admission"),
+                    connector.clone(),
+                )
+                .await
+                .expect("connect");
+                client.db.inner.borrow_mut().disconnect_upstream();
+
+                let inner = Rc::clone(&client.db.inner);
+                let stale_task = tokio::task::spawn_local(async move {
+                    ClientDbInner::reconnect_upstream(&inner).await
+                });
+                wait_for_connect_count(&connector, 2).await;
+                let inner = Rc::clone(&client.db.inner);
+                let newer_task = tokio::task::spawn_local(async move {
+                    ClientDbInner::reconnect_upstream(&inner).await
+                });
+                wait_for_connect_count(&connector, 3).await;
+                let _terminal = newer.succeed();
+                assert!(
+                    newer_task.await.expect("task").expect("admission"),
+                    "newer generation installs"
+                );
+                client.db.inner.borrow_mut().disconnect_upstream();
+                let generation = client.db.inner.borrow().upstream_generation;
+
+                let _terminal = stale.succeed();
+                assert!(
+                    !stale_task.await.expect("task").expect("admission"),
+                    "stale completion must not install"
+                );
+                let state = client.db.inner.borrow();
+                assert!(state.upstream.is_none());
+                assert_eq!(state.upstream_generation, generation);
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn ownership_loss_during_retry_prevents_installation() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                for shutdown in [false, true] {
+                    let (mut first, first_admission) = successful_controlled_admission();
+                    let observed = Arc::clone(&first.observed);
+                    let (_replacement, replacement) = successful_controlled_admission();
+                    let connector = Arc::new(ControlledNativeConnector::new(vec![
+                        first_admission,
+                        replacement,
+                    ]));
+                    let client = JazzClient::connect_with_native_transport(
+                        make_native_context(if shutdown {
+                            "shutdown-during-retry"
+                        } else {
+                            "owner-drop-during-retry"
+                        }),
+                        connector.clone(),
+                    )
+                    .await
+                    .expect("connect");
+                    let inner = Rc::clone(&client.db.inner);
+                    let scheduler = Rc::clone(&inner.borrow().scheduler);
+                    let recovery = tokio::task::spawn_local(async move {
+                        let mut attempts = 0;
+                        recover_tick_driver_error(
+                            &inner,
+                            &scheduler,
+                            TickDriverErrorClass::Reconnect,
+                            &tick_reconnect_error(),
+                            &mut attempts,
+                        )
+                        .await
+                    });
+                    tokio::task::yield_now().await;
+
+                    if shutdown {
+                        client.shutdown().await.expect("shutdown");
+                        tokio::time::advance(TICK_DRIVER_RETRY_BASE_DELAY).await;
+                        recovery.await.expect("recovery task");
+                        assert_eq!(connector.connect_count(), 1);
+                    } else {
+                        first.send(NativeTransportTerminal::OwnerDropped);
+                        wait_for_terminal_observation(&observed).await;
+                        yield_until(
+                            || client.db.inner.borrow().upstream.is_none(),
+                            "OwnerDropped must detach",
+                        )
+                        .await;
+                        tokio::time::advance(TICK_DRIVER_RETRY_BASE_DELAY).await;
+                        recovery.await.expect("recovery task");
+                        assert_eq!(connector.connect_count(), 1);
+                        client.shutdown().await.expect("shutdown");
+                    }
+                }
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stale_exhaustion_does_not_poison_current_generation() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (_first, first) = successful_controlled_admission();
+                let (_replacement, replacement) = successful_controlled_admission();
+                let stale_reconnect =
+                    refused_controlled_admission("stale recovery must not reconnect");
+                let connector = Arc::new(ControlledNativeConnector::new(vec![
+                    first,
+                    replacement,
+                    stale_reconnect,
+                ]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("stale-exhaustion"),
+                    connector,
+                )
+                .await
+                .expect("connect");
+                let inner = Rc::clone(&client.db.inner);
+                let stale_generation = inner.borrow().upstream_generation;
+                let scheduler = Rc::clone(&inner.borrow().scheduler);
+                let (recovery_started, recovery_started_rx) = oneshot::channel();
+                let stale_inner = Rc::clone(&inner);
+                let stale_recovery = tokio::task::spawn_local(async move {
+                    let mut attempts = MAX_TICK_DRIVER_RECOVERY_ATTEMPTS - 1;
+                    recovery_started
+                        .send(())
+                        .expect("stale recovery owner remains observed");
+                    recover_tick_driver_error(
+                        &stale_inner,
+                        &scheduler,
+                        TickDriverErrorClass::Reconnect,
+                        &tick_reconnect_error(),
+                        &mut attempts,
+                    )
+                    .await;
+                    recover_tick_driver_error(
+                        &stale_inner,
+                        &scheduler,
+                        TickDriverErrorClass::Reconnect,
+                        &tick_reconnect_error(),
+                        &mut attempts,
+                    )
+                    .await;
+                });
+                recovery_started_rx
+                    .await
+                    .expect("stale recovery owner starts");
+                assert!(
+                    !stale_recovery.is_finished(),
+                    "old-generation recovery must be pending before replacement installation"
+                );
+
+                inner.borrow_mut().disconnect_upstream();
+                assert!(
+                    ClientDbInner::reconnect_upstream(&inner)
+                        .await
+                        .expect("replacement admission"),
+                    "newer replacement installs"
+                );
+                let current_generation = inner.borrow().upstream_generation;
+                assert_ne!(current_generation, stale_generation);
+                assert!(
+                    inner.borrow().upstream.is_some(),
+                    "newer replacement must be installed before stale exhaustion"
+                );
+
+                tokio::time::advance(tick_driver_retry_delay(MAX_TICK_DRIVER_RECOVERY_ATTEMPTS))
+                    .await;
+                stale_recovery.await.expect("stale recovery task");
+
+                let state = inner.borrow();
+                assert!(
+                    state.upstream.is_some(),
+                    "stale exhaustion must retain the newer upstream"
+                );
+                assert_eq!(
+                    state.upstream_generation, current_generation,
+                    "stale exhaustion must not advance the current generation"
+                );
+                assert!(
+                    state.tick_driver_error.is_none(),
+                    "stale exhaustion must not stop the current generation"
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn local_tick_work_remains_responsive_during_retry_delay() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (mut first, first_admission) = successful_controlled_admission();
+                let refused = refused_controlled_admission("replacement refused");
+                let (_replacement, replacement) = successful_controlled_admission();
+                let connector = Arc::new(ControlledNativeConnector::new(vec![
+                    first_admission,
+                    refused,
+                    replacement,
+                ]));
+                let client = JazzClient::connect_with_native_transport(
+                    make_native_context("responsive-during-retry"),
+                    connector.clone(),
+                )
+                .await
+                .expect("connect");
+                let observed = Arc::clone(&first.observed);
+
+                first.send(NativeTransportTerminal::Failed(NativeTransportError(
+                    "controlled terminal failure".to_owned(),
+                )));
+                wait_for_terminal_observation(&observed).await;
+                wait_for_connect_count(&connector, 2).await;
+                tokio::task::yield_now().await;
+                assert_eq!(
+                    connector.connect_count(),
+                    2,
+                    "refused replacement must leave recovery waiting in retry backoff"
+                );
+
+                let (_, _, transaction) = client
+                    .insert(
+                        "todos",
+                        crate::row_input!("title" => "local", "completed" => false),
+                    )
+                    .expect("insert");
+                let transaction = transaction.expect("committed transaction");
+                let retained = client.clone();
+                let local_wait = tokio::task::spawn_local(async move {
+                    retained
+                        .wait_for_transaction(transaction, DurabilityTier::Local)
+                        .await
+                });
+                for _ in 0..256 {
+                    if local_wait.is_finished() {
+                        break;
+                    }
+                    tokio::task::yield_now().await;
+                }
+                assert!(
+                    local_wait.is_finished(),
+                    "local tick work must not wait for retry delay"
+                );
+                assert_eq!(
+                    connector.connect_count(),
+                    2,
+                    "retry admission must not begin before local durability completes"
+                );
+                local_wait.await.expect("task").expect("local durability");
             })
             .await;
     }

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -4164,6 +4164,12 @@ mod tests {
         assert_eq!(scheduler.take(), None, "waking does not create a hot loop");
     }
 
+    /// Given alice's idle native peer closes, when its terminal resolves, then
+    /// alice's client observes it and installs a replacement without wire traffic.
+    ///
+    /// ```text
+    /// peer ──close──► alice terminal watcher ──► generation recovery ──► replacement
+    /// ```
     #[tokio::test(flavor = "current_thread")]
     async fn persistent_storage_open_yields_without_sync_polling() {
         let temp_dir = TempDir::new().expect("temp client dir");
@@ -4692,6 +4698,8 @@ mod tests {
     ///
     /// alice ──local write──► offline local store
     /// alice ──Remote read──► transient subscription ──wait──► authority
+    /// Given alice deliberately drops her native transport, when its terminal resolves,
+    /// then the client detaches it without reconnecting.
     #[tokio::test(flavor = "current_thread")]
     async fn strict_remote_one_shot_uses_transient_subscription_not_ambient_all() {
         let client = JazzClient::connect(make_offline_context(
@@ -4750,6 +4758,8 @@ mod tests {
     // means corrupt local state; creating that through the public API would
     // require deliberately corrupting a storage backend. The assertion itself
     // is public: a normal `JazzClient::query` must report the stopped driver.
+    /// Given alice shuts down, when an old peer-close terminal resolves afterward,
+    /// then the terminal watcher cannot start another connection.
     #[tokio::test(flavor = "current_thread")]
     async fn fatal_tick_driver_failure_is_reported_to_callers() {
         let client = JazzClient::connect(make_offline_context(
@@ -5153,6 +5163,12 @@ mod tests {
             .await;
     }
 
+    /// Given alice's peer closes or fails and its first replacement is refused, when
+    /// retry backoff expires, then the same generation admits the next replacement.
+    ///
+    /// ```text
+    /// peer ──close/fail──► alice ──refused reconnect──► backoff ──► replacement
+    /// ```
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn recoverable_native_terminals_retry_refused_replacement() {
         tokio::task::LocalSet::new()
@@ -5196,6 +5212,8 @@ mod tests {
             .await;
     }
 
+    /// Given alice receives both a core reconnect error and a peer-close terminal for
+    /// one generation, when recovery starts, then only one replacement admission owns it.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn tick_error_and_terminal_coalesce_to_one_recovery_owner() {
         tokio::task::LocalSet::new()
@@ -5247,6 +5265,8 @@ mod tests {
             .await;
     }
 
+    /// Given alice begins an old reconnect admission and a newer generation wins, when
+    /// the old admission completes, then it cannot install or replace the newer upstream.
     #[tokio::test(flavor = "current_thread")]
     async fn stale_admission_completion_cannot_install_after_newer_generation() {
         tokio::task::LocalSet::new()
@@ -5297,6 +5317,8 @@ mod tests {
             .await;
     }
 
+    /// Given alice loses recovery ownership by shutdown or deliberate owner drop during
+    /// backoff, when the delay expires, then no replacement admission is installed.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn ownership_loss_during_retry_prevents_installation() {
         tokio::task::LocalSet::new()
@@ -5357,6 +5379,8 @@ mod tests {
             .await;
     }
 
+    /// Given alice's old recovery is about to exhaust while a newer generation is live,
+    /// when the old retry finishes, then it neither detaches nor poisons the replacement.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn stale_exhaustion_does_not_poison_current_generation() {
         tokio::task::LocalSet::new()
@@ -5446,6 +5470,8 @@ mod tests {
             .await;
     }
 
+    /// Given alice is waiting to retry a refused peer-failure replacement, when she
+    /// commits local work, then local durability progresses before retry backoff ends.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn local_tick_work_remains_responsive_during_retry_delay() {
         tokio::task::LocalSet::new()

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -4120,10 +4120,11 @@ mod tests {
     }
 
     fn make_native_context(name: &str) -> AppContext {
-        let mut context = make_offline_context(
+        let mut context = make_offline_context_with_storage(
             AppId::from_name(name),
             std::path::PathBuf::new(),
             declared_todo_schema(),
+            ClientStorage::Memory,
         );
         context.server_url = "ws://native-transport.test".to_owned();
         context

--- a/crates/jazz/src/tools/client.rs
+++ b/crates/jazz/src/tools/client.rs
@@ -4164,12 +4164,6 @@ mod tests {
         assert_eq!(scheduler.take(), None, "waking does not create a hot loop");
     }
 
-    /// Given alice's idle native peer closes, when its terminal resolves, then
-    /// alice's client observes it and installs a replacement without wire traffic.
-    ///
-    /// ```text
-    /// peer ──close──► alice terminal watcher ──► generation recovery ──► replacement
-    /// ```
     #[tokio::test(flavor = "current_thread")]
     async fn persistent_storage_open_yields_without_sync_polling() {
         let temp_dir = TempDir::new().expect("temp client dir");
@@ -4698,8 +4692,6 @@ mod tests {
     ///
     /// alice ──local write──► offline local store
     /// alice ──Remote read──► transient subscription ──wait──► authority
-    /// Given alice deliberately drops her native transport, when its terminal resolves,
-    /// then the client detaches it without reconnecting.
     #[tokio::test(flavor = "current_thread")]
     async fn strict_remote_one_shot_uses_transient_subscription_not_ambient_all() {
         let client = JazzClient::connect(make_offline_context(
@@ -4758,8 +4750,6 @@ mod tests {
     // means corrupt local state; creating that through the public API would
     // require deliberately corrupting a storage backend. The assertion itself
     // is public: a normal `JazzClient::query` must report the stopped driver.
-    /// Given alice shuts down, when an old peer-close terminal resolves afterward,
-    /// then the terminal watcher cannot start another connection.
     #[tokio::test(flavor = "current_thread")]
     async fn fatal_tick_driver_failure_is_reported_to_callers() {
         let client = JazzClient::connect(make_offline_context(
@@ -5078,6 +5068,12 @@ mod tests {
             .await;
     }
 
+    /// Given alice's idle native peer closes, when its terminal resolves, then
+    /// alice's client observes it and installs a replacement without wire traffic.
+    ///
+    /// ```text
+    /// peer ──close──► alice terminal watcher ──► generation recovery ──► replacement
+    /// ```
     #[tokio::test(flavor = "current_thread")]
     async fn idle_peer_closed_terminal_reconnects_without_semantic_traffic() {
         tokio::task::LocalSet::new()
@@ -5108,6 +5104,8 @@ mod tests {
             .await;
     }
 
+    /// Given alice deliberately drops her native transport, when its terminal resolves,
+    /// then the client detaches it without reconnecting.
     #[tokio::test(flavor = "current_thread")]
     async fn owner_dropped_terminal_does_not_reconnect() {
         tokio::task::LocalSet::new()
@@ -5136,6 +5134,8 @@ mod tests {
             .await;
     }
 
+    /// Given alice shuts down, when an old peer-close terminal resolves afterward,
+    /// then the terminal watcher cannot start another connection.
     #[tokio::test(flavor = "current_thread")]
     async fn shutdown_does_not_reconnect_after_terminal() {
         tokio::task::LocalSet::new()


### PR DESCRIPTION
🤖 Supersedes #2476 with its native terminal-lifecycle repair adapted to current main. Independent adversarial review found no blocker; canonical CI is green. Anselm's review remains pending.

## Before / after

The native client installed a connected transport but dropped the connector's terminal future without polling it. An idle peer could close its socket while the client continued treating the dead upstream as an idle live connection indefinitely.

The client now retains a weak, generation-tagged terminal watcher and feeds its outcome into the existing tick/recovery driver:

- `PeerClosed` and recoverable failures detach the matching connection and retry through one generation-owned recovery flow.
- Deliberate owner drop and shutdown do not reconnect.
- A terminal event from an older generation cannot detach, poison, or replace a newer connection.
- Losing ownership during a retry prevents the late connection from being installed.
- Recovery backoff remains asynchronous, so local database ticks continue.

For example, if an otherwise-idle server disappears, the terminal watcher wakes the client and starts recovery without requiring application traffic. If the app deliberately closes while that recovery is pending, the pending attempt cannot resurrect the connection.

This reuses the existing connector, scheduler, and reconnect machinery rather than creating a second transport path. It does not change storage/wire formats or public APIs.

## Verification

- Nine focused lifecycle tests pass: idle close, recoverable terminal classes, owner drop, shutdown race, stale admission/exhaustion, ownership loss, terminal/tick coalescing, and local-tick responsiveness.
- Native transport terminal tests: 2 passed.
- On exact pre-fix main, the idle-close regression timed out because the terminal future was never polled.
- Suppressing `PeerClosed` recovery makes the regression fail; restored afterward.
- Independent review found no correctness blocker.
- All nine tests have the required contract/actor documentation; formatting, Clippy, and diff checks pass. A review-found placement error was corrected and rechecked.
- The lifecycle tests use explicit in-memory storage so parallel execution cannot contend over a process-global default RocksDB path; the complete parallel client partition passes 37/37.
- Canonical CI is green across lint, Rust workspace/focused/differential, storage compatibility, and TypeScript jobs.

Original #2476 behavior is preserved in adapted commit `dd16b00d8a`, followed by test documentation and isolation corrections through `5af63890f7`. The original branch has not been rewritten.
