### PR TITLE
Test maintained indexed hydration through browser workers

### DIFF
--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -1796,9 +1796,13 @@ describe("SharedWorker bridge with IndexedDB", () => {
       }),
     );
     const seededTitle = `indexed-seeded-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    await writer
+    const seededFirst = await writer
       .insert(maintainedIndexedTodos, { title: seededTitle, done: false })
       .wait({ tier: "global" });
+    const seededSecond = await writer
+      .insert(maintainedIndexedTodos, { title: seededTitle, done: false })
+      .wait({ tier: "global" });
+    const expectedSeededIds = [seededFirst.id, seededSecond.id].sort();
 
     const fresh = track(
       await createDb({
@@ -1825,8 +1829,11 @@ describe("SharedWorker bridge with IndexedDB", () => {
       15_000,
       "fresh IndexedDB worker must receive an authoritative settled indexed snapshot",
     );
-    expect(settledSnapshots[0]).toHaveLength(1);
-    expect(settledSnapshots[0]?.[0]).toMatchObject({ title: seededTitle, done: false });
+    // The first global callback is authoritative, not merely nonempty: a
+    // partial hydration that delivers either matching row is a failure.
+    expect(settledSnapshots[0]).toHaveLength(2);
+    expect(settledSnapshots[0]?.map((row) => row.id).sort()).toEqual(expectedSeededIds);
+    expect(settledSnapshots[0]?.every((row) => row.title === seededTitle && !row.done)).toBe(true);
     stopSettled();
 
     const emptyTitle = `indexed-empty-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -1887,56 +1887,65 @@ describe("SharedWorker bridge with IndexedDB", () => {
         { tier: "global" },
       ),
     );
