### PR TITLE
Avoid recursive evaluator polling for cached inputs

### DIFF
--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -967,7 +967,41 @@ impl TickEvaluator<'_> {
         &mut self,
         node: NodeId,
     ) -> StorageFuture<'_, Result<Arc<RecordDeltas>, IvmRuntimeError>> {
-        Box::pin(self.update_subgraph(node))
+        // The postorder driver has already evaluated ordinary inputs. Check
+        // their memo before entering another evaluator future: even a cache
+        // hit inside update_one_node would recursively poll that wide future
+        // beneath its parent, overflowing Safari's WebAssembly call stack.
+        match self.cached_node_records(node) {
+            Ok(Some(records)) => Box::pin(std::future::ready(Ok(records))),
+            Err(error) => Box::pin(std::future::ready(Err(error))),
+            Ok(None) => Box::pin(self.update_subgraph(node)),
+        }
+    }
+
+    fn cached_node_records(
+        &mut self,
+        node: NodeId,
+    ) -> Result<Option<Arc<RecordDeltas>>, IvmRuntimeError> {
+        let signature = self.input_signature(node)?;
+        let memo_key = self.memo_key(node, &signature)?;
+        let current_watermark = self.input_generation(node);
+        let requires_state_rebuild = (self.context.hydrate_arrangements
+            && self.node_depends_on_aggregate(node)?
+            && !self.aggregate_arrangements_are_current(node)?)
+            || (self.context.eval_mode == EvalMode::Tick
+                && self.context.arrangement_update_mode == ArrangementUpdateMode::Replace);
+        if !requires_state_rebuild
+            && let Some(entry) = self.eval_memo.get_mut(&memo_key)
+            && entry.input_watermark == current_watermark
+        {
+            *self.memo_use_clock += 1;
+            entry.last_used = *self.memo_use_clock;
+            if self.context.eval_mode == EvalMode::Hydrate {
+                self.metrics.hydration_memo_hits += 1;
+            }
+            return Ok(Some(Arc::clone(&entry.records)));
+        }
+        Ok(None)
     }
 
     fn update_one_node(
@@ -975,6 +1009,9 @@ impl TickEvaluator<'_> {
         node: NodeId,
     ) -> StorageFuture<'_, Result<Arc<RecordDeltas>, IvmRuntimeError>> {
         Box::pin(async move {
+            if let Some(records) = self.cached_node_records(node)? {
+                return Ok(records);
+            }
             let graph_node = self
                 .graph
                 .node(node)
@@ -982,22 +1019,6 @@ impl TickEvaluator<'_> {
             let signature = self.input_signature(node)?;
             let memo_key = self.memo_key(node, &signature)?;
             let current_watermark = self.input_generation(node);
-            let requires_state_rebuild = (self.context.hydrate_arrangements
-                && self.node_depends_on_aggregate(node)?
-                && !self.aggregate_arrangements_are_current(node)?)
-                || (self.context.eval_mode == EvalMode::Tick
-                    && self.context.arrangement_update_mode == ArrangementUpdateMode::Replace);
-            if !requires_state_rebuild
-                && let Some(entry) = self.eval_memo.get_mut(&memo_key)
-                && entry.input_watermark == current_watermark
-            {
-                *self.memo_use_clock += 1;
-                entry.last_used = *self.memo_use_clock;
-                if self.context.eval_mode == EvalMode::Hydrate {
-                    self.metrics.hydration_memo_hits += 1;
-                }
-                return Ok(Arc::clone(&entry.records));
-            }
 
             if self.context.eval_mode == EvalMode::Hydrate {
                 self.metrics.hydration_memo_computes += 1;

--- a/packages/jazz-tools/tests/browser/db.local-persistence.test.ts
+++ b/packages/jazz-tools/tests/browser/db.local-persistence.test.ts
@@ -1,0 +1,37 @@
+import { expect, it } from "vitest";
+import { schema as s, generateAuthSecret } from "../../src/index.js";
+import { createDb } from "../../src/runtime/default-create-db.js";
+
+const app = s.defineApp({
+  tasks: s.table({ title: s.string(), done: s.boolean() }),
+});
+
+it("settles an empty local read and retains acknowledged writes across repeated reopen", async () => {
+  const config = {
+    appId: crypto.randomUUID(),
+    secret: generateAuthSecret(),
+    driver: { type: "persistent" as const, dbName: `local-reopen-${crypto.randomUUID()}` },
+  };
+  let db = await createDb(config);
+  const titles: string[] = [];
+  try {
+    // Safari used to overflow the WASM stack while a projection fetched its
+    // already evaluated input. This first read hung before any write was made.
+    expect(await db.all(app.tasks, { tier: "local" })).toEqual([]);
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const title = `synthetic task ${cycle}`;
+      await db.insert(app.tasks, { title, done: false }).wait({ tier: "local" });
+      titles.push(title);
+      expect((await db.all(app.tasks, { tier: "local" })).map((row) => row.title).sort()).toEqual(
+        titles,
+      );
+      await db.shutdown();
+      db = await createDb(config);
+      expect((await db.all(app.tasks, { tier: "local" })).map((row) => row.title).sort()).toEqual(
+        titles,
+      );
+    }
+  } finally {
+    await db.shutdown();
+  }
+}, 60_000);


### PR DESCRIPTION
🤖 Avoid a WebAssembly stack overflow when a query operator requests an input that the evaluator has already computed (#2430).

The postorder evaluator computes child nodes first, but update_node previously entered another update_subgraph/update_one_node future before recognizing a memo hit. Actual Safari tracing found a call-stack failure during initial MapProject evaluation, leaving the initial read pending. The candidate checks the existing memo-validity conditions at update_node entry and returns a ready result for a valid hit, avoiding that redundant evaluator descent.

The helper retains the input signature, context-derived memo key, input generation, aggregate arrangement rebuild and Tick/Replace conditions. A stale result or required rebuild still takes the original evaluation path. Memo usage accounting remains. Rows, storage/wire formats and durability acknowledgement semantics are unchanged.

For example, an empty local query must settle before the first write; after local acknowledgement, each added row must survive repeated shutdown/reopen. The new public browser regression covers that sequence for three cycles. An optimistic write without acknowledgement is not promised to survive reload.

This is the core fix and public regression from Mac candidate 5c5c8b9a4db237eb130c4ef0c60a86f9cba4a857, applied unchanged to the release consolidation as 5f5dff15fe068579c1faaef6b1f0fb7129a4be0a. Diagnostic-page/driver changes remain on the Mac investigation branch. Mac evidence and remaining acceptance are recorded at https://github.com/garden-co/jazz/issues/2430#issuecomment-5555040723.

Independent adversarial source review approved the memo invalidation and recursion behavior. Coordinator verification on this release tree passed: Groove 700 passed / 2 ignored; full browser suite 302 passed / 1 expected failure / 3 skipped; BandChat 5 passed, including a run concurrent with the full browser suite. Generated artifact fingerprints were archived and restored; the committed source tree is clean. All CI partitions are green, including TypeScript, storage compatibility, Rust differential/workspace, React Native bridge and lint: https://github.com/garden-co/jazz/actions/runs/33994586665.

On the exact Mac candidate, actual stable Safari passed three acknowledged-write → completed shutdown/reopen → full-reload cycles. Reverting only the evaluator change made the unchanged public WebKit regression fail; restoring the candidate passes. The native differential oracle passed 10 seeds at default churn depths. Evidence: https://github.com/garden-co/jazz/issues/2430#issuecomment-5555096271.

Private Safari acceptance is awaiting local Touch ID unlock; physical iOS remains outstanding. These results do not establish that the intermittent Chromium failures had this same cause. Keep #2430 open until its full acceptance is recorded.
