### PR TITLE
fix(ci): unblock official alpha release previews

### DIFF
--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -12,7 +12,11 @@ concurrency:
 
 permissions:
   actions: read
-  contents: read
+  # The reusable publisher declares `contents: write` for the real-release
+  # source-tag step. GitHub validates reusable-workflow permissions before it
+  # evaluates the dry-run guards, so the preview caller must grant the same
+  # ceiling even though dry-run never executes a repository write.
+  contents: write
   id-token: write
   pull-requests: read
   statuses: write

--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -11,21 +11,16 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  actions: read
-  # The reusable publisher declares `contents: write` for the real-release
-  # source-tag step. GitHub validates reusable-workflow permissions before it
-  # evaluates the dry-run guards, so the preview caller must grant the same
-  # ceiling even though dry-run never executes a repository write.
-  contents: write
-  id-token: write
-  pull-requests: read
-  statuses: write
+  contents: read
 
 jobs:
   mark-preview-pending:
     name: Mark release preview pending
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: startsWith(github.ref, 'refs/heads/changeset-release/')
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - name: Set pending commit status
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -44,6 +39,14 @@ jobs:
   preview:
     name: Release preview build
     uses: ./.github/workflows/publish-jazz-tools-alpha.yml
+    # GitHub validates the full reusable-workflow permission graph before it
+    # evaluates dry-run guards. Match the publisher's maximum permission
+    # ceiling only on this job; dry-run never executes its write steps.
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+      pull-requests: read
     with:
       mode: dry-run
     secrets: inherit
@@ -53,6 +56,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: always() && startsWith(github.ref, 'refs/heads/changeset-release/')
     needs: [mark-preview-pending, preview]
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - name: Set final commit status
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/dev/artifacts/release-staging-contract.test.mjs
+++ b/dev/artifacts/release-staging-contract.test.mjs
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
+import { parse } from "yaml";
 import { stageNapiLoader } from "./stage-napi-loader.mjs";
 import { stageNativeFingerprints } from "./stage-native-fingerprints.mjs";
 
@@ -352,17 +353,32 @@ test("release publishing rebuilds when workflow changes invalidate preview artif
 });
 
 test("alpha release preview can call the publisher without elevating nested permissions", () => {
-  const previewWorkflow = readFileSync(
+  const previewWorkflowText = readFileSync(
     new URL("../../.github/workflows/preview-jazz-tools-alpha-release.yml", import.meta.url),
     "utf8",
   );
+  const previewWorkflow = parse(previewWorkflowText);
   const publisherWorkflow = readFileSync(
     new URL("../../.github/workflows/publish-jazz-tools-alpha.yml", import.meta.url),
     "utf8",
   );
 
-  assert.match(previewWorkflow, /permissions:[\s\S]*?contents: write/);
-  assert.match(previewWorkflow, /mode: dry-run/);
+  assert.deepEqual(previewWorkflow.permissions, { contents: "read" });
+  assert.deepEqual(previewWorkflow.jobs.preview.permissions, {
+    actions: "read",
+    contents: "write",
+    "id-token": "write",
+    "pull-requests": "read",
+  });
+  assert.deepEqual(previewWorkflow.jobs["mark-preview-pending"].permissions, {
+    contents: "read",
+    statuses: "write",
+  });
+  assert.deepEqual(previewWorkflow.jobs["mark-preview-final"].permissions, {
+    contents: "read",
+    statuses: "write",
+  });
+  assert.equal(previewWorkflow.jobs.preview.with.mode, "dry-run");
   assert.match(publisherWorkflow, /permissions:[\s\S]*?contents: write/);
   assert.match(publisherWorkflow, /if: env\.RELEASE_MODE == 'publish'/);
 });

--- a/dev/artifacts/release-staging-contract.test.mjs
+++ b/dev/artifacts/release-staging-contract.test.mjs
@@ -350,3 +350,19 @@ test("release publishing rebuilds when workflow changes invalidate preview artif
   );
   assert.doesNotMatch(workflow, /workflow-only drift|nonWorkflowFiles/);
 });
+
+test("alpha release preview can call the publisher without elevating nested permissions", () => {
+  const previewWorkflow = readFileSync(
+    new URL("../../.github/workflows/preview-jazz-tools-alpha-release.yml", import.meta.url),
+    "utf8",
+  );
+  const publisherWorkflow = readFileSync(
+    new URL("../../.github/workflows/publish-jazz-tools-alpha.yml", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(previewWorkflow, /permissions:[\s\S]*?contents: write/);
+  assert.match(previewWorkflow, /mode: dry-run/);
+  assert.match(publisherWorkflow, /permissions:[\s\S]*?contents: write/);
+  assert.match(publisherWorkflow, /if: env\.RELEASE_MODE == 'publish'/);
+});


### PR DESCRIPTION
🤖 Fixes the official alpha release preview failing at workflow startup before any job can run.

Before:
- The preview caller provided only `contents: read` to its reusable publisher job.
- The called publisher declares `contents: write` for the real-release source-tag step.
- GitHub validates the complete reusable-workflow permission graph before evaluating dry-run conditions, so every preview dispatch ended as `startup_failure` with zero jobs.

After:
- The workflow default remains read-only.
- Only the reusable `preview` job receives the publisher permission ceiling required by GitHub validation.
- The two status-reporting jobs receive only `contents: read` and `statuses: write`.
- The publisher is still invoked with `mode: dry-run`; tag creation, npm publication, and inspector production promotion remain guarded to `publish` mode and do not execute.
- A parsed workflow-contract test enforces the job-level scopes and dry-run mode.

Evidence:
- Five consecutive preview dispatches on `changeset-release/main` failed at startup with zero jobs, most recently run 33823980785.
- `node --test dev/artifacts/release-staging-contract.test.mjs`: 14 passed.

Follow-up:
- Split read-only build/pack verification from mutating publication so the reusable preview job itself can eventually return to a read-only token.