### PR TITLE
fix(inspector): import QueryOptions for release builds

### DIFF
--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -14,6 +14,7 @@ import {
   PersistedWriteRejectedError,
   type ColumnDescriptor,
   type ColumnType,
+  type QueryOptions,
   type TableProxy,
   type Value,
   type WriteResult,


### PR DESCRIPTION
🤖 Release starter preparation failed before any starter scenarios ran because the inspector referenced the public `QueryOptions` type in three annotations without importing it. Add the missing type-only import from `jazz-tools`; query behavior and emitted runtime code are unchanged.

The coordinator independently reran `pnpm --filter inspector build`: TypeScript, web and embedded Vite builds all passed on the committed tree. The implementation-lane build also passed. Original failure: https://github.com/garden-co/jazz/actions/runs/33998138454/job/101392143711.
