### PR TITLE
Fix Rust shadow checkout and source fingerprint validation

### DIFF
--- a/.github/workflows/ci-rust-shadow.yml
+++ b/.github/workflows/ci-rust-shadow.yml
@@ -103,6 +103,8 @@ jobs:
         run: node dev/gates/rust-shadow-matrix.mjs clean-source-baseline "$RUST_SHADOW_SOURCE_BASELINE" "${{ github.sha }}"
       - uses: ./.github/actions/setup-blacksmith
       - name: Run exact-inventory Rust shadow shard
+        env:
+          RUST_SHADOW_SOURCE_BASELINE: ${{ runner.temp }}/rust-shadow-source.json
         run: node dev/gates/rust-shadow-matrix.mjs shard ${{ matrix.index }} 2 "target/rust-shadow/shard-${{ matrix.index }}.json"
       - name: Upload shadow shard receipt
         if: always()

--- a/.github/workflows/ci-rust-shadow.yml
+++ b/.github/workflows/ci-rust-shadow.yml
@@ -78,6 +78,13 @@ jobs:
           # Do not perform checkout's preliminary clean/reset. Tracked residue
           # is guarded above because checkout itself later forces its branch.
           clean: false
+      # The checkout is owned by the runner while this job's container executes
+      # the source-integrity diagnostics. Trust only this exact workspace before
+      # the first diagnostic Git command; setup-blacksmith repeats the same
+      # scoped configuration for later tool invocations.
+      - name: Trust checked-out workspace for Git diagnostics
+        shell: bash
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
       - name: Record checkout source state
         # Never repair an unexpected checkout and then attest to the repaired
         # tree: the next baseline step must fail closed for any tracked, index,

--- a/dev/gates/rust-shadow-matrix.mjs
+++ b/dev/gates/rust-shadow-matrix.mjs
@@ -340,6 +340,7 @@ function aggregate(argv) {
       "commit",
       "headTree",
       "indexTree",
+      "staged",
       "unstaged",
       "untracked",
       "fingerprint",

--- a/dev/gates/rust-shadow-matrix.mjs
+++ b/dev/gates/rust-shadow-matrix.mjs
@@ -46,7 +46,7 @@ const sourceFingerprint = (source) =>
   crypto
     .createHash("sha256")
     .update(
-      ["headTree", "indexTree", "unstaged", "untracked"]
+      ["headTree", "indexTree", "staged", "unstaged", "untracked"]
         .map((field) => `${field}\0${source[field]}\0`)
         .join(""),
     )
@@ -56,6 +56,7 @@ const validSourceIdentity = (source) =>
   /^[0-9a-f]{40}$/.test(source.commit) &&
   /^[0-9a-f]{40}$/.test(source.headTree) &&
   /^[0-9a-f]{40}$/.test(source.indexTree) &&
+  /^[0-9a-f]{64}$/.test(source.staged) &&
   /^[0-9a-f]{64}$/.test(source.unstaged) &&
   /^[0-9a-f]{64}$/.test(source.untracked) &&
   /^[0-9a-f]{64}$/.test(source.fingerprint) &&

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -802,6 +802,7 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
     commit: "a".repeat(40),
     headTree: "b".repeat(40),
     indexTree: "b".repeat(40),
+    staged: "e".repeat(64),
     unstaged: "c".repeat(64),
     untracked: "d".repeat(64),
     dirty: false,
@@ -810,7 +811,7 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
     crypto
       .createHash("sha256")
       .update(
-        ["headTree", "indexTree", "unstaged", "untracked"]
+        ["headTree", "indexTree", "staged", "unstaged", "untracked"]
           .map((field) => `${field}\0${value[field]}\0`)
           .join(""),
       )
@@ -973,6 +974,30 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
       message,
       `planted ${name} mismatch must identify the violated binding`,
     );
