### PR TITLE
ci(rn): run the bridge TypeScript suite explicitly

### DIFF
--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -285,3 +285,60 @@ jobs:
       - name: Report sccache statistics
         if: always()
         run: sccache --show-stats
+
+  # The ordinary TypeScript consumer suite intentionally excludes
+  # tests/react-native. Keep this bridge-enabled producer and the RN tests in
+  # their own named partition so a green web framework suite cannot stand in
+  # for native bridge coverage.
+  test-react-native:
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 20
+    container:
+      image: ghcr.io/garden-co/jazz-ci-toolchain@sha256:dcb4ec5e4f5507b258805617d58ee6976f7dcee2e9afe1b05ae3d41cc185ef35
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Authenticate trusted sccache writer
+        if: inputs.trusted-cache && inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: ${{ vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Authenticate trusted sccache reader
+        if: inputs.trusted-cache && !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: ${{ vars.SCCACHE_PR_READER_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.SCCACHE_REGION }}
+      - name: Export trusted sccache configuration
+        if: inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '')
+        env:
+          CACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+          CACHE_REGION: ${{ vars.SCCACHE_REGION }}
+        run: |
+          echo "SCCACHE_BUCKET=${CACHE_BUCKET}" >> "${GITHUB_ENV}"
+          echo "SCCACHE_REGION=${CACHE_REGION}" >> "${GITHUB_ENV}"
+          echo "SCCACHE_S3_USE_SSL=true" >> "${GITHUB_ENV}"
+          echo "SCCACHE_S3_KEY_PREFIX=jazz-ci/v1/production/blacksmith-v1" >> "${GITHUB_ENV}"
+      - name: Export trusted Turbo cache signing key
+        if: inputs.trusted-cache
+        env:
+          CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+        run: echo "TURBO_REMOTE_CACHE_SIGNATURE_KEY=${CACHE_SIGNATURE_KEY}" >> "${GITHUB_ENV}"
+      - name: Set up signed Turbo Remote Cache
+        if: inputs.trusted-cache
+        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
+        with:
+          team: garden-co
+          policy: pol_0b019736-e95d-4f60-a5dd-e9415148834c
+          audience: https://github.com/garden-co
+      - uses: ./.github/actions/setup-blacksmith
+        with:
+          sccache-s3: ${{ inputs.trusted-cache && (inputs.sccache-write && vars.SCCACHE_TRUSTED_WRITER_AWS_ROLE_ARN != '' || !inputs.sccache-write && vars.SCCACHE_PR_READER_AWS_ROLE_ARN != '') }}
+      - name: Run CI-equivalent React Native bridge partition
+        run: node dev/gates/local-ci-equivalent.mjs --ci-partition react-native
+      - name: Report sccache statistics
+        if: always()
+        run: sccache --show-stats

--- a/dev/gates/local-ci-equivalent.mjs
+++ b/dev/gates/local-ci-equivalent.mjs
@@ -13,6 +13,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
@@ -278,6 +279,14 @@ export function assertReactNativeBridgeBoundary(commands) {
     throw new Error("CI-equivalent React Native plan runs tests before the admitted Jazz Tools build.");
   if (!tests.args.includes("vitest.react-native.config.ts"))
     throw new Error("CI-equivalent React Native plan omits the React Native Vitest configuration.");
+  if (tests.args.includes("--passWithNoTests"))
+    throw new Error("CI-equivalent React Native plan permits an empty React Native test run.");
+  const configPath = resolve(root, "packages/jazz-tools/vitest.react-native.config.ts");
+  if (!existsSync(configPath))
+    throw new Error("CI-equivalent React Native plan references a missing React Native Vitest configuration.");
+  const config = readFileSync(configPath, "utf8");
+  if (!/include:\s*\[\s*["']tests\/react-native\/\*\*\/\*\.test\.\{ts,tsx\}["']\s*\]/.test(config))
+    throw new Error("CI-equivalent React Native Vitest configuration does not select React Native tests.");
 }
 
 /**
@@ -365,6 +374,8 @@ async function main(argv) {
       assertReactNativeBridgeBoundary(commands);
       console.log("local-ci: CI-equivalent mode; running every CI command partition serially.");
     }
+    if (mode === "ci-equivalent" || partition === "react-native")
+      assertReactNativeBridgeBoundary(planFor({ partition: "react-native" }));
     await runPlan(commands, runCommand, baseEnvironment);
   } else {
     console.log("local-ci: focused mode only; this is NOT CI-equivalent.");

--- a/dev/gates/local-ci-equivalent.mjs
+++ b/dev/gates/local-ci-equivalent.mjs
@@ -42,6 +42,7 @@ export const ciPartitionJobs = Object.freeze({
   "rust-differential": "test-rust-differential",
   "storage-compat": "test-storage-compat",
   typescript: "test-ts",
+  "react-native": "test-react-native",
 });
 
 const command = (label, executable, args, options = {}) =>
@@ -145,6 +146,50 @@ export const ciPartitions = Object.freeze({
       env: { JAZZ_REQUIRE_CI_TEST_COMMANDS: "1" },
     }),
   ]),
+  "react-native": Object.freeze([
+    // React Native's bridge is deliberately opt-in. This producer must be
+    // separate from the ordinary TypeScript partition so its manifest proves
+    // the native bridge was actually present when the RN suite ran.
+    command(
+      "React Native bridge correctness-artifact producer",
+      "pnpm",
+      ["build:correctness-artifacts"],
+      { env: { JAZZ_RN_TEST_BRIDGE: "1" } },
+    ),
+    command(
+      "admitted Jazz Tools build for React Native",
+      "node",
+      [
+        "dev/gates/run-correctness-consumer.mjs",
+        "--",
+        "pnpm",
+        "exec",
+        "turbo",
+        "run",
+        "build",
+        "--filter=jazz-tools",
+        "--only",
+      ],
+      { env: { JAZZ_RN_TEST_BRIDGE: "1" } },
+    ),
+    command(
+      "React Native bridge tests",
+      "node",
+      [
+        "dev/gates/run-correctness-consumer.mjs",
+        "--",
+        "pnpm",
+        "--dir",
+        "packages/jazz-tools",
+        "exec",
+        "vitest",
+        "run",
+        "--config",
+        "vitest.react-native.config.ts",
+      ],
+      { env: { JAZZ_RN_TEST_BRIDGE: "1" } },
+    ),
+  ]),
   "storage-compat": Object.freeze([
     command("native storage compatibility corpus", "bash", ["dev/gates/storage-compat.sh"]),
     command("native correctness-artifact producer", "node", [
@@ -211,6 +256,28 @@ export function assertArtifactBoundary(commands) {
     throw new Error("CI-equivalent TypeScript plan omits artifacts or test suites.");
   if (commands.indexOf(artifacts) > commands.indexOf(suites))
     throw new Error("CI-equivalent TypeScript plan runs tests before correctness artifacts.");
+}
+
+export function assertReactNativeBridgeBoundary(commands) {
+  const producer = commands.find(
+    ({ label }) => label === "React Native bridge correctness-artifact producer",
+  );
+  const toolsBuild = commands.find(
+    ({ label }) => label === "admitted Jazz Tools build for React Native",
+  );
+  const tests = commands.find(({ label }) => label === "React Native bridge tests");
+  if (!producer || !toolsBuild || !tests)
+    throw new Error("CI-equivalent React Native plan omits its bridge producer, build, or tests.");
+  for (const item of [producer, toolsBuild, tests]) {
+    if (item.env?.JAZZ_RN_TEST_BRIDGE !== "1")
+      throw new Error(`CI-equivalent React Native plan omits JAZZ_RN_TEST_BRIDGE for ${item.label}.`);
+  }
+  if (commands.indexOf(producer) > commands.indexOf(toolsBuild))
+    throw new Error("CI-equivalent React Native plan builds Jazz Tools before bridge artifacts.");
+  if (commands.indexOf(toolsBuild) > commands.indexOf(tests))
+    throw new Error("CI-equivalent React Native plan runs tests before the admitted Jazz Tools build.");
+  if (!tests.args.includes("vitest.react-native.config.ts"))
+    throw new Error("CI-equivalent React Native plan omits the React Native Vitest configuration.");
 }
 
 /**
@@ -295,6 +362,7 @@ async function main(argv) {
     if (mode === "ci-equivalent") {
       assertFullWorkspaceCoverage(commands);
       assertArtifactBoundary(commands);
+      assertReactNativeBridgeBoundary(commands);
       console.log("local-ci: CI-equivalent mode; running every CI command partition serially.");
     }
     await runPlan(commands, runCommand, baseEnvironment);

--- a/dev/gates/local-ci-equivalent.mjs
+++ b/dev/gates/local-ci-equivalent.mjs
@@ -271,22 +271,30 @@ export function assertReactNativeBridgeBoundary(commands) {
     throw new Error("CI-equivalent React Native plan omits its bridge producer, build, or tests.");
   for (const item of [producer, toolsBuild, tests]) {
     if (item.env?.JAZZ_RN_TEST_BRIDGE !== "1")
-      throw new Error(`CI-equivalent React Native plan omits JAZZ_RN_TEST_BRIDGE for ${item.label}.`);
+      throw new Error(
+        `CI-equivalent React Native plan omits JAZZ_RN_TEST_BRIDGE for ${item.label}.`,
+      );
   }
   if (commands.indexOf(producer) > commands.indexOf(toolsBuild))
     throw new Error("CI-equivalent React Native plan builds Jazz Tools before bridge artifacts.");
   if (commands.indexOf(toolsBuild) > commands.indexOf(tests))
-    throw new Error("CI-equivalent React Native plan runs tests before the admitted Jazz Tools build.");
+    throw new Error(
+      "CI-equivalent React Native plan runs tests before the admitted Jazz Tools build.",
+    );
   if (!tests.args.includes("vitest.react-native.config.ts"))
     throw new Error("CI-equivalent React Native plan omits the React Native Vitest configuration.");
   if (tests.args.includes("--passWithNoTests"))
     throw new Error("CI-equivalent React Native plan permits an empty React Native test run.");
   const configPath = resolve(root, "packages/jazz-tools/vitest.react-native.config.ts");
   if (!existsSync(configPath))
-    throw new Error("CI-equivalent React Native plan references a missing React Native Vitest configuration.");
+    throw new Error(
+      "CI-equivalent React Native plan references a missing React Native Vitest configuration.",
+    );
   const config = readFileSync(configPath, "utf8");
   if (!/include:\s*\[\s*["']tests\/react-native\/\*\*\/\*\.test\.\{ts,tsx\}["']\s*\]/.test(config))
-    throw new Error("CI-equivalent React Native Vitest configuration does not select React Native tests.");
+    throw new Error(
+      "CI-equivalent React Native Vitest configuration does not select React Native tests.",
+    );
 }
 
 /**

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -105,7 +105,7 @@ const benchmarkSmokeMode = (mode) => {
   return benchmarkSmokeGate.slice(startIndex + start.length, endIndex);
 };
 const assertUsesBlacksmithRunner = (jobName, jobSource) => {
-  const cpu = jobName === "test-ts" ? 16 : 4;
+  const cpu = ["test-ts", "test-react-native"].includes(jobName) ? 16 : 4;
   assert.match(jobSource, new RegExp(`runs-on: blacksmith-${cpu}vcpu-ubuntu-2404`));
   assert.doesNotMatch(jobSource, /^    runs-on: jazz-ci$/m);
 };
@@ -1756,6 +1756,16 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   assert.match(runner, /Browser test suite exit status:/);
   assert.match(runner, /node_tests_status.*-ne 0 \|\|.*browser_tests_status.*-ne 0/);
   assert.doesNotMatch(typescript, /rust-components: clippy,rustfmt/);
+});
+
+test("React Native CI has a separate bridge-enabled producer and real Vitest admission", () => {
+  const reactNative = job("test-react-native");
+  const localCi = fs.readFileSync(path.join(root, "dev/gates/local-ci-equivalent.mjs"), "utf8");
+  assert.match(reactNative, /local-ci-equivalent\.mjs --ci-partition react-native/);
+  assert.match(localCi, /React Native bridge correctness-artifact producer[\s\S]*pnpm[\s\S]*build:correctness-artifacts/);
+  assert.match(localCi, /admitted Jazz Tools build for React Native[\s\S]*run-correctness-consumer\.mjs/);
+  assert.match(localCi, /React Native bridge tests[\s\S]*vitest\.react-native\.config\.ts/);
+  assert.match(localCi, /JAZZ_RN_TEST_BRIDGE: "1"/);
 });
 
 test("TypeScript CI runs the inspector's freshly built embedded browser receipt", () => {

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1762,8 +1762,14 @@ test("React Native CI has a separate bridge-enabled producer and real Vitest adm
   const reactNative = job("test-react-native");
   const localCi = fs.readFileSync(path.join(root, "dev/gates/local-ci-equivalent.mjs"), "utf8");
   assert.match(reactNative, /local-ci-equivalent\.mjs --ci-partition react-native/);
-  assert.match(localCi, /React Native bridge correctness-artifact producer[\s\S]*pnpm[\s\S]*build:correctness-artifacts/);
-  assert.match(localCi, /admitted Jazz Tools build for React Native[\s\S]*run-correctness-consumer\.mjs/);
+  assert.match(
+    localCi,
+    /React Native bridge correctness-artifact producer[\s\S]*pnpm[\s\S]*build:correctness-artifacts/,
+  );
+  assert.match(
+    localCi,
+    /admitted Jazz Tools build for React Native[\s\S]*run-correctness-consumer\.mjs/,
+  );
   assert.match(localCi, /React Native bridge tests[\s\S]*vitest\.react-native\.config\.ts/);
   assert.match(localCi, /JAZZ_RN_TEST_BRIDGE: "1"/);
 });

--- a/dev/gates/test/local-ci-equivalent.test.mjs
+++ b/dev/gates/test/local-ci-equivalent.test.mjs
@@ -11,6 +11,7 @@ import {
   ALLOWED_INHERITED_CI_JAZZ_ENV,
   assertArtifactBoundary,
   assertFullWorkspaceCoverage,
+  assertReactNativeBridgeBoundary,
   ciPartitionJobs,
   ciPartitions,
   commandEnvironment,
@@ -323,6 +324,35 @@ test("the generated-artifact boundary fails before Node/browser tests can use st
     "all Rust workspace target classes",
     "native correctness-artifact producer",
   ]);
+});
+
+test("React Native is a distinct bridge-enabled CI partition with an admitted build", async () => {
+  const reactNative = planFor({ partition: "react-native" });
+  assert.doesNotThrow(() => assertReactNativeBridgeBoundary(reactNative));
+  assert.deepEqual(
+    reactNative.map(({ label }) => label),
+    [
+      "React Native bridge correctness-artifact producer",
+      "admitted Jazz Tools build for React Native",
+      "React Native bridge tests",
+    ],
+  );
+  for (const command of reactNative)
+    assert.equal(command.env?.JAZZ_RN_TEST_BRIDGE, "1", `${command.label} must enable the RN bridge`);
+
+  const missingTests = reactNative.filter(({ label }) => label !== "React Native bridge tests");
+  assert.throws(() => assertReactNativeBridgeBoundary(missingTests), /omits its bridge producer, build, or tests/);
+
+  const seen = [];
+  await assert.rejects(
+    () =>
+      runPlan(reactNative, async (item) => {
+        seen.push(item.label);
+        if (item.label === "React Native bridge tests") throw new Error("planted RN bridge failure");
+      }),
+    /planted RN bridge failure/,
+  );
+  assert.deepEqual(seen, reactNative.map(({ label }) => label));
 });
 
 test("a successful native producer remains visible when a TypeScript consumer fails", async () => {

--- a/dev/gates/test/local-ci-equivalent.test.mjs
+++ b/dev/gates/test/local-ci-equivalent.test.mjs
@@ -338,35 +338,52 @@ test("React Native is a distinct bridge-enabled CI partition with an admitted bu
     ],
   );
   for (const command of reactNative)
-    assert.equal(command.env?.JAZZ_RN_TEST_BRIDGE, "1", `${command.label} must enable the RN bridge`);
+    assert.equal(
+      command.env?.JAZZ_RN_TEST_BRIDGE,
+      "1",
+      `${command.label} must enable the RN bridge`,
+    );
 
   const missingTests = reactNative.filter(({ label }) => label !== "React Native bridge tests");
-  assert.throws(() => assertReactNativeBridgeBoundary(missingTests), /omits its bridge producer, build, or tests/);
+  assert.throws(
+    () => assertReactNativeBridgeBoundary(missingTests),
+    /omits its bridge producer, build, or tests/,
+  );
 
   const noConfig = reactNative.map((item) =>
     item.label === "React Native bridge tests"
       ? { ...item, args: item.args.filter((arg) => arg !== "vitest.react-native.config.ts") }
       : item,
   );
-  assert.throws(() => assertReactNativeBridgeBoundary(noConfig), /omits the React Native Vitest configuration/);
+  assert.throws(
+    () => assertReactNativeBridgeBoundary(noConfig),
+    /omits the React Native Vitest configuration/,
+  );
 
   const emptySuccess = reactNative.map((item) =>
     item.label === "React Native bridge tests"
       ? { ...item, args: [...item.args, "--passWithNoTests"] }
       : item,
   );
-  assert.throws(() => assertReactNativeBridgeBoundary(emptySuccess), /permits an empty React Native test run/);
+  assert.throws(
+    () => assertReactNativeBridgeBoundary(emptySuccess),
+    /permits an empty React Native test run/,
+  );
 
   const seen = [];
   await assert.rejects(
     () =>
       runPlan(reactNative, async (item) => {
         seen.push(item.label);
-        if (item.label === "React Native bridge tests") throw new Error("planted RN bridge failure");
+        if (item.label === "React Native bridge tests")
+          throw new Error("planted RN bridge failure");
       }),
     /planted RN bridge failure/,
   );
-  assert.deepEqual(seen, reactNative.map(({ label }) => label));
+  assert.deepEqual(
+    seen,
+    reactNative.map(({ label }) => label),
+  );
 });
 
 test("a successful native producer remains visible when a TypeScript consumer fails", async () => {

--- a/dev/gates/test/local-ci-equivalent.test.mjs
+++ b/dev/gates/test/local-ci-equivalent.test.mjs
@@ -343,6 +343,20 @@ test("React Native is a distinct bridge-enabled CI partition with an admitted bu
   const missingTests = reactNative.filter(({ label }) => label !== "React Native bridge tests");
   assert.throws(() => assertReactNativeBridgeBoundary(missingTests), /omits its bridge producer, build, or tests/);
 
+  const noConfig = reactNative.map((item) =>
+    item.label === "React Native bridge tests"
+      ? { ...item, args: item.args.filter((arg) => arg !== "vitest.react-native.config.ts") }
+      : item,
+  );
+  assert.throws(() => assertReactNativeBridgeBoundary(noConfig), /omits the React Native Vitest configuration/);
+
+  const emptySuccess = reactNative.map((item) =>
+    item.label === "React Native bridge tests"
+      ? { ...item, args: [...item.args, "--passWithNoTests"] }
+      : item,
+  );
+  assert.throws(() => assertReactNativeBridgeBoundary(emptySuccess), /permits an empty React Native test run/);
+
   const seen = [];
   await assert.rejects(
     () =>


### PR DESCRIPTION
🤖 Add an explicit React Native TypeScript correctness job so green web/framework tests cannot be mistaken for RN bridge coverage.

The ordinary TypeScript partition excludes tests/react-native. The new test-react-native CI job runs the named react-native partition shared with the local CI-equivalent driver. It produces sealed artifacts with JAZZ_RN_TEST_BRIDGE=1, builds Jazz Tools through artifact admission, and runs vitest.react-native.config.ts through the same admission boundary. Both full and single-partition execution reject missing RN configuration, missing bridge controls, incorrect command order and passWithNoTests.

Independent adversarial review passed at d36a03a97ee19234e7fb44f374f6ff59b465e32d. Focused workflow contracts passed 59/59; artifact/provenance contracts 36/36; consumer/cache contracts 9/9. The implementation lane also ran the complete workflow-contract suite, 202/202. The final integrated RN producer/consumer and CI partition passed on release revision `dd095dd7e410b5c140acef3afdfa87a33d5312c4` (33985766907). Actual Android/iOS acceptance also passed on that revision (33985769186), separately from the scaffold checks.

Part of #2567 release coverage. No runtime or storage format changes.

