### PR TITLE
Pin the WebSocket admission prelude contract

### DIFF
--- a/crates/jazz-native-transport/src/lib.rs
+++ b/crates/jazz-native-transport/src/lib.rs
@@ -1148,6 +1148,49 @@ mod tests {
         );
     }
 
+    // This is an internal test because a JSON prelude is emitted before a Db
+    // exists. The shared fixture pins the native writer's exact first-message
+    // contract for the server and TypeScript carrier tests.
+    #[test]
+    fn native_writer_matches_websocket_prelude_v1_fixture() {
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../jazz/fixtures/websocket_prelude_v1.json",
+        ))
+        .expect("parse websocket prelude fixture");
+        for entry in fixture["fixtures"]
+            .as_array()
+            .expect("fixture entries")
+            .iter()
+            .filter(|entry| entry["writer"] == "rust-native")
+        {
+            let identity = AuthorSubject::from_canonical(
+                entry["peer_identity"]
+                    .as_str()
+                    .expect("fixture peer identity"),
+            )
+            .expect("fixture canonical peer identity");
+            let auth: AuthConfig =
+                serde_json::from_value(entry["auth"].clone()).expect("fixture native auth");
+            let actual = String::from_utf8(
+                encode_prelude(
+                    identity,
+                    auth,
+                    entry["bootstrap_catalogue"]
+                        .as_bool()
+                        .expect("fixture bootstrap flag"),
+                )
+                .expect("encode fixture prelude"),
+            )
+            .expect("native prelude is UTF-8 JSON");
+            assert_eq!(
+                actual,
+                entry["json"].as_str().expect("fixture JSON"),
+                "native writer drifted for {}",
+                entry["name"].as_str().expect("fixture name")
+            );
+        }
+    }
+
     #[test]
     fn snapshot_bootstrap_prelude_explicitly_marks_the_snapshot_only_exchange() {
         let bytes = encode_prelude(AuthorSubject::SYSTEM, AuthConfig::default(), true)

--- a/crates/jazz-server/src/server/routes/websocket.rs
+++ b/crates/jazz-server/src/server/routes/websocket.rs
@@ -1448,6 +1448,68 @@ mod tests {
             .state
     }
 
+    // Internal admission-boundary test: scoped-link selection is made before
+    // the server shell opens, so a public WebSocket client can only observe
+    // its later feature-negotiated consequence.
+    #[tokio::test]
+    async fn ws_scope_isolated_request_requires_session_and_preserves_only_that_request() {
+        let state = make_ws_test_state().await;
+        let identity = AuthorSubject::for_test_bytes([0x72; 16]);
+        let (issuer, user_id) = issuer_and_subject(identity);
+        let scoped_session = ws_admission(
+            WebSocketPrelude {
+                peer_identity: identity.canonical().to_owned(),
+                bootstrap_catalogue: false,
+                requested_link: RequestedWebSocketLink::ScopeIsolatedClientRelay,
+                auth: jazz::tools::websocket_prelude_auth::AuthConfig {
+                    backend_secret: Some("backend-secret".to_owned()),
+                    backend_session: Some(serde_json::json!({
+                        "issuer": issuer,
+                        "user_id": user_id,
+                        "claims": {},
+                        "authMode": "external",
+                    })),
+                    ..Default::default()
+                },
+            },
+            &HeaderMap::new(),
+            &state,
+        )
+        .await
+        .expect("authenticated session scope request");
+        assert_eq!(scoped_session.credential, WebSocketCredential::Session);
+        assert_eq!(
+            scoped_session.requested_link,
+            RequestedWebSocketLink::ScopeIsolatedClientRelay,
+            "a verified session must retain its scope-isolated request for feature negotiation"
+        );
+
+        let backend_scope_request = ws_admission(
+            WebSocketPrelude {
+                peer_identity: AuthorSubject::SYSTEM.canonical().to_owned(),
+                bootstrap_catalogue: false,
+                requested_link: RequestedWebSocketLink::ScopeIsolatedClientRelay,
+                auth: jazz::tools::websocket_prelude_auth::AuthConfig {
+                    backend_secret: Some("backend-secret".to_owned()),
+                    ..Default::default()
+                },
+            },
+            &HeaderMap::new(),
+            &state,
+        )
+        .await
+        .expect("backend authentication ignores client-only scope request");
+        assert_eq!(
+            backend_scope_request.credential,
+            WebSocketCredential::Backend
+        );
+        assert_eq!(
+            backend_scope_request.requested_link,
+            RequestedWebSocketLink::OrdinarySession,
+            "backend credentials must not select scope-isolated client admission"
+        );
+    }
+
     #[tokio::test]
     async fn ws_admin_authority_capability_is_distinct_from_backend_attribution() {
         let state = make_ws_test_state().await;
@@ -1960,10 +2022,14 @@ mod tests {
         let frames: Vec<Vec<u8>> =
             postcard::from_bytes(&response).expect("decode server hello batch");
         assert_eq!(frames.len(), 1);
-        assert!(matches!(
-            decode_frame(&frames[0]).expect("decode server hello"),
-            WireFrame::Hello(_)
-        ));
+        let WireFrame::Hello(server_hello) = decode_frame(&frames[0]).expect("decode server hello")
+        else {
+            panic!("expected server WireFrame::Hello");
+        };
+        assert_eq!(
+            server_hello.features, features,
+            "server Hello must retain every negotiated client feature"
+        );
     }
 
     async fn oversized_ws_prelude_never_reaches_admission(message: WsMessage, url: String) {

--- a/crates/jazz-server/src/server/routes/websocket.rs
+++ b/crates/jazz-server/src/server/routes/websocket.rs
@@ -1469,6 +1469,27 @@ mod tests {
         assert_eq!(relay.credential, WebSocketCredential::Admin);
         assert_eq!(relay.trust, CommitUnitTrust::TrustedAuthority);
 
+        let admin_scope_request = ws_admission(
+            WebSocketPrelude {
+                peer_identity: AuthorSubject::SYSTEM.canonical().to_owned(),
+                bootstrap_catalogue: false,
+                requested_link: RequestedWebSocketLink::ScopeIsolatedClientRelay,
+                auth: jazz::tools::websocket_prelude_auth::AuthConfig {
+                    admin_secret: Some("admin-secret".to_owned()),
+                    ..Default::default()
+                },
+            },
+            &HeaderMap::new(),
+            &state,
+        )
+        .await
+        .expect("admin authentication ignores the client-only scope request");
+        assert_eq!(
+            admin_scope_request.requested_link,
+            RequestedWebSocketLink::OrdinarySession,
+            "admin credentials must not select scope-isolated client admission"
+        );
+
         let bootstrap = ws_admission(
             WebSocketPrelude {
                 peer_identity: AuthorSubject::SYSTEM.canonical().to_owned(),
@@ -2077,12 +2098,66 @@ mod tests {
                 WsMessage::Binary(json.into_bytes().into())
             };
             ws.send(message).await.expect("send writer prelude");
-            expect_ws_server_hello(
-                &mut ws,
+            let features = FEATURE_SYNC_MESSAGE_PAYLOAD
+                | FEATURE_STRUCTURED_ERRORS
+                | if entry["requested_link"] == "scope_isolated_client_relay" {
+                    jazz::wire::FEATURE_SCOPE_ISOLATED_CLIENT_RELAY
+                } else {
+                    0
+                };
+            expect_ws_server_hello(&mut ws, features).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn websocket_scope_isolated_prelude_requires_negotiated_scope_feature() {
+        let state = make_ws_test_state().await;
+        let addr = start_ws_test_server(state.clone()).await;
+        let fixture = websocket_prelude_v1_fixture();
+        let scope_fixture = fixture["fixtures"]
+            .as_array()
+            .expect("fixture entries")
+            .iter()
+            .find(|entry| entry["name"] == "typescript_scope_isolated_session")
+            .expect("scope-isolated TypeScript fixture");
+        let (mut ws, _) = connect_async(ws_url(addr, state.app_id))
+            .await
+            .expect("connect websocket");
+        ws.send(WsMessage::Text(
+            scope_fixture["json"]
+                .as_str()
+                .expect("scope fixture JSON")
+                .to_owned()
+                .into(),
+        ))
+        .await
+        .expect("send scope-isolated prelude");
+        ws.send(WsMessage::Binary(
+            ws_client_hello_batch_with_features(
                 FEATURE_SYNC_MESSAGE_PAYLOAD | FEATURE_STRUCTURED_ERRORS,
             )
-            .await;
-        }
+            .into(),
+        ))
+        .await
+        .expect("send client hello without scope feature");
+        let response = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("server must reject unnegotiated scope request")
+            .expect("server rejection frame")
+            .expect("server websocket result");
+        let WsMessage::Binary(response) = response else {
+            panic!("expected structured wire error, got {response:?}");
+        };
+        let frames: Vec<Vec<u8>> = postcard::from_bytes(&response).expect("decode error batch");
+        assert_eq!(frames.len(), 1);
+        assert!(matches!(
+            decode_frame(&frames[0]).expect("decode error frame"),
+            WireFrame::Error(WireError {
+                code: WireErrorCode::UnsupportedFeature,
+                retry: WireRetry::Never,
+                ..
+            })
+        ));
     }
 
     #[tokio::test]

--- a/crates/jazz-server/src/server/routes/websocket.rs
+++ b/crates/jazz-server/src/server/routes/websocket.rs
@@ -1891,10 +1891,233 @@ mod tests {
         (identity, prelude)
     }
 
+    fn websocket_prelude_v1_fixture() -> serde_json::Value {
+        serde_json::from_str(include_str!(
+            "../../../../jazz/fixtures/websocket_prelude_v1.json",
+        ))
+        .expect("parse websocket prelude fixture")
+    }
+
+    fn padded_ws_prelude(identity: AuthorSubject, byte_len: usize) -> String {
+        let prefix = format!(
+            r##"{{"peer_identity":{},"auth":{{"admin_secret":"admin-secret"}},"future_top_level":""##,
+            serde_json::to_string(identity.canonical()).expect("encode identity"),
+        );
+        let suffix = "\"}";
+        assert!(byte_len >= prefix.len() + suffix.len());
+        let prelude = format!(
+            "{prefix}{}{suffix}",
+            "x".repeat(byte_len - prefix.len() - suffix.len())
+        );
+        assert_eq!(
+            prelude.len(),
+            byte_len,
+            "test prelude must hit the physical boundary"
+        );
+        prelude
+    }
+
+    async fn expect_ws_server_hello(
+        ws: &mut tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        features: u64,
+    ) {
+        ws.send(WsMessage::Binary(
+            ws_client_hello_batch_with_features(features).into(),
+        ))
+        .await
+        .expect("send client wire hello");
+        let response = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("wait for server hello")
+            .expect("server response")
+            .expect("server websocket result");
+        let WsMessage::Binary(response) = response else {
+            panic!("expected binary server hello, got {response:?}");
+        };
+        let frames: Vec<Vec<u8>> =
+            postcard::from_bytes(&response).expect("decode server hello batch");
+        assert_eq!(frames.len(), 1);
+        assert!(matches!(
+            decode_frame(&frames[0]).expect("decode server hello"),
+            WireFrame::Hello(_)
+        ));
+    }
+
+    async fn oversized_ws_prelude_never_reaches_admission(message: WsMessage, url: String) {
+        let (mut ws, _) = connect_async(url).await.expect("connect websocket");
+        ws.send(message).await.expect("send oversized prelude");
+        // If the physical cap is accidentally raised, this valid follow-up
+        // reaches normal handshake admission and produces a server Hello.
+        let _ = ws
+            .send(WsMessage::Binary(
+                ws_client_hello_batch_with_features(
+                    FEATURE_SYNC_MESSAGE_PAYLOAD | FEATURE_STRUCTURED_ERRORS,
+                )
+                .into(),
+            ))
+            .await;
+        let response = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("oversized prelude must resolve by close or error");
+        let admitted = matches!(
+            response,
+            Some(Ok(WsMessage::Binary(bytes)))
+                if postcard::from_bytes::<Vec<Vec<u8>>>(&bytes)
+                    .ok()
+                    .and_then(|frames| frames.first().cloned())
+                    .and_then(|frame| decode_frame(&frame).ok())
+                    .is_some_and(|frame| matches!(frame, WireFrame::Hello(_)))
+        );
+        assert!(
+            !admitted,
+            "a prelude larger than the Axum message cap must not reach admission"
+        );
+    }
+
     fn ws_client_hello_batch_with_features(features: u64) -> Vec<u8> {
         let hello = WireFrame::Hello(WireHello::current(WirePeerRole::Client, features));
         let encoded = vec![encode_frame(&hello).expect("encode client hello")];
         postcard::to_allocvec(&encoded).expect("encode websocket hello batch")
+    }
+
+    // Prelude parsing is an internal protocol-boundary test: no Db exists
+    // until after this first JSON message has been accepted. The shared corpus
+    // also pins both native writers without introducing another serializer.
+    #[test]
+    fn websocket_prelude_v1_fixture_parses_with_documented_evolution_rules() {
+        let fixture = websocket_prelude_v1_fixture();
+        for entry in fixture["fixtures"].as_array().expect("fixture entries") {
+            let parsed: WebSocketPrelude =
+                serde_json::from_str(entry["json"].as_str().expect("fixture JSON"))
+                    .expect("writer prelude accepted by server");
+            assert_eq!(
+                parsed.peer_identity,
+                entry["peer_identity"]
+                    .as_str()
+                    .expect("fixture peer identity"),
+            );
+            assert_eq!(
+                parsed.bootstrap_catalogue,
+                entry["bootstrap_catalogue"]
+                    .as_bool()
+                    .expect("fixture bootstrap flag")
+            );
+            assert_eq!(
+                parsed.requested_link,
+                match entry["requested_link"]
+                    .as_str()
+                    .expect("fixture requested link")
+                {
+                    "ordinary_session" => RequestedWebSocketLink::OrdinarySession,
+                    "scope_isolated_client_relay" => {
+                        RequestedWebSocketLink::ScopeIsolatedClientRelay
+                    }
+                    other => panic!("unsupported fixture requested_link {other}"),
+                }
+            );
+        }
+
+        let peer_identity = serde_json::to_string(AuthorSubject::SYSTEM.canonical())
+            .expect("encode fixture peer identity");
+        let defaults: WebSocketPrelude = serde_json::from_str(
+            &serde_json::json!({
+                "peer_identity": AuthorSubject::SYSTEM.canonical(),
+                "auth": {
+                    "admin_secret": "admin-secret",
+                    "future_auth_field": true,
+                },
+                "future_top_level_field": "ignored",
+            })
+            .to_string(),
+        )
+        .expect("unknown top-level and AuthConfig fields remain forward-compatible");
+        assert!(!defaults.bootstrap_catalogue);
+        assert_eq!(
+            defaults.requested_link,
+            RequestedWebSocketLink::OrdinarySession
+        );
+        assert_eq!(defaults.auth.admin_secret.as_deref(), Some("admin-secret"));
+
+        for malformed in [
+            "not-json".to_owned(),
+            format!(r#"{{"peer_identity":{peer_identity}}}"#),
+            format!(r#"{{"peer_identity":{peer_identity},"auth":{{}}}} trailing"#),
+        ] {
+            assert!(
+                serde_json::from_str::<WebSocketPrelude>(&malformed).is_err(),
+                "malformed prelude must reject: {malformed}"
+            );
+        }
+        assert!(
+            serde_json::from_str::<WebSocketPrelude>(&format!(
+                r#"{{"peer_identity":{peer_identity},"auth":{{}},"requested_link":"future_link"}}"#,
+            ))
+            .is_err(),
+            "unknown requested_link is an authority request, not an ignored extension"
+        );
+    }
+
+    #[tokio::test]
+    async fn websocket_prelude_v1_fixture_writers_reach_server_handshake() {
+        let state = make_ws_test_state().await;
+        let addr = start_ws_test_server(state.clone()).await;
+        for entry in websocket_prelude_v1_fixture()["fixtures"]
+            .as_array()
+            .expect("fixture entries")
+        {
+            let (mut ws, _) = connect_async(ws_url(addr, state.app_id))
+                .await
+                .expect("connect websocket");
+            let json = entry["json"].as_str().expect("fixture JSON").to_owned();
+            let message = if entry["writer"] == "typescript-native-runtime" {
+                WsMessage::Text(json.into())
+            } else {
+                WsMessage::Binary(json.into_bytes().into())
+            };
+            ws.send(message).await.expect("send writer prelude");
+            expect_ws_server_hello(
+                &mut ws,
+                FEATURE_SYNC_MESSAGE_PAYLOAD | FEATURE_STRUCTURED_ERRORS,
+            )
+            .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn websocket_prelude_message_cap_admits_exact_and_rejects_oversize_text_and_binary() {
+        let state = make_ws_test_state().await;
+        let addr = start_ws_test_server(state.clone()).await;
+        let identity = AuthorSubject::SYSTEM;
+        let exact = padded_ws_prelude(identity, WS_MAX_MESSAGE_BYTES);
+
+        for message in [
+            WsMessage::Text(exact.clone().into()),
+            WsMessage::Binary(exact.clone().into_bytes().into()),
+        ] {
+            let (mut ws, _) = connect_async(ws_url(addr, state.app_id))
+                .await
+                .expect("connect websocket");
+            ws.send(message).await.expect("send exact-cap prelude");
+            expect_ws_server_hello(
+                &mut ws,
+                FEATURE_SYNC_MESSAGE_PAYLOAD | FEATURE_STRUCTURED_ERRORS,
+            )
+            .await;
+        }
+
+        let oversized = padded_ws_prelude(identity, WS_MAX_MESSAGE_BYTES + 1);
+        oversized_ws_prelude_never_reaches_admission(
+            WsMessage::Text(oversized.clone().into()),
+            ws_url(addr, state.app_id),
+        )
+        .await;
+        oversized_ws_prelude_never_reaches_admission(
+            WsMessage::Binary(oversized.into_bytes().into()),
+            ws_url(addr, state.app_id),
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/jazz-server/src/server/routes/websocket.rs
+++ b/crates/jazz-server/src/server/routes/websocket.rs
@@ -210,6 +210,32 @@ enum RequestedWebSocketLink {
     ScopeIsolatedClientRelay,
 }
 
+/// Select the server-owned link capability after credential admission and wire
+/// feature negotiation. This stays separate from the client prelude because a
+/// request alone cannot grant scoped relay authority.
+fn ws_link_admission(
+    admission: &WebSocketAdmission,
+    negotiated_features: u64,
+    admission_epoch: u64,
+) -> Result<ServerLinkAdmission, WireError> {
+    match admission.requested_link {
+        RequestedWebSocketLink::OrdinarySession => Ok(ServerLinkAdmission::OrdinarySession),
+        RequestedWebSocketLink::ScopeIsolatedClientRelay
+            if admission.credential == WebSocketCredential::Session
+                && negotiated_features & jazz::wire::FEATURE_SCOPE_ISOLATED_CLIENT_RELAY != 0 =>
+        {
+            // This epoch was minted by the server for this accepted socket.
+            // Reconnects necessarily get a fresh capability.
+            Ok(ServerLinkAdmission::ScopeIsolatedClientRelay { admission_epoch })
+        }
+        RequestedWebSocketLink::ScopeIsolatedClientRelay => Err(WireError::new(
+            WireErrorCode::UnsupportedFeature,
+            WireRetry::Never,
+            "scope-isolated client relay requires an authenticated session and negotiated relay feature",
+        )),
+    }
+}
+
 async fn ws_admission(
     prelude: WebSocketPrelude,
     request_headers: &HeaderMap,
@@ -723,32 +749,15 @@ async fn handle_ws_connection(
     } else {
         None
     };
-    let link_admission = match admission.requested_link {
-        RequestedWebSocketLink::OrdinarySession => ServerLinkAdmission::OrdinarySession,
-        RequestedWebSocketLink::ScopeIsolatedClientRelay
-            if admission.credential == WebSocketCredential::Session
-                && negotiated.features & jazz::wire::FEATURE_SCOPE_ISOLATED_CLIENT_RELAY != 0 =>
-        {
-            // This epoch was minted by the server for this accepted socket.
-            // Reconnects necessarily get a fresh capability.
-            ServerLinkAdmission::ScopeIsolatedClientRelay {
-                admission_epoch: server_endpoint.epoch,
+    let link_admission =
+        match ws_link_admission(&admission, negotiated.features, server_endpoint.epoch) {
+            Ok(link_admission) => link_admission,
+            Err(error) => {
+                send_ws_error(&mut socket, error).await;
+                let _ = socket.close().await;
+                return;
             }
-        }
-        RequestedWebSocketLink::ScopeIsolatedClientRelay => {
-            send_ws_error(
-                &mut socket,
-                WireError::new(
-                    WireErrorCode::UnsupportedFeature,
-                    WireRetry::Never,
-                    "scope-isolated client relay requires an authenticated session and negotiated relay feature",
-                ),
-            )
-            .await;
-            let _ = socket.close().await;
-            return;
-        }
-    };
+        };
     let session = match core_server_shell
         .open_with_session_context(
             admission.identity,
@@ -1483,6 +1492,25 @@ mod tests {
             RequestedWebSocketLink::ScopeIsolatedClientRelay,
             "a verified session must retain its scope-isolated request for feature negotiation"
         );
+        assert!(matches!(
+            ws_link_admission(
+                &scoped_session,
+                jazz::wire::FEATURE_SCOPE_ISOLATED_CLIENT_RELAY,
+                73,
+            )
+            .expect("session plus scope feature selects scoped server admission"),
+            ServerLinkAdmission::ScopeIsolatedClientRelay {
+                admission_epoch: 73
+            }
+        ));
+        assert!(matches!(
+            ws_link_admission(&scoped_session, 0, 73),
+            Err(WireError {
+                code: WireErrorCode::UnsupportedFeature,
+                retry: WireRetry::Never,
+                ..
+            })
+        ));
 
         let backend_scope_request = ws_admission(
             WebSocketPrelude {
@@ -1508,6 +1536,15 @@ mod tests {
             RequestedWebSocketLink::OrdinarySession,
             "backend credentials must not select scope-isolated client admission"
         );
+        assert!(matches!(
+            ws_link_admission(
+                &backend_scope_request,
+                jazz::wire::FEATURE_SCOPE_ISOLATED_CLIENT_RELAY,
+                73,
+            )
+            .expect("normalized backend request selects the ordinary server link"),
+            ServerLinkAdmission::OrdinarySession
+        ));
     }
 
     #[tokio::test]

--- a/crates/jazz/SPEC/8_sync_protocol.md
+++ b/crates/jazz/SPEC/8_sync_protocol.md
@@ -346,7 +346,11 @@ The prelude object has these server-owned fields:
 - `bootstrap_catalogue`: optional boolean; omission means `false`.
 - `requested_link`: optional string enum; omission means `ordinary_session`.
   The only admitted values are `ordinary_session` and
-  `scope_isolated_client_relay`.
+  `scope_isolated_client_relay`. The latter produces its scoped-link admission
+  only for an authenticated session that negotiated
+  `FEATURE_SCOPE_ISOLATED_CLIENT_RELAY`; a session missing that feature
+  receives `UnsupportedFeature/Never`. Admin and backend credentials retain
+  their ordinary-link admission when they send this client-only request.
 
 The JSON object is an evolution envelope, not an authority grant. Unknown
 top-level fields and unknown fields nested in `auth` are ignored. An unknown

--- a/crates/jazz/SPEC/8_sync_protocol.md
+++ b/crates/jazz/SPEC/8_sync_protocol.md
@@ -325,6 +325,50 @@ selected view and MUST redact `tx.n_total_writes` to `versions.len()`. It never
 establishes complete-payload coverage, even when those numbers happen to equal
 the authored transaction's true cardinality.
 
+### 8.1.2 WebSocket admission prelude (SPEC08)
+
+Before the binary `WireFrame` carrier begins, a client sends exactly one
+UTF-8 JSON object as its first WebSocket message. The server accepts that
+prelude as either a WebSocket text message or a binary message containing the
+same UTF-8 bytes. It then requires one binary WebSocket message that decodes to
+exactly one `WireFrame::Hello`. The ordinary writer form is a complete
+postcard `Vec<Vec<u8>>` singleton batch; the route also accepts its documented
+complete raw-postcard `WireFrame` handshake form. The prelude and that first
+wire message each have the ordinary two-second handshake read deadline. Only
+the first message is parsed as a prelude; later text messages have no admission
+effect.
+
+The prelude object has these server-owned fields:
+
+- `peer_identity`: required canonical `AuthorSubject` JSON string.
+- `auth`: required `AuthConfig` object. Its current fields are `jwt_token`,
+  `backend_secret`, `admin_secret`, and `backend_session`.
+- `bootstrap_catalogue`: optional boolean; omission means `false`.
+- `requested_link`: optional string enum; omission means `ordinary_session`.
+  The only admitted values are `ordinary_session` and
+  `scope_isolated_client_relay`.
+
+The JSON object is an evolution envelope, not an authority grant. Unknown
+top-level fields and unknown fields nested in `auth` are ignored. An unknown
+`requested_link` is rejected, because it requests an authority-bearing link
+mode. Missing required fields, non-UTF-8 bytes, malformed JSON, a trailing JSON
+suffix, or an invalid known field are rejected before admission.
+
+The native Rust writer serializes only `peer_identity`, `auth`, and a true
+`bootstrap_catalogue`; its optional `AuthConfig` members currently serialize as
+explicit JSON nulls. The TypeScript native-runtime writer preserves its
+existing top-level auth and `sub` compatibility fields while also writing the
+nested `auth` object; those extra top-level fields are ignored by the server.
+Neither representation is a second protocol nor an authorization alias. The
+shared `jazz-websocket-prelude-v1` fixture pins the exact writer strings and
+server parse result.
+
+Axum applies a 2 MiB ceiling to both inbound WebSocket frame and message size,
+including the initial text or binary prelude. An exactly 2 MiB valid prelude
+may proceed to the wire Hello; a valid prelude of 2 MiB plus one byte must not
+reach admission. This is the physical carrier ceiling, not a reduced logical
+sync or catalogue limit.
+
 ### 8.2 Upstream: commit units
 
 Upstream sync moves committed history, not in-progress edits. A committed

--- a/crates/jazz/fixtures/README.md
+++ b/crates/jazz/fixtures/README.md
@@ -10,6 +10,7 @@ ABI runtime. Future fixtures should target stable byte payloads directly:
 - `AbiEncodedCellPatch` write/probe payloads
 - `AbiSubscriptionStreamChunk` subscription payloads
 - wire `WireFrame` envelopes
+- WebSocket v1 admission preludes (the one JSON message before binary wire frames)
 
 Fixture generators should use core `Db`/`Node` APIs directly rather than routing
 through a binding object manager.

--- a/crates/jazz/fixtures/websocket_prelude_v1.json
+++ b/crates/jazz/fixtures/websocket_prelude_v1.json
@@ -1,0 +1,33 @@
+{
+  "fixture_set": "jazz-websocket-prelude-v1",
+  "transport": "first WebSocket message is one UTF-8 JSON object",
+  "fixtures": [
+    {
+      "name": "native_admin_default_link",
+      "writer": "rust-native",
+      "peer_identity": "[\"urn:jazz:system\",\"system\"]",
+      "auth": { "admin_secret": "admin-secret" },
+      "bootstrap_catalogue": false,
+      "requested_link": "ordinary_session",
+      "json": "{\"peer_identity\":\"[\\\"urn:jazz:system\\\",\\\"system\\\"]\",\"auth\":{\"jwt_token\":null,\"backend_secret\":null,\"admin_secret\":\"admin-secret\",\"backend_session\":null}}"
+    },
+    {
+      "name": "native_admin_catalogue_bootstrap",
+      "writer": "rust-native",
+      "peer_identity": "[\"urn:jazz:system\",\"system\"]",
+      "auth": { "admin_secret": "admin-secret" },
+      "bootstrap_catalogue": true,
+      "requested_link": "ordinary_session",
+      "json": "{\"peer_identity\":\"[\\\"urn:jazz:system\\\",\\\"system\\\"]\",\"auth\":{\"jwt_token\":null,\"backend_secret\":null,\"admin_secret\":\"admin-secret\",\"backend_session\":null},\"bootstrap_catalogue\":true}"
+    },
+    {
+      "name": "typescript_admin_default_link",
+      "writer": "typescript-native-runtime",
+      "peer_identity": "[\"urn:jazz:system\",\"system\"]",
+      "auth_json": "{\"admin_secret\":\"admin-secret\"}",
+      "bootstrap_catalogue": false,
+      "requested_link": "ordinary_session",
+      "json": "{\"peer_identity\":\"[\\\"urn:jazz:system\\\",\\\"system\\\"]\",\"admin_secret\":\"admin-secret\",\"auth\":{\"admin_secret\":\"admin-secret\",\"sub\":\"system\"},\"sub\":\"system\"}"
+    }
+  ]
+}

--- a/crates/jazz/fixtures/websocket_prelude_v1.json
+++ b/crates/jazz/fixtures/websocket_prelude_v1.json
@@ -6,7 +6,9 @@
       "name": "native_admin_default_link",
       "writer": "rust-native",
       "peer_identity": "[\"urn:jazz:system\",\"system\"]",
-      "auth": { "admin_secret": "admin-secret" },
+      "auth": {
+        "admin_secret": "admin-secret"
+      },
       "bootstrap_catalogue": false,
       "requested_link": "ordinary_session",
       "json": "{\"peer_identity\":\"[\\\"urn:jazz:system\\\",\\\"system\\\"]\",\"auth\":{\"jwt_token\":null,\"backend_secret\":null,\"admin_secret\":\"admin-secret\",\"backend_session\":null}}"
@@ -15,7 +17,9 @@
       "name": "native_admin_catalogue_bootstrap",
       "writer": "rust-native",
       "peer_identity": "[\"urn:jazz:system\",\"system\"]",
-      "auth": { "admin_secret": "admin-secret" },
+      "auth": {
+        "admin_secret": "admin-secret"
+      },
       "bootstrap_catalogue": true,
       "requested_link": "ordinary_session",
       "json": "{\"peer_identity\":\"[\\\"urn:jazz:system\\\",\\\"system\\\"]\",\"auth\":{\"jwt_token\":null,\"backend_secret\":null,\"admin_secret\":\"admin-secret\",\"backend_session\":null},\"bootstrap_catalogue\":true}"
@@ -28,6 +32,15 @@
       "bootstrap_catalogue": false,
       "requested_link": "ordinary_session",
       "json": "{\"peer_identity\":\"[\\\"urn:jazz:system\\\",\\\"system\\\"]\",\"admin_secret\":\"admin-secret\",\"auth\":{\"admin_secret\":\"admin-secret\",\"sub\":\"system\"},\"sub\":\"system\"}"
+    },
+    {
+      "name": "typescript_scope_isolated_session",
+      "writer": "typescript-native-runtime",
+      "peer_identity": "[\"https://fixture.example\",\"scope-user\"]",
+      "auth_json": "{\"backend_secret\":\"backend-secret\",\"backend_session\":{\"issuer\":\"https://fixture.example\",\"user_id\":\"scope-user\",\"claims\":{},\"authMode\":\"external\"}}",
+      "bootstrap_catalogue": false,
+      "requested_link": "scope_isolated_client_relay",
+      "json": "{\"peer_identity\":\"[\\\"https://fixture.example\\\",\\\"scope-user\\\"]\",\"backend_secret\":\"backend-secret\",\"backend_session\":{\"issuer\":\"https://fixture.example\",\"user_id\":\"scope-user\",\"claims\":{},\"authMode\":\"external\"},\"auth\":{\"backend_secret\":\"backend-secret\",\"backend_session\":{\"issuer\":\"https://fixture.example\",\"user_id\":\"scope-user\",\"claims\":{},\"authMode\":\"external\"},\"sub\":\"scope-user\"},\"sub\":\"scope-user\",\"requested_link\":\"scope_isolated_client_relay\"}"
     }
   ]
 }

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -161,6 +161,38 @@ describe("websocket frame carrier", () => {
     });
   });
 
+  it("matches the shared websocket prelude v1 fixture", () => {
+    const fixture = JSON.parse(
+      readFileSync(
+        new URL("../../../../../crates/jazz/fixtures/websocket_prelude_v1.json", import.meta.url),
+        "utf8",
+      ),
+    ) as {
+      fixtures: Array<{
+        name: string;
+        writer: string;
+        peer_identity: string;
+        auth_json?: string;
+        requested_link: string;
+        json: string;
+      }>;
+    };
+
+    for (const entry of fixture.fixtures.filter(
+      (candidate) => candidate.writer === "typescript-native-runtime",
+    )) {
+      expect(
+        encodeWebSocketPrelude(
+          entry.auth_json!,
+          new TextEncoder().encode(entry.peer_identity),
+          entry.requested_link === "scope_isolated_client_relay"
+            ? "scope_isolated_client_relay"
+            : undefined,
+        ),
+      ).toBe(entry.json);
+    }
+  });
+
   it("uses the JWT subject for the websocket auth prelude when present", () => {
     const token = `header.${btoa(JSON.stringify({ iss: "https://issuer.example", sub: "user-123" }))}.sig`;
 


### PR DESCRIPTION
🤖 Document and test the existing WebSocket admission prelude identified by the format sweep in #2592.

Before binary sync begins, native Rust and TypeScript clients send a JSON authentication prelude. This PR pins both existing writer representations in one shared fixture, tests them against the server, and records required fields, defaults, unknown-field behavior, Hello ordering and the 2 MiB physical message boundary in SPEC08. It retains the existing prelude encoding; #2597 separately moves the query tree to Postcard.

A scoped relay request becomes a scoped server capability only for an authenticated session with the negotiated feature. Missing that feature rejects with UnsupportedFeature/Never; backend and admin credentials retain ordinary admission. The existing production selection is extracted into a private helper so tests assert the actual capability passed to the server session. The decision and error behavior are unchanged.

For example, omitting requested_link selects ordinary admission; an unknown link value rejects, while unknown extension fields are ignored. An exactly 2 MiB valid text or binary prelude reaches Hello; one byte more cannot reach admission. Row encodings and storage formats are unchanged.

Validation: independent adversarial review approved; coordinator reran 48 server WebSocket tests, the Rust writer fixture test, and 31 TypeScript carrier tests, all passing on the clean committed tree. Lane checks included formatting, Clippy and planted regressions for the size boundary, default behavior and forced ordinary-link selection; each plant failed and was restored. All CI partitions pass: https://github.com/garden-co/jazz/actions/runs/33995076252.
