### PR TITLE
Verify current packed NAPI loaders in release dry runs

### DIFF
--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -635,10 +635,7 @@ jobs:
           TMP_DIR=$(mktemp -d)
           pnpm --filter jazz-napi pack --pack-destination "${TMP_DIR}"
           TARBALL=$(ls "${TMP_DIR}"/jazz-napi-*.tgz | head -n 1)
-          tar -tf "${TARBALL}" | grep -q "package/index.js"
-          tar -tf "${TARBALL}" | grep -q "package/index.d.ts"
-          tar -xOf "${TARBALL}" package/package.json | node -e 'let s="";process.stdin.on("data",(d)=>s+=d);process.stdin.on("end",()=>{const p=JSON.parse(s);const optional=p.optionalDependencies||{};for(const [name,version] of Object.entries(optional)){if(typeof version==="string"&&version.startsWith("workspace:")){throw new Error(`optionalDependencies.${name} uses workspace protocol (${version}) in packed manifest`);}}for(const name of ["@garden-co/jazz-napi-linux-x64-gnu","@garden-co/jazz-napi-darwin-x64","@garden-co/jazz-napi-darwin-arm64","@garden-co/jazz-napi-win32-x64-msvc"]){if(!optional[name]){throw new Error(`missing optional dependency ${name} in packed manifest`);}}console.log(`Packed manifest OK for ${p.name}@${p.version}`);});'
-          tar -xOf "${TARBALL}" package/index.js | node -e 'let s="";process.stdin.on("data",(d)=>s+=d);process.stdin.on("end",()=>{const unscoped=[...s.matchAll(/require\((["\x27])((?!\.\/)jazz-napi-[^"\x27)]+)\1\)/g)].map((m)=>m[2]);if(unscoped.length){throw new Error(`packed index.js still references unscoped native packages: ${[...new Set(unscoped)].join(", ")}`);}if(!s.includes("@garden-co")){throw new Error("packed index.js is missing the @garden-co package scope");}console.log("Packed loader uses scoped native package names");});'
+          node dev/artifacts/verify-packed-napi.mjs "${TARBALL}"
 
       - name: Verify packed jazz-rn relay payload
         env: *release-artifact-source-revision-env

--- a/dev/artifacts/release-staging-contract.test.mjs
+++ b/dev/artifacts/release-staging-contract.test.mjs
@@ -6,6 +6,7 @@ import {
   mkdtempSync,
   mkdirSync,
   readFileSync,
+  rmSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -13,6 +14,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
 import { parse } from "yaml";
+import { verifyPackedNapi } from "./verify-packed-napi.mjs";
 import { stageNapiLoader } from "./stage-napi-loader.mjs";
 import { stageNativeFingerprints } from "./stage-native-fingerprints.mjs";
 
@@ -382,3 +384,127 @@ test("alpha release preview can call the publisher without elevating nested perm
   assert.match(publisherWorkflow, /permissions:[\s\S]*?contents: write/);
   assert.match(publisherWorkflow, /if: env\.RELEASE_MODE == 'publish'/);
 });