+  }
+});
+
+test("a clean checkout seals a Rust shadow source baseline", () => {
+  const receipt = path.join(os.tmpdir(), `jazz-rust-shadow-source-${process.pid}-${Date.now()}.json`);
+  try {
+    const commit = spawnSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" });
+    assert.equal(commit.status, 0, commit.stderr);
+    const result = spawnSync(
+      "node",
+      [
+        path.join(root, "dev/gates/rust-shadow-matrix.mjs"),
+        "clean-source-baseline",
+        receipt,
+        commit.stdout.trim(),
+      ],
+      { cwd: root, encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const source = JSON.parse(fs.readFileSync(receipt, "utf8"));
+    assert.equal(source.dirty, false);
+    assert.match(source.staged, /^[0-9a-f]{64}$/);
+  } finally {
+    fs.rmSync(receipt, { force: true });
   }
 });
 

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -743,8 +743,8 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
     "the ownership exception must name only the Actions workspace",
   );
   assert.ok(
-    shard.steps.indexOf(checkout) < shard.steps.indexOf(safeDirectory)
-      && shard.steps.indexOf(safeDirectory) < shard.steps.indexOf(normalizeCheckout),
+    shard.steps.indexOf(checkout) < shard.steps.indexOf(safeDirectory) &&
+      shard.steps.indexOf(safeDirectory) < shard.steps.indexOf(normalizeCheckout),
     "the safe-directory setup must follow checkout and precede the first Git diagnostic",
   );
   assert.ok(normalizeCheckout, "shadow must record checkout state before sealing source identity");
@@ -979,7 +979,10 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
 
 test("a clean checkout seals a Rust shadow source baseline", () => {
   const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-rust-shadow-source-"));
-  const receipt = path.join(os.tmpdir(), `jazz-rust-shadow-receipt-${process.pid}-${Date.now()}.json`);
+  const receipt = path.join(
+    os.tmpdir(),
+    `jazz-rust-shadow-receipt-${process.pid}-${Date.now()}.json`,
+  );
   try {
     const gates = path.join(fixture, "dev/gates");
     fs.mkdirSync(gates, { recursive: true });
@@ -999,7 +1002,12 @@ test("a clean checkout seals a Rust shadow source baseline", () => {
       if (args[0] === "rev-parse") {
         const baseline = spawnSync(
           "node",
-          [path.join(gates, "rust-shadow-matrix.mjs"), "clean-source-baseline", receipt, result.stdout.trim()],
+          [
+            path.join(gates, "rust-shadow-matrix.mjs"),
+            "clean-source-baseline",
+            receipt,
+            result.stdout.trim(),
+          ],
           { cwd: fixture, encoding: "utf8" },
         );
         assert.equal(baseline.status, 0, baseline.stderr);

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -711,6 +711,9 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
   const preCheckout = shard.steps.find(
     (step) => step.name === "Reject pre-checkout source residue",
   );
+  const safeDirectory = shard.steps.find(
+    (step) => step.name === "Trust checked-out workspace for Git diagnostics",
+  );
   const normalizeCheckout = shard.steps.find(
     (step) => step.name === "Record checkout source state",
   );
@@ -732,6 +735,17 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
   assert.ok(
     shard.steps.indexOf(preCheckout) < shard.steps.indexOf(checkout),
     "pre-checkout inspection must run before actions/checkout",
+  );
+  assert.ok(safeDirectory, "shadow must trust its exact container checkout before Git diagnostics");
+  assert.match(
+    safeDirectory.run,
+    /git config --global --add safe\.directory "\$\{GITHUB_WORKSPACE:\?GITHUB_WORKSPACE is required\}"/,
+    "the ownership exception must name only the Actions workspace",
+  );
+  assert.ok(
+    shard.steps.indexOf(checkout) < shard.steps.indexOf(safeDirectory)
+      && shard.steps.indexOf(safeDirectory) < shard.steps.indexOf(normalizeCheckout),
+    "the safe-directory setup must follow checkout and precede the first Git diagnostic",
   );
   assert.ok(normalizeCheckout, "shadow must record checkout state before sealing source identity");
   assert.match(normalizeCheckout.run, /git status --short --untracked-files=all/);

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -978,25 +978,39 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
 });
 
 test("a clean checkout seals a Rust shadow source baseline", () => {
-  const receipt = path.join(os.tmpdir(), `jazz-rust-shadow-source-${process.pid}-${Date.now()}.json`);
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-rust-shadow-source-"));
+  const receipt = path.join(os.tmpdir(), `jazz-rust-shadow-receipt-${process.pid}-${Date.now()}.json`);
   try {
-    const commit = spawnSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" });
-    assert.equal(commit.status, 0, commit.stderr);
-    const result = spawnSync(
-      "node",
-      [
-        path.join(root, "dev/gates/rust-shadow-matrix.mjs"),
-        "clean-source-baseline",
-        receipt,
-        commit.stdout.trim(),
-      ],
-      { cwd: root, encoding: "utf8" },
-    );
-    assert.equal(result.status, 0, result.stderr);
-    const source = JSON.parse(fs.readFileSync(receipt, "utf8"));
-    assert.equal(source.dirty, false);
-    assert.match(source.staged, /^[0-9a-f]{64}$/);
+    const gates = path.join(fixture, "dev/gates");
+    fs.mkdirSync(gates, { recursive: true });
+    for (const file of ["rust-shadow-matrix.mjs", "source-identity.mjs"])
+      fs.copyFileSync(path.join(root, "dev/gates", file), path.join(gates, file));
+    fs.writeFileSync(path.join(fixture, "synthetic-source.txt"), "committed fixture source\n");
+    for (const args of [
+      ["init", "--quiet"],
+      ["config", "user.email", "test@example.invalid"],
+      ["config", "user.name", "Test"],
+      ["add", "."],
+      ["commit", "--quiet", "-m", "fixture"],
+      ["rev-parse", "HEAD"],
+    ]) {
+      const result = spawnSync("git", args, { cwd: fixture, encoding: "utf8" });
+      assert.equal(result.status, 0, result.stderr);
+      if (args[0] === "rev-parse") {
+        const baseline = spawnSync(
+          "node",
+          [path.join(gates, "rust-shadow-matrix.mjs"), "clean-source-baseline", receipt, result.stdout.trim()],
+          { cwd: fixture, encoding: "utf8" },
+        );
+        assert.equal(baseline.status, 0, baseline.stderr);
+        const source = JSON.parse(fs.readFileSync(receipt, "utf8"));
+        assert.equal(source.commit, result.stdout.trim());
+        assert.equal(source.dirty, false);
+        assert.match(source.staged, /^[0-9a-f]{64}$/);
+      }
+    }
   } finally {
+    fs.rmSync(fixture, { recursive: true, force: true });
     fs.rmSync(receipt, { force: true });
   }
 });

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -720,6 +720,9 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
   const sealBaseline = shard.steps.find(
     (step) => step.name === "Seal clean checked-out source baseline",
   );
+  const runShard = shard.steps.find(
+    (step) => step.name === "Run exact-inventory Rust shadow shard",
+  );
   const checkout = shard.steps.find((step) => step.uses?.startsWith("actions/checkout@"));
   assert.equal(
     checkout?.with?.clean,
@@ -763,6 +766,11 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
     sealBaseline.env.RUST_SHADOW_SOURCE_BASELINE,
     "${{ runner.temp }}/rust-shadow-source.json",
     "the source baseline must resolve runner.temp at step scope",
+  );
+  assert.equal(
+    runShard?.env?.RUST_SHADOW_SOURCE_BASELINE,
+    "${{ runner.temp }}/rust-shadow-source.json",
+    "the exact partition producer must consume the sealed source baseline",
   );
   assert.match(
     rustShadowWorkflow,
@@ -940,6 +948,14 @@ test("the non-required Rust throughput shadow proves two exact hash partitions a
       "M3 receipt semantics",
       (shards) => (shards[0].m3.runner = "cargo-test"),
       /maintained M3 seed 11/,
+    ],
+    [
+      "nested receipt staged source identity",
+      (shards) => {
+        shards[0].testReceipt.source.staged = "f".repeat(64);
+        shards[0].testReceipt.source.fingerprint = sourceFingerprint(shards[0].testReceipt.source);
+      },
+      /partition test receipt source staged does not match its inventory receipt/,
     ],
     [
       "nested receipt source identity",


### PR DESCRIPTION
🤖 Fix two setup failures preventing Rust throughput shadow jobs from running tests.

First, Git rejected the container checkout's ownership before the shared setup configured safe.directory. Configure trust for the exact Actions workspace immediately after checkout, before source-state diagnostics. Both shards use the step; no wildcard or parent-directory trust is added.

Second, the baseline validator omitted the staged field when recomputing the producer's source fingerprint. This rejected even clean checkouts. Include and validate that field so producer and validator agree, retaining dirty-source rejection.

Finally, pass the sealed baseline into the shard execution step. Its previous step-local environment did not propagate, causing otherwise passing shards to record post-setup untracked state and fail aggregation. Bind staged source identity between inventory and nested test receipts as well.

Validation: coordinator source review and 48 workflow contract tests pass. A new test invokes the real baseline producer/validator in a temporary committed synthetic repository, independent of ambient edits. Removing the staged field fails the relevant tests; the plant was restored. Actual runner testing exposed each issue in sequence: https://github.com/garden-co/jazz/actions/runs/33995096008 and https://github.com/garden-co/jazz/actions/runs/33995368091. Both actual test shards passed after the first two fixes; their aggregate exposed the baseline propagation omission. The complete actual two-shard workflow and aggregate now pass: https://github.com/garden-co/jazz/actions/runs/33996252168. Standard PR CI also passes: https://github.com/garden-co/jazz/actions/runs/33996233239.
