### PR TITLE
Schedule simulation writes at the requested rate

### DIFF
--- a/crates/jazz-sim/src/fixture.rs
+++ b/crates/jazz-sim/src/fixture.rs
@@ -750,13 +750,21 @@ impl WriteStream {
             !authors.is_empty(),
             "write stream authors must be non-empty"
         );
+        assert!(
+            edits_per_sec > 0,
+            "write stream edits per second must be positive"
+        );
         let mut rng = Lcg::new(seed);
         let row_zipf = Zipf::new(rows.len(), row_zipf_s);
         let author_zipf = Zipf::new(authors.len(), author_zipf_s);
-        let interval_ms = 1_000 / edits_per_sec.max(1);
         let steps = (0..steps)
             .map(|idx| WriteStep {
-                at_ms: idx as u64 * interval_ms,
+                at_ms: u64::try_from(
+                    (u128::try_from(idx).expect("write stream step index must fit in u128")
+                        * 1_000)
+                        / u128::from(edits_per_sec),
+                )
+                .expect("write stream timestamp must fit in u64"),
                 row_uuid: rows[row_zipf.sample(&mut rng)],
                 author: authors[author_zipf.sample(&mut rng)],
             })

--- a/crates/jazz-sim/src/fixture.rs
+++ b/crates/jazz-sim/src/fixture.rs
@@ -838,4 +838,54 @@ mod tests {
         let b = WriteStream::new(7, 10, 16, &rows, &authors, 1.1, 1.1);
         assert_eq!(a.steps(), b.steps());
     }
+
+    #[test]
+    fn write_stream_uses_fractional_millisecond_cadence_at_600_per_second() {
+        let rows = vec![deterministic_row_uuid(1, "rows", 0)];
+        let authors = vec![
+            AuthorSubject::authenticated("urn:jazz:sim", &rows[0].0.to_string())
+                .expect("simulation issuer is external"),
+        ];
+        let stream = WriteStream::new(7, 600, 6, &rows, &authors, 1.1, 1.1);
+
+        assert_eq!(
+            stream
+                .steps()
+                .iter()
+                .map(|step| step.at_ms)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 3, 5, 6, 8]
+        );
+    }
+
+    #[test]
+    fn write_stream_repeats_milliseconds_at_2000_per_second() {
+        let rows = vec![deterministic_row_uuid(1, "rows", 0)];
+        let authors = vec![
+            AuthorSubject::authenticated("urn:jazz:sim", &rows[0].0.to_string())
+                .expect("simulation issuer is external"),
+        ];
+        let stream = WriteStream::new(7, 2_000, 8, &rows, &authors, 1.1, 1.1);
+
+        assert_eq!(
+            stream
+                .steps()
+                .iter()
+                .map(|step| step.at_ms)
+                .collect::<Vec<_>>(),
+            vec![0, 0, 1, 1, 2, 2, 3, 3]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "write stream edits per second must be positive")]
+    fn write_stream_rejects_zero_rate() {
+        let rows = vec![deterministic_row_uuid(1, "rows", 0)];
+        let authors = vec![
+            AuthorSubject::authenticated("urn:jazz:sim", &rows[0].0.to_string())
+                .expect("simulation issuer is external"),
+        ];
+
+        let _ = WriteStream::new(7, 0, 1, &rows, &authors, 1.1, 1.1);
+    }
 }


### PR DESCRIPTION
## Summary
- Schedule deterministic simulation writes from their absolute index and requested rate.
- Reject a zero rate instead of silently treating it as one edit per second.

## Before
`WriteStream` truncated `1,000 / rate` to whole milliseconds. A rate of 600/s scheduled 1,000/s, rates above 1,000/s put every write at 0ms, and zero was silently clamped.

## After
Each timestamp is `floor(index × 1,000 / rate)`. Fractional and sub-millisecond cadences retain their requested average rate, while zero is rejected. Row and author selection and the public constructor shape are unchanged.

## Test plan
- [ ] `cargo test -p jazz-sim --lib fixture::tests::write_stream_ -- --nocapture`