### PR TITLE
Preserve artifact source identity across Windows and nested source directories

### DIFF
--- a/dev/artifacts/provenance.mjs
+++ b/dev/artifacts/provenance.mjs
@@ -229,7 +229,8 @@ function trackedInputContents(root, paths) {
       const blob = objects.stdout.subarray(offset, offset + size);
       const working = readFileSync(join(root, path));
       const onlyExpectedLineEndings =
-        crlfSmudge && Buffer.from(working.toString("latin1").replaceAll("\r\n", "\n")).equals(blob);
+        crlfSmudge &&
+        Buffer.from(working.toString("latin1").replaceAll("\r\n", "\n"), "latin1").equals(blob);
       // A Git clean filter can hide bytes that the compiler will still read.
       // The index blob is authoritative only when the worktree matches it, or
       // when core.autocrlf accounts for the entire difference.

--- a/dev/artifacts/provenance.mjs
+++ b/dev/artifacts/provenance.mjs
@@ -108,7 +108,7 @@ function files(root, paths) {
         visit(child);
       }
     else if (stat.isFile()) {
-      const repoPath = relative(root, path);
+      const repoPath = relative(root, path).replaceAll("\\", "/");
       if (
         repoPath.endsWith(".node") ||
         repoPath.endsWith(".jazz-artifact-manifest.json") ||
@@ -148,7 +148,7 @@ function trackedFiles(root, paths) {
     const path = resolve(root, rawPath);
     if (relative(root, path).startsWith("..") || !existsSync(path) || !statSync(path).isFile())
       continue;
-    const repoPath = relative(root, path);
+    const repoPath = relative(root, path).replaceAll("\\", "/");
     if (
       repoPath.endsWith(".node") ||
       repoPath.endsWith(".jazz-artifact-manifest.json") ||
@@ -171,39 +171,77 @@ function trackedFiles(root, paths) {
 // to have a different ABI. Dirty files remain working-tree inputs so local
 // edits still invalidate the provenance they produced.
 function trackedInputContents(root, paths) {
-  const dirty = spawnSync("git", ["diff", "--name-only", "-z", "HEAD", "--", ...paths], {
+  const repository = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
     cwd: root,
-    encoding: "buffer",
+    encoding: "utf8",
   });
-  if (dirty.status !== 0)
+  if (repository.status !== 0 || repository.stdout.trim() !== "true")
     return new Map(paths.map((path) => [path, readFileSync(join(root, path))]));
-  const dirtyPaths = new Set(dirty.stdout.toString("utf8").split("\0").filter(Boolean));
-  const cleanPaths = paths.filter((path) => !dirtyPaths.has(path));
-  const objects = spawnSync("git", ["cat-file", "--batch"], {
+  const autocrlf = spawnSync("git", ["config", "--bool", "core.autocrlf"], {
     cwd: root,
-    input: Buffer.from(cleanPaths.map((path) => `:${path}\n`).join("")),
-    encoding: "buffer",
+    encoding: "utf8",
   });
-  if (objects.status !== 0)
-    return new Map(paths.map((path) => [path, readFileSync(join(root, path))]));
+  const crlfSmudge = autocrlf.status === 0 && autocrlf.stdout.trim().toLowerCase() === "true";
 
-  const contents = new Map();
-  let offset = 0;
-  for (const path of cleanPaths) {
-    const end = objects.stdout.indexOf(0x0a, offset);
-    const header = end === -1 ? "" : objects.stdout.subarray(offset, end).toString("utf8");
-    const match = /^[a-f0-9]+ blob (\d+)$/.exec(header);
-    if (!match) {
-      contents.set(path, readFileSync(join(root, path)));
-      offset = end === -1 ? objects.stdout.length : end + 1;
-      continue;
-    }
-    const size = Number(match[1]);
-    offset = end + 1;
-    contents.set(path, objects.stdout.subarray(offset, offset + size));
-    offset += size + 1;
+  const dirtyPaths = new Set();
+  for (const args of [
+    ["diff", "--name-only", "-z", "--cached", "HEAD", "--", ...paths],
+    ["diff", "--name-only", "-z", "--", ...paths],
+  ]) {
+    const dirty = spawnSync("git", args, { cwd: root, encoding: "buffer" });
+    if (dirty.status !== 0) throw new Error("artifact provenance: could not inspect dirty inputs");
+    for (const path of dirty.stdout.toString("utf8").split("\0")) if (path) dirtyPaths.add(path);
   }
-  for (const path of dirtyPaths) contents.set(path, readFileSync(join(root, path)));
+  const cleanPaths = paths.filter(
+    (path) => !dirtyPaths.has(path) && !lstatSync(join(root, path)).isSymbolicLink(),
+  );
+  const contents = new Map();
+  const batchLimit = 256 * 1024;
+  for (let start = 0; start < cleanPaths.length; ) {
+    let bytes = 0;
+    let end = start;
+    while (end < cleanPaths.length) {
+      const size = lstatSync(join(root, cleanPaths[end])).size;
+      if (end > start && bytes + size > batchLimit) break;
+      bytes += size;
+      end += 1;
+    }
+    const batch = cleanPaths.slice(start, end);
+    const objects = spawnSync("git", ["cat-file", "--batch"], {
+      cwd: root,
+      input: Buffer.from(batch.map((path) => `:${path}\n`).join("")),
+      encoding: "buffer",
+      maxBuffer: bytes + batch.length * 128 + 1,
+    });
+    if (objects.status !== 0)
+      throw new Error(`artifact provenance: could not read ${batch.length} clean Git inputs`);
+    let offset = 0;
+    for (const path of batch) {
+      const headerEnd = objects.stdout.indexOf(0x0a, offset);
+      const header =
+        headerEnd === -1 ? "" : objects.stdout.subarray(offset, headerEnd).toString("utf8");
+      const match = /^[a-f0-9]+ blob (\d+)$/.exec(header);
+      if (!match) throw new Error(`artifact provenance: Git input is not a blob (${path})`);
+      const size = Number(match[1]);
+      offset = headerEnd + 1;
+      if (offset + size >= objects.stdout.length)
+        throw new Error(`artifact provenance: truncated Git input (${path})`);
+      const blob = objects.stdout.subarray(offset, offset + size);
+      const working = readFileSync(join(root, path));
+      const onlyExpectedLineEndings =
+        crlfSmudge && Buffer.from(working.toString("latin1").replaceAll("\r\n", "\n")).equals(blob);
+      // A Git clean filter can hide bytes that the compiler will still read.
+      // The index blob is authoritative only when the worktree matches it, or
+      // when core.autocrlf accounts for the entire difference.
+      contents.set(path, working.equals(blob) || onlyExpectedLineEndings ? blob : working);
+      offset += size + 1;
+    }
+    if (offset !== objects.stdout.length)
+      throw new Error("artifact provenance: malformed Git input batch");
+    start = end;
+  }
+  for (const path of paths.filter((path) => !contents.has(path)))
+    contents.set(path, readFileSync(join(root, path)));
   return contents;
 }
 

--- a/dev/artifacts/provenance.mjs
+++ b/dev/artifacts/provenance.mjs
@@ -165,6 +165,48 @@ function trackedFiles(root, paths) {
   return found.sort();
 }
 
+// Git's clean tracked blobs are the portable source identity. In particular,
+// a Windows checkout may smudge those blobs to CRLF while macOS and Linux keep
+// LF; hashing working-tree bytes would make the same committed source appear
+// to have a different ABI. Dirty files remain working-tree inputs so local
+// edits still invalidate the provenance they produced.
+function trackedInputContents(root, paths) {
+  const dirty = spawnSync("git", ["diff", "--name-only", "-z", "HEAD", "--", ...paths], {
+    cwd: root,
+    encoding: "buffer",
+  });
+  if (dirty.status !== 0)
+    return new Map(paths.map((path) => [path, readFileSync(join(root, path))]));
+  const dirtyPaths = new Set(dirty.stdout.toString("utf8").split("\0").filter(Boolean));
+  const cleanPaths = paths.filter((path) => !dirtyPaths.has(path));
+  const objects = spawnSync("git", ["cat-file", "--batch"], {
+    cwd: root,
+    input: Buffer.from(cleanPaths.map((path) => `:${path}\n`).join("")),
+    encoding: "buffer",
+  });
+  if (objects.status !== 0)
+    return new Map(paths.map((path) => [path, readFileSync(join(root, path))]));
+
+  const contents = new Map();
+  let offset = 0;
+  for (const path of cleanPaths) {
+    const end = objects.stdout.indexOf(0x0a, offset);
+    const header = end === -1 ? "" : objects.stdout.subarray(offset, end).toString("utf8");
+    const match = /^[a-f0-9]+ blob (\d+)$/.exec(header);
+    if (!match) {
+      contents.set(path, readFileSync(join(root, path)));
+      offset = end === -1 ? objects.stdout.length : end + 1;
+      continue;
+    }
+    const size = Number(match[1]);
+    offset = end + 1;
+    contents.set(path, objects.stdout.subarray(offset, offset + size));
+    offset += size + 1;
+  }
+  for (const path of dirtyPaths) contents.set(path, readFileSync(join(root, path)));
+  return contents;
+}
+
 const sharedInputs = [
   "Cargo.toml",
   "Cargo.lock",
@@ -304,12 +346,10 @@ function packageInputsFingerprint(root, kind) {
     ...inputsFor[kind],
     ...workspaceDependencyInputs(root, kind),
   ]);
+  const contents = trackedInputContents(root, trackedInputs);
   const inputHash = createHash("sha256");
   for (const path of trackedInputs) {
-    inputHash
-      .update(`${path}\0`)
-      .update(readFileSync(join(root, path)))
-      .update("\0");
+    inputHash.update(`${path}\0`).update(contents.get(path)).update("\0");
   }
   return inputHash.digest("hex");
 }
@@ -382,10 +422,14 @@ export function nativeArtifactFingerprint(root, kind, profile, targetOverride) {
     kind === "napi"
       ? ["crates/jazz-napi/index.cjs", "crates/jazz-napi/index.mjs"]
       : ["packages/jazz-tools/src/types/jazz-wasm.d.ts"];
+  const surfaceContents = trackedInputContents(
+    root,
+    surface.filter((path) => existsSync(join(root, path))),
+  );
   const surfaceHash = createHash("sha256");
   for (const path of surface) {
     surfaceHash.update(`${path}\0`);
-    surfaceHash.update(existsSync(join(root, path)) ? readFileSync(join(root, path)) : "missing");
+    surfaceHash.update(surfaceContents.get(path) ?? "missing");
     surfaceHash.update("\0");
   }
   return sha256(`${packageInputs}\0${surfaceHash.digest("hex")}`);

--- a/dev/artifacts/provenance.test.mjs
+++ b/dev/artifacts/provenance.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import test from "node:test";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -389,6 +389,72 @@ test("clean CRLF checkout retains the committed NAPI ABI identity", () =>
     writeFileSync(join(root, "crates/jazz-napi/src/lib.rs"), "// planted dirty source\r\n");
     assert.notEqual(nativeArtifactFingerprint(root, "napi", "release"), baseline);
     rmSync(root, { recursive: true, force: true });
+  }));
+
+test("NAPI provenance batches real-size CRLF inputs without masking staged or dirty sources", () =>
+  withRepositoryGitProvenance(() => {
+    const root = fixture();
+    const source = join(root, "crates/jazz-napi/src/lib.rs");
+    writeFileSync(source, "// real-size provenance input\n".repeat(60_000));
+    git(root, ["init", "--quiet"]);
+    git(root, ["config", "user.email", "tests@example.invalid"]);
+    git(root, ["config", "user.name", "Jazz tests"]);
+    git(root, ["add", "."]);
+    git(root, ["commit", "--quiet", "-m", "fixture"]);
+    const baseline = nativeArtifactFingerprint(root, "napi", "release");
+
+    git(root, ["config", "core.autocrlf", "true"]);
+    rmSync(source);
+    git(root, ["checkout", "--", "crates/jazz-napi/src/lib.rs"]);
+    assert.match(readFileSync(source, "utf8"), /\r\n/);
+    assert.equal(nativeArtifactFingerprint(root, "napi", "release"), baseline);
+
+    const original = readFileSync(source);
+    writeFileSync(source, "// staged replacement\r\n");
+    git(root, ["add", "crates/jazz-napi/src/lib.rs"]);
+    const staged = nativeArtifactFingerprint(root, "napi", "release");
+    writeFileSync(source, original);
+    assert.notEqual(nativeArtifactFingerprint(root, "napi", "release"), staged);
+    rmSync(root, { recursive: true, force: true });
+  }));
+
+test("NAPI provenance reads compiler-visible symlink and clean-filter source bytes", () =>
+  withRepositoryGitProvenance(() => {
+    const root = fixture();
+    const source = join(root, "crates/jazz-napi/src/lib.rs");
+    const target = join(root, "shared-source.rs");
+    writeFileSync(target, "// source A\n");
+    rmSync(source);
+    symlinkSync("../../../shared-source.rs", source);
+    git(root, ["init", "--quiet"]);
+    git(root, ["config", "user.email", "tests@example.invalid"]);
+    git(root, ["config", "user.name", "Jazz tests"]);
+    git(root, ["add", "."]);
+    git(root, ["commit", "--quiet", "-m", "symlink fixture"]);
+    const symlinkBaseline = nativeArtifactFingerprint(root, "napi", "release");
+    writeFileSync(target, "// source B\n");
+    assert.notEqual(nativeArtifactFingerprint(root, "napi", "release"), symlinkBaseline);
+    rmSync(root, { recursive: true, force: true });
+
+    const filtered = fixture();
+    const filteredSource = join(filtered, "crates/jazz-napi/src/lib.rs");
+    writeFileSync(filteredSource, "pub const FLAG: bool = true;\n");
+    writeFileSync(join(filtered, ".gitattributes"), "crates/jazz-napi/src/lib.rs filter=review\n");
+    git(filtered, ["init", "--quiet"]);
+    git(filtered, ["config", "user.email", "tests@example.invalid"]);
+    git(filtered, ["config", "user.name", "Jazz tests"]);
+    git(filtered, ["config", "filter.review.clean", "sed s/false/true/g"]);
+    git(filtered, ["config", "filter.review.smudge", "cat"]);
+    git(filtered, ["add", "."]);
+    git(filtered, ["commit", "--quiet", "-m", "filtered fixture"]);
+    const filterBaseline = nativeArtifactFingerprint(filtered, "napi", "release");
+    writeFileSync(filteredSource, "pub const FLAG: bool = false;\n");
+    assert.equal(
+      execFileSync("git", ["diff", "--name-only", "HEAD"], { cwd: filtered, encoding: "utf8" }),
+      "",
+    );
+    assert.notEqual(nativeArtifactFingerprint(filtered, "napi", "release"), filterBaseline);
+    rmSync(filtered, { recursive: true, force: true });
   }));
 
 test("tracked NAPI bootstrap changes invalidate sealed provenance and its ABI fingerprint", () => {

--- a/dev/artifacts/provenance.test.mjs
+++ b/dev/artifacts/provenance.test.mjs
@@ -369,6 +369,28 @@ test("native fingerprints agree across clean worktree locations", () => {
   assert.equal(nativeArtifactFingerprint(first, "napi"), nativeArtifactFingerprint(second, "napi"));
 });
 
+test("clean CRLF checkout retains the committed NAPI ABI identity", () =>
+  withRepositoryGitProvenance(() => {
+    const root = fixture();
+    git(root, ["init", "--quiet"]);
+    git(root, ["config", "user.email", "tests@example.invalid"]);
+    git(root, ["config", "user.name", "Jazz tests"]);
+    git(root, ["add", "."]);
+    git(root, ["commit", "--quiet", "-m", "fixture"]);
+    const baseline = nativeArtifactFingerprint(root, "napi", "release");
+
+    git(root, ["config", "core.autocrlf", "true"]);
+    const source = join(root, "crates/jazz-napi/src/lib.rs");
+    rmSync(source);
+    git(root, ["checkout", "--", "crates/jazz-napi/src/lib.rs"]);
+    assert.match(readFileSync(source, "utf8"), /\r\n/);
+    assert.equal(nativeArtifactFingerprint(root, "napi", "release"), baseline);
+
+    writeFileSync(join(root, "crates/jazz-napi/src/lib.rs"), "// planted dirty source\r\n");
+    assert.notEqual(nativeArtifactFingerprint(root, "napi", "release"), baseline);
+    rmSync(root, { recursive: true, force: true });
+  }));
+
 test("tracked NAPI bootstrap changes invalidate sealed provenance and its ABI fingerprint", () => {
   const root = fixture();
   const bootstrap = join(root, "crates/jazz-napi/native-binding.cjs");

--- a/dev/artifacts/provenance.test.mjs
+++ b/dev/artifacts/provenance.test.mjs
@@ -395,7 +395,7 @@ test("NAPI provenance batches real-size CRLF inputs without masking staged or di
   withRepositoryGitProvenance(() => {
     const root = fixture();
     const source = join(root, "crates/jazz-napi/src/lib.rs");
-    writeFileSync(source, "// real-size provenance input\n".repeat(60_000));
+    writeFileSync(source, "// real-size provenance π input\n".repeat(60_000));
     git(root, ["init", "--quiet"]);
     git(root, ["config", "user.email", "tests@example.invalid"]);
     git(root, ["config", "user.name", "Jazz tests"]);

--- a/dev/gates/source-identity.mjs
+++ b/dev/gates/source-identity.mjs
@@ -44,6 +44,28 @@ function filteredRecords(buffer, pathspecs, pathFromRecord = (record) => record)
   );
 }
 
+// Git reports an untracked nested repository as one directory entry, even
+// without --directory. Expand its tracked and untracked source files rather
+// than reading the directory as a file or silently omitting its contents.
+function untrackedContent(root, relative, excludePathspecs, ancestors = new Set()) {
+  const absolute = path.join(root, relative);
+  if (!fs.statSync(absolute).isDirectory()) return fs.readFileSync(absolute);
+  const real = fs.realpathSync(absolute);
+  if (ancestors.has(real)) throw new Error("source identity: cyclic directory input");
+  const nextAncestors = new Set([...ancestors, real]);
+  const entries = git(absolute, ["ls-files", "--cached", "--others", "--exclude-standard", "-z"])
+    .toString("utf8").split("\0").filter(Boolean).sort();
+  const hash = crypto.createHash("sha256");
+  for (const entry of entries) {
+    const child = path.posix.join(relative, entry);
+    if (excluded(child, excludePathspecs)) continue;
+    const content = untrackedContent(root, child, excludePathspecs, nextAncestors);
+    hash.update(Buffer.byteLength(entry).toString()).update("\0").update(entry).update("\0");
+    hash.update(content.length.toString()).update("\0").update(content).update("\0");
+  }
+  return Buffer.from(`directory\0${hash.digest("hex")}`);
+}
+
 // This intentionally stores only opaque hashes. It distinguishes the checked
 // out HEAD tree, index tree, unstaged patch, and every untracked path/content
 // pair without placing source text or filenames in a receipt.
@@ -89,7 +111,7 @@ export function sourceIdentity(root, { excludePathspecs = [] } = {}) {
     .filter(Boolean);
   const untrackedHash = crypto.createHash("sha256");
   for (const relative of untracked) {
-    const content = fs.readFileSync(path.join(root, relative));
+    const content = untrackedContent(root, relative, excludePathspecs);
     untrackedHash
       .update(Buffer.byteLength(relative).toString())
       .update("\0")

--- a/dev/gates/source-identity.mjs
+++ b/dev/gates/source-identity.mjs
@@ -54,7 +54,10 @@ function untrackedContent(root, relative, excludePathspecs, ancestors = new Set(
   if (ancestors.has(real)) throw new Error("source identity: cyclic directory input");
   const nextAncestors = new Set([...ancestors, real]);
   const entries = git(absolute, ["ls-files", "--cached", "--others", "--exclude-standard", "-z"])
-    .toString("utf8").split("\0").filter(Boolean).sort();
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)
+    .sort();
   const hash = crypto.createHash("sha256");
   for (const entry of entries) {
     const child = path.posix.join(relative, entry);

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1329,7 +1329,7 @@ test("CI runs the workflow contract test through its package script", () => {
   const lint = job("lint");
   assert.equal(
     packageJson.scripts["test:ci-workflow"],
-    "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/docs-vercel-preview.test.mjs dev/gates/test/local-ci-equivalent.test.mjs dev/gates/test/ci-tool-bundle.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs dev/gates/test/jazz-rn-packaging.test.mjs dev/artifacts/provenance.test.mjs dev/artifacts/wasm-build-contract.test.mjs dev/artifacts/napi-build-contract.test.mjs dev/artifacts/release-staging-contract.test.mjs dev/artifacts/test-artifact-store.test.mjs && node dev/gates/ignored-tests.mjs --self-test",
+    "node --test dev/gates/test/source-identity.test.mjs dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/docs-vercel-preview.test.mjs dev/gates/test/local-ci-equivalent.test.mjs dev/gates/test/ci-tool-bundle.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs dev/gates/test/jazz-rn-packaging.test.mjs dev/artifacts/provenance.test.mjs dev/artifacts/wasm-build-contract.test.mjs dev/artifacts/napi-build-contract.test.mjs dev/artifacts/release-staging-contract.test.mjs dev/artifacts/test-artifact-store.test.mjs && node dev/gates/ignored-tests.mjs --self-test",
   );
   assert.match(lint, /local-ci-equivalent\.mjs --ci-partition lint/);
 });

--- a/dev/gates/test/source-identity.test.mjs
+++ b/dev/gates/test/source-identity.test.mjs
@@ -69,3 +69,49 @@ test("identity reads survive a container checkout ownership boundary", () => {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+
+test("untracked nested repository sources retain tracked and untracked byte identity", () => {
+  const root = fixture();
+  try {
+    const clean = sourceIdentity(root);
+    const nested = path.join(root, "nested");
+    fs.mkdirSync(nested);
+    git(nested, ["init", "--quiet"]);
+    fs.writeFileSync(path.join(nested, "tracked.rs"), "original source");
+    git(nested, ["add", "tracked.rs"]);
+    fs.writeFileSync(path.join(nested, "untracked.rs"), "untracked source");
+    const initial = sourceIdentity(root);
+    assert.equal(initial.dirty, true);
+    assert.notEqual(initial.fingerprint, clean.fingerprint);
+    fs.writeFileSync(path.join(nested, "tracked.rs"), "changed source");
+    const changedTracked = sourceIdentity(root);
+    assert.notEqual(changedTracked.fingerprint, initial.fingerprint);
+    fs.writeFileSync(path.join(nested, "untracked.rs"), "changed untracked source");
+    assert.notEqual(sourceIdentity(root).fingerprint, changedTracked.fingerprint);
+    fs.rmSync(nested, { recursive: true });
+    assert.equal(sourceIdentity(root).fingerprint, clean.fingerprint);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("nested repository identity applies root-relative exclusions at every depth", () => {
+  const root = fixture();
+  try {
+    const nested = path.join(root, "nested", "deeper");
+    fs.mkdirSync(nested, { recursive: true });
+    git(path.join(root, "nested"), ["init", "--quiet"]);
+    git(nested, ["init", "--quiet"]);
+    fs.writeFileSync(path.join(nested, "source.rs"), "source");
+    fs.writeFileSync(path.join(nested, "generated.bin"), "first output");
+    const options = { excludePathspecs: ["nested/**/generated.bin"] };
+    const before = sourceIdentity(root, options);
+    fs.writeFileSync(path.join(nested, "generated.bin"), "second output");
+    assert.equal(sourceIdentity(root, options).fingerprint, before.fingerprint);
+    fs.writeFileSync(path.join(nested, "source.rs"), "changed source");
+    assert.notEqual(sourceIdentity(root, options).fingerprint, before.fingerprint);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/dev/gates/test/source-identity.test.mjs
+++ b/dev/gates/test/source-identity.test.mjs
@@ -70,7 +70,6 @@ test("identity reads survive a container checkout ownership boundary", () => {
   }
 });
 
-
 test("untracked nested repository sources retain tracked and untracked byte identity", () => {
   const root = fixture();
   try {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:vercel-preview-skip": "node --test dev/scripts/skip-new-core-vercel-preview.test.mjs",
     "test:turbo-cache-inputs": "node dev/gates/test/turbo-cache-inputs.test.mjs",
     "test:tooling:real": "sh dev/scripts/clippy-staged.real.test.sh",
-    "test:ci-workflow": "node --test dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/docs-vercel-preview.test.mjs dev/gates/test/local-ci-equivalent.test.mjs dev/gates/test/ci-tool-bundle.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs dev/gates/test/jazz-rn-packaging.test.mjs dev/artifacts/provenance.test.mjs dev/artifacts/wasm-build-contract.test.mjs dev/artifacts/napi-build-contract.test.mjs dev/artifacts/release-staging-contract.test.mjs dev/artifacts/test-artifact-store.test.mjs && node dev/gates/ignored-tests.mjs --self-test",
+    "test:ci-workflow": "node --test dev/gates/test/source-identity.test.mjs dev/gates/test/ci-rust-throughput.test.mjs dev/gates/test/docs-vercel-preview.test.mjs dev/gates/test/local-ci-equivalent.test.mjs dev/gates/test/ci-tool-bundle.test.mjs dev/gates/test/test-artifact-pipeline.test.mjs dev/gates/test/release-gates.test.mjs dev/gates/test/jazz-rn-packaging.test.mjs dev/artifacts/provenance.test.mjs dev/artifacts/wasm-build-contract.test.mjs dev/artifacts/napi-build-contract.test.mjs dev/artifacts/release-staging-contract.test.mjs dev/artifacts/test-artifact-store.test.mjs && node dev/gates/ignored-tests.mjs --self-test",
     "ensure:rust-toolchain": "rustup target add wasm32-unknown-unknown && (wasm-pack --version >/dev/null 2>&1 || cargo install wasm-pack@0.13.1 --locked)",
     "build:vercel-docs": "pnpm --filter docs build",
     "build:vercel-inspector": "pnpm --filter inspector run build:vercel",


### PR DESCRIPTION
🤖 Keep native artifact source identity consistent across Windows and Unix while preserving invalidation for real source edits, including nested source repositories.

Previously, Windows checkout line endings produced a different fingerprint for the same clean Git tree, preventing cross-platform release artifact assembly. Separately, Git can report an untracked nested repository as a directory; treating it as a file made provenance fail with EISDIR.

The implementation recognizes exact clean checkout line-ending conversion, hashes compiler-visible edits and filter/symlink inputs, and recursively fingerprints nested source directories with Git exclusions. For example, a clean CRLF checkout agrees with its Unix counterpart, but staged or unstaged edits change identity. Editing an included nested file also changes identity, while ignored untracked files stay excluded. Read errors and cycles fail closed. No database storage bytes or artifact compatibility checks are weakened.

Final revision787d40d68f: coordinator canonical contracts185/185 and ignored-test selfcheck passed; GitHub CI is green. Independent review passed22 source/pipeline tests and5 adversarial directory probes; planted omission regressions failed as intended. Earlier Windows-specific review passed20 tests and7 controls.

Official dry-run33921820883 at the preceding Windows checkpoint f35c9fd10c passed all platform builds, including Windows NAPI, cross-platform npm assembly, and packaged RN consumers. Its later dry-run tarball check failed because it still expects the retired index.js loader; that separate release-check repair is in progress. This is not an exact787 full release receipt.

Known tooling limitation: an unstaged deletion of a nested tracked file fails closed with raw ENOENT. This does not permit stale artifact reuse. User approval is required before merge.