+
+function packedNapiFixture(mutate = () => {}) {
+  const root = mkdtempSync(join(tmpdir(), "jazz-packed-napi-check-"));
+  const packageDir = join(root, "input");
+  mkdirSync(packageDir);
+  const sourceDir = join(repositoryRoot, "crates/jazz-napi");
+  const manifest = JSON.parse(readFileSync(join(sourceDir, "package.json"), "utf8"));
+  manifest.scripts = {};
+  manifest.optionalDependencies = Object.fromEntries(
+    ["linux-x64-gnu", "darwin-x64", "darwin-arm64", "win32-x64-msvc"].map((target) => [
+      `@garden-co/jazz-napi-${target}`,
+      manifest.version,
+    ]),
+  );
+  for (const name of [
+    "index.cjs",
+    "index.mjs",
+    "index.d.ts",
+    "native-binding.cjs",
+    "close-pollable.cjs",
+  ])
+    writeFileSync(join(packageDir, name), readFileSync(join(sourceDir, name)));
+  writeFileSync(
+    join(packageDir, "native-artifact-fingerprint.cjs"),
+    `module.exports = { expectedNativeArtifactFingerprint: "${fingerprint}" };`,
+  );
+  writeFileSync(
+    join(packageDir, "native-loader.cjs"),
+    Object.keys(manifest.optionalDependencies)
+      .map((name) => `require(${JSON.stringify(name)});`)
+      .join("\n"),
+  );
+  try {
+    mutate(packageDir, manifest);
+    writeFileSync(join(packageDir, "package.json"), JSON.stringify(manifest));
+    const [receipt] = JSON.parse(
+      execFileSync("npm", ["pack", "--ignore-scripts", "--json", "--pack-destination", root], {
+        cwd: packageDir,
+        encoding: "utf8",
+      }),
+    );
+    return { root, tarball: join(root, receipt.filename) };
+  } catch (error) {
+    rmSync(root, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+test("release packed NAPI verification accepts current public loaders without legacy index.js", () => {
+  const fixture = packedNapiFixture();
+  try {
+    assert.equal(verifyPackedNapi(fixture.tarball).name, "jazz-napi");
+    execFileSync(process.execPath, [
+      join(repositoryRoot, "dev/artifacts/verify-packed-napi.mjs"),
+      fixture.tarball,
+    ]);
+    const inventory = execFileSync("tar", ["-tf", fixture.tarball], { encoding: "utf8" });
+    assert.ok(!inventory.split("\n").includes("package/index.js"));
+    const workflow = readFileSync(
+      join(repositoryRoot, ".github/workflows/publish-jazz-tools-alpha.yml"),
+      "utf8",
+    );
+    const step = workflow.split("- name: Verify packed jazz-napi payload")[1].split("- name:")[0];
+    assert.match(step, /node dev\/artifacts\/verify-packed-napi\.mjs "\$\{TARBALL\}"/);
+    assert.doesNotMatch(step, /package\/index\.js/);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+for (const [name, mutate, expected] of [
+  ["missing public ESM entrypoint", (dir) => rmSync(join(dir, "index.mjs")), /missing index.mjs/],
+  [
+    "missing published loader despite legacy index.js",
+    (dir) => {
+      rmSync(join(dir, "native-loader.cjs"));
+      writeFileSync(join(dir, "index.js"), "// legacy loader @garden-co");
+    },
+    /missing native-loader.cjs/,
+  ],
+  [
+    "unscoped native loader dependency",
+    (dir) =>
+      writeFileSync(
+        join(dir, "native-loader.cjs"),
+        "require('jazz-napi-linux-x64-gnu'); // @garden-co",
+      ),
+    /unscoped native packages/,
+  ],
+  [
+    "stale manifest export",
+    (dir, manifest) => {
+      manifest.exports["."].import = "./index.js";
+    },
+    /current CJS, ESM, and type entrypoints/,
+  ],
+  [
+    "missing required native dependency",
+    (dir, manifest) => {
+      delete manifest.optionalDependencies["@garden-co/jazz-napi-win32-x64-msvc"];
+    },
+    /missing optional dependency/,
+  ],
+  [
+    "missing scoped loader branch",
+    (dir) => writeFileSync(join(dir, "native-loader.cjs"), "// @garden-co"),
+    /missing scoped native package/,
+  ],
+  [
+    "workspace optional dependency",
+    (dir, manifest) => {
+      manifest.optionalDependencies["@garden-co/jazz-napi-linux-x64-gnu"] = "workspace:*";
+    },
+    /workspace protocol/,
+  ],
+])
+  test(`release packed NAPI verification rejects ${name}`, () => {
+    const fixture = packedNapiFixture(mutate);
+    try {
+      assert.throws(() => verifyPackedNapi(fixture.tarball), expected);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });

--- a/dev/artifacts/verify-packed-napi.mjs
+++ b/dev/artifacts/verify-packed-napi.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const nativePackages = [
+  "@garden-co/jazz-napi-linux-x64-gnu",
+  "@garden-co/jazz-napi-darwin-x64",
+  "@garden-co/jazz-napi-darwin-arm64",
+  "@garden-co/jazz-napi-win32-x64-msvc",
+];
+
+/** Verify the published package boundary, not an ignored build-stage index.js. */
+export function verifyPackedNapi(tarball) {
+  const files = new Set(execFileSync("tar", ["-tf", tarball], { encoding: "utf8" }).split("\n"));
+  const read = (name) => {
+    if (!files.has(`package/${name}`)) throw new Error(`packed jazz-napi is missing ${name}`);
+    return execFileSync("tar", ["-xOf", tarball, `package/${name}`], { encoding: "utf8" });
+  };
+  const manifest = JSON.parse(read("package.json"));
+  const entry = manifest.exports?.["."];
+  if (
+    manifest.name !== "jazz-napi" ||
+    manifest.main !== "index.cjs" ||
+    manifest.types !== "index.d.ts" ||
+    entry?.require !== "./index.cjs" ||
+    entry?.import !== "./index.mjs" ||
+    entry?.types !== "./index.d.ts" ||
+    entry?.default !== "./index.cjs"
+  ) {
+    throw new Error(
+      "packed jazz-napi manifest must expose the current CJS, ESM, and type entrypoints",
+    );
+  }
+  for (const name of [
+    "index.cjs",
+    "index.mjs",
+    "index.d.ts",
+    "native-binding.cjs",
+    "close-pollable.cjs",
+    "native-artifact-fingerprint.cjs",
+  ])
+    read(name);
+  const optional = manifest.optionalDependencies ?? {};
+  for (const [name, version] of Object.entries(optional)) {
+    if (typeof version === "string" && version.startsWith("workspace:"))
+      throw new Error(`optionalDependencies.${name} uses workspace protocol in packed manifest`);
+  }
+  for (const name of nativePackages) {
+    if (!optional[name]) throw new Error(`missing optional dependency ${name} in packed manifest`);
+  }
+  const loader = read("native-loader.cjs");
+  const requests = [...loader.matchAll(/\brequire\s*\(\s*(["'])([^"']+)\1\s*\)/g)].map(
+    (match) => match[2],
+  );
+  const unscoped = requests.filter((name) => name.startsWith("jazz-napi-"));
+  if (unscoped.length)
+    throw new Error(
+      `packed native-loader.cjs references unscoped native packages: ${unscoped.join(", ")}`,
+    );
+  for (const name of nativePackages) {
+    if (!requests.includes(name))
+      throw new Error(`packed native-loader.cjs is missing scoped native package ${name}`);
+  }
+  return manifest;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    if (process.argv.length !== 3) throw new Error("usage: verify-packed-napi.mjs <tarball>");
+    const manifest = verifyPackedNapi(process.argv[2]);
+    console.log(
+      `Packed public loaders and native dependencies verified for ${manifest.name}@${manifest.version}`,
+    );
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
🤖 Repair the release dry-run's packed NAPI verification. Platform builds and package assembly succeeded, but verification still required the retired package/index.js file. The package now exposes index.cjs and index.mjs, with native package selection in native-loader.cjs.

The workflow calls a reusable verifier that checks the declared CJS/ESM/type exports, their supporting files, required native optional dependencies and actual scoped native-loader imports. A valid current tarball without index.js passes; missing entrypoints, stale exports, missing loader/dependency branches, unscoped imports and workspace dependency versions fail with specific diagnostics. Publishing behavior is unchanged.

Validation at61dac5ba59: coordinator independently passed22 release contracts, including a real packed tarball and seven planted negative fixtures. Implementation also passed184 canonical contracts and4 existing packaging contracts. Independent review is complete, including six additional real CLI/tarball checks. The coordinator reran all22 release staging contracts and those six checks on the exact committed tree; all passed with a clean worktree. Current-head CI is green. The triggering official dry-run was33921820883; this patch does not itself publish packages or establish a final release receipt.

