### PR TITLE
Verify mixed writes in the historical browser storage corpus

### DIFF
--- a/packages/jazz-tools/tests/browser/indexeddb-jazz-compat.test.ts
+++ b/packages/jazz-tools/tests/browser/indexeddb-jazz-compat.test.ts
@@ -25,7 +25,11 @@ import {
   INDEXEDDB_STORAGE_MANIFEST_STORE,
   IndexedDbPageStore,
 } from "../../src/runtime/indexeddb-page-store.js";
-import { getJazzServerInfo } from "./testing-server.js";
+import {
+  blockJazzServerNetwork,
+  getJazzServerInfo,
+  unblockJazzServerNetwork,
+} from "./testing-server.js";
 import { sleep, TestCleanup, uniqueDbName, withTimeout } from "./support.js";
 
 const app = s.defineApp({
@@ -184,32 +188,42 @@ describe("browser Jazz storage compatibility corpus", () => {
       rawAfterReadOnlyInspection[INDEXEDDB_BTREE_PAGES_STORE],
     );
 
-    db = await openPersistentDb(config);
-    expect(await trackPhysicalDatabase(dbName)).toBe(physicalDbName);
-    const mixedMain = await db.all(app.documents, inspectorLocalQueryOptions({ branch: "main" }));
-    const mixedDraft = await db.all(app.documents, inspectorLocalQueryOptions({ branch: "draft" }));
-    const mixedProjects = await db.all(app.projects, inspectorLocalQueryOptions({}));
-    expect(mixedMain).toHaveLength(2);
-    expect(mixedMain).toEqual(expect.arrayContaining(reopenedMain));
-    expect(mixedMain).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          title: "current writer document",
-          branch: "main",
-          body: currentBody,
-        }),
-      ]),
-    );
-    expect(mixedDraft).toEqual(reopenedDraft);
-    expect(mixedProjects).toHaveLength(historicalProjects.length + 1);
-    expect(mixedProjects).toEqual(expect.arrayContaining(historicalProjects));
-    const currentProject = mixedProjects.find(
-      (project) => project.name === "current writer project",
-    );
-    expect(currentProject).toBeDefined();
-    expect(
-      mixedMain.find((document) => document.title === "current writer document")?.projectId,
-    ).toBe(currentProject!.id);
+    // Network isolation makes this a persistence receipt: the server cannot
+    // repair lost current pages before the post-reopen assertions.
+    await blockJazzServerNetwork(server.serverUrl);
+    try {
+      db = await openPersistentDb(config);
+      expect(await trackPhysicalDatabase(dbName)).toBe(physicalDbName);
+      const mixedMain = await db.all(app.documents, inspectorLocalQueryOptions({ branch: "main" }));
+      const mixedDraft = await db.all(
+        app.documents,
+        inspectorLocalQueryOptions({ branch: "draft" }),
+      );
+      const mixedProjects = await db.all(app.projects, inspectorLocalQueryOptions({}));
+      expect(mixedMain).toHaveLength(2);
+      expect(mixedMain).toEqual(expect.arrayContaining(reopenedMain));
+      expect(mixedMain).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            title: "current writer document",
+            branch: "main",
+            body: currentBody,
+          }),
+        ]),
+      );
+      expect(mixedDraft).toEqual(reopenedDraft);
+      expect(mixedProjects).toHaveLength(historicalProjects.length + 1);
+      expect(mixedProjects).toEqual(expect.arrayContaining(historicalProjects));
+      const currentProject = mixedProjects.find(
+        (project) => project.name === "current writer project",
+      );
+      expect(currentProject).toBeDefined();
+      expect(
+        mixedMain.find((document) => document.title === "current writer document")?.projectId,
+      ).toBe(currentProject!.id);
+    } finally {
+      await unblockJazzServerNetwork(server.serverUrl);
+    }
   }, 90_000);
 
   it("rejects a corrupt durable epoch before handing a public Jazz handle to the app", async () => {

--- a/packages/jazz-tools/tests/browser/indexeddb-jazz-compat.test.ts
+++ b/packages/jazz-tools/tests/browser/indexeddb-jazz-compat.test.ts
@@ -150,6 +150,66 @@ describe("browser Jazz storage compatibility corpus", () => {
     expect(normalizeRuntimeLeaseRecords(plantedLeaseRegression)).not.toEqual(
       normalizeRuntimeLeaseRecords(rawAfterReadOnlyInspection),
     );
+
+    // Append with today's writer only after the historical read-only/raw-byte
+    // receipt above. Both generations must survive a fresh public open of
+    // this same authenticated principal root.
+    db = await openPersistentDb(config);
+    const historicalProjects = await db.all(app.projects, inspectorLocalQueryOptions({}));
+    const currentBody = "current writer large value ".repeat(12_000);
+    const currentWrite = await db.transaction((tx) => {
+      const project = tx.insert(app.projects, { name: "current writer project" });
+      const document = tx.insert(
+        app.documents,
+        {
+          branch: "main",
+          title: "current writer document",
+          projectId: project.id,
+          body: currentBody,
+        },
+        { branch: "main" },
+      );
+      return { project, document };
+    });
+    await withTimeout(
+      currentWrite.wait({ tier: "local" }),
+      10_000,
+      "current corpus write did not settle locally",
+    );
+    await db.shutdown();
+    openDbs.splice(openDbs.indexOf(db), 1);
+    await sleep(100);
+    const rawAfterCurrentWrite = await rawRecords(physicalDbName);
+    expect(rawAfterCurrentWrite[INDEXEDDB_BTREE_PAGES_STORE]).not.toEqual(
+      rawAfterReadOnlyInspection[INDEXEDDB_BTREE_PAGES_STORE],
+    );
+
+    db = await openPersistentDb(config);
+    expect(await trackPhysicalDatabase(dbName)).toBe(physicalDbName);
+    const mixedMain = await db.all(app.documents, inspectorLocalQueryOptions({ branch: "main" }));
+    const mixedDraft = await db.all(app.documents, inspectorLocalQueryOptions({ branch: "draft" }));
+    const mixedProjects = await db.all(app.projects, inspectorLocalQueryOptions({}));
+    expect(mixedMain).toHaveLength(2);
+    expect(mixedMain).toEqual(expect.arrayContaining(reopenedMain));
+    expect(mixedMain).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "current writer document",
+          branch: "main",
+          body: currentBody,
+        }),
+      ]),
+    );
+    expect(mixedDraft).toEqual(reopenedDraft);
+    expect(mixedProjects).toHaveLength(historicalProjects.length + 1);
+    expect(mixedProjects).toEqual(expect.arrayContaining(historicalProjects));
+    const currentProject = mixedProjects.find(
+      (project) => project.name === "current writer project",
+    );
+    expect(currentProject).toBeDefined();
+    expect(
+      mixedMain.find((document) => document.title === "current writer document")?.projectId,
+    ).toBe(currentProject!.id);
   }, 90_000);
 
   it("rejects a corrupt durable epoch before handing a public Jazz handle to the app", async () => {


### PR DESCRIPTION
🤖 Extend the existing #2308 historical browser Jazz corpus with mixed historical/current writes and an offline reopen receipt.

Before, the corpus installed and read the pinned historical root but did not prove that today's writer could append to it and preserve both generations across reopening. This slice adds a current project and large document in one transaction, waits for local durability, closes the database, blocks server HTTP/WebSocket access and reopens the same authenticated physical root. It checks the old main/draft/project state alongside the new document, large body and project reference.

The historical fixture, producer metadata and checksums remain unchanged. Existing raw/read-only inspection runs before the append. This is acceptance coverage, with no production codec or runtime changes.

Current checkpoint7bc3b05c67 on ab976caee4: sealed artifact producer and Jazz Tools build passed; real-Chromium corpus passed2/2 with offline reopening. Independent test-design review found no actionable findings. Reinstalling the historical root immediately before offline reopen produces the expected lost-append failure (one main row instead of two); restoring the source returns2/2 passing. The coordinator independently rebuilt artifacts and reran the real Chromium corpus:2/2 passed. Fresh GitHub CI remains required.

This does not close #2308: explicit page/authoritative-payload corruption, additional history/catalogue/profile receipts and dedicated storage-compat partition registration remain. The final chosen descriptor/V1 representation still needs the complete corpus rerun under #2461/#2160.