-    await waitForCondition(
-      async () => transitionSnapshots.some((rows) => rows.length === 0),
-      15_000,
+    const matchingTransition = { id: transition.id, title: transitionTitle, done: false };
+    const expectedTransitionSnapshots: { id: string; title: string; done: boolean }[][] = [];
+    const assertTransitionSnapshots = () => {
+      expect(
+        transitionSnapshots.map((rows) => rows.map(({ id, title, done }) => ({ id, title, done }))),
+      ).toEqual(expectedTransitionSnapshots);
+    };
+    const awaitTransitionSnapshot = async (
+      cursor: number,
+      expectedRows: { id: string; title: string; done: boolean }[],
+      message: string,
+    ) => {
+      await waitForCondition(async () => transitionSnapshots.length > cursor, 15_000, message);
+      expectedTransitionSnapshots.push(expectedRows);
+      assertTransitionSnapshots();
+    };
+    await awaitTransitionSnapshot(
+      0,
+      [],
       "non-matching indexed row must not appear in the initial intersected snapshot",
     );
+    let transitionCursor = transitionSnapshots.length;
     await writer
       .update(maintainedIndexedTodos, transition.id, { done: false })
       .wait({ tier: "global" });
-    await waitForCondition(
-      async () =>
-        transitionSnapshots.some(
-          (rows) => rows.length === 1 && rows[0]?.id === transition.id && rows[0]?.done === false,
-        ),
-      15_000,
+    await awaitTransitionSnapshot(
+      transitionCursor,
+      [matchingTransition],
       "changing an indexed equality must enter the remote maintained subscription",
     );
+    transitionCursor = transitionSnapshots.length;
     await writer
       .update(maintainedIndexedTodos, transition.id, { title: `${transitionTitle}-outside` })
       .wait({ tier: "global" });
-    await waitForCondition(
-      async () => transitionSnapshots.filter((rows) => rows.length === 0).length >= 2,
-      15_000,
+    await awaitTransitionSnapshot(
+      transitionCursor,
+      [],
       "changing title equality must leave the remote maintained subscription",
     );
+    transitionCursor = transitionSnapshots.length;
     await writer
       .update(maintainedIndexedTodos, transition.id, { title: transitionTitle })
       .wait({ tier: "global" });
-    await waitForCondition(
-      async () =>
-        transitionSnapshots.filter(
-          (rows) => rows.length === 1 && rows[0]?.id === transition.id && rows[0]?.done === false,
-        ).length >= 2,
-      15_000,
+    await awaitTransitionSnapshot(
+      transitionCursor,
+      [matchingTransition],
       "restoring title equality must re-enter the remote maintained subscription",
     );
+    transitionCursor = transitionSnapshots.length;
     await writer
       .update(maintainedIndexedTodos, transition.id, { done: true })
       .wait({ tier: "global" });
-    await waitForCondition(
-      async () => transitionSnapshots.filter((rows) => rows.length === 0).length >= 3,
-      15_000,
+    await awaitTransitionSnapshot(
+      transitionCursor,
+      [],
       "changing done equality back must leave the remote maintained subscription",
     );
     await sleep(500);
-    expect(
-      transitionSnapshots.filter(
-        (rows) => rows.length === 1 && rows[0]?.id === transition.id && rows[0]?.done === false,
-      ),
-    ).toHaveLength(2);
-    expect(transitionSnapshots.filter((rows) => rows.length === 0)).toHaveLength(3);
+    assertTransitionSnapshots();
     stopTransition();
   }, 120000);
 

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -1834,6 +1834,10 @@ describe("SharedWorker bridge with IndexedDB", () => {
     expect(settledSnapshots[0]).toHaveLength(2);
     expect(settledSnapshots[0]?.map((row) => row.id).sort()).toEqual(expectedSeededIds);
     expect(settledSnapshots[0]?.every((row) => row.title === seededTitle && !row.done)).toBe(true);
+    // Keep the opening live long enough to catch a duplicated, partial, or
+    // stale settled snapshot before retiring this subscription.
+    await sleep(500);
+    expect(settledSnapshots).toHaveLength(1);
     stopSettled();
 
     const emptyTitle = `indexed-empty-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -143,6 +143,25 @@ const app: s.App<AppSchema> = s.defineApp(schema);
 const { projects, todos } = app;
 type Todo = s.RowOf<typeof todos>;
 
+// Keep the maintained-index hydration fixture separate from the broadly used
+// worker-bridge schema: this test must exercise the same two-equality indexed
+// source shape as the native receipt, without changing unrelated test schemas.
+const maintainedIndexedSchema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s
+    .table({
+      title: s.string(),
+      done: s.boolean(),
+    })
+    .indexOnly(["title", "done"]),
+};
+type MaintainedIndexedSchema = s.Schema<typeof maintainedIndexedSchema>;
+const maintainedIndexedApp: s.App<MaintainedIndexedSchema> = s.defineApp(maintainedIndexedSchema);
+const { todos: maintainedIndexedTodos } = maintainedIndexedApp;
+type MaintainedIndexedTodo = s.RowOf<typeof maintainedIndexedTodos>;
+
 const transactionIdentitySchema = {
   projects: s.table({
     name: s.string(),
@@ -1748,6 +1767,167 @@ describe("SharedWorker bridge with IndexedDB", () => {
 
     unsubscribe();
   }, 90000);
+
+  /**
+   * The browser worker uses the same maintained indexed source as native
+   * subscriptions.  A fresh remote reader must hydrate its settled snapshot,
+   * keep an empty intersected equality source live for its first insert, and
+   * apply enter/leave changes when either equality changes.
+   *
+   * writer ──global write──► server ──settled indexed source──► fresh worker
+   *                                                         └──► subscription
+   */
+  it("maintains indexed remote subscriptions through IndexedDB worker hydration", async () => {
+    const syncServer = await publishSyncServerSchemaAndPermissions(
+      "maintained-indexed-worker-hydration",
+      undefined,
+      maintainedIndexedApp.wasmSchema,
+    );
+    const sharedLocalAuthToken = generateAuthSecret();
+    const writer = track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: {
+          type: "persistent",
+          dbName: uniqueDbName("maintained-indexed-worker-writer"),
+        },
+        serverUrl: syncServer.serverUrl,
+        secret: sharedLocalAuthToken,
+      }),
+    );
+    const seededTitle = `indexed-seeded-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    await writer
+      .insert(maintainedIndexedTodos, { title: seededTitle, done: false })
+      .wait({ tier: "global" });
+
+    const fresh = track(
+      await createDb({
+        appId: syncServer.appId,
+        driver: {
+          type: "persistent",
+          dbName: uniqueDbName("maintained-indexed-worker-fresh"),
+        },
+        serverUrl: syncServer.serverUrl,
+        secret: sharedLocalAuthToken,
+      }),
+    );
+
+    const settledSnapshots: MaintainedIndexedTodo[][] = [];
+    const stopSettled = trackSubscription(
+      fresh.subscribe(
+        maintainedIndexedTodos.where({ title: seededTitle, done: false }),
+        (rows) => settledSnapshots.push(rows),
+        { tier: "global" },
+      ),
+    );
+    await waitForCondition(
+      async () => settledSnapshots.length > 0,
+      15_000,
+      "fresh IndexedDB worker must receive an authoritative settled indexed snapshot",
+    );
+    expect(settledSnapshots[0]).toHaveLength(1);
+    expect(settledSnapshots[0]?.[0]).toMatchObject({ title: seededTitle, done: false });
+    stopSettled();
+
+    const emptyTitle = `indexed-empty-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const emptySnapshots: MaintainedIndexedTodo[][] = [];
+    const stopEmpty = trackSubscription(
+      fresh.subscribe(
+        maintainedIndexedTodos.where({ title: emptyTitle, done: false }),
+        (rows) => emptySnapshots.push(rows),
+        {
+          tier: "global",
+        },
+      ),
+    );
+    await waitForCondition(
+      async () => emptySnapshots.some((rows) => rows.length === 0),
+      15_000,
+      "empty intersected equality source must settle before its first matching insert",
+    );
+    await writer
+      .insert(maintainedIndexedTodos, { title: emptyTitle, done: false })
+      .wait({ tier: "global" });
+    await waitForCondition(
+      async () =>
+        emptySnapshots.some(
+          (rows) => rows.length === 1 && rows[0]?.title === emptyTitle && rows[0]?.done === false,
+        ),
+      15_000,
+      "first matching remote insert must enter an initially empty indexed subscription",
+    );
+    await sleep(500);
+    expect(
+      emptySnapshots.filter(
+        (rows) => rows.length === 1 && rows[0]?.title === emptyTitle && rows[0]?.done === false,
+      ),
+    ).toHaveLength(1);
+    stopEmpty();
+
+    const transitionTitle = `indexed-transition-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const transition = await writer
+      .insert(maintainedIndexedTodos, { title: transitionTitle, done: true })
+      .wait({ tier: "global" });
+    const transitionSnapshots: MaintainedIndexedTodo[][] = [];
+    const stopTransition = trackSubscription(
+      fresh.subscribe(
+        maintainedIndexedTodos.where({ title: transitionTitle, done: false }),
+        (rows) => transitionSnapshots.push(rows),
+        { tier: "global" },
+      ),
+    );
+    await waitForCondition(
+      async () => transitionSnapshots.some((rows) => rows.length === 0),
+      15_000,
+      "non-matching indexed row must not appear in the initial intersected snapshot",
+    );
+    await writer
+      .update(maintainedIndexedTodos, transition.id, { done: false })
+      .wait({ tier: "global" });
+    await waitForCondition(
+      async () =>
+        transitionSnapshots.some(
+          (rows) => rows.length === 1 && rows[0]?.id === transition.id && rows[0]?.done === false,
+        ),
+      15_000,
+      "changing an indexed equality must enter the remote maintained subscription",
+    );
+    await writer
+      .update(maintainedIndexedTodos, transition.id, { title: `${transitionTitle}-outside` })
+      .wait({ tier: "global" });
+    await waitForCondition(
+      async () => transitionSnapshots.filter((rows) => rows.length === 0).length >= 2,
+      15_000,
+      "changing title equality must leave the remote maintained subscription",
+    );
+    await writer
+      .update(maintainedIndexedTodos, transition.id, { title: transitionTitle })
+      .wait({ tier: "global" });
+    await waitForCondition(
+      async () =>
+        transitionSnapshots.filter(
+          (rows) => rows.length === 1 && rows[0]?.id === transition.id && rows[0]?.done === false,
+        ).length >= 2,
+      15_000,
+      "restoring title equality must re-enter the remote maintained subscription",
+    );
+    await writer
+      .update(maintainedIndexedTodos, transition.id, { done: true })
+      .wait({ tier: "global" });
+    await waitForCondition(
+      async () => transitionSnapshots.filter((rows) => rows.length === 0).length >= 3,
+      15_000,
+      "changing done equality back must leave the remote maintained subscription",
+    );
+    await sleep(500);
+    expect(
+      transitionSnapshots.filter(
+        (rows) => rows.length === 1 && rows[0]?.id === transition.id && rows[0]?.done === false,
+      ),
+    ).toHaveLength(2);
+    expect(transitionSnapshots.filter((rows) => rows.length === 0)).toHaveLength(3);
+    stopTransition();
+  }, 120000);
 
   it("delivers an initial scoped subscription snapshot after seeding many synced rows", async () => {
     const sharedLocalAuthToken = generateAuthSecret();


### PR DESCRIPTION
🤖 Closes #2077 by exercising maintained indexed hydration across Chromium, SharedWorker, IndexedDB and the sync server.

The first global snapshot must contain every settled matching row exactly once. An initially empty two-equality indexed subscription must receive its first matching insert once. Subsequent remote updates must produce the complete ordered sequence empty → matching row → empty → matching row → empty as each indexed predicate changes.

Each transition checks row identity, title and done values, and consumes a callback after its corresponding write. Comparing the complete sequence rejects duplicate, out-of-order and unrelated snapshots that historical filtered counts could accidentally accept. No product implementation or browser-only query path is added; the existing native selective_global_hydration receipt remains the scaling measurement.

Validation: sealed artifacts and Jazz Tools build passed; implementation and coordinator independently ran the focused Chromium test (one passed, 74 skipped). An exact-test-body fault harness accepts normal delivery and rejects duplicate opening, missing first insert, duplicate-empty/missing-removal and extra-invalid-snapshot cases. Fresh full CI runs on the strengthened test head.
