### PR TITLE
Retain the admitted session for direct subscriptions

### DIFF
--- a/packages/jazz-tools/src/runtime/db.read-tier.test.ts
+++ b/packages/jazz-tools/src/runtime/db.read-tier.test.ts
@@ -131,6 +131,30 @@ async function settle(): Promise<void> {
 }
 
 describe("Db ReadTier.RemoteIfPossible", () => {
+  it("uses the Db's admitted session for a direct subscription", async () => {
+    const client = makeClient();
+    const session = {
+      issuer: "https://issuer.example",
+      user_id: "alice",
+      claims: { role: "reader" },
+      authMode: "external" as const,
+    };
+    const db = await createDbWithRuntimeSource(
+      {
+        appId: "direct-subscription-session",
+        serverUrl: "https://example.test",
+        cookieSession: session,
+      },
+      new TestRuntimeSource(client),
+    );
+    dbs.push(db);
+
+    const unsubscribe = db.subscribe(query(), () => undefined);
+
+    expect(client.subscribe.mock.calls.at(-1)?.[3]).toEqual(session);
+    unsubscribe();
+  });
+
   it("keeps explicit Local reads propagating whether connected or explicitly offline", async () => {
     const client = makeClient();
     const db = await createDbWithRuntimeSource(

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -2759,7 +2759,11 @@ export class Db {
             },
           },
           subscriptionOptions,
-          context?.readSession ?? context?.session ?? session,
+          context?.readSession ??
+            context?.session ??
+            session ??
+            getDbInternalSession(this) ??
+            undefined,
         );
       } catch (error) {
         subscription.installing = false;


### PR DESCRIPTION
🤖 Retain the Db's admitted auth session when installing a direct subscription.

The TypeScript Better Auth starter creates a todo but cannot display it after reload. Its auth cookie and JWT remain valid; the subscription is rejected with ServerFailure/Internal. Framework adapters pass their Db session through the subscription orchestrator, while a direct public Db.subscribe() call can reach native subscription installation without that context.

Use the Db's admitted internal session when no read-context, context-session or explicit session was supplied. Preserve those existing precedence rules. This brings the direct public API in line with framework subscriptions; it does not merge identities or alter persistent storage scope.

WIP verification: coordinator reran25 focused runtime tests successfully. Independent adversarial review and actual packed TypeScript starter reload/signin reproduction are running. No storage or wire format changes.

Stacked after #2608 so starter verification includes the repaired native/TypeScript artifact handoff. The separate hybrid ownership decision is tracked in #2611 and is not fixed by this change.
