### PR TITLE
Link the shared Postcard query contract and corpus

### DIFF
--- a/crates/jazz/SPEC/8_sync_protocol.md
+++ b/crates/jazz/SPEC/8_sync_protocol.md
@@ -86,6 +86,18 @@ replace row encoding. The same split applies at the binding ABI (ch. 13):
 commands, acks, and event metadata are postcard envelopes, while row-shaped
 payloads are descriptor/raw `Record` bytes at the hot boundary.
 
+#### Relation-query Postcard grammar in peer and binding envelopes
+
+Where a peer `ShapeAst` or binding `Query.relation`/`ShapeBody::Relation`
+contains a relation subtree, it uses the one typed Postcard relation-query
+grammar specified in [§19, Relation-query Postcard carrier](19_native_relays.md#relation-query-postcard-carrier).
+The direct native relation-read `WireRelationQuery` uses that same grammar; no
+WireFrame- or binding-specific relation subcodec exists. The committed
+`fixtures/relation_query_postcard.json` corpus pins its semantic-to-byte cases,
+the Rust receipt rejects noncanonical payloads, and TypeScript independently
+encodes the corpus and rejects malformed relation input. It is compatibility
+evidence, not a migration input.
+
 **Decision, 2026-08-28 — the sole wire protocol is v1.** `ViewUpdate` carries
 settled version payloads only through `version_carriers`; the transitional
 duplicate `version_bundles` field is absent. Every endpoint advertises exactly

--- a/crates/jazz/fixtures/persistent_codec_family_registry.json
+++ b/crates/jazz/fixtures/persistent_codec_family_registry.json
@@ -512,6 +512,10 @@
         {
           "path": "packages/jazz-tools/src/runtime/native-runtime/wire-frame-artifact-corpus.test.ts",
           "anchor": "describe(\"wire frame artifact corpus\""
+        },
+        {
+          "path": "crates/jazz/SPEC/8_sync_protocol.md",
+          "anchor": "#### Relation-query Postcard grammar in peer and binding envelopes"
         }
       ]
     },
@@ -534,6 +538,36 @@
         {
           "path": "crates/jazz/tests/wire_fixtures.rs",
           "anchor": "native_row_codec_fixture_round_trips_every_groove_value_type"
+        },
+        {
+          "path": "packages/jazz-tools/src/ir.test.ts",
+          "anchor": "test(\"matches the Rust-produced typed Postcard corpus\""
+        }
+      ]
+    },
+    {
+      "id": "jazz.relation-query-postcard.v1",
+      "boundary": "wire-binding-abi",
+      "spec": {
+        "path": "crates/jazz/SPEC/19_native_relays.md",
+        "anchor": "### Relation-query Postcard carrier"
+      },
+      "semantic_fixture": {
+        "path": "crates/jazz/fixtures/relation_query_postcard.json",
+        "anchor": "jazz-relation-query-postcard-v1"
+      },
+      "rejection_receipt": {
+        "path": "crates/jazz/src/query/relation_codec.rs",
+        "anchor": "fn typed_postcard_rejects_trailing_or_noncanonical_payloads()"
+      },
+      "evidence": [
+        {
+          "path": "crates/jazz/src/query/relation_codec.rs",
+          "anchor": "fn typed_postcard_corpus_is_current()"
+        },
+        {
+          "path": "packages/jazz-tools/src/ir.test.ts",
+          "anchor": "test(\"matches the Rust-produced typed Postcard corpus\""
         }
       ]
     },

--- a/crates/jazz/fixtures/relation_query_postcard.json
+++ b/crates/jazz/fixtures/relation_query_postcard.json
@@ -1,4 +1,5 @@
 {
+  "fixture_set": "jazz-relation-query-postcard-v1",
   "cases": [
     {
       "name": "table_scan",


### PR DESCRIPTION
🤖 Complete the format-audit references for the shared relation-query Postcard codec introduced by #2597 (#2160, #2461, #2592).

SPEC08 now points peer ShapeAst and binding relation payloads to the shared SPEC19 grammar. The codec registry links its exact-byte corpus, Rust rejection/corpus tests and independent TypeScript encoder evidence; existing wire-frame and binding entries also reference it. A fixture-set label identifies the corpus without changing any case bytes.

No runtime behavior, query encoding or storage bytes change. This makes the already-reviewed implementation discoverable from both peer and native format documentation.

Validation: coordinator reviewed the complete diff and reran the exact registry test (1 passed). Lane validation also passed the Rust corpus test, TypeScript corpus tests (6/6), spec check and formatting. CI pending.
