### PR TITLE
Build coherent native artifacts and TypeScript packages for starters

### DIFF
--- a/.github/workflows/starters-e2e.yml
+++ b/.github/workflows/starters-e2e.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Build core workspace
         run: pnpm run build:core
 
+      - name: Verify starter package artifact hand-off
+        run: node dev/artifacts/verify-starter-e2e-artifacts.mjs
+
       - name: Pack workspace tarballs
         # Mirrors PACKAGES_TO_PACK in run-starter.ts. The harness picks these up
         # via `--tarball-dir` and pins them as `pnpm.overrides` in each

--- a/dev/artifacts/stage-native-fingerprints.mjs
+++ b/dev/artifacts/stage-native-fingerprints.mjs
@@ -14,19 +14,18 @@ const wasmArtifactFiles = [
 export function stageNativeFingerprints(root, { local = false, workspace = false } = {}) {
   if (local && workspace) throw new Error("--local and --workspace are mutually exclusive");
   const wasm = read(join(root, "crates/jazz-wasm/pkg/.jazz-artifact-manifest.json"));
-  const napi = local
-    ? read(
-        join(
-          root,
-          "crates/jazz-napi/.native-artifacts",
-          /generation-[A-Za-z0-9.-]+/.exec(
-            readFileSync(join(root, "crates/jazz-napi/native-binding.pointer.cjs"), "utf8"),
-          )?.[0] ?? "missing",
-          ".jazz-artifact-manifest.json",
-        ),
-      )
-    : workspace
-      ? read(join(root, "crates/jazz-napi/jazz-napi.linux-x64-gnu.manifest.json"))
+  const napi =
+    local || workspace
+      ? read(
+          join(
+            root,
+            "crates/jazz-napi/.native-artifacts",
+            /generation-[A-Za-z0-9.-]+/.exec(
+              readFileSync(join(root, "crates/jazz-napi/native-binding.pointer.cjs"), "utf8"),
+            )?.[0] ?? "missing",
+            ".jazz-artifact-manifest.json",
+          ),
+        )
       : read(join(root, "crates/jazz-napi/provenance/jazz-napi.linux-x64-gnu.manifest.json"));
   for (const [name, manifest] of [
     ["wasm", wasm],

--- a/dev/artifacts/stage-native-fingerprints.mjs
+++ b/dev/artifacts/stage-native-fingerprints.mjs
@@ -11,7 +11,8 @@ const wasmArtifactFiles = [
   "jazz_wasm.d.ts",
   "jazz_wasm.js",
 ];
-export function stageNativeFingerprints(root, { local = false } = {}) {
+export function stageNativeFingerprints(root, { local = false, workspace = false } = {}) {
+  if (local && workspace) throw new Error("--local and --workspace are mutually exclusive");
   const wasm = read(join(root, "crates/jazz-wasm/pkg/.jazz-artifact-manifest.json"));
   const napi = local
     ? read(
@@ -24,7 +25,9 @@ export function stageNativeFingerprints(root, { local = false } = {}) {
           ".jazz-artifact-manifest.json",
         ),
       )
-    : read(join(root, "crates/jazz-napi/provenance/jazz-napi.linux-x64-gnu.manifest.json"));
+    : workspace
+      ? read(join(root, "crates/jazz-napi/jazz-napi.linux-x64-gnu.manifest.json"))
+      : read(join(root, "crates/jazz-napi/provenance/jazz-napi.linux-x64-gnu.manifest.json"));
   for (const [name, manifest] of [
     ["wasm", wasm],
     ["napi", napi],
@@ -73,7 +76,10 @@ export function stageNativeFingerprints(root, { local = false } = {}) {
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const root = resolve(fileURLToPath(new URL("../..", import.meta.url)));
   try {
-    stageNativeFingerprints(root, { local: process.argv.includes("--local") });
+    stageNativeFingerprints(root, {
+      local: process.argv.includes("--local"),
+      workspace: process.argv.includes("--workspace"),
+    });
   } catch (error) {
     console.error(`stage native fingerprints: ${error.message}`);
     process.exitCode = 1;

--- a/dev/artifacts/verify-starter-e2e-artifacts.mjs
+++ b/dev/artifacts/verify-starter-e2e-artifacts.mjs
@@ -7,6 +7,7 @@
  * timeouts.
  */
 import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -49,10 +50,19 @@ async function wasmFingerprint(root) {
     throw new Error("WASM module lacks a native artifact fingerprint");
   return actual;
 }
+function napiFingerprints(root) {
+  const pointer = join(root, "crates/jazz-napi/native-binding.pointer.cjs");
+  const { nativeBinding, expectedNativeArtifactFingerprint } = createRequire(pointer)(pointer);
+  return {
+    actual: nativeBinding.nativeArtifactFingerprint(),
+    expected: expectedNativeArtifactFingerprint,
+  };
+}
 
 export async function verifyStarterE2EArtifacts(
   root = repositoryRoot,
   loadWasmFingerprint = wasmFingerprint,
+  loadNapiFingerprints = napiFingerprints,
 ) {
   const expected = {
     wasm: manifestFingerprint(
@@ -81,6 +91,15 @@ export async function verifyStarterE2EArtifacts(
   if (actualWasm !== expected.wasm)
     throw new Error(
       `starter E2E WASM package hand-off mismatch: manifest expects ${expected.wasm}, module returns ${actualWasm}.`,
+    );
+  const napi = await loadNapiFingerprints(root);
+  if (
+    napi.actual !== expected.napi ||
+    napi.expected !== expected.napi ||
+    napi.actual !== compiled.napi
+  )
+    throw new Error(
+      `starter E2E NAPI package hand-off mismatch: manifest and jazz-tools expect ${expected.napi}, pointer expects ${napi.expected}, module returns ${napi.actual}.`,
     );
 }
 

--- a/dev/artifacts/verify-starter-e2e-artifacts.mjs
+++ b/dev/artifacts/verify-starter-e2e-artifacts.mjs
@@ -28,25 +28,38 @@ function compiledFingerprint(path, symbol) {
   return match[1];
 }
 
+function activeNapiManifest(root) {
+  const pointer = readFileSync(join(root, "crates/jazz-napi/native-binding.pointer.cjs"), "utf8");
+  const generation = /generation-[A-Za-z0-9.-]+/.exec(pointer)?.[0];
+  if (!generation) throw new Error("NAPI build has no active generation pointer");
+  return join(
+    root,
+    "crates/jazz-napi/.native-artifacts",
+    generation,
+    ".jazz-artifact-manifest.json",
+  );
+}
+
 async function wasmFingerprint(root) {
   const pkg = join(root, "crates/jazz-wasm/pkg");
   const bindings = await import(pathToFileURL(join(pkg, "jazz_wasm.js")).href);
   bindings.initSync({ module: readFileSync(join(pkg, "jazz_wasm_bg.wasm")) });
   const actual = bindings.nativeArtifactFingerprint();
-  if (!/^[a-f0-9]{64}$/.test(actual)) throw new Error("WASM module lacks a native artifact fingerprint");
+  if (!/^[a-f0-9]{64}$/.test(actual))
+    throw new Error("WASM module lacks a native artifact fingerprint");
   return actual;
 }
 
-export async function verifyStarterE2EArtifacts(root = repositoryRoot) {
+export async function verifyStarterE2EArtifacts(
+  root = repositoryRoot,
+  loadWasmFingerprint = wasmFingerprint,
+) {
   const expected = {
     wasm: manifestFingerprint(
       join(root, "crates/jazz-wasm/pkg/.jazz-artifact-manifest.json"),
       "wasm",
     ),
-    napi: manifestFingerprint(
-      join(root, "crates/jazz-napi/jazz-napi.linux-x64-gnu.manifest.json"),
-      "napi",
-    ),
+    napi: manifestFingerprint(activeNapiManifest(root), "napi"),
   };
   const compiled = {
     wasm: compiledFingerprint(
@@ -64,7 +77,7 @@ export async function verifyStarterE2EArtifacts(root = repositoryRoot) {
         `starter E2E ${kind.toUpperCase()} package hand-off mismatch: jazz-tools expects ${compiled[kind]}, native artifact is ${expected[kind]}. Re-stage native fingerprints and rebuild jazz-tools.`,
       );
   }
-  const actualWasm = await wasmFingerprint(root);
+  const actualWasm = await loadWasmFingerprint(root);
   if (actualWasm !== expected.wasm)
     throw new Error(
       `starter E2E WASM package hand-off mismatch: manifest expects ${expected.wasm}, module returns ${actualWasm}.`,

--- a/dev/artifacts/verify-starter-e2e-artifacts.mjs
+++ b/dev/artifacts/verify-starter-e2e-artifacts.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * The starter E2E prepare job packs jazz-tools and jazz-wasm separately.  A
+ * Jazz Tools build must therefore be compiled after the generated runtime
+ * fingerprint sources are staged from the exact native artifacts being packed.
+ * Check that hand-off before the matrix can turn it into twelve opaque browser
+ * timeouts.
+ */
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repositoryRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+
+function manifestFingerprint(path, kind) {
+  const manifest = JSON.parse(readFileSync(path, "utf8"));
+  if (manifest.kind !== kind || manifest.profile !== "release")
+    throw new Error(`${kind} manifest has an unexpected kind or profile`);
+  if (!/^[a-f0-9]{64}$/.test(manifest.nativeArtifactFingerprint ?? ""))
+    throw new Error(`${kind} manifest lacks a native artifact fingerprint`);
+  return manifest.nativeArtifactFingerprint;
+}
+
+function compiledFingerprint(path, symbol) {
+  const source = readFileSync(path, "utf8");
+  const match = source.match(new RegExp(`export const ${symbol} = "([a-f0-9]{64})"`));
+  if (!match) throw new Error(`${symbol} is missing from ${path}`);
+  return match[1];
+}
+
+async function wasmFingerprint(root) {
+  const pkg = join(root, "crates/jazz-wasm/pkg");
+  const bindings = await import(pathToFileURL(join(pkg, "jazz_wasm.js")).href);
+  bindings.initSync({ module: readFileSync(join(pkg, "jazz_wasm_bg.wasm")) });
+  const actual = bindings.nativeArtifactFingerprint();
+  if (!/^[a-f0-9]{64}$/.test(actual)) throw new Error("WASM module lacks a native artifact fingerprint");
+  return actual;
+}
+
+export async function verifyStarterE2EArtifacts(root = repositoryRoot) {
+  const expected = {
+    wasm: manifestFingerprint(
+      join(root, "crates/jazz-wasm/pkg/.jazz-artifact-manifest.json"),
+      "wasm",
+    ),
+    napi: manifestFingerprint(
+      join(root, "crates/jazz-napi/jazz-napi.linux-x64-gnu.manifest.json"),
+      "napi",
+    ),
+  };
+  const compiled = {
+    wasm: compiledFingerprint(
+      join(root, "packages/jazz-tools/dist/runtime/native-artifact-fingerprint-wasm.js"),
+      "EXPECTED_WASM_ARTIFACT_FINGERPRINT",
+    ),
+    napi: compiledFingerprint(
+      join(root, "packages/jazz-tools/dist/runtime/native-artifact-fingerprint-napi.js"),
+      "EXPECTED_NAPI_ARTIFACT_FINGERPRINT",
+    ),
+  };
+  for (const kind of ["wasm", "napi"]) {
+    if (compiled[kind] !== expected[kind])
+      throw new Error(
+        `starter E2E ${kind.toUpperCase()} package hand-off mismatch: jazz-tools expects ${compiled[kind]}, native artifact is ${expected[kind]}. Re-stage native fingerprints and rebuild jazz-tools.`,
+      );
+  }
+  const actualWasm = await wasmFingerprint(root);
+  if (actualWasm !== expected.wasm)
+    throw new Error(
+      `starter E2E WASM package hand-off mismatch: manifest expects ${expected.wasm}, module returns ${actualWasm}.`,
+    );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await verifyStarterE2EArtifacts();
+  console.log("starter E2E package hand-off: jazz-tools matches release WASM and NAPI artifacts");
+}

--- a/dev/artifacts/verify-starter-e2e-artifacts.test.mjs
+++ b/dev/artifacts/verify-starter-e2e-artifacts.test.mjs
@@ -1,11 +1,9 @@
 import assert from "node:assert/strict";
-import { cpSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import test from "node:test";
 import { verifyStarterE2EArtifacts } from "./verify-starter-e2e-artifacts.mjs";
-
-const repositoryRoot = resolve(import.meta.dirname, "../..");
 
 function writeFingerprint(path, symbol, fingerprint) {
   writeFileSync(path, `export const ${symbol} = ${JSON.stringify(fingerprint)};\n`);
@@ -19,16 +17,24 @@ function fixture() {
   mkdirSync(wasmDir, { recursive: true });
   mkdirSync(runtimeDir, { recursive: true });
   mkdirSync(napiDir, { recursive: true });
-  for (const file of ["jazz_wasm.js", "jazz_wasm_bg.wasm"])
-    cpSync(join(repositoryRoot, "crates/jazz-wasm/pkg", file), join(wasmDir, file));
-  const fingerprint = "51c31773364d88405c4ac753e5ed7bfaf7b0a2eca40d9a0ac7b2c79be31bf0e9";
+  return { root, runtimeDir, wasmDir, napiDir };
+}
+
+function writeFixtureReceipts({ wasmDir, napiDir, runtimeDir }) {
+  const fingerprint = "a".repeat(64);
   writeFileSync(
     join(wasmDir, ".jazz-artifact-manifest.json"),
     JSON.stringify({ kind: "wasm", profile: "release", nativeArtifactFingerprint: fingerprint }),
   );
+  const generation = join(napiDir, ".native-artifacts/generation-test");
+  mkdirSync(generation, { recursive: true });
   writeFileSync(
-    join(napiDir, "jazz-napi.linux-x64-gnu.manifest.json"),
+    join(generation, ".jazz-artifact-manifest.json"),
     JSON.stringify({ kind: "napi", profile: "release", nativeArtifactFingerprint: fingerprint }),
+  );
+  writeFileSync(
+    join(napiDir, "native-binding.pointer.cjs"),
+    'module.exports = require("./.native-artifacts/generation-test/index.js");\n',
   );
   writeFingerprint(
     join(runtimeDir, "native-artifact-fingerprint-wasm.js"),
@@ -40,16 +46,20 @@ function fixture() {
     "EXPECTED_NAPI_ARTIFACT_FINGERPRINT",
     fingerprint,
   );
-  return { root, runtimeDir };
 }
 
 test("starter E2E artifact hand-off executes packaged WASM and rejects a stale Jazz Tools expectation", async () => {
-  const { root, runtimeDir } = fixture();
-  await verifyStarterE2EArtifacts(root);
+  const fixtureState = fixture();
+  writeFixtureReceipts(fixtureState);
+  const { root, runtimeDir } = fixtureState;
+  await verifyStarterE2EArtifacts(root, async () => "a".repeat(64));
   writeFingerprint(
     join(runtimeDir, "native-artifact-fingerprint-wasm.js"),
     "EXPECTED_WASM_ARTIFACT_FINGERPRINT",
     "b".repeat(64),
   );
-  await assert.rejects(() => verifyStarterE2EArtifacts(root), /WASM package hand-off mismatch/);
+  await assert.rejects(
+    () => verifyStarterE2EArtifacts(root, async () => "a".repeat(64)),
+    /WASM package hand-off mismatch/,
+  );
 });

--- a/dev/artifacts/verify-starter-e2e-artifacts.test.mjs
+++ b/dev/artifacts/verify-starter-e2e-artifacts.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { cpSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { verifyStarterE2EArtifacts } from "./verify-starter-e2e-artifacts.mjs";
+
+const repositoryRoot = resolve(import.meta.dirname, "../..");
+
+function writeFingerprint(path, symbol, fingerprint) {
+  writeFileSync(path, `export const ${symbol} = ${JSON.stringify(fingerprint)};\n`);
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "jazz-starter-e2e-artifacts-"));
+  const wasmDir = join(root, "crates/jazz-wasm/pkg");
+  const runtimeDir = join(root, "packages/jazz-tools/dist/runtime");
+  const napiDir = join(root, "crates/jazz-napi");
+  mkdirSync(wasmDir, { recursive: true });
+  mkdirSync(runtimeDir, { recursive: true });
+  mkdirSync(napiDir, { recursive: true });
+  for (const file of ["jazz_wasm.js", "jazz_wasm_bg.wasm"])
+    cpSync(join(repositoryRoot, "crates/jazz-wasm/pkg", file), join(wasmDir, file));
+  const fingerprint = "51c31773364d88405c4ac753e5ed7bfaf7b0a2eca40d9a0ac7b2c79be31bf0e9";
+  writeFileSync(
+    join(wasmDir, ".jazz-artifact-manifest.json"),
+    JSON.stringify({ kind: "wasm", profile: "release", nativeArtifactFingerprint: fingerprint }),
+  );
+  writeFileSync(
+    join(napiDir, "jazz-napi.linux-x64-gnu.manifest.json"),
+    JSON.stringify({ kind: "napi", profile: "release", nativeArtifactFingerprint: fingerprint }),
+  );
+  writeFingerprint(
+    join(runtimeDir, "native-artifact-fingerprint-wasm.js"),
+    "EXPECTED_WASM_ARTIFACT_FINGERPRINT",
+    fingerprint,
+  );
+  writeFingerprint(
+    join(runtimeDir, "native-artifact-fingerprint-napi.js"),
+    "EXPECTED_NAPI_ARTIFACT_FINGERPRINT",
+    fingerprint,
+  );
+  return { root, runtimeDir };
+}
+
+test("starter E2E artifact hand-off executes packaged WASM and rejects a stale Jazz Tools expectation", async () => {
+  const { root, runtimeDir } = fixture();
+  await verifyStarterE2EArtifacts(root);
+  writeFingerprint(
+    join(runtimeDir, "native-artifact-fingerprint-wasm.js"),
+    "EXPECTED_WASM_ARTIFACT_FINGERPRINT",
+    "b".repeat(64),
+  );
+  await assert.rejects(() => verifyStarterE2EArtifacts(root), /WASM package hand-off mismatch/);
+});

--- a/dev/artifacts/verify-starter-e2e-artifacts.test.mjs
+++ b/dev/artifacts/verify-starter-e2e-artifacts.test.mjs
@@ -5,61 +5,95 @@ import { join } from "node:path";
 import test from "node:test";
 import { verifyStarterE2EArtifacts } from "./verify-starter-e2e-artifacts.mjs";
 
+const fingerprintA = "a".repeat(64);
+const fingerprintB = "b".repeat(64);
+
 function writeFingerprint(path, symbol, fingerprint) {
   writeFileSync(path, `export const ${symbol} = ${JSON.stringify(fingerprint)};\n`);
 }
 
-function fixture() {
+function fixture({
+  wasm = fingerprintA,
+  napiManifest = fingerprintA,
+  napiPointer = napiManifest,
+  napiActual = napiPointer,
+  compiledWasm = wasm,
+  compiledNapi = napiManifest,
+} = {}) {
   const root = mkdtempSync(join(tmpdir(), "jazz-starter-e2e-artifacts-"));
   const wasmDir = join(root, "crates/jazz-wasm/pkg");
   const runtimeDir = join(root, "packages/jazz-tools/dist/runtime");
-  const napiDir = join(root, "crates/jazz-napi");
+  const generationDir = join(root, "crates/jazz-napi/.native-artifacts/generation-test");
   mkdirSync(wasmDir, { recursive: true });
   mkdirSync(runtimeDir, { recursive: true });
-  mkdirSync(napiDir, { recursive: true });
-  return { root, runtimeDir, wasmDir, napiDir };
-}
-
-function writeFixtureReceipts({ wasmDir, napiDir, runtimeDir }) {
-  const fingerprint = "a".repeat(64);
+  mkdirSync(generationDir, { recursive: true });
   writeFileSync(
     join(wasmDir, ".jazz-artifact-manifest.json"),
-    JSON.stringify({ kind: "wasm", profile: "release", nativeArtifactFingerprint: fingerprint }),
-  );
-  const generation = join(napiDir, ".native-artifacts/generation-test");
-  mkdirSync(generation, { recursive: true });
-  writeFileSync(
-    join(generation, ".jazz-artifact-manifest.json"),
-    JSON.stringify({ kind: "napi", profile: "release", nativeArtifactFingerprint: fingerprint }),
+    JSON.stringify({ kind: "wasm", profile: "release", nativeArtifactFingerprint: wasm }),
   );
   writeFileSync(
-    join(napiDir, "native-binding.pointer.cjs"),
-    'module.exports = require("./.native-artifacts/generation-test/index.js");\n',
+    join(generationDir, ".jazz-artifact-manifest.json"),
+    JSON.stringify({ kind: "napi", profile: "release", nativeArtifactFingerprint: napiManifest }),
+  );
+  writeFileSync(
+    join(generationDir, "index.js"),
+    `module.exports = { nativeArtifactFingerprint: () => ${JSON.stringify(napiActual)} };\n`,
+  );
+  writeFileSync(
+    join(root, "crates/jazz-napi/native-binding.pointer.cjs"),
+    `const nativeBinding = require("./.native-artifacts/generation-test/index.js");\nmodule.exports = { nativeBinding, expectedNativeArtifactFingerprint: ${JSON.stringify(napiPointer)} };\n`,
   );
   writeFingerprint(
     join(runtimeDir, "native-artifact-fingerprint-wasm.js"),
     "EXPECTED_WASM_ARTIFACT_FINGERPRINT",
-    fingerprint,
+    compiledWasm,
   );
   writeFingerprint(
     join(runtimeDir, "native-artifact-fingerprint-napi.js"),
     "EXPECTED_NAPI_ARTIFACT_FINGERPRINT",
-    fingerprint,
+    compiledNapi,
   );
+  return { root };
 }
 
-test("starter E2E artifact hand-off executes packaged WASM and rejects a stale Jazz Tools expectation", async () => {
-  const fixtureState = fixture();
-  writeFixtureReceipts(fixtureState);
-  const { root, runtimeDir } = fixtureState;
-  await verifyStarterE2EArtifacts(root, async () => "a".repeat(64));
-  writeFingerprint(
-    join(runtimeDir, "native-artifact-fingerprint-wasm.js"),
-    "EXPECTED_WASM_ARTIFACT_FINGERPRINT",
-    "b".repeat(64),
-  );
+test("starter E2E artifact hand-off checks self-contained staged receipts against injected WASM and active NAPI bindings", async () => {
+  const { root } = fixture();
+  await verifyStarterE2EArtifacts(root, async () => fingerprintA);
+});
+
+test("starter E2E artifact hand-off rejects a stale Jazz Tools expectation", async () => {
+  const { root } = fixture({ compiledWasm: fingerprintB });
   await assert.rejects(
-    () => verifyStarterE2EArtifacts(root, async () => "a".repeat(64)),
+    () => verifyStarterE2EArtifacts(root, async () => fingerprintA),
     /WASM package hand-off mismatch/,
+  );
+});
+
+test("starter E2E artifact hand-off rejects a packaged WASM runtime with a coherent stale receipt", async () => {
+  const { root } = fixture({ wasm: fingerprintB, compiledWasm: fingerprintB });
+  await assert.rejects(
+    () => verifyStarterE2EArtifacts(root, async () => fingerprintA),
+    /manifest expects b{64}, module returns a{64}/,
+  );
+});
+
+test("starter E2E artifact hand-off rejects an active NAPI binding that disagrees with its manifest and Jazz Tools", async () => {
+  const { root } = fixture({
+    napiManifest: fingerprintB,
+    napiPointer: fingerprintB,
+    napiActual: fingerprintA,
+    compiledNapi: fingerprintB,
+  });
+  await assert.rejects(
+    () => verifyStarterE2EArtifacts(root, async () => fingerprintA),
+    /manifest and jazz-tools expect b{64}, pointer expects b{64}, module returns a{64}/,
+  );
+});
+
+test("starter E2E artifact hand-off rejects a NAPI pointer receipt that disagrees with its active manifest", async () => {
+  const { root } = fixture({ napiPointer: fingerprintB });
+  await assert.rejects(
+    () => verifyStarterE2EArtifacts(root, async () => fingerprintA),
+    /manifest and jazz-tools expect a{64}, pointer expects b{64}, module returns b{64}/,
   );
 });

--- a/dev/gates/test/correctness-consumer-contract.test.mjs
+++ b/dev/gates/test/correctness-consumer-contract.test.mjs
@@ -102,10 +102,16 @@ test("sealed consumers select content-addressed artifact paths rather than workt
 
   const worker = read("packages/jazz-tools/scripts/bundle-broker-worker.mjs");
   assert.match(worker, /JAZZ_CORRECTNESS_WASM_PACKAGE/);
+  assert.match(worker, /JAZZ_CORRECTNESS_ARTIFACT_RUN/);
   assert.ok(
     worker.indexOf("const sealedWasmPackage") <
-      worker.indexOf("const snapshot = sealedWasmPackage"),
-    "sealed worker bundling must not consult a mutable WASM pointer",
+      worker.indexOf("if (correctnessArtifactRun && !sealedWasmPackage)"),
+    "worker bundling must reject an explicit correctness run without its sealed WASM package",
+  );
+  assert.doesNotMatch(
+    worker,
+    /readCorrectnessArtifactSnapshot/,
+    "ordinary worker bundling must not pair workspace glue with an ignored correctness snapshot",
   );
 
   for (const config of [

--- a/dev/gates/test/release-gates.test.mjs
+++ b/dev/gates/test/release-gates.test.mjs
@@ -66,6 +66,7 @@ test("release starter gate exercises packaged artifacts through create-jazz-e2e"
   const prepare = job("prepare", "e2e");
   const e2e = job("e2e");
   assert.match(prepare, /pnpm run build:core/);
+  assert.match(prepare, /node dev\/artifacts\/verify-starter-e2e-artifacts\.mjs/);
   assert.match(prepare, /for pkg in jazz-tools jazz-napi jazz-wasm;/);
   assert.match(prepare, /name: starters-e2e-build-state/);
   // The clean matrix checkout keeps tracked bootstrap files, but the NAPI

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:vercel-docs": "pnpm --filter docs build",
     "build:vercel-inspector": "pnpm --filter inspector run build:vercel",
     "build": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build --filter=!jazz-wasm --only",
-    "build:core": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build --filter=./packages/** --filter=jazz-napi --only",
+    "build:core": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm --filter=jazz-napi --only && node dev/artifacts/stage-native-fingerprints.mjs --workspace && turbo run build --filter=./packages/** --only && node dev/artifacts/verify-starter-e2e-artifacts.mjs",
     "build:ci": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build --filter=jazz-napi --filter=jazz-tools --only",
     "build:correctness-artifacts": "node dev/gates/build-test-artifacts.mjs",
     "test:typescript-consumers": "node dev/gates/run-ts-consumers.mjs",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:vercel-docs": "pnpm --filter docs build",
     "build:vercel-inspector": "pnpm --filter inspector run build:vercel",
     "build": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build --filter=!jazz-wasm --only",
-    "build:core": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm --filter=jazz-napi --only && node dev/artifacts/stage-native-fingerprints.mjs --workspace && turbo run build --filter=./packages/** --only && node dev/artifacts/verify-starter-e2e-artifacts.mjs",
+    "build:core": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm --only && turbo run build --filter=jazz-napi --only && node dev/artifacts/stage-native-fingerprints.mjs --workspace && turbo run build --filter=./packages/** --only && node dev/artifacts/verify-starter-e2e-artifacts.mjs",
     "build:ci": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build --filter=jazz-napi --filter=jazz-tools --only",
     "build:correctness-artifacts": "node dev/gates/build-test-artifacts.mjs",
     "test:typescript-consumers": "node dev/gates/run-ts-consumers.mjs",

--- a/packages/jazz-tools/scripts/bundle-broker-worker.mjs
+++ b/packages/jazz-tools/scripts/bundle-broker-worker.mjs
@@ -15,8 +15,9 @@ const correctnessArtifactRun = process.env.JAZZ_CORRECTNESS_ARTIFACT_RUN === "1"
 const sealedWasmPackage = process.env.JAZZ_CORRECTNESS_WASM_PACKAGE;
 if (correctnessArtifactRun && !sealedWasmPackage)
   throw new Error("sealed correctness consumer is missing its admitted WASM package");
-const wasmSource = sealedWasmPackage
-  ? resolve(sealedWasmPackage, "jazz_wasm_bg.wasm")
+const correctnessWasmPackage = correctnessArtifactRun ? sealedWasmPackage : undefined;
+const wasmSource = correctnessWasmPackage
+  ? resolve(correctnessWasmPackage, "jazz_wasm_bg.wasm")
   : fileURLToPath(new URL("../../../crates/jazz-wasm/pkg/jazz_wasm_bg.wasm", import.meta.url));
 
 export function brokerWorkerOutputDir(args = process.argv.slice(2)) {
@@ -57,7 +58,9 @@ export async function bundleBrokerWorker(outputDir = canonicalOutputDir) {
       // Correctness consumers pin both wasm-bindgen glue and the binary.  A
       // binary-only override would still let esbuild follow a mutable package
       // pointer for the JS half of the ABI pair.
-      alias: sealedWasmPackage ? { "jazz-wasm": resolve(sealedWasmPackage, "jazz_wasm.js") } : {},
+      alias: correctnessWasmPackage
+        ? { "jazz-wasm": resolve(correctnessWasmPackage, "jazz_wasm.js") }
+        : {},
       bundle: true,
       format: "esm",
       platform: "browser",

--- a/packages/jazz-tools/scripts/bundle-broker-worker.mjs
+++ b/packages/jazz-tools/scripts/bundle-broker-worker.mjs
@@ -7,22 +7,17 @@ import { copyFile, mkdir, mkdtemp, readFile, rename, rm } from "node:fs/promises
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertWasmGlueInstantiates } from "../../../dev/artifacts/wasm-glue-abi.mjs";
-import { readCorrectnessArtifactSnapshot } from "../../../dev/artifacts/test-artifact-store.mjs";
 
 const packageRoot = fileURLToPath(new URL("..", import.meta.url));
 const entry = fileURLToPath(new URL("../src/worker/jazz-broker-worker.ts", import.meta.url));
 const canonicalOutputDir = fileURLToPath(new URL("../dist/worker", import.meta.url));
+const correctnessArtifactRun = process.env.JAZZ_CORRECTNESS_ARTIFACT_RUN === "1";
 const sealedWasmPackage = process.env.JAZZ_CORRECTNESS_WASM_PACKAGE;
-const snapshot = sealedWasmPackage
-  ? null
-  : readCorrectnessArtifactSnapshot(fileURLToPath(new URL("../../..", import.meta.url)));
-if (process.env.JAZZ_CORRECTNESS_ARTIFACT_RUN === "1" && !sealedWasmPackage)
+if (correctnessArtifactRun && !sealedWasmPackage)
   throw new Error("sealed correctness consumer is missing its admitted WASM package");
 const wasmSource = sealedWasmPackage
   ? resolve(sealedWasmPackage, "jazz_wasm_bg.wasm")
-  : snapshot
-    ? resolve(snapshot.wasmPackage, "jazz_wasm_bg.wasm")
-    : fileURLToPath(new URL("../../../crates/jazz-wasm/pkg/jazz_wasm_bg.wasm", import.meta.url));
+  : fileURLToPath(new URL("../../../crates/jazz-wasm/pkg/jazz_wasm_bg.wasm", import.meta.url));
 
 export function brokerWorkerOutputDir(args = process.argv.slice(2)) {
   if (args.length === 0) return canonicalOutputDir;

--- a/packages/jazz-tools/src/worker/broker-worker-bundle.test.ts
+++ b/packages/jazz-tools/src/worker/broker-worker-bundle.test.ts
@@ -78,7 +78,11 @@ describe("broker worker packaging", () => {
       );
       await execFileAsync(process.execPath, [bundleScript, "--out-dir", outputDir], {
         cwd: packageRoot,
-        env: { ...process.env, JAZZ_CORRECTNESS_WASM_PACKAGE: fakeSealedPackage },
+        env: {
+          ...process.env,
+          JAZZ_CORRECTNESS_ARTIFACT_RUN: "0",
+          JAZZ_CORRECTNESS_WASM_PACKAGE: fakeSealedPackage,
+        },
       });
       await expect(access(join(outputDir, "jazz-broker-worker.js"))).resolves.toBeUndefined();
       await expect(access(join(outputDir, "jazz_wasm_bg.wasm"))).resolves.toBeUndefined();

--- a/packages/jazz-tools/src/worker/broker-worker-bundle.test.ts
+++ b/packages/jazz-tools/src/worker/broker-worker-bundle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { execFile } from "node:child_process";
-import { access, mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -62,5 +62,29 @@ describe("broker worker packaging", () => {
     ).rejects.toMatchObject({
       stderr: expect.stringContaining("worker output is sealed for concurrent tests"),
     });
+  });
+
+  it("does not let an ambient sealed WASM path steer an ordinary worker bundle", async () => {
+    const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const bundleScript = fileURLToPath(
+      new URL("../../scripts/bundle-broker-worker.mjs", import.meta.url),
+    );
+    const outputDir = await mkdtemp(join(tmpdir(), "jazz-broker-worker-normal-"));
+    const fakeSealedPackage = await mkdtemp(join(tmpdir(), "jazz-broker-worker-sealed-"));
+    try {
+      await writeFile(
+        join(fakeSealedPackage, "jazz_wasm.js"),
+        'throw new Error("ordinary bundle used ambient sealed WASM path");\n',
+      );
+      await execFileAsync(process.execPath, [bundleScript, "--out-dir", outputDir], {
+        cwd: packageRoot,
+        env: { ...process.env, JAZZ_CORRECTNESS_WASM_PACKAGE: fakeSealedPackage },
+      });
+      await expect(access(join(outputDir, "jazz-broker-worker.js"))).resolves.toBeUndefined();
+      await expect(access(join(outputDir, "jazz_wasm_bg.wasm"))).resolves.toBeUndefined();
+    } finally {
+      await rm(outputDir, { recursive: true, force: true });
+      await rm(fakeSealedPackage, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
🤖 Build Jazz Tools against the fingerprints of the native artifacts packed with it.

After #2606 restored the NAPI loader, the starter matrix reached browser startup and failed before rendering: Jazz Tools expected WASM fingerprint2351d808… while the packed WASM returned aeb2708f…. Auth signup succeeded; the missing todo input was downstream of this ABI rejection.

This change orders build:core as native builds → generated fingerprint staging → TypeScript package builds, then executes the WASM package to check its runtime fingerprint against the manifest and compiled expectations before packing. A mismatched pair should fail during preparation rather than twelve browser journeys later. The published0394059 preview tools/WASM pair independently passes the same runtime/expectation comparison; this defect was observed in starter CI preparation.

Stacked after #2606. No storage or wire format changes.

Normal worker builds now select workspace WASM even if old correctness pointers or an ambient sealed-package path are present. Explicit correctness mode requires and uses its admitted sealed package; a missing path still fails closed. This fixes the mixed glue/binary failure seen when switching from tests back to a normal build.

Validation:
- Independent adversarial review approved the final changes. Native producers ran serially; after the selector repair, fingerprint staging → package build → executable verifier passed.
- Coordinator passed19 artifact/release/correctness contract tests and3 worker bundle tests, including poisoned ambient package selection and coherent-but-wrong runtime pairs. Formatting passes.
- Full standard CI passed on a229c5e1b9 before the worker-selector follow-ups; fresh CI is running on the final head.
- Full clean CI preparation34002971096 passed, including actual WASM/NAPI fingerprint comparison. Eight starter app jobs passed. Three later failures concern todo persistence/identity handoff and are being diagnosed separately; one job was still running when this description was updated. Those failures no longer report ABI mismatch.
- Local packed ts-localfirst scaffold/install/build passed; that receipt intentionally skipped browser E2E.

The stack remains unmerged while the remaining starter failures are addressed. No npm release or release-PR merge is authorized by this change.
