### PR TITLE
fix(rn): preserve local work across established relay loss

### DIFF
--- a/crates/jazz-cli/tests/cli_dry_run.rs
+++ b/crates/jazz-cli/tests/cli_dry_run.rs
@@ -87,7 +87,7 @@ fn wait_for_successful_exit(child: &mut Child, timeout: Duration) {
 }
 
 #[cfg(unix)]
-fn start_jazz_tools_server(data_dir: &Path, bound_port_file: &Path) -> Child {
+fn start_jazz_tools_server(data_dir: &Path, bound_port_file: &Path) -> (Child, u16) {
     let mut child = jazz_tools_command()
         .args([
             "server",
@@ -109,26 +109,36 @@ fn start_jazz_tools_server(data_dir: &Path, bound_port_file: &Path) -> Child {
         .expect("spawn jazz-tools server");
 
     let deadline = Instant::now() + Duration::from_secs(10);
-    while !bound_port_file.exists() {
+    let port = loop {
         if let Some(status) = child.try_wait().expect("poll jazz-tools startup") {
             panic!("jazz-tools server exited before binding: {status}");
+        }
+        if let Ok(contents) = std::fs::read_to_string(bound_port_file)
+            && let Some(port) = parse_bound_port_record(&contents)
+        {
+            break port;
         }
         if Instant::now() >= deadline {
             let _ = child.kill();
             let _ = child.wait();
-            panic!("jazz-tools server did not bind within 10s");
+            panic!("jazz-tools server did not publish a complete bound-port record within 10s");
         }
         thread::sleep(Duration::from_millis(20));
-    }
-    child
+    };
+    (child, port)
 }
 
 #[cfg(unix)]
-fn publish_empty_schema_and_wait_for_live_core(bound_port_file: &Path, data_dir: &Path) {
-    let port = std::fs::read_to_string(bound_port_file)
-        .expect("read bound port")
-        .parse::<u16>()
-        .expect("bound port is numeric");
+fn parse_bound_port_record(contents: &str) -> Option<u16> {
+    let record = contents.strip_suffix('\n')?;
+    if record.is_empty() || record.contains('\n') {
+        return None;
+    }
+    record.parse::<u16>().ok().filter(|port| *port != 0)
+}
+
+#[cfg(unix)]
+fn publish_empty_schema_and_wait_for_live_core(port: u16, data_dir: &Path) {
     let body = r#"{"schema":{"tables":{}}}"#;
     let mut stream = TcpStream::connect(("127.0.0.1", port)).expect("connect admin schema API");
     write!(
@@ -569,8 +579,8 @@ fn jazz_tools_server_sigterm_exits_cleanly_and_releases_storage() {
     let temp_dir = tempfile::tempdir().expect("create server temp dir");
     let data_dir = temp_dir.path().join("data");
     let first_port_file = temp_dir.path().join("first-port");
-    let mut first = start_jazz_tools_server(&data_dir, &first_port_file);
-    publish_empty_schema_and_wait_for_live_core(&first_port_file, &data_dir);
+    let (mut first, first_port) = start_jazz_tools_server(&data_dir, &first_port_file);
+    publish_empty_schema_and_wait_for_live_core(first_port, &data_dir);
 
     // SAFETY: `first.id()` names the live child process spawned above.
     let result = unsafe { libc::kill(first.id() as libc::pid_t, libc::SIGTERM) };
@@ -580,12 +590,28 @@ fn jazz_tools_server_sigterm_exits_cleanly_and_releases_storage() {
     // Reopening the same RocksDB directory proves controlled shutdown released
     // the process-local storage lock rather than merely stopping the listener.
     let second_port_file = temp_dir.path().join("second-port");
-    let mut second = start_jazz_tools_server(&data_dir, &second_port_file);
+    let (mut second, _second_port) = start_jazz_tools_server(&data_dir, &second_port_file);
     assert!(data_dir.join("server-shell.rocksdb").is_dir());
     // SAFETY: `second.id()` names the live child process spawned above.
     let result = unsafe { libc::kill(second.id() as libc::pid_t, libc::SIGTERM) };
     assert_eq!(result, 0, "send SIGTERM to restarted jazz-tools server");
     wait_for_successful_exit(&mut second, Duration::from_secs(10));
+}
+
+/// Bound-port readiness accepts only one complete newline-terminated numeric record.
+///
+/// This internal parser test is necessary because a process test can observe the
+/// readiness file between creation and completion, before any public network API
+/// can be contacted.
+#[cfg(unix)]
+#[test]
+fn bound_port_record_waits_for_a_complete_line() {
+    assert_eq!(parse_bound_port_record(""), None);
+    assert_eq!(parse_bound_port_record("42"), None);
+    assert_eq!(parse_bound_port_record("\n"), None);
+    assert_eq!(parse_bound_port_record("not-a-port\n"), None);
+    assert_eq!(parse_bound_port_record("0\n"), None);
+    assert_eq!(parse_bound_port_record("42000\n"), Some(42000));
 }
 
 #[test]

--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -4070,34 +4070,61 @@ impl NativeRelayWire {
 /// relay's ordinary pump. Keeping the bridge generic makes the production
 /// `WebSocketTransport` path and deterministic edge fixtures exercise exactly
 /// the same framing boundary.
-pub fn bridge_native_relay_wire_once<T: WireTransport>(
+enum NativeRelayWireBridgeError {
+    Relay(RelayError),
+    /// `WebSocketTransport` closed its outbound receiver after choosing an
+    /// established transport terminal. This is deliberately distinct from a
+    /// relay/wire liveness closure, which means the owner is gone.
+    SocketPumpClosed,
+}
+
+fn bridge_native_relay_wire_once_classified<T: WireTransport>(
     relay_wire: &NativeRelayWire,
     upstream: &mut jazz::db::WireTransportAdapter<T>,
-) -> Result<bool, RelayError> {
+) -> Result<bool, NativeRelayWireBridgeError> {
     let mut progressed = false;
-    for message in relay_wire.take_outbound()? {
-        let _live_connection = relay_wire.enter()?;
+    for message in relay_wire
+        .take_outbound()
+        .map_err(NativeRelayWireBridgeError::Relay)?
+    {
+        let _live_connection = relay_wire
+            .enter()
+            .map_err(NativeRelayWireBridgeError::Relay)?;
         upstream.send(message).map_err(|error| match error {
             // `WebSocketTransport` exposes an already-retired peer through
-            // this concrete transport state. Preserve it as `Closed` so the
-            // socket worker can reconnect; every other send error remains a
-            // terminal foreground error.
+            // this concrete transport state. Its terminal future decides
+            // whether the socket worker reconnects; every other send error
+            // remains a terminal foreground error.
             TransportError::Failed(message) if message == "websocket pump is closed" => {
-                RelayError::Closed
+                NativeRelayWireBridgeError::SocketPumpClosed
             }
-            error => RelayError::ForegroundCommand(format!("native upstream send: {error:?}")),
+            error => NativeRelayWireBridgeError::Relay(RelayError::ForegroundCommand(format!(
+                "native upstream send: {error:?}"
+            ))),
         })?;
         progressed = true;
     }
     loop {
         match upstream.try_recv() {
             Some(message) => {
-                relay_wire.push_inbound(message)?;
+                relay_wire
+                    .push_inbound(message)
+                    .map_err(NativeRelayWireBridgeError::Relay)?;
                 progressed = true;
             }
             None => return Ok(progressed),
         }
     }
+}
+
+pub fn bridge_native_relay_wire_once<T: WireTransport>(
+    relay_wire: &NativeRelayWire,
+    upstream: &mut jazz::db::WireTransportAdapter<T>,
+) -> Result<bool, RelayError> {
+    bridge_native_relay_wire_once_classified(relay_wire, upstream).map_err(|error| match error {
+        NativeRelayWireBridgeError::Relay(error) => error,
+        NativeRelayWireBridgeError::SocketPumpClosed => RelayError::Closed,
+    })
 }
 
 /// Native-owned socket lifecycle for one untrusted foreground relay scope.
@@ -4340,7 +4367,19 @@ async fn run_native_relay_socket_worker(
             }) {
                 Ok(true) => break,
                 Ok(false) | Err(RelayError::OwnerQueueFull) => {}
-                Err(_) => continue 'reconnect,
+                Err(error) => {
+                    // The socket may retry a peer transport loss, but it must
+                    // never replace a dead or failed relay owner. In
+                    // particular, preserving a poisoned storage/Db error as a
+                    // reconnect would strand strict foreground operations
+                    // without a lifecycle failure.
+                    if !cancelled.load(Ordering::Acquire) {
+                        (config.on_event)(NativeRelaySocketEvent::TerminalError(format!(
+                            "native relay upstream transition failed: {error}"
+                        )));
+                    }
+                    break 'reconnect;
+                }
             }
             tokio::select! {
                 _ = tokio::time::sleep(std::time::Duration::from_millis(1)) => {},
@@ -4362,13 +4401,23 @@ async fn run_native_relay_socket_worker(
                 (config.on_event)(NativeRelaySocketEvent::Stopped);
                 return;
             }
-            if let Err(error) = bridge_native_relay_wire_once(&lease.wire, &mut upstream) {
-                if matches!(error, RelayError::Closed) {
+            match bridge_native_relay_wire_once_classified(&lease.wire, &mut upstream) {
+                Ok(_) => {}
+                Err(NativeRelayWireBridgeError::SocketPumpClosed) => {
                     // The outbound pump is closed only after its owner has
                     // published the established transport terminal. That
                     // terminal, rather than the private queue-close marker,
                     // decides whether this outage is retryable.
-                    let terminal = terminal.await;
+                    let terminal = loop {
+                        if cancelled.load(Ordering::Acquire) {
+                            break 'reconnect;
+                        }
+                        tokio::select! {
+                            terminal = &mut terminal => break terminal,
+                            _ = wake.notified() => {},
+                            _ = tokio::time::sleep(std::time::Duration::from_millis(10)) => {},
+                        }
+                    };
                     if let NativeTransportTerminal::Failed(NativeTransportError::Terminal(error)) =
                         terminal
                     {
@@ -4376,18 +4425,25 @@ async fn run_native_relay_socket_worker(
                             "native relay socket terminated: {error}"
                         )));
                     }
-                } else {
-                    (config.on_event)(NativeRelaySocketEvent::TerminalError(format!(
-                        "native relay wire bridge failed: {error}"
-                    )));
+                    break;
                 }
-                break;
+                Err(NativeRelayWireBridgeError::Relay(error)) => {
+                    if !cancelled.load(Ordering::Acquire) {
+                        (config.on_event)(NativeRelaySocketEvent::TerminalError(format!(
+                            "native relay wire bridge failed: {error}"
+                        )));
+                    }
+                    break 'reconnect;
+                }
             }
             if let Err(error) = relay.pump() {
-                // Only the explicit closed state is the expected race with a
-                // peer teardown. Every other owner/storage/program error must
-                // remain visible as terminal to the foreground host.
-                if !matches!(error, RelayError::Closed) {
+                // Relay closure is an owner/scope lifetime boundary. It is
+                // distinct from the connection-local closure above: report it
+                // to foreground work, then stop rather than resurrecting a
+                // relay whose owner has gone away. Cancellation may race this
+                // path during intentional host teardown, for which Stopped is
+                // the only lifecycle event.
+                if !cancelled.load(Ordering::Acquire) {
                     (config.on_event)(NativeRelaySocketEvent::TerminalError(format!(
                         "native relay owner pump failed: {error}"
                     )));
@@ -6789,6 +6845,102 @@ mod tests {
                         } else {
                             Box::pin(std::future::pending())
                         },
+                    },
+                )
+            })
+        }
+
+        fn bootstrap_catalogue(
+            &self,
+            _request: NativeTransportRequest,
+        ) -> jazz::tools::native_transport_connector::NativeCatalogueBootstrapFuture {
+            Box::pin(async { panic!("ordinary relay socket must not bootstrap as Edge") })
+        }
+    }
+
+    struct ClosedPumpWire;
+
+    impl WireTransport for ClosedPumpWire {
+        fn send_frame(&mut self, _frame: Vec<u8>) -> Result<(), TransportError> {
+            // This is the private WebSocketTransport signal that its outbound
+            // pump has already selected a terminal result.
+            Err(TransportError::Failed(
+                "websocket pump is closed".to_owned(),
+            ))
+        }
+
+        fn try_recv_frame(&mut self) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
+    struct ClosedPumpTestConnector {
+        calls: AtomicUsize,
+        first_terminal: Arc<Mutex<Option<tokio::sync::oneshot::Sender<NativeTransportTerminal>>>>,
+    }
+
+    impl NativeTransportConnector for ClosedPumpTestConnector {
+        fn connect(
+            &self,
+            _request: NativeTransportRequest,
+        ) -> jazz::tools::native_transport_connector::NativeTransportFuture {
+            let call = self.calls.fetch_add(1, Ordering::AcqRel);
+            let first_terminal = Arc::clone(&self.first_terminal);
+            Box::pin(async move {
+                let terminal: jazz::tools::native_transport_connector::NativeTransportTerminalFuture =
+                    if call == 0 {
+                        let (sender, receiver) = tokio::sync::oneshot::channel();
+                        *first_terminal.lock().unwrap() = Some(sender);
+                        Box::pin(async move {
+                        receiver.await.unwrap_or(NativeTransportTerminal::OwnerDropped)
+                    })
+                    } else {
+                        Box::pin(std::future::pending())
+                    };
+                Ok(
+                    jazz::tools::native_transport_connector::ConnectedNativeTransport {
+                        transport: if call == 0 {
+                            Box::new(ClosedPumpWire)
+                        } else {
+                            Box::new(IdleWire)
+                        },
+                        protocol_version: jazz::wire::WIRE_PROTOCOL_VERSION,
+                        features: jazz::wire::current_wire_features(),
+                        session_context: None,
+                        permits_delegated_sessions: false,
+                        terminal,
+                    },
+                )
+            })
+        }
+
+        fn bootstrap_catalogue(
+            &self,
+            _request: NativeTransportRequest,
+        ) -> jazz::tools::native_transport_connector::NativeCatalogueBootstrapFuture {
+            Box::pin(async { panic!("ordinary relay socket must not bootstrap as Edge") })
+        }
+    }
+
+    struct PendingTestConnector {
+        calls: AtomicUsize,
+    }
+
+    impl NativeTransportConnector for PendingTestConnector {
+        fn connect(
+            &self,
+            _request: NativeTransportRequest,
+        ) -> jazz::tools::native_transport_connector::NativeTransportFuture {
+            self.calls.fetch_add(1, Ordering::AcqRel);
+            Box::pin(async {
+                Ok(
+                    jazz::tools::native_transport_connector::ConnectedNativeTransport {
+                        transport: Box::new(IdleWire),
+                        protocol_version: jazz::wire::WIRE_PROTOCOL_VERSION,
+                        features: jazz::wire::current_wire_features(),
+                        session_context: None,
+                        permits_delegated_sessions: false,
+                        terminal: Box::pin(std::future::pending()),
                     },
                 )
             })
@@ -11610,6 +11762,197 @@ mod tests {
         saturated.release_and_wait();
         assert_eq!(stopped.unwrap(), NativeRelaySocketEvent::Stopped);
         assert_eq!(relay.run(|worker| Ok(worker.socket_generation)).unwrap(), 0);
+    }
+
+    #[test]
+    fn closed_bridge_uses_its_owned_terminal_before_reconnecting() {
+        let directory = tempfile::tempdir().unwrap();
+        let relay = NativeRelay::spawn(config(
+            directory.path().join("closed-bridge.sqlite"),
+            Some("closed-bridge"),
+        ))
+        .unwrap();
+        let (events_tx, events_rx) = mpsc::channel();
+        let connector = Arc::new(ClosedPumpTestConnector {
+            calls: AtomicUsize::new(0),
+            first_terminal: Arc::new(Mutex::new(None)),
+        });
+        let worker = NativeRelaySocketWorker::start_with_connector(
+            relay.clone(),
+            NativeRelaySocketConfig {
+                server_url: "https://edge.example".into(),
+                app_id: AppId::from_name("closed-bridge"),
+                peer_identity: AuthorSubject::for_test_bytes([0x63; 16]),
+                auth: AuthConfig {
+                    jwt_token: Some("edge-validated-bearer".into()),
+                    ..AuthConfig::default()
+                },
+                reconnect_delay: std::time::Duration::ZERO,
+                on_event: Arc::new(move |event| {
+                    let _ = events_tx.send(event);
+                }),
+            },
+            connector.clone(),
+        )
+        .unwrap();
+        assert_eq!(
+            events_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            NativeRelaySocketEvent::Connected
+        );
+        relay
+            .run(|worker| {
+                worker
+                    .socket_wire
+                    .as_ref()
+                    .expect("first socket is installed")
+                    .outbound
+                    .lock()
+                    .unwrap()
+                    .push(
+                        SyncMessage::SessionClaims {
+                            identity: AuthorSubject::SYSTEM,
+                            claims: BTreeMap::new(),
+                        },
+                        "test closed bridge",
+                    )
+            })
+            .unwrap();
+        let terminal = connector
+            .first_terminal
+            .lock()
+            .unwrap()
+            .take()
+            .expect("first connector published its terminal sender");
+        terminal
+            .send(NativeTransportTerminal::Failed(
+                NativeTransportError::Terminal("malformed peer wire batch".into()),
+            ))
+            .unwrap();
+        assert!(matches!(
+            events_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            NativeRelaySocketEvent::TerminalError(error)
+                if error.contains("malformed peer wire batch")
+        ));
+        assert_eq!(
+            events_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            NativeRelaySocketEvent::Reconnecting
+        );
+        assert_eq!(
+            events_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            NativeRelaySocketEvent::Connected
+        );
+        worker.cancel();
+        assert_eq!(
+            events_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            NativeRelaySocketEvent::Stopped
+        );
+    }
+
+    #[test]
+    fn cancellation_does_not_wait_for_a_closed_bridge_terminal() {
+        let directory = tempfile::tempdir().unwrap();
+        let relay = NativeRelay::spawn(config(
+            directory.path().join("closed-bridge-cancel.sqlite"),
+            Some("closed-bridge-cancel"),
+        ))
+        .unwrap();
+        let (events_tx, events_rx) = mpsc::channel();
+        let connector = Arc::new(ClosedPumpTestConnector {
+            calls: AtomicUsize::new(0),
+            first_terminal: Arc::new(Mutex::new(None)),
+        });
+        let worker = NativeRelaySocketWorker::start_with_connector(
+            relay.clone(),
+            NativeRelaySocketConfig {
+                server_url: "https://edge.example".into(),
+                app_id: AppId::from_name("closed-bridge-cancel"),
+                peer_identity: AuthorSubject::for_test_bytes([0x63; 16]),
+                auth: AuthConfig {
+                    jwt_token: Some("edge-validated-bearer".into()),
+                    ..AuthConfig::default()
+                },
+                reconnect_delay: std::time::Duration::ZERO,
+                on_event: Arc::new(move |event| {
+                    let _ = events_tx.send(event);
+                }),
+            },
+            connector,
+        )
+        .unwrap();
+        assert_eq!(
+            events_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            NativeRelaySocketEvent::Connected
+        );
+        relay
+            .run(|worker| {
+                worker
+                    .socket_wire
+                    .as_ref()
+                    .expect("first socket is installed")
+                    .outbound
+                    .lock()
+                    .unwrap()
+                    .push(
+                        SyncMessage::SessionClaims {
+                            identity: AuthorSubject::SYSTEM,
+                            claims: BTreeMap::new(),
+                        },
+                        "test closed bridge cancellation",
+                    )
+            })
+            .unwrap();
+        worker.cancel();
+        assert_eq!(
+            events_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            NativeRelaySocketEvent::Stopped
+        );
+    }
+
+    #[test]
+    fn owner_close_is_terminal_and_never_resurrects_the_socket() {
+        let directory = tempfile::tempdir().unwrap();
+        let relay = NativeRelay::spawn(config(
+            directory.path().join("owner-close.sqlite"),
+            Some("owner-close"),
+        ))
+        .unwrap();
+        let (events_tx, events_rx) = mpsc::channel();
+        let connector = Arc::new(PendingTestConnector {
+            calls: AtomicUsize::new(0),
+        });
+        let worker = NativeRelaySocketWorker::start_with_connector(
+            relay.clone(),
+            NativeRelaySocketConfig {
+                server_url: "https://edge.example".into(),
+                app_id: AppId::from_name("owner-close"),
+                peer_identity: AuthorSubject::for_test_bytes([0x63; 16]),
+                auth: AuthConfig {
+                    jwt_token: Some("edge-validated-bearer".into()),
+                    ..AuthConfig::default()
+                },
+                reconnect_delay: std::time::Duration::ZERO,
+                on_event: Arc::new(move |event| {
+                    let _ = events_tx.send(event);
+                }),
+            },
+            connector.clone(),
+        )
+        .unwrap();
+        assert_eq!(
+            events_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            NativeRelaySocketEvent::Connected
+        );
+        relay.inner.shutdown().unwrap();
+        assert!(matches!(
+            events_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            NativeRelaySocketEvent::TerminalError(error) if error.contains("native relay is closed")
+        ));
+        assert_eq!(
+            events_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            NativeRelaySocketEvent::Stopped
+        );
+        assert_eq!(connector.calls.load(Ordering::Acquire), 1);
+        drop(worker);
     }
 
     #[test]

--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -4356,9 +4356,12 @@ async fn run_native_relay_socket_worker(
                 return;
             }
             if let Err(error) = bridge_native_relay_wire_once(&lease.wire, &mut upstream) {
-                (config.on_event)(NativeRelaySocketEvent::TerminalError(format!(
-                    "native relay wire bridge failed: {error}"
-                )));
+                // A closed established socket can surface first as a failed
+                // bridge send, before its terminal future wins this select.
+                // It shares the retryable reconnect path below; pre-connect
+                // authentication and protocol admission failures remain
+                // terminal above.
+                let _ = error;
                 break;
             }
             if let Err(error) = relay.pump() {

--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -4077,8 +4077,15 @@ pub fn bridge_native_relay_wire_once<T: WireTransport>(
     let mut progressed = false;
     for message in relay_wire.take_outbound()? {
         let _live_connection = relay_wire.enter()?;
-        upstream.send(message).map_err(|error| {
-            RelayError::ForegroundCommand(format!("native upstream send: {error:?}"))
+        upstream.send(message).map_err(|error| match error {
+            // `WebSocketTransport` exposes an already-retired peer through
+            // this concrete transport state. Preserve it as `Closed` so the
+            // socket worker can reconnect; every other send error remains a
+            // terminal foreground error.
+            TransportError::Failed(message) if message == "websocket pump is closed" => {
+                RelayError::Closed
+            }
+            error => RelayError::ForegroundCommand(format!("native upstream send: {error:?}")),
         })?;
         progressed = true;
     }
@@ -4361,15 +4368,22 @@ async fn run_native_relay_socket_worker(
                 // It shares the retryable reconnect path below; pre-connect
                 // authentication and protocol admission failures remain
                 // terminal above.
-                let _ = error;
+                if !matches!(error, RelayError::Closed) {
+                    (config.on_event)(NativeRelaySocketEvent::TerminalError(format!(
+                        "native relay wire bridge failed: {error}"
+                    )));
+                }
                 break;
             }
             if let Err(error) = relay.pump() {
-                // Peer teardown can invalidate the borrowed upstream while an
-                // owner turn is in flight. The reconnect owner has already
-                // retained local state; retry from a fresh socket instead of
-                // poisoning foreground-local SQLite work.
-                let _ = error;
+                // Only the explicit closed state is the expected race with a
+                // peer teardown. Every other owner/storage/program error must
+                // remain visible as terminal to the foreground host.
+                if !matches!(error, RelayError::Closed) {
+                    (config.on_event)(NativeRelaySocketEvent::TerminalError(format!(
+                        "native relay owner pump failed: {error}"
+                    )));
+                }
                 break;
             }
             tokio::select! {

--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -3969,6 +3969,30 @@ impl NativeRelayWire {
             .transpose()?;
         Ok((owner, connection))
     }
+
+    /// A retired connection is a transient transport condition: its owner may
+    /// still be detaching the old peer or installing its replacement. Keep the
+    /// owner and connection liveness domains separate so core retains outbound
+    /// work until the replacement has been installed.
+    fn enter_queue_transport(&self) -> Result<WireLivenessGuards<'_>, TransportError> {
+        let owner = self
+            .liveness
+            .as_ref()
+            .map(|l| l.enter())
+            .transpose()
+            .map_err(transport_queue_error)?;
+        let connection = match self
+            .connection_liveness
+            .as_ref()
+            .map(|l| l.enter())
+            .transpose()
+        {
+            Ok(connection) => connection,
+            Err(RelayError::Closed) => return Err(TransportError::Backpressure),
+            Err(error) => return Err(transport_queue_error(error)),
+        };
+        Ok((owner, connection))
+    }
     fn retire_connection(&self) {
         if let Some(liveness) = &self.connection_liveness {
             let _guard = liveness
@@ -4492,7 +4516,7 @@ impl Transport for QueueTransport {
         self.session_context
     }
     fn send(&mut self, message: SyncMessage) -> Result<(), TransportError> {
-        let _terminal = self.wire.enter().map_err(transport_queue_error)?;
+        let _terminal = self.wire.enter_queue_transport()?;
         self.wire
             .outbound
             .lock()
@@ -9005,6 +9029,33 @@ mod tests {
             ForegroundOperationPoll::Ready(ForegroundOperationResult::TransactionSettled(_))
         ));
         client.close().unwrap();
+    }
+
+    #[test]
+    fn retired_connection_backpressures_but_owner_close_stays_terminal() {
+        let owner = Arc::new(RelayLiveness::new());
+        let wire = NativeRelayWire::for_owner(Arc::clone(&owner));
+        let mut transport = QueueTransport {
+            wire: wire.clone(),
+            session_context: None,
+        };
+        let message = SyncMessage::SessionClaims {
+            identity: AuthorSubject::SYSTEM,
+            claims: BTreeMap::new(),
+        };
+
+        wire.retire_connection();
+        assert!(matches!(
+            transport.send(message.clone()),
+            Err(TransportError::Backpressure)
+        ));
+        assert!(matches!(wire.take_outbound(), Err(RelayError::Closed)));
+
+        owner.mark_terminal();
+        assert!(matches!(
+            transport.send(message),
+            Err(TransportError::Failed(error)) if error.contains("native relay is closed")
+        ));
     }
 
     #[test]

--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -4363,12 +4363,20 @@ async fn run_native_relay_socket_worker(
                 return;
             }
             if let Err(error) = bridge_native_relay_wire_once(&lease.wire, &mut upstream) {
-                // A closed established socket can surface first as a failed
-                // bridge send, before its terminal future wins this select.
-                // It shares the retryable reconnect path below; pre-connect
-                // authentication and protocol admission failures remain
-                // terminal above.
-                if !matches!(error, RelayError::Closed) {
+                if matches!(error, RelayError::Closed) {
+                    // The outbound pump is closed only after its owner has
+                    // published the established transport terminal. That
+                    // terminal, rather than the private queue-close marker,
+                    // decides whether this outage is retryable.
+                    let terminal = terminal.await;
+                    if let NativeTransportTerminal::Failed(NativeTransportError::Terminal(error)) =
+                        terminal
+                    {
+                        (config.on_event)(NativeRelaySocketEvent::TerminalError(format!(
+                            "native relay socket terminated: {error}"
+                        )));
+                    }
+                } else {
                     (config.on_event)(NativeRelaySocketEvent::TerminalError(format!(
                         "native relay wire bridge failed: {error}"
                     )));
@@ -4384,7 +4392,9 @@ async fn run_native_relay_socket_worker(
                         "native relay owner pump failed: {error}"
                     )));
                 }
-                break;
+                // A closed relay means its owner/scope is gone, not merely
+                // that this socket needs replacement. Never resurrect it.
+                break 'reconnect;
             }
             tokio::select! {
                 terminal = &mut terminal => {

--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -4365,9 +4365,11 @@ async fn run_native_relay_socket_worker(
                 break;
             }
             if let Err(error) = relay.pump() {
-                (config.on_event)(NativeRelaySocketEvent::TerminalError(format!(
-                    "native relay owner pump failed: {error}"
-                )));
+                // Peer teardown can invalidate the borrowed upstream while an
+                // owner turn is in flight. The reconnect owner has already
+                // retained local state; retry from a fresh socket instead of
+                // poisoning foreground-local SQLite work.
+                let _ = error;
                 break;
             }
             tokio::select! {

--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -39,7 +39,9 @@ use jazz::schema::JazzSchema;
 use jazz::storage_codec_profile::epoch_1_storage_codec_profile;
 use jazz::time::TxTime;
 use jazz::tools::AppId;
-use jazz::tools::native_transport_connector::{NativeTransportConnector, NativeTransportRequest};
+use jazz::tools::native_transport_connector::{
+    NativeTransportConnector, NativeTransportError, NativeTransportRequest, NativeTransportTerminal,
+};
 use jazz::tools::websocket_prelude_auth::AuthConfig;
 use jazz::tools::{OpenTransactionId, TransactionId};
 use jazz::tx::{DurabilityTier as CoreDurabilityTier, TxId};
@@ -4367,9 +4369,16 @@ async fn run_native_relay_socket_worker(
             }
             tokio::select! {
                 terminal = &mut terminal => {
-                    (config.on_event)(NativeRelaySocketEvent::TerminalError(format!(
-                        "native relay socket terminated: {terminal:?}"
-                    )));
+                    // An established peer loss is retryable transport state:
+                    // the ClientDb retains local work and its existing recovery
+                    // driver parks strict remote operations until replacement.
+                    // Do not poison the foreground host, which would turn a
+                    // network outage into a local SQLite failure.
+                    if let NativeTransportTerminal::Failed(NativeTransportError::Terminal(error)) = terminal {
+                        (config.on_event)(NativeRelaySocketEvent::TerminalError(format!(
+                            "native relay socket terminated: {error}"
+                        )));
+                    }
                     break;
                 },
                 _ = tokio::time::sleep(std::time::Duration::from_millis(10)) => {},
@@ -11610,15 +11619,6 @@ mod tests {
                 .recv_timeout(std::time::Duration::from_secs(1))
                 .unwrap(),
             NativeRelaySocketEvent::Connected
-        );
-        assert_eq!(
-            events_rx
-                .recv_timeout(std::time::Duration::from_secs(1))
-                .unwrap(),
-            NativeRelaySocketEvent::TerminalError(
-                "native relay socket terminated: PeerClosed(\"test close\")".to_owned()
-            ),
-            "a terminal adapter result is surfaced before retry rather than discarded"
         );
         assert_eq!(
             events_rx

--- a/crates/jazz-native-transport/src/lib.rs
+++ b/crates/jazz-native-transport/src/lib.rs
@@ -111,6 +111,13 @@ fn native_transport_error(error: WebSocketClientError) -> NativeTransportError {
             )
         }
         WebSocketClientError::HandshakeTimeout => true,
+        // An HTTP 5xx response is a typed server-unavailability result before
+        // the authenticated wire handshake. It must retry like a refused
+        // connection; 4xx responses remain terminal authorization/admission
+        // failures.
+        WebSocketClientError::Connect(tokio_tungstenite::tungstenite::Error::Http(response)) => {
+            response.status().is_server_error()
+        }
         WebSocketClientError::ServerWireError(error) => {
             error.code == jazz::wire::WireErrorCode::NotReady
                 && error.retry == jazz::wire::WireRetry::Later
@@ -898,6 +905,20 @@ mod tests {
         ));
         assert!(native_transport_error(refused).is_retryable());
         assert!(native_transport_error(WebSocketClientError::HandshakeTimeout).is_retryable());
+        for (status, retryable) in [(503, true), (401, false), (403, false), (429, false)] {
+            let response = tokio_tungstenite::tungstenite::http::Response::builder()
+                .status(status)
+                .body(None::<Vec<u8>>)
+                .unwrap();
+            assert_eq!(
+                native_transport_error(WebSocketClientError::Connect(
+                    tokio_tungstenite::tungstenite::Error::Http(Box::new(response))
+                ))
+                .is_retryable(),
+                retryable,
+                "HTTP {status} must use its typed availability category"
+            );
+        }
         for (code, retry, expected) in [
             (WireErrorCode::NotReady, WireRetry::Later, true),
             (WireErrorCode::NotReady, WireRetry::AfterAuth, false),

--- a/crates/jazz-native-transport/src/lib.rs
+++ b/crates/jazz-native-transport/src/lib.rs
@@ -775,8 +775,8 @@ async fn run_ws_pump(
                                 }
                             };
                             if let Err(error) = ws.send(Message::Binary(bytes.into())).await {
-                                return NativeTransportTerminal::Failed(NativeTransportError::Terminal(
-                                    format!("websocket send failed: {error}"),
+                                return NativeTransportTerminal::Failed(native_transport_error(
+                                    WebSocketClientError::Send(error),
                                 ));
                             }
                             batch.clear();
@@ -797,9 +797,9 @@ async fn run_ws_pump(
                         }
                     };
                     if let Err(error) = ws.send(Message::Binary(bytes.into())).await {
-                        return NativeTransportTerminal::Failed(NativeTransportError::Terminal(format!(
-                            "websocket send failed: {error}"
-                        )));
+                        return NativeTransportTerminal::Failed(native_transport_error(
+                            WebSocketClientError::Send(error),
+                        ));
                     }
                     drop(batch);
                     if outbound_backpressured.swap(false, Ordering::AcqRel) {
@@ -822,9 +822,10 @@ async fn run_ws_pump(
                             return NativeTransportTerminal::Failed(NativeTransportError::Terminal(reason));
                         }
                         Some(Err(error)) => {
-                            let reason = format!("websocket receive failed: {error}");
+                            let classified = native_transport_error(WebSocketClientError::Receive(error));
+                            let reason = classified.to_string();
                             fail_inbound(&inbound_error, &inbound_notify, &reason);
-                            return NativeTransportTerminal::Failed(NativeTransportError::Terminal(reason));
+                            return NativeTransportTerminal::Failed(classified);
                         }
                         None => {
                             let reason = "websocket peer closed before completing wire exchange"

--- a/crates/jazz-server/src/lib.rs
+++ b/crates/jazz-server/src/lib.rs
@@ -83,7 +83,10 @@ pub async fn run(
         || spawn_sigterm_shutdown_task(shutdown.clone()),
         || {
             bound_port_file.map_or(Ok(()), |path| {
-                std::fs::write(&path, bound_addr.port().to_string()).map_err(|error| {
+                // The bound-port file is a readiness record consumed by process
+                // tests. Terminate it so readers can distinguish a complete
+                // record from a file observed while its write is in progress.
+                std::fs::write(&path, format!("{}\n", bound_addr.port())).map_err(|error| {
                     std::io::Error::new(
                         error.kind(),
                         format!("failed to write bound port file {path}: {error}"),

--- a/crates/jazz/src/binding_codec.rs
+++ b/crates/jazz/src/binding_codec.rs
@@ -359,7 +359,8 @@ mod tests {
                 .unwrap(),
             descriptor,
         );
-        let cells = decode_named_cells(&encode_named_cells(&record).unwrap()).unwrap();
+        let encoded = encode_named_cells(&record).unwrap();
+        let cells = decode_named_cells(&encoded).unwrap();
         let Some(Value::Array(items)) = cells.get("payload") else {
             panic!("array payload")
         };
@@ -370,6 +371,22 @@ mod tests {
         assert_eq!(
             inner.descriptor().fields()[0].identity,
             Some(FieldIdentity::Name("literal".to_owned()))
+        );
+
+        // The recursive descriptor grammar must reject a non-minimal varint
+        // below the outer envelope as well. A top-level round-trip alone would
+        // not prove that a nested field name cannot smuggle alternate bytes.
+        let nested_name = b"literal";
+        let name_start = encoded
+            .windows(nested_name.len())
+            .position(|window| window == nested_name)
+            .expect("nested descriptor contains its field name");
+        assert_eq!(encoded[name_start - 1], nested_name.len() as u8);
+        let mut nested_nonminimal = encoded;
+        nested_nonminimal.splice(name_start - 1..name_start, [0x87, 0x00]);
+        assert!(
+            decode_named_cells(&nested_nonminimal).is_err(),
+            "nested descriptor lengths must use their canonical minimal encoding"
         );
     }
 

--- a/packages/jazz-tools/tests/browser/indexeddb-jazz-compat.test.ts
+++ b/packages/jazz-tools/tests/browser/indexeddb-jazz-compat.test.ts
@@ -76,16 +76,51 @@ describe("browser Jazz storage compatibility corpus", () => {
   // root that the public Db actually opened.
   const databaseNames = new Set<string>();
   const openDbs: Db[] = [];
+  const openDbLabels = new Map<Db, string>();
+  let pinnedCorpusPhase = "not started";
+
+  function receipt(stage: string): void {
+    console.info(`[jazz-browser-corpus-phase] ${stage}`);
+  }
+
+  async function pinnedPhase<T>(stage: string, operation: () => Promise<T>): Promise<T> {
+    pinnedCorpusPhase = `${stage}:start`;
+    receipt(pinnedCorpusPhase);
+    try {
+      const result = await operation();
+      pinnedCorpusPhase = `${stage}:done`;
+      receipt(pinnedCorpusPhase);
+      return result;
+    } catch (error) {
+      pinnedCorpusPhase = `${stage}:failed`;
+      receipt(pinnedCorpusPhase);
+      throw error;
+    }
+  }
+
+  async function shutdownTrackedDb(db: Db, label: string): Promise<void> {
+    receipt(`shutdown:${label}:start; pinned-phase=${pinnedCorpusPhase}`);
+    await db.shutdown();
+    receipt(`shutdown:${label}:done; pinned-phase=${pinnedCorpusPhase}`);
+    openDbLabels.delete(db);
+  }
 
   afterEach(async () => {
+    receipt(
+      `cleanup:start; pinned-phase=${pinnedCorpusPhase}; open=${openDbs
+        .map((db) => openDbLabels.get(db) ?? "unlabeled")
+        .join(",")}`,
+    );
     await Promise.all(
       openDbs
         .splice(0)
         .reverse()
-        .map((db) => db.shutdown()),
+        .map((db) => shutdownTrackedDb(db, openDbLabels.get(db) ?? "unlabeled")),
     );
+    receipt(`cleanup:dbs-done; pinned-phase=${pinnedCorpusPhase}`);
     await Promise.all([...databaseNames].map((name) => IndexedDbPageStore.destroy(name)));
     databaseNames.clear();
+    receipt(`cleanup:done; pinned-phase=${pinnedCorpusPhase}`);
   });
 
   it("produces the current catalogue/history/branch/large-value corpus through public WasmDb", async () => {
@@ -170,14 +205,20 @@ describe("browser Jazz storage compatibility corpus", () => {
   }, 90_000);
 
   it("opens the pinned catalogue/history/branch/large-value corpus through public WasmDb", async () => {
-    const server = await getJazzServerInfo("ba96582c-7167-5f52-ba63-3ebefe1c2b96");
-    await deploy({
-      appId: server.appId,
-      serverUrl: server.serverUrl,
-      adminSecret: server.adminSecret,
-      schema: app.wasmSchema,
-      permissions,
-    });
+    pinnedCorpusPhase = "pinned-test:start";
+    receipt(pinnedCorpusPhase);
+    const server = await pinnedPhase("server-info", () =>
+      getJazzServerInfo("ba96582c-7167-5f52-ba63-3ebefe1c2b96"),
+    );
+    await pinnedPhase("deploy", () =>
+      deploy({
+        appId: server.appId,
+        serverUrl: server.serverUrl,
+        adminSecret: server.adminSecret,
+        schema: app.wasmSchema,
+        permissions,
+      }),
+    );
 
     const dbName = "browser-storage-compat-historical-root-v1";
     const secret = "jazz-auth-v1:AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8";
@@ -187,27 +228,33 @@ describe("browser Jazz storage compatibility corpus", () => {
     // so the pre-auth config's physical-name helper points at the anonymous
     // root. Provision once through the public path to identify the actual
     // principal-scoped root before installing the historical receipt.
-    const bootstrap = await openPersistentDb(config);
-    const physicalDbName = await trackPhysicalDatabase(dbName);
-    await bootstrap.shutdown();
+    const bootstrap = await pinnedPhase("bootstrap-open", () =>
+      openPersistentDb(config, "pinned-bootstrap"),
+    );
+    const physicalDbName = await pinnedPhase("physical-root", () => trackPhysicalDatabase(dbName));
+    await pinnedPhase("bootstrap-shutdown", () => shutdownTrackedDb(bootstrap, "pinned-bootstrap"));
     openDbs.splice(openDbs.indexOf(bootstrap), 1);
-    await sleep(100);
+    await pinnedPhase("bootstrap-settle", () => sleep(100));
     const rawBeforeReadOnlyInspection = JSON.parse(currentCorpus) as Record<string, string>;
-    await installRawRecords(physicalDbName, rawBeforeReadOnlyInspection);
-    expect(await rawRecords(physicalDbName)).toEqual(rawBeforeReadOnlyInspection);
+    await pinnedPhase("install-pinned-records", () =>
+      installRawRecords(physicalDbName, rawBeforeReadOnlyInspection),
+    );
+    expect(await pinnedPhase("read-installed-records", () => rawRecords(physicalDbName))).toEqual(
+      rawBeforeReadOnlyInspection,
+    );
 
-    let db = await openPersistentDb(config);
-    const rawWhileReopened = await rawRecords(physicalDbName);
+    let db = await pinnedPhase("readonly-open", () => openPersistentDb(config, "pinned-readonly"));
+    const rawWhileReopened = await pinnedPhase("read-open-records", () =>
+      rawRecords(physicalDbName),
+    );
     // Reopen must materialize the durable local replica without depending on
     // a fresh remote-coverage round trip. The earlier edge read proves the
     // synced fixture; this is specifically the offline persistence boundary.
-    const reopenedMain = await db.all(
-      app.documents,
-      inspectorLocalQueryOptions({ branch: "main" }),
+    const reopenedMain = await pinnedPhase("readonly-main-query", () =>
+      db.all(app.documents, inspectorLocalQueryOptions({ branch: "main" })),
     );
-    const reopenedDraft = await db.all(
-      app.documents,
-      inspectorLocalQueryOptions({ branch: "draft" }),
+    const reopenedDraft = await pinnedPhase("readonly-draft-query", () =>
+      db.all(app.documents, inspectorLocalQueryOptions({ branch: "draft" })),
     );
     expect(reopenedMain).toHaveLength(1);
     expect(reopenedDraft).toHaveLength(1);
@@ -217,10 +264,12 @@ describe("browser Jazz storage compatibility corpus", () => {
     expect(reopenedDraft).toMatchObject({
       0: { branch: "draft", title: "draft override", body: "large value ".repeat(20_000) },
     });
-    await db.shutdown();
+    await pinnedPhase("readonly-shutdown", () => shutdownTrackedDb(db, "pinned-readonly"));
     openDbs.splice(openDbs.indexOf(db), 1);
-    await sleep(100);
-    const rawAfterReadOnlyInspection = await rawRecords(physicalDbName);
+    await pinnedPhase("readonly-settle", () => sleep(100));
+    const rawAfterReadOnlyInspection = await pinnedPhase("read-post-readonly-records", () =>
+      rawRecords(physicalDbName),
+    );
     expectForegroundLeaseLifecycle(
       rawBeforeReadOnlyInspection,
       rawWhileReopened,
@@ -241,48 +290,61 @@ describe("browser Jazz storage compatibility corpus", () => {
     // Append with today's writer only after the historical read-only/raw-byte
     // receipt above. Both generations must survive a fresh public open of
     // this same authenticated principal root.
-    db = await openPersistentDb(config);
-    const historicalProjects = await db.all(app.projects, inspectorLocalQueryOptions({}));
-    const currentBody = "current writer large value ".repeat(12_000);
-    const currentWrite = await db.transaction((tx) => {
-      const project = tx.insert(app.projects, { name: "current writer project" });
-      const document = tx.insert(
-        app.documents,
-        {
-          branch: "main",
-          title: "current writer document",
-          projectId: project.id,
-          body: currentBody,
-        },
-        { branch: "main" },
-      );
-      return { project, document };
-    });
-    await withTimeout(
-      currentWrite.wait({ tier: "local" }),
-      10_000,
-      "current corpus write did not settle locally",
+    db = await pinnedPhase("writer-open", () => openPersistentDb(config, "pinned-writer"));
+    const historicalProjects = await pinnedPhase("writer-projects-query", () =>
+      db.all(app.projects, inspectorLocalQueryOptions({})),
     );
-    await db.shutdown();
+    const currentBody = "current writer large value ".repeat(12_000);
+    const currentWrite = await pinnedPhase("writer-transaction", () =>
+      db.transaction((tx) => {
+        const project = tx.insert(app.projects, { name: "current writer project" });
+        const document = tx.insert(
+          app.documents,
+          {
+            branch: "main",
+            title: "current writer document",
+            projectId: project.id,
+            body: currentBody,
+          },
+          { branch: "main" },
+        );
+        return { project, document };
+      }),
+    );
+    await pinnedPhase("writer-local-settlement", () =>
+      withTimeout(
+        currentWrite.wait({ tier: "local" }),
+        10_000,
+        "current corpus write did not settle locally",
+      ),
+    );
+    await pinnedPhase("writer-shutdown", () => shutdownTrackedDb(db, "pinned-writer"));
     openDbs.splice(openDbs.indexOf(db), 1);
-    await sleep(100);
-    const rawAfterCurrentWrite = await rawRecords(physicalDbName);
+    await pinnedPhase("writer-settle", () => sleep(100));
+    const rawAfterCurrentWrite = await pinnedPhase("read-post-writer-records", () =>
+      rawRecords(physicalDbName),
+    );
     expect(rawAfterCurrentWrite[INDEXEDDB_BTREE_PAGES_STORE]).not.toEqual(
       rawAfterReadOnlyInspection[INDEXEDDB_BTREE_PAGES_STORE],
     );
 
     // Network isolation makes this a persistence receipt: the server cannot
     // repair lost current pages before the post-reopen assertions.
-    await blockJazzServerNetwork(server.serverUrl);
+    await pinnedPhase("block-network", () => blockJazzServerNetwork(server.serverUrl));
     try {
-      db = await openPersistentDb(config);
-      expect(await trackPhysicalDatabase(dbName)).toBe(physicalDbName);
-      const mixedMain = await db.all(app.documents, inspectorLocalQueryOptions({ branch: "main" }));
-      const mixedDraft = await db.all(
-        app.documents,
-        inspectorLocalQueryOptions({ branch: "draft" }),
+      db = await pinnedPhase("offline-open", () => openPersistentDb(config, "pinned-offline"));
+      expect(await pinnedPhase("offline-physical-root", () => trackPhysicalDatabase(dbName))).toBe(
+        physicalDbName,
       );
-      const mixedProjects = await db.all(app.projects, inspectorLocalQueryOptions({}));
+      const mixedMain = await pinnedPhase("offline-main-query", () =>
+        db.all(app.documents, inspectorLocalQueryOptions({ branch: "main" })),
+      );
+      const mixedDraft = await pinnedPhase("offline-draft-query", () =>
+        db.all(app.documents, inspectorLocalQueryOptions({ branch: "draft" })),
+      );
+      const mixedProjects = await pinnedPhase("offline-projects-query", () =>
+        db.all(app.projects, inspectorLocalQueryOptions({})),
+      );
       expect(mixedMain).toHaveLength(2);
       expect(mixedMain).toEqual(expect.arrayContaining(reopenedMain));
       expect(mixedMain).toEqual(
@@ -305,8 +367,10 @@ describe("browser Jazz storage compatibility corpus", () => {
         mixedMain.find((document) => document.title === "current writer document")?.projectId,
       ).toBe(currentProject!.id);
     } finally {
-      await unblockJazzServerNetwork(server.serverUrl);
+      await pinnedPhase("unblock-network", () => unblockJazzServerNetwork(server.serverUrl));
     }
+    pinnedCorpusPhase = "pinned-test:complete";
+    receipt(pinnedCorpusPhase);
   }, 90_000);
 
   it("rejects the historical retired-result codec profile without rewriting its pages", async () => {
@@ -399,9 +463,10 @@ describe("browser Jazz storage compatibility corpus", () => {
     };
   }
 
-  async function openPersistentDb(config: DbConfig): Promise<Db> {
+  async function openPersistentDb(config: DbConfig, label = "unlabeled"): Promise<Db> {
     const db = await createDb(config);
     openDbs.push(db);
+    openDbLabels.set(db, label);
     return db;
   }
 });

--- a/packages/jazz-tools/tests/react-native/remote-tiers.test.ts
+++ b/packages/jazz-tools/tests/react-native/remote-tiers.test.ts
@@ -1,4 +1,7 @@
 import { expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { schema } from "../../src/schema-namespace.js";
 import { ReadTier } from "../../src/runtime/client.js";
 import { withNativeRelayFixture } from "./fixture.js";
@@ -157,3 +160,82 @@ it("resumes strict remote reads and both write tiers after native reconnect", as
     await issuer.stop();
   }
 }, 30_000);
+
+it("keeps local and RemoteIfPossible reads usable across an established native socket outage", async () => {
+  const { startLocalJazzServer, startTestJwtIssuer, deploy, mergePermissionsIntoWasmSchema } =
+    await import("../../src/testing/index.js");
+  const issuer = await startTestJwtIssuer();
+  const dataDir = await mkdtemp(join(tmpdir(), "jazz-rn-established-outage-"));
+  let server = await startLocalJazzServer({
+    dataDir,
+    jwksUrl: issuer.jwksUrl,
+    jwtIssuer: issuer.issuer,
+    jwtAudience: issuer.audience,
+  });
+  try {
+    const permissions = schema.definePermissions(app, ({ policy }) => [
+      policy.todos.allowRead.always(),
+      policy.todos.allowInsert.always(),
+    ]);
+    await deploy({
+      appId: server.appId,
+      serverUrl: server.url,
+      adminSecret: server.adminSecret,
+      schema: app,
+      permissions,
+    });
+    const initial = {
+      appId: server.appId,
+      port: server.port,
+      adminSecret: server.adminSecret,
+      backendSecret: server.backendSecret,
+    };
+    await withNativeRelayFixture(
+      { wasmSchema: mergePermissionsIntoWasmSchema(app.wasmSchema, permissions) },
+      async (fixture) => {
+        const db = await fixture.createDb();
+        expect(await db.all(app.todos, { tier: ReadTier.Remote })).toEqual([]);
+        await server.stop();
+
+        const write = db.insert(app.todos, { title: "durable through outage", done: false });
+        const local = await write.wait({ tier: "local" });
+        await expect.poll(async () => db.all(app.todos, { tier: ReadTier.Local })).toEqual([local]);
+        await expect
+          .poll(async () => db.all(app.todos, { tier: ReadTier.RemoteIfPossible }))
+          .toEqual([local]);
+
+        const strict = db.all(app.todos, { tier: ReadTier.Remote });
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        let strictSettled = false;
+        void strict.then(() => {
+          strictSettled = true;
+        });
+        expect(strictSettled).toBe(false);
+
+        server = await startLocalJazzServer({
+          ...initial,
+          dataDir,
+          jwksUrl: issuer.jwksUrl,
+          jwtIssuer: issuer.issuer,
+          jwtAudience: issuer.audience,
+        });
+        await expect(strict).resolves.toEqual(expect.arrayContaining([local]));
+        await write.wait({ tier: "global" });
+      },
+      {
+        appId: initial.appId,
+        session: {
+          issuer: issuer.issuer,
+          user_id: "rn-established-outage",
+          claims: {},
+          authMode: "external",
+        },
+        upstream: { serverUrl: server.url, jwt: issuer.jwtForUser("rn-established-outage") },
+      },
+    );
+  } finally {
+    await server.stop();
+    await issuer.stop();
+    await rm(dataDir, { recursive: true, force: true });
+  }
+}, 45_000);

--- a/packages/jazz-tools/tests/react-native/remote-tiers.test.ts
+++ b/packages/jazz-tools/tests/react-native/remote-tiers.test.ts
@@ -204,12 +204,18 @@ it("keeps local and RemoteIfPossible reads usable across an established native s
           .poll(async () => db.all(app.todos, { tier: ReadTier.RemoteIfPossible }))
           .toEqual([local]);
 
-        const strict = db.all(app.todos, { tier: ReadTier.Remote });
-        await new Promise((resolve) => setTimeout(resolve, 100));
         let strictSettled = false;
-        void strict.then(() => {
-          strictSettled = true;
-        });
+        const strict = db.all(app.todos, { tier: ReadTier.Remote }).then(
+          (rows) => {
+            strictSettled = true;
+            return rows;
+          },
+          (error) => {
+            strictSettled = true;
+            throw error;
+          },
+        );
+        await new Promise((resolve) => setTimeout(resolve, 100));
         expect(strictSettled).toBe(false);
 
         server = await startLocalJazzServer({

--- a/packages/jazz-tools/tests/react-native/remote-tiers.test.ts
+++ b/packages/jazz-tools/tests/react-native/remote-tiers.test.ts
@@ -161,7 +161,7 @@ it("resumes strict remote reads and both write tiers after native reconnect", as
   }
 }, 30_000);
 
-it("keeps local and RemoteIfPossible reads usable across an established native socket outage", async () => {
+it("keeps local work usable while remote read tiers recover from an established native socket outage", async () => {
   const { startLocalJazzServer, startTestJwtIssuer, deploy, mergePermissionsIntoWasmSchema } =
     await import("../../src/testing/index.js");
   const issuer = await startTestJwtIssuer();
@@ -200,10 +200,18 @@ it("keeps local and RemoteIfPossible reads usable across an established native s
         const write = db.insert(app.todos, { title: "durable through outage", done: false });
         const local = await write.wait({ tier: "local" });
         await expect.poll(async () => db.all(app.todos, { tier: ReadTier.Local })).toEqual([local]);
-        await expect
-          .poll(async () => db.all(app.todos, { tier: ReadTier.RemoteIfPossible }))
-          .toEqual([local]);
 
+        let remoteIfPossibleSettled = false;
+        const remoteIfPossible = db.all(app.todos, { tier: ReadTier.RemoteIfPossible }).then(
+          (rows) => {
+            remoteIfPossibleSettled = true;
+            return rows;
+          },
+          (error) => {
+            remoteIfPossibleSettled = true;
+            throw error;
+          },
+        );
         let strictSettled = false;
         const strict = db.all(app.todos, { tier: ReadTier.Remote }).then(
           (rows) => {
@@ -216,7 +224,7 @@ it("keeps local and RemoteIfPossible reads usable across an established native s
           },
         );
         await new Promise((resolve) => setTimeout(resolve, 100));
-        expect(strictSettled).toBe(false);
+        expect([remoteIfPossibleSettled, strictSettled]).toEqual([false, false]);
 
         server = await startLocalJazzServer({
           ...initial,
@@ -225,8 +233,14 @@ it("keeps local and RemoteIfPossible reads usable across an established native s
           jwtIssuer: issuer.issuer,
           jwtAudience: issuer.audience,
         });
-        await expect(strict).resolves.toEqual(expect.arrayContaining([local]));
+        const [resumedIfPossible, resumedStrict] = await Promise.all([remoteIfPossible, strict]);
+        for (const rows of [resumedIfPossible, resumedStrict]) {
+          // Recovery establishes a fresh authority snapshot, which may precede
+          // this queued write's later Global admission.
+          expect(rows.every((row) => row.id === local.id)).toBe(true);
+        }
         await write.wait({ tier: "global" });
+        await expect(db.all(app.todos, { tier: ReadTier.Remote })).resolves.toEqual([local]);
       },
       {
         appId: initial.appId,


### PR DESCRIPTION
🤖 Keep foreground-local React Native database work usable after an established relay connection drops. This follows public union #2582 in the release stack and extends #2567 coverage.

Previously, clean peer closure or socket teardown races could poison the foreground lifecycle and cause a local SQLite write to fail with LifecycleFailure. The fix distinguishes socket-pump closure, retired connection queues, and explicit owner closure. A retired connection returns backpressure so the shared durable outbox retains queued writes for its replacement. Owner/transition failures remain terminal and stop the owner. HTTP 5xx handshake failures are retryable; authentication/protocol errors retain their existing classification.

A closed outbound socket queue waits for its owned transport terminal, with bounded cancellation, before choosing an outcome. Explicit shutdown and ownership generations continue to prevent resurrection. This does not change storage layout.

Read-tier semantics remain unchanged: Local work continues during transient transport loss; Remote and RemoteIfPossible retain the remote freshness gate. RemoteIfPossible falls back locally only after explicit disconnect. The new real-server regression checks both remote choices stay parked during loss, restarts the authority with persisted state, and checks recovery. A fresh remote snapshot may precede acceptance of the queued local write; after Global settlement, a fresh Remote read must contain it.

Validation at `b1045f57c7ce4fa515d48734af2f193d7bb39cf0`: an official bridge-enabled, source-bound native producer and the actual RN consumer pass **92/92 tests across 13 files**, including all four remote-tier tests. Generated fingerprints were archived and restored; the source checkout is clean. A different adversarial reviewer approved the native changes and test correction; planted retired-connection liveness regression failed as intended, and restored liveness, closed-bridge, cancellation and owner-close canaries passed. The coordinator independently passed the retired-connection/owner-close canary on the integrated tree and inspected the RN receipt.

Combined-stack correctness CI passed on `dd095dd7e410b5c140acef3afdfa87a33d5312c4` (run 33985766907). Actual installed Android and iOS acceptance both passed on that same revision (run 33985769186), including foreground result and upstream-stopped reopen receipts. The subsequent stack propagation has identical release-tip file contents. The accompanying CLI test repair waits for a complete newline-terminated internal bound-port record instead of merely waiting for the file to exist. This prevents reading the empty or partial readiness file before the SIGTERM/storage-reopen test begins; all signal and persistence assertions remain. It passed independent review and the coordinator’s 19-test CLI process suite. It does not change the RN runtime or a public wire/storage format. Ordinary React/Svelte/Solid suites are not RN evidence.

