### PR TITLE
Cover overlapping live relation queries across browser reopen and reconnect

### DIFF
--- a/packages/jazz-tools/tests/browser/db.live-edge-replay.server.test.ts
+++ b/packages/jazz-tools/tests/browser/db.live-edge-replay.server.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { commands } from "vitest/browser";
 import { createDb, generateAuthSecret, type Db } from "../../src/index.js";
-import { resolveDefaultPersistentDbName } from "../../src/runtime/db.js";
 import { deploy } from "../../src/dev/catalogue.js";
 import {
   liveEdgeApp as app,
@@ -49,7 +48,11 @@ describe("live authoritative overlapping relation replay", () => {
       for (let reopen = 0; reopen < 2; reopen++) {
         const db = cleanup.track(await createDb(config));
         await assertUnrelatedRead(db);
-        const openedPhysical = resolveDefaultPersistentDbName(db.config);
+        const matchingDatabases = (await indexedDB.databases())
+          .map((entry) => entry.name)
+          .filter((name): name is string => name?.startsWith(config.driver.dbName) === true);
+        expect(matchingDatabases).toHaveLength(1);
+        const openedPhysical = matchingDatabases[0]!;
         if (reopen === 0) {
           expect(databasesBeforeOpen).not.toContain(openedPhysical);
           physical = openedPhysical;

--- a/packages/jazz-tools/tests/browser/db.live-edge-replay.server.test.ts
+++ b/packages/jazz-tools/tests/browser/db.live-edge-replay.server.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { commands } from "vitest/browser";
+import { createDb, generateAuthSecret, type Db } from "../../src/index.js";
+import { resolveDefaultPersistentDbName } from "../../src/runtime/db.js";
+import { deploy } from "../../src/dev/catalogue.js";
+import {
+  liveEdgeApp as app,
+  liveEdgePermissions,
+  type LiveEdgeSeed,
+} from "./live-edge-replay-schema.js";
+import { getJazzServerInfo, type JazzServerInfo } from "./testing-server.js";
+import { TestCleanup, uniqueDbName, waitForCondition, withTimeout } from "./support.js";
+
+interface BackendCommands {
+  liveEdgeBackendOpen(info: JazzServerInfo): Promise<LiveEdgeSeed>;
+  liveEdgeBackendInsert(appId: string, seed: LiveEdgeSeed, title: string): Promise<string>;
+  liveEdgeBackendClose(appId: string): Promise<void>;
+}
+const backend = commands as unknown as BackendCommands;
+const cleanup = new TestCleanup();
+let backendAppId: string | undefined;
+afterEach(async () => {
+  await cleanup.cleanup();
+  if (backendAppId) await backend.liveEdgeBackendClose(backendAppId);
+  backendAppId = undefined;
+});
+
+// #2363: a fresh root hydrated successfully but overlapping forward includes
+// poisoned it after a live authoritative insert. Keep both carriers active and
+// prove subsequent unrelated Edge reads work, not merely backend settlement.
+describe("live authoritative overlapping relation replay", () => {
+  it("keeps fresh, reopened and reconnected persistent roots usable after live inserts", async () => {
+    const info = await getJazzServerInfo(uniqueDbName("live-edge-replay"));
+    await deploy({ ...info, schema: app.wasmSchema, permissions: liveEdgePermissions });
+    backendAppId = info.appId;
+    const seed = await withTimeout(backend.liveEdgeBackendOpen(info), 20_000, "backend seed");
+    const expected = [seed.itemId];
+    const roots: string[] = [];
+    const secret = generateAuthSecret();
+    for (let fresh = 0; fresh < 2; fresh++) {
+      const config = {
+        appId: info.appId,
+        serverUrl: info.serverUrl,
+        secret,
+        driver: { type: "persistent" as const, dbName: uniqueDbName("live-edge-root") },
+      };
+      const databasesBeforeOpen = (await indexedDB.databases()).map((entry) => entry.name);
+      let physical: string | undefined;
+      for (let reopen = 0; reopen < 2; reopen++) {
+        const db = cleanup.track(await createDb(config));
+        await assertUnrelatedRead(db);
+        const openedPhysical = resolveDefaultPersistentDbName(db.config);
+        if (reopen === 0) {
+          expect(databasesBeforeOpen).not.toContain(openedPhysical);
+          physical = openedPhysical;
+          roots.push(openedPhysical);
+        } else {
+          expect(openedPhysical).toBe(physical);
+        }
+        const included = app.items
+          .where({ parent_id: seed.parentId })
+          .include({ author: true, label: true })
+          .orderBy("$createdAt", "desc")
+          .limit(250);
+        const plain = app.items
+          .where({ author_id: seed.authorId })
+          .orderBy("$createdAt", "desc")
+          .limit(100);
+        let includedIds: string[] = [];
+        let plainIds: string[] = [];
+        let includesComplete = false;
+        const stopIncluded = cleanup.trackSubscription(
+          db.subscribe(
+            included,
+            (rows) => {
+              includedIds = rows.map((row) => row.id);
+              includesComplete = rows.every(
+                (row) => row.author?.name === "Author" && row.label?.name === "Label",
+              );
+            },
+            { tier: "edge" },
+          ),
+        );
+        const stopPlain = cleanup.trackSubscription(
+          db.subscribe(
+            plain,
+            (rows) => {
+              plainIds = rows.map((row) => row.id);
+            },
+            { tier: "edge" },
+          ),
+        );
+        const waitForBoth = () =>
+          waitForCondition(
+            async () =>
+              includesComplete &&
+              expected.every((id) => includedIds.includes(id) && plainIds.includes(id)),
+            15_000,
+            `both overlapping carriers (root=${fresh}, reopen=${reopen})`,
+          );
+        await waitForBoth();
+        await assertUnrelatedRead(db);
+        expect((await indexedDB.databases()).map((entry) => entry.name)).toContain(physical);
+        const live = await withTimeout(
+          backend.liveEdgeBackendInsert(info.appId, seed, `live-${fresh}-${reopen}`),
+          15_000,
+          "live global insert",
+        );
+        expected.push(live);
+        await waitForBoth();
+        await assertUnrelatedRead(db);
+
+        await db.disconnect();
+        const offline = await withTimeout(
+          backend.liveEdgeBackendInsert(info.appId, seed, `offline-${fresh}-${reopen}`),
+          15_000,
+          "disconnected global insert",
+        );
+        expected.push(offline);
+        await db.reconnect();
+        await waitForBoth();
+        await assertUnrelatedRead(db);
+        const resumed = await withTimeout(
+          backend.liveEdgeBackendInsert(info.appId, seed, `resumed-${fresh}-${reopen}`),
+          15_000,
+          "resumed global insert",
+        );
+        expected.push(resumed);
+        await waitForBoth();
+        await assertUnrelatedRead(db);
+        stopIncluded();
+        stopPlain();
+        await db.shutdown();
+        cleanup.untrack(db);
+      }
+      // Retain the previous physical database when opening a genuinely new root.
+      expect((await indexedDB.databases()).map((entry) => entry.name)).toEqual(
+        expect.arrayContaining(roots),
+      );
+    }
+    expect(new Set(roots).size).toBe(2);
+  }, 120_000);
+});
+
+async function assertUnrelatedRead(db: Db): Promise<void> {
+  expect(
+    await withTimeout(
+      db.all(app.unrelated, { tier: "edge" }),
+      10_000,
+      "unrelated read after carrier delivery",
+    ),
+  ).toMatchObject([{ value: "still usable" }]);
+}

--- a/packages/jazz-tools/tests/browser/live-edge-replay-node.ts
+++ b/packages/jazz-tools/tests/browser/live-edge-replay-node.ts
@@ -1,0 +1,54 @@
+import { createJazzContext } from "../../src/backend/create-jazz-context.js";
+import {
+  liveEdgeApp as app,
+  liveEdgePermissions,
+  type LiveEdgeSeed,
+} from "./live-edge-replay-schema.js";
+import type { JazzServerInfo } from "./testing-server.js";
+
+const contexts = new Map<string, ReturnType<typeof createJazzContext>>();
+export async function liveEdgeBackendOpen(info: JazzServerInfo): Promise<LiveEdgeSeed> {
+  const context = createJazzContext({
+    ...info,
+    backendSecret: "jazz-browser-test-backend",
+    app,
+    permissions: liveEdgePermissions,
+    driver: { type: "memory" },
+    tier: "edge",
+    defaultDurabilityTier: "global",
+  });
+  contexts.set(info.appId, context);
+  const db = context.asBackend();
+  const parent = await db.insert(app.parents, { name: "Parent" }).wait({ tier: "global" });
+  const author = await db.insert(app.authors, { name: "Author" }).wait({ tier: "global" });
+  const label = await db.insert(app.labels, { name: "Label" }).wait({ tier: "global" });
+  await db.insert(app.unrelated, { value: "still usable" }).wait({ tier: "global" });
+  const seed = { parentId: parent.id, authorId: author.id, labelId: label.id, itemId: "" };
+  seed.itemId = await liveEdgeBackendInsert(info.appId, seed, "hydrated");
+  return seed;
+}
+export async function liveEdgeBackendInsert(
+  appId: string,
+  seed: LiveEdgeSeed,
+  title: string,
+): Promise<string> {
+  const context = contexts.get(appId);
+  if (!context) throw new Error("Live-edge backend was not opened");
+  const db = context.asBackend();
+  const row = await db
+    .insert(app.items, {
+      title,
+      parent_id: seed.parentId,
+      author_id: seed.authorId,
+      label_id: seed.labelId,
+    })
+    .wait({ tier: "global" });
+  const readable = await db.all(app.items.where({ id: row.id }), { tier: "global" });
+  if (readable.length !== 1) throw new Error("Globally settled backend insert is not readable");
+  return row.id;
+}
+export async function liveEdgeBackendClose(appId: string): Promise<void> {
+  const context = contexts.get(appId);
+  contexts.delete(appId);
+  await context?.shutdown();
+}

--- a/packages/jazz-tools/tests/browser/live-edge-replay-schema.ts
+++ b/packages/jazz-tools/tests/browser/live-edge-replay-schema.ts
@@ -1,0 +1,33 @@
+import { schema } from "../../src/index.js";
+
+// Name-blind public fixture for #2363's two forward-reference carriers.
+export const liveEdgeApp = schema.defineApp({
+  parents: schema.table({ name: schema.string() }),
+  authors: schema.table({ name: schema.string() }),
+  labels: schema.table({ name: schema.string() }),
+  items: schema.table({
+    title: schema.string(),
+    parent_id: schema.ref("parents"),
+    author_id: schema.ref("authors"),
+    label_id: schema.ref("labels"),
+  }),
+  unrelated: schema.table({ value: schema.string() }),
+});
+export const liveEdgePermissions = schema.definePermissions(liveEdgeApp, ({ policy }) => [
+  policy.parents.allowRead.always(),
+  policy.parents.allowInsert.always(),
+  policy.authors.allowRead.always(),
+  policy.authors.allowInsert.always(),
+  policy.labels.allowRead.always(),
+  policy.labels.allowInsert.always(),
+  policy.items.allowRead.always(),
+  policy.items.allowInsert.always(),
+  policy.unrelated.allowRead.always(),
+  policy.unrelated.allowInsert.always(),
+]);
+export interface LiveEdgeSeed {
+  parentId: string;
+  authorId: string;
+  labelId: string;
+  itemId: string;
+}

--- a/packages/jazz-tools/vitest.config.browser.ts
+++ b/packages/jazz-tools/vitest.config.browser.ts
@@ -1,3 +1,8 @@
+import {
+  liveEdgeBackendOpen,
+  liveEdgeBackendInsert,
+  liveEdgeBackendClose,
+} from "./tests/browser/live-edge-replay-node.js";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { defineConfig } from "vitest/config";
 import wasm from "vite-plugin-wasm";
@@ -106,6 +111,10 @@ export default defineConfig({
         },
       ],
       commands: {
+        liveEdgeBackendOpen: async (_context, info) => liveEdgeBackendOpen(info),
+        liveEdgeBackendInsert: async (_context, appId, seed, title) =>
+          liveEdgeBackendInsert(appId, seed, title),
+        liveEdgeBackendClose: async (_context, appId) => liveEdgeBackendClose(appId),
         jazzBrowserTopologyLog: async (_context, status, label, elapsedMs) => {
           console.info(`[jazz-browser-topology] ${status} ${label} (${elapsedMs}ms)`);
         },


### PR DESCRIPTION
🤖 Add a real Chromium regression replay for the overlapping forward-reference subscriptions reported in #2363. A synthetic backend globally settles inserts while a persistent browser keeps a parent-filtered query with two includes and an overlapping author-filtered query active.

The test covers two fresh physical databases, reopening each, twelve subsequent backend inserts across live/disconnected/reconnected phases, both referenced values, and unrelated Edge reads after delivery. It uses the existing public query APIs and browser command harness.

Validation: the implementation lane and coordinator independently pass the exact committed-head Chromium replay. Omitting one reference include fails the carrier assertion; restoring it passes. This is an input negative control, not a planted core ConflictingCommitUnit defect. The synthetic Linux Chromium sequence does not reproduce the reported failure; this does not prove every conflict scenario or macOS Electron behavior is fixed. Focused new-file typechecking and formatting pass. No production behavior or storage encoding changes.
