### PR TITLE
test: wait for edge catalogue bootstrap before admission

### DIFF
--- a/crates/jazz-testkit/tests/edge_server_mode.rs
+++ b/crates/jazz-testkit/tests/edge_server_mode.rs
@@ -811,6 +811,24 @@ async fn connect_user(server: &JazzServer, schema: Schema, user_id: &str) -> Jaz
     client
 }
 
+/// Dynamic edges admit downstream clients only after their authoritative
+/// catalogue has bootstrapped. The testkit helper retries that explicit
+/// `NotReady/Later` bootstrap response and then proves the edge can serve the
+/// table; any other connection failure remains terminal.
+async fn connect_user_after_catalogue_bootstrap(
+    server: &JazzServer,
+    schema: Schema,
+    user_id: &str,
+) -> JazzClient {
+    TestingClient::builder()
+        .with_server(server)
+        .with_schema(schema)
+        .with_user_id(user_id)
+        .ready_on("todos", Duration::from_secs(30))
+        .connect_after_retry_later(Duration::from_secs(30))
+        .await
+}
+
 async fn wait_for_row(
     client: &JazzClient,
     tier: DurabilityTier,
@@ -1309,9 +1327,13 @@ async fn core_write_reaches_clients_on_both_edges() {
                 .start()
                 .await;
 
-            let alice = connect_user(&edge_us, schema.clone(), "alice-edge-us").await;
-            let bob = connect_user(&edge_eu, schema.clone(), "bob-edge-eu").await;
-            let carol = connect_user(&core, schema, "carol-core").await;
+            let alice =
+                connect_user_after_catalogue_bootstrap(&edge_us, schema.clone(), "alice-edge-us")
+                    .await;
+            let bob =
+                connect_user_after_catalogue_bootstrap(&edge_eu, schema.clone(), "bob-edge-eu")
+                    .await;
+            let carol = connect_user_after_catalogue_bootstrap(&core, schema, "carol-core").await;
             let mut alice_stream = alice
                 .subscribe(todo_query())
                 .await


### PR DESCRIPTION
🤖 A multi-edge test sometimes connected before an Edge finished bootstrapping its authoritative catalogue. The server correctly returned retryable `NotReady/Later`, but the test failed immediately before reaching its query-readiness check.

Use the existing testkit bootstrap-aware connection helper in this scenario. It keeps one client context, retries only the recognized catalogue-bootstrap response within a bounded deadline, and then requires the `todos` query to be ready. Other connection failures remain terminal. The existing Core-to-both-Edges subscription assertions are unchanged; no production runtime behavior changes.

Validation: focused test passed independently in the coordinator checkout (1/1); independent review approved. Implementation-lane Clippy and format checks passed. CI is pending. The triggering main CI failure is https://github.com/garden-co/jazz/actions/runs/33998090245/job/101392015952; the parallel release-candidate workspace partition passed, consistent with a readiness race.
