### PR TITLE
fix(ci): normalize NAPI declaration line endings

### DIFF
--- a/dev/artifacts/build.mjs
+++ b/dev/artifacts/build.mjs
@@ -396,13 +396,15 @@ export function validateNapiStage(
   // semantic ABI guard, so Windows CRLF must compare equal to the checked-in
   // LF surface while every other generated difference remains fatal.
   const normalizeLineEndings = (value) => value.replaceAll("\r\n", "\n");
-  if (normalizeLineEndings(generatedDeclarations) !== normalizeLineEndings(stableDeclarations))
+  const normalizedGeneratedDeclarations = normalizeLineEndings(generatedDeclarations);
+  const normalizedStableDeclarations = normalizeLineEndings(stableDeclarations);
+  if (normalizedGeneratedDeclarations !== normalizedStableDeclarations)
     throw new Error(
       declarationMismatchDiagnostic(
         stableDeclarationsPath,
         declarations,
-        stableDeclarations,
-        generatedDeclarations,
+        normalizedStableDeclarations,
+        normalizedGeneratedDeclarations,
       ),
     );
   if (target !== hostTarget) return;

--- a/dev/artifacts/build.mjs
+++ b/dev/artifacts/build.mjs
@@ -392,7 +392,11 @@ export function validateNapiStage(
   assertRealNapiGeneration(stagePath, expectedBinding, { sealed: false });
   const generatedDeclarations = readFileSync(declarations, "utf8");
   const stableDeclarations = readFileSync(stableDeclarationsPath, "utf8");
-  if (generatedDeclarations !== stableDeclarations)
+  // napi-rs follows the host's native line endings. Declaration parity is a
+  // semantic ABI guard, so Windows CRLF must compare equal to the checked-in
+  // LF surface while every other generated difference remains fatal.
+  const normalizeLineEndings = (value) => value.replaceAll("\r\n", "\n");
+  if (normalizeLineEndings(generatedDeclarations) !== normalizeLineEndings(stableDeclarations))
     throw new Error(
       declarationMismatchDiagnostic(
         stableDeclarationsPath,

--- a/dev/artifacts/napi-build-contract.test.mjs
+++ b/dev/artifacts/napi-build-contract.test.mjs
@@ -375,6 +375,26 @@ test("a newly generated public export absent from the stable package declaration
   }
 });
 
+test("Windows line endings do not create false declaration drift", () => {
+  const root = fixture();
+  try {
+    const staged = stage(root, ".napi-stage-windows", "next");
+    const stableDeclarations = join(root, "index.d.ts");
+    writeFileSync(stableDeclarations, "export declare class NapiDb { tick(): void }\n");
+    writeFileSync(
+      join(staged, "index.d.ts"),
+      "export declare class NapiDb { tick(): void }\r\n",
+    );
+    assert.doesNotThrow(() =>
+      validateNapiStage(staged, "jazz-napi.linux-x64-gnu.node", "next", "cross-target", {
+        stableDeclarationsPath: stableDeclarations,
+      }),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("the package declaration overlay exposes Promise close without leaking the raw pollable ABI", () => {
   const root = fixture();
   try {

--- a/dev/artifacts/napi-build-contract.test.mjs
+++ b/dev/artifacts/napi-build-contract.test.mjs
@@ -381,10 +381,7 @@ test("Windows line endings do not create false declaration drift", () => {
     const staged = stage(root, ".napi-stage-windows", "next");
     const stableDeclarations = join(root, "index.d.ts");
     writeFileSync(stableDeclarations, "export declare class NapiDb { tick(): void }\n");
-    writeFileSync(
-      join(staged, "index.d.ts"),
-      "export declare class NapiDb { tick(): void }\r\n",
-    );
+    writeFileSync(join(staged, "index.d.ts"), "export declare class NapiDb { tick(): void }\r\n");
     assert.doesNotThrow(() =>
       validateNapiStage(staged, "jazz-napi.linux-x64-gnu.node", "next", "cross-target", {
         stableDeclarationsPath: stableDeclarations,
@@ -400,20 +397,19 @@ test("Windows declaration drift points at the substantive changed line", () => {
   try {
     const staged = stage(root, ".napi-stage-windows-drift", "next");
     const stableDeclarations = join(root, "index.d.ts");
-    writeFileSync(stableDeclarations, "export declare const first: 1\nexport declare const second: 2\n");
+    writeFileSync(
+      stableDeclarations,
+      "export declare const first: 1\nexport declare const second: 2\n",
+    );
     writeFileSync(
       join(staged, "index.d.ts"),
       "export declare const first: 1\r\nexport declare const second: 3\r\n",
     );
     assert.throws(
       () =>
-        validateNapiStage(
-          staged,
-          "jazz-napi.linux-x64-gnu.node",
-          "next",
-          "cross-target",
-          { stableDeclarationsPath: stableDeclarations },
-        ),
+        validateNapiStage(staged, "jazz-napi.linux-x64-gnu.node", "next", "cross-target", {
+          stableDeclarationsPath: stableDeclarations,
+        }),
       /first difference near line 2/,
     );
   } finally {

--- a/dev/artifacts/napi-build-contract.test.mjs
+++ b/dev/artifacts/napi-build-contract.test.mjs
@@ -395,6 +395,32 @@ test("Windows line endings do not create false declaration drift", () => {
   }
 });
 
+test("Windows declaration drift points at the substantive changed line", () => {
+  const root = fixture();
+  try {
+    const staged = stage(root, ".napi-stage-windows-drift", "next");
+    const stableDeclarations = join(root, "index.d.ts");
+    writeFileSync(stableDeclarations, "export declare const first: 1\nexport declare const second: 2\n");
+    writeFileSync(
+      join(staged, "index.d.ts"),
+      "export declare const first: 1\r\nexport declare const second: 3\r\n",
+    );
+    assert.throws(
+      () =>
+        validateNapiStage(
+          staged,
+          "jazz-napi.linux-x64-gnu.node",
+          "next",
+          "cross-target",
+          { stableDeclarationsPath: stableDeclarations },
+        ),
+      /first difference near line 2/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("the package declaration overlay exposes Promise close without leaking the raw pollable ABI", () => {
   const root = fixture();
   try {


### PR DESCRIPTION
🤖 Fix Windows-only NAPI declaration rejection caused by host line endings.

Generated and checked-in TypeScript declarations compare after CRLF-to-LF normalization only. Substantive declaration changes, lone carriage returns, whitespace changes and missing final newlines remain fatal; diagnostics identify the changed line.

The three patches approved at a81bd63b89 are unchanged at d74c85d090, restacked onto merged RN main. Independent review and coordinator each pass16 contract tests with planted guard regressions. Normal PR CI passes.

Exact-head official Windows native build passes in https://github.com/garden-co/jazz/actions/runs/33919017680, as do packaged Android and iOS consumers. Subsequent npm assembly fails on a separate pre-existing provenance issue: CRLF checkout conversion changes Windows package-input and ABI hashes despite the same Git tree. That follow-up is isolated from this declaration-comparison fix and does not invalidate its Windows receipt.
