### PR TITLE
Fix cargo-ndk provenance in the alpha publisher

### DIFF
--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -29,6 +29,7 @@ on:
         type: string
 
 env:
+  JAZZ_RN_CARGO_NDK_VERSION: 4.1.2
   CACHE_SCOPE_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || github.repository_id }}
 
 jobs:

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -2462,6 +2462,23 @@ ${
       },
     );
 
+    // An explicitly empty pin was the release publisher's failure mode. Neither
+    // an empty expectation nor a different toolchain may accept sealed bytes.
+    for (const expectedCargoNdk of ["", "4.1.1"]) {
+      assert.throws(
+        () =>
+          execFileSync(
+            process.execPath,
+            [verifier.pathname, "--package-root", packageRoot, "android"],
+            {
+              env: { ...environment, JAZZ_NATIVE_RELAY_CARGO_NDK_VERSION: expectedCargoNdk },
+              stdio: "pipe",
+            },
+          ),
+        /Android relay manifest does not match cargo-ndk provenance/,
+      );
+    }
+
     for (const transitiveInput of ["crates/idb-tree/", "crates/jazz-compression/"]) {
       const entry = nativeSourceInventory
         .split("\n")
@@ -2987,4 +3004,33 @@ test("RN preview publishes selected packages once and device acceptance grants K
     "Assemble, launch, and require the run-bound receipt",
   );
   assert.match(android.steps[grant].run, /sudo setfacl/);
+});
+
+test("release publisher pins the same cargo-ndk provenance as native producers", async () => {
+  const workflows = await Promise.all(
+    ["build-jazz-packages", "rn-native-artifacts", "publish-jazz-tools-alpha"].map(async (name) =>
+      parse(
+        await readFile(new URL(`../../../.github/workflows/${name}.yml`, import.meta.url), "utf8"),
+      ),
+    ),
+  );
+  const producerPin = workflows[0].env.JAZZ_RN_CARGO_NDK_VERSION;
+  assert.match(producerPin, /^[0-9]+\.[0-9]+\.[0-9]+$/);
+  for (const workflow of workflows) {
+    assert.equal(workflow.env.JAZZ_RN_CARGO_NDK_VERSION, producerPin, workflow.name);
+    const packedCheck = Object.values(workflow.jobs)
+      .flatMap((job) => job.steps ?? [])
+      .find((step) => step.name === "Verify packed jazz-rn relay payload");
+    if (packedCheck) {
+      assert.match(
+        packedCheck.run,
+        /JAZZ_NATIVE_RELAY_CARGO_NDK_VERSION="\$\{JAZZ_RN_CARGO_NDK_VERSION\}"/,
+      );
+      const actual = execFileSync("bash", ["-c", 'printf "%s" "${JAZZ_RN_CARGO_NDK_VERSION}"'], {
+        env: { ...process.env, ...workflow.env, ...packedCheck.env },
+        encoding: "utf8",
+      });
+      assert.equal(actual, producerPin);
+    }
+  }
 });


### PR DESCRIPTION
🤖 The alpha preview currently fails packed Android RN verification because the publisher expands an undefined cargo-ndk version into an explicitly empty expected provenance. Pin the publisher to 4.1.2, matching both producer workflows, so genuine matching artifacts pass while empty or mismatched provenance remains rejected.

Validation: coordinator independently ran all 22 RN packaging tests successfully. Separate adversarial review passed all 22 tests and proved regression sensitivity by removing the publisher pin and independently bypassing each provenance comparison; all planted defects failed the intended tests and were restored. No native artifact or verifier relaxation is included.
