### PR TITLE
Bind Next correctness builds to sealed WASM artifacts

### DIFF
--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, relative, resolve } from "node:path";
 import { createTempRootTracker, getAvailablePort, todoSchema } from "./test-helpers.js";
 import * as devServer from "./dev-server.js";
 import * as catalogueProject from "./catalogue-project.js";
@@ -15,6 +15,8 @@ const PRODUCTION_BUILD_PHASE = "phase-production-build";
 const tempRoots = createTempRootTracker();
 const originalJazzServerUrl = process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
 const originalJazzAppId = process.env.NEXT_PUBLIC_JAZZ_APP_ID;
+const originalCorrectnessRun = process.env.JAZZ_CORRECTNESS_ARTIFACT_RUN;
+const originalCorrectnessWasmPackage = process.env.JAZZ_CORRECTNESS_WASM_PACKAGE;
 
 async function resolveWrappedConfig(
   wrapped: ReturnType<typeof withJazz>,
@@ -39,6 +41,8 @@ beforeEach(async () => {
   delete process.env.NEXT_PUBLIC_JAZZ_SERVER_URL;
   delete process.env.JAZZ_ADMIN_SECRET;
   delete process.env.BACKEND_SECRET;
+  delete process.env.JAZZ_CORRECTNESS_ARTIFACT_RUN;
+  delete process.env.JAZZ_CORRECTNESS_WASM_PACKAGE;
 
   // Redirect cwd to a per-test directory for managed-runtime state.
   const fakeCwd = await tempRoots.create("jazz-next-test-cwd-");
@@ -61,6 +65,12 @@ afterEach(async () => {
   } else {
     process.env.NEXT_PUBLIC_JAZZ_APP_ID = originalJazzAppId;
   }
+
+  if (originalCorrectnessRun === undefined) delete process.env.JAZZ_CORRECTNESS_ARTIFACT_RUN;
+  else process.env.JAZZ_CORRECTNESS_ARTIFACT_RUN = originalCorrectnessRun;
+  if (originalCorrectnessWasmPackage === undefined)
+    delete process.env.JAZZ_CORRECTNESS_WASM_PACKAGE;
+  else process.env.JAZZ_CORRECTNESS_WASM_PACKAGE = originalCorrectnessWasmPackage;
 });
 
 describe("withJazz", () => {
@@ -107,6 +117,36 @@ describe("withJazz", () => {
     expect(resolved.env?.NEXT_PUBLIC_JAZZ_SERVER_URL).toBeUndefined();
     expect(process.env.NEXT_PUBLIC_JAZZ_APP_ID).toBeUndefined();
     expect(process.env.NEXT_PUBLIC_JAZZ_SERVER_URL).toBeUndefined();
+  });
+
+  it("routes both Next bundlers to the admitted WASM snapshot", async () => {
+    process.env.JAZZ_CORRECTNESS_ARTIFACT_RUN = "1";
+    process.env.JAZZ_CORRECTNESS_WASM_PACKAGE = "/sealed/wasm";
+    const resolved = (await resolveWrappedConfig(
+      withJazz({ turbopack: { resolveAlias: { existing: "./existing" } } }),
+      PRODUCTION_BUILD_PHASE,
+    )) as NextConfigLike & {
+      turbopack?: { resolveAlias?: Record<string, string> };
+      webpack?: (config: { resolve?: { alias?: Record<string, string> } }) => unknown;
+    };
+
+    expect(resolved.turbopack?.resolveAlias?.existing).toBe("./existing");
+    const wasmEntry = resolve("/sealed/wasm", "jazz_wasm.js");
+    const fromProject = relative(process.cwd(), wasmEntry);
+    expect(resolved.turbopack?.resolveAlias?.["jazz-wasm"]).toBe(
+      fromProject.startsWith(".") ? fromProject : `./${fromProject}`,
+    );
+    const finalConfig = resolved.webpack!({ resolve: { alias: {} } }) as {
+      resolve: { alias: Record<string, string> };
+    };
+    expect(finalConfig.resolve.alias["jazz-wasm"]).toBe(wasmEntry);
+  });
+
+  it("fails before Next can resolve a mutable WASM package in a sealed run", async () => {
+    process.env.JAZZ_CORRECTNESS_ARTIFACT_RUN = "1";
+    await expect(resolveWrappedConfig(withJazz({}), PRODUCTION_BUILD_PHASE)).rejects.toThrow(
+      "sealed correctness consumer is missing its admitted WASM package",
+    );
   });
 
   it("starts a local server in development and injects NEXT_PUBLIC_JAZZ_* env vars", async () => {

--- a/packages/jazz-tools/src/dev/next.ts
+++ b/packages/jazz-tools/src/dev/next.ts
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { buildInspectorLink } from "./inspector-link.js";
 import { ManagedDevRuntime } from "./managed-runtime.js";
 import type { JazzPluginOptions, JazzServerOptions } from "./vite.js";
@@ -37,6 +37,25 @@ const PUBLIC_SERVER_URL_ENV = "NEXT_PUBLIC_JAZZ_SERVER_URL";
 const PUBLIC_TELEMETRY_COLLECTOR_URL_ENV = "NEXT_PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL";
 const SCHEMA_HASH_STUB_SUBPATH = join("node_modules", ".cache", "jazz", "schema-hash.js");
 const SCHEMA_HASH_ALIAS = "jazz-tools/_dev/schema-hash";
+const WASM_PACKAGE_ALIAS = "jazz-wasm";
+
+function sealedWasmAliases() {
+  const sealedWasmPackage = process.env.JAZZ_CORRECTNESS_WASM_PACKAGE;
+  if (process.env.JAZZ_CORRECTNESS_ARTIFACT_RUN === "1" && !sealedWasmPackage)
+    throw new Error("sealed correctness consumer is missing its admitted WASM package");
+  if (!sealedWasmPackage) return undefined;
+
+  const entry = resolve(sealedWasmPackage, "jazz_wasm.js");
+  // Turbopack interprets absolute alias targets as server-relative paths. Its
+  // project-relative spelling and Webpack's absolute spelling name the same
+  // immutable snapshot for every Next runtime import.
+  const fromProject = relative(process.cwd(), entry);
+  return {
+    webpack: entry,
+    turbopack:
+      fromProject === "" ? "." : fromProject.startsWith(".") ? fromProject : `./${fromProject}`,
+  };
+}
 
 async function writeSchemaHashStub(appRoot: string, hash: string): Promise<void> {
   const stubPath = join(appRoot, SCHEMA_HASH_STUB_SUBPATH);
@@ -74,15 +93,50 @@ export function withJazz(
 
   return async (phase, context) => {
     const resolved = await resolveConfig(nextConfig, phase, context);
+    const sealedWasm = sealedWasmAliases();
     const merged: NextConfigLike = {
       ...resolved,
       serverExternalPackages: mergeServerExternalPackages(resolved.serverExternalPackages),
     };
 
+    const previousWebpack = merged.webpack as
+      | ((config: WebpackConfig, ctx: unknown) => WebpackConfig)
+      | undefined;
+    const previousTurbopack = (merged.turbopack as TurbopackConfig | undefined) ?? {};
+
+    const withSealedWasm = (config: NextConfigLike): NextConfigLike => {
+      if (!sealedWasm) return config;
+      const configuredWebpack = config.webpack as
+        | ((config: WebpackConfig, ctx: unknown) => WebpackConfig)
+        | undefined;
+      const configuredTurbopack = config.turbopack as TurbopackConfig | undefined;
+      return {
+        ...config,
+        turbopack: {
+          ...previousTurbopack,
+          ...configuredTurbopack,
+          resolveAlias: {
+            ...previousTurbopack.resolveAlias,
+            ...configuredTurbopack?.resolveAlias,
+            [WASM_PACKAGE_ALIAS]: sealedWasm.turbopack,
+          },
+        },
+        webpack: (config: WebpackConfig, ctx: unknown) => {
+          const next = configuredWebpack ? configuredWebpack(config, ctx) : config;
+          next.resolve = next.resolve ?? {};
+          next.resolve.alias = {
+            ...next.resolve.alias,
+            [WASM_PACKAGE_ALIAS]: sealedWasm.webpack,
+          };
+          return next;
+        },
+      };
+    };
+
     // Everything below is dev-only: managed server, APP_ID/SERVER_URL
     // injection. In production the host app supplies those via its own env.
     if (phase !== DEVELOPMENT_PHASE || options.server === false) {
-      return merged;
+      return withSealedWasm(merged);
     }
 
     const serverOpt = options.server;
@@ -114,12 +168,7 @@ export function withJazz(
     // refuses to resolve them. Use the project-root-relative form there. Webpack
     // is happy with either, so feed it the absolute path for clarity.
     const turbopackStubPath = `./${SCHEMA_HASH_STUB_SUBPATH}`;
-    const previousWebpack = merged.webpack as
-      | ((config: WebpackConfig, ctx: unknown) => WebpackConfig)
-      | undefined;
-    const previousTurbopack = (merged.turbopack as TurbopackConfig | undefined) ?? {};
-
-    return {
+    return withSealedWasm({
       ...merged,
       env: {
         ...merged.env,
@@ -146,7 +195,7 @@ export function withJazz(
         };
         return next;
       },
-    };
+    });
   };
 }
 


### PR DESCRIPTION
🤖 Correctness-artifact repair discovered while validating #2525.

## Problem

The correctness producer seals an admitted WASM package, but a later Jazz Tools worker build can still read the mutable `crates/jazz-wasm/pkg` output when the sealed environment is not carried through Next's resolver. A concurrent package build can therefore give Turbopack two different `jazz_wasm_bg.wasm` contents for one output path. The Next example then fails before its web server starts.

This reproduced locally and in #2525's CI. Reverting #2525's `server-only` import and externalizing Jazz Tools did not fix it; the credential behavior is unrelated.

## Intended repair

During an admitted correctness-artifact run, both Webpack and Turbopack resolve `jazz-wasm` to the exact sealed snapshot. If the run marker is present without an admitted package, Next configuration fails closed before reading mutable output. Normal application builds without the correctness-run marker remain unchanged.

For example, the worker bundle and browser runtime must both receive `/sealed/<fingerprint>/jazz_wasm.js`; neither may fall back to a concurrently changing workspace `pkg` directory.

## Verification

- Unit tests pin existing aliases and both Webpack/Turbopack sealed resolution.
- A missing admitted package under the correctness-run marker fails closed.
- Full correctness-artifact production completed with fresh admitted NAPI and WASM snapshots.
- The exact TypeScript consumer partition passed: 20 browser files (294 tests, one expected failure, three skipped) plus the Node suite, with both suite exit statuses 0.
- A real sealed Next application build passed with Turbopack and Webpack; emitted artifacts resolve the sealed snapshot rather than mutable workspace output.
- Independent adversarial review found no correctness blocker and planted/targeted contract tests passed.
- Canonical CI is green across lint, Rust, differential, storage-compatibility, and TypeScript jobs.
