### PR TITLE
Restore NAPI runtime artifacts in starter CI

### DIFF
--- a/.github/workflows/starters-e2e.yml
+++ b/.github/workflows/starters-e2e.yml
@@ -176,6 +176,11 @@ jobs:
           name: starters-e2e-build-state
           path: .
 
+      - name: Verify restored NAPI harness runtime
+        # Fail before creating a starter when the artifact handoff is missing
+        # any generated bootstrap file required by jazz-tools/dev.
+        run: node -e 'require("./crates/jazz-napi")'
+
       - name: Cache Playwright browsers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:

--- a/.github/workflows/starters-e2e.yml
+++ b/.github/workflows/starters-e2e.yml
@@ -108,15 +108,21 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: starters-e2e-build-state
-          # Tarballs feed `--tarball-dir`. jazz-tools/dist and jazz-napi's JS +
-          # native binary are needed at *harness* runtime (the harness imports
-          # `jazz-tools/dev`, which in turn requires jazz-napi).
+          # Tarballs feed `--tarball-dir`. jazz-tools/dist and jazz-napi's
+          # generated root runtime closure are needed at *harness* runtime (the
+          # harness imports `jazz-tools/dev`, which in turn requires jazz-napi).
+          # The tracked bootstrap loads native-loader.cjs and its fingerprint
+          # receipt when the machine-local build pointer is absent in a clean
+          # matrix checkout.
           path: |
             _e2e-state/tarballs/**
             packages/jazz-tools/dist/**
             crates/jazz-napi/index.js
             crates/jazz-napi/index.d.ts
             crates/jazz-napi/*.node
+            crates/jazz-napi/*.manifest.json
+            crates/jazz-napi/native-loader.cjs
+            crates/jazz-napi/native-artifact-fingerprint.cjs
           if-no-files-found: error
           retention-days: 1
 

--- a/dev/gates/test/release-gates.test.mjs
+++ b/dev/gates/test/release-gates.test.mjs
@@ -68,6 +68,20 @@ test("release starter gate exercises packaged artifacts through create-jazz-e2e"
   assert.match(prepare, /pnpm run build:core/);
   assert.match(prepare, /for pkg in jazz-tools jazz-napi jazz-wasm;/);
   assert.match(prepare, /name: starters-e2e-build-state/);
+  // The clean matrix checkout keeps tracked bootstrap files, but the NAPI
+  // loader, its fingerprint receipt, native binary, and manifest are build
+  // outputs restored from the prepare artifact.
+  for (const runtimeArtifact of [
+    "crates/jazz-napi/*.node",
+    "crates/jazz-napi/*.manifest.json",
+    "crates/jazz-napi/native-loader.cjs",
+    "crates/jazz-napi/native-artifact-fingerprint.cjs",
+  ]) {
+    assert.ok(
+      prepare.includes(runtimeArtifact),
+      `missing NAPI runtime artifact ${runtimeArtifact}`,
+    );
+  }
   assert.match(e2e, /name: starters-e2e-build-state/);
   assert.match(e2e, /--tarball-dir "\$GITHUB_WORKSPACE\/_e2e-state\/tarballs"/);
   assert.match(e2e, /--verbose --keep/);

--- a/dev/gates/test/release-gates.test.mjs
+++ b/dev/gates/test/release-gates.test.mjs
@@ -83,6 +83,10 @@ test("release starter gate exercises packaged artifacts through create-jazz-e2e"
     );
   }
   assert.match(e2e, /name: starters-e2e-build-state/);
+  assert.match(
+    e2e,
+    /name: Restore prebuilt artifacts[\s\S]*?name: Verify restored NAPI harness runtime[\s\S]*?require\("\.\/crates\/jazz-napi"\)/,
+  );
   assert.match(e2e, /--tarball-dir "\$GITHUB_WORKSPACE\/_e2e-state\/tarballs"/);
   assert.match(e2e, /--verbose --keep/);
 });


### PR DESCRIPTION
🤖 Restore the generated NAPI loader and fingerprint in the Starters E2E artifact handoff.

All twelve starter jobs in run33999681640 fail before app tests: the clean matrix checkout has the tracked NAPI bootstrap and restored native binary, but lacks native-loader.cjs. The prepare job stages this loader while packing jazz-napi, yet its upload list omits it.

The handoff now includes that generated loader, its matching fingerprint, and native manifests. A clean consumer therefore loads the same staged native generation without relying on the prepare runner's machine-local pointer. No runtime, storage format, starter behavior, or acceptance assertion changes.

A post-restore NAPI import preflight now reports incomplete handoffs immediately, before scaffolding.

Validation: independent adversarial review passed, including32 focused contract/provenance tests and clean-checkout restoration. The restored package imports successfully; deleting its loader, fingerprint receipt, or native binary causes failure. Coordinator independently reran6 release-gate tests, formatting, clean import and loader/fingerprint deletion negatives. No findings.

Full CI34000981589 passed after an exact TypeScript retry; the recurrent BandChat test-input failure was separately diagnosed and fixed in merged #2610. Matrix34000984904 verified this NAPI handoff and reached all12 app harnesses, then exposed a separate tools/WASM fingerprint mismatch. Stacked #2608 repairs that build ordering. The combined matrix34002971096 is running. User approval remains conditional on green CI and the full starter matrix; this PR is not merged yet.
