### PR TITLE
Bound edge catalogue request forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3798,12 +3798,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -4669,6 +4671,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5180,6 +5195,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/jazz-server/Cargo.toml
+++ b/crates/jazz-server/Cargo.toml
@@ -33,7 +33,7 @@ jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_c
 hex = "0.4"
 opentelemetry = { version = "0.31", optional = true }
 postcard = { version = "1.1.3", features = ["alloc"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = "0.10"

--- a/crates/jazz-server/Cargo.toml
+++ b/crates/jazz-server/Cargo.toml
@@ -33,7 +33,11 @@ jsonwebtoken = { version = "10.4", default-features = false, features = ["rust_c
 hex = "0.4"
 opentelemetry = { version = "0.31", optional = true }
 postcard = { version = "1.1.3", features = ["alloc"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "stream",
+  "rustls-tls",
+] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = "0.10"

--- a/crates/jazz-server/src/lib.rs
+++ b/crates/jazz-server/src/lib.rs
@@ -50,12 +50,19 @@ pub async fn run(
     } else {
         info!("Data directory: {}", data_dir);
     }
+    let edge_catalogue_list_limit = catalogue_list_limit_from_env(upstream_url.is_some(), || {
+        std::env::var("JAZZ_CATALOGUE_LIST_RESPONSE_LIMIT_BYTES")
+    })?;
     let builder = ServerBuilder::new(app_id)
         .with_auth_config(auth_config)
         .with_shutdown_timeout(shutdown_timeout)
         .with_native_transport_connector(native_transport);
     let builder = match upstream_url {
         Some(url) => builder.with_upstream_url(url),
+        None => builder,
+    };
+    let builder = match edge_catalogue_list_limit {
+        Some(limit) => builder.with_catalogue_list_response_limit_bytes(limit),
         None => builder,
     };
     let builder = match edge_cache_budget {
@@ -177,6 +184,62 @@ pub async fn run(
     }
     abort_task(&mut sigterm_task).await;
     Ok(())
+}
+
+fn catalogue_list_limit_from_env(
+    edge: bool,
+    read: impl FnOnce() -> Result<String, std::env::VarError>,
+) -> Result<Option<usize>, String> {
+    if !edge {
+        return Ok(None);
+    }
+    match read() {
+        Ok(value) => {
+            let parsed = value.parse::<usize>().map_err(|_| {
+                "JAZZ_CATALOGUE_LIST_RESPONSE_LIMIT_BYTES must be a positive decimal usize"
+                    .to_owned()
+            })?;
+            if parsed == 0 {
+                return Err(
+                    "JAZZ_CATALOGUE_LIST_RESPONSE_LIMIT_BYTES must be a positive decimal usize"
+                        .to_owned(),
+                );
+            }
+            Ok(Some(parsed))
+        }
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(format!(
+            "failed to read JAZZ_CATALOGUE_LIST_RESPONSE_LIMIT_BYTES: {error}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod environment_tests {
+    use super::catalogue_list_limit_from_env;
+
+    #[test]
+    fn catalogue_limit_environment_is_edge_only() {
+        assert_eq!(
+            catalogue_list_limit_from_env(false, || Ok("not-a-limit".to_owned())).unwrap(),
+            None
+        );
+    }
+    #[test]
+    fn catalogue_limit_environment_validates_edge_values() {
+        assert_eq!(
+            catalogue_list_limit_from_env(true, || Ok("12345".to_owned())).unwrap(),
+            Some(12345)
+        );
+        assert_eq!(
+            catalogue_list_limit_from_env(true, || Err(std::env::VarError::NotPresent)).unwrap(),
+            None
+        );
+        assert!(catalogue_list_limit_from_env(true, || Ok("0".to_owned())).is_err());
+        assert!(
+            catalogue_list_limit_from_env(true, || Ok("usize-max-overflow".to_owned())).is_err()
+        );
+    }
 }
 
 fn install_signal_before_readiness<T, E>(

--- a/crates/jazz-server/src/server/builder.rs
+++ b/crates/jazz-server/src/server/builder.rs
@@ -17,8 +17,8 @@ use crate::middleware::auth::{
 };
 use crate::server::routes;
 use crate::server::{
-    CatalogueKvStorage, CatalogueMemoryStorage, DynCatalogueStorage, EdgeUpstreamHealth,
-    ServerState, ServerTopology, StoredCatalogue,
+    CatalogueForwardingPolicy, CatalogueKvStorage, CatalogueMemoryStorage, DynCatalogueStorage,
+    EdgeUpstreamHealth, ServerState, ServerTopology, StoredCatalogue,
 };
 use jazz::tools::AppId;
 use jazz::tools::native_transport_connector::{
@@ -89,6 +89,7 @@ pub struct ServerBuilder {
     storage_backend: StorageBackend,
     core_server_shell_schema: Option<JazzSchema>,
     upstream_url: Option<String>,
+    catalogue_list_response_limit_bytes: usize,
     edge_cache_budget: Option<EdgeCacheBudget>,
     shutdown_timeout: Duration,
     native_transport_connector: Option<Arc<dyn NativeTransportConnector>>,
@@ -109,6 +110,8 @@ impl ServerBuilder {
             },
             core_server_shell_schema: None,
             upstream_url: None,
+            catalogue_list_response_limit_bytes:
+                crate::server::DEFAULT_CATALOGUE_LIST_RESPONSE_LIMIT_BYTES,
             edge_cache_budget: None,
             shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
             native_transport_connector: None,
@@ -128,6 +131,11 @@ impl ServerBuilder {
 
     pub fn with_upstream_url(mut self, upstream_url: impl Into<String>) -> Self {
         self.upstream_url = Some(upstream_url.into());
+        self
+    }
+    /// Configure the maximum body accepted from the forwarded `/schemas` list.
+    pub fn with_catalogue_list_response_limit_bytes(mut self, limit: usize) -> Self {
+        self.catalogue_list_response_limit_bytes = limit;
         self
     }
 
@@ -209,9 +217,14 @@ impl ServerBuilder {
 
         let (catalogue_store, latest_catalogue_schema) = self.build_catalogue_store()?;
         let http_client = reqwest::Client::builder()
+            .http1_only()
             .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(Duration::from_secs(5))
+            .pool_max_idle_per_host(1)
             .build()
             .map_err(|e| format!("failed to build HTTP client: {e}"))?;
+        let forwarding_policy =
+            CatalogueForwardingPolicy::new(self.catalogue_list_response_limit_bytes)?;
 
         let core_server_shell_storage_config = self.build_core_server_shell_storage_config();
         let core_server_shell = self.build_core_server_shell(
@@ -254,6 +267,7 @@ impl ServerBuilder {
             topology,
             jwt_verifier,
             http_client,
+            forwarding_policy,
             core_server_shell: std::sync::RwLock::new(core_server_shell),
             core_server_shell_storage_config,
             storage_factory: self.storage_factory.clone(),

--- a/crates/jazz-server/src/server/mod.rs
+++ b/crates/jazz-server/src/server/mod.rs
@@ -75,6 +75,48 @@ pub async fn push_catalogue_in_memory(
 /// small amount of slack for unusual topologies) without giving an
 /// attacker meaningful amplification before the cap bites.
 pub(crate) const PER_CLIENT_CONNECTION_CAP: usize = 4;
+pub(crate) const MAX_CATALOGUE_REQUEST_BODY_BYTES: usize = 8 << 20;
+pub(crate) const DEFAULT_CATALOGUE_LIST_RESPONSE_LIMIT_BYTES: usize = 64 << 20;
+pub(crate) const FIXED_CATALOGUE_RESPONSE_LIMIT_BYTES: usize = 8 << 20;
+pub(crate) const FORWARDING_APPLICATION_CHUNK_BYTES: usize = 64 << 10;
+const FORWARDING_TRANSPORT_BYTES: usize = 2 * 1_032_192;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CatalogueForwardingPolicy {
+    pub(crate) list_response_limit_bytes: usize,
+}
+
+impl CatalogueForwardingPolicy {
+    pub(crate) fn new(list_response_limit_bytes: usize) -> Result<Self, String> {
+        let chunks = list_response_limit_bytes
+            .checked_div(FORWARDING_APPLICATION_CHUNK_BYTES)
+            .and_then(|whole| {
+                list_response_limit_bytes
+                    .checked_rem(FORWARDING_APPLICATION_CHUNK_BYTES)
+                    .and_then(|remainder| whole.checked_add(usize::from(remainder != 0)))
+            })
+            .ok_or_else(|| "catalogue forwarding response limit is invalid".to_owned())?;
+        if list_response_limit_bytes == 0 {
+            return Err("catalogue forwarding response limit must be positive".to_owned());
+        }
+        let application_bytes = chunks
+            .checked_mul(FORWARDING_APPLICATION_CHUNK_BYTES)
+            .ok_or_else(|| "catalogue forwarding allocation budget is invalid".to_owned())?;
+        let descriptor_bytes = chunks
+            .checked_mul(std::mem::size_of::<Option<axum::body::Bytes>>())
+            .ok_or_else(|| "catalogue forwarding descriptor budget is invalid".to_owned())?;
+        let _descriptor_layout = std::alloc::Layout::array::<Option<axum::body::Bytes>>(chunks)
+            .map_err(|_| "catalogue forwarding descriptor layout is invalid".to_owned())?;
+        MAX_CATALOGUE_REQUEST_BODY_BYTES
+            .checked_add(application_bytes)
+            .and_then(|value| value.checked_add(descriptor_bytes))
+            .and_then(|value| value.checked_add(FORWARDING_TRANSPORT_BYTES))
+            .ok_or_else(|| "catalogue forwarding allocation budget is invalid".to_owned())?;
+        Ok(Self {
+            list_response_limit_bytes,
+        })
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ServerTopology {
@@ -121,8 +163,12 @@ pub struct ServerState {
     /// Whether this process is the core/global node or an edge syncing upstream.
     pub topology: ServerTopology,
     /// Shared HTTP client for forwarding admin requests to a remote authority.
+    ///
+    /// Replacement clients retain forwarding's application/body/deadline safety
+    /// but do not carry the builder client's bounded HTTP transport allowance.
     pub http_client: reqwest::Client,
-    /// Configured verifier for external JWTs.
+    /// Private bounds and lifecycle policy used by edge catalogue forwarding.
+    pub(crate) forwarding_policy: CatalogueForwardingPolicy,
     pub jwt_verifier: Option<Arc<JwtVerifier>>,
     /// Sendable handle to the local-owner server shell for the websocket route.
     pub(crate) core_server_shell: StdRwLock<Option<ServerRuntimeHandle>>,
@@ -693,6 +739,10 @@ mod tests {
             http_client: reqwest::Client::builder()
                 .build()
                 .expect("build HTTP client"),
+            forwarding_policy: CatalogueForwardingPolicy::new(
+                DEFAULT_CATALOGUE_LIST_RESPONSE_LIMIT_BYTES,
+            )
+            .expect("default forwarding policy"),
             jwt_verifier: None,
             core_server_shell: StdRwLock::new(None),
             core_server_shell_storage_config: None,

--- a/crates/jazz-server/src/server/routes/http.rs
+++ b/crates/jazz-server/src/server/routes/http.rs
@@ -2,17 +2,30 @@
 
 //! HTTP routes for the Jazz server.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    alloc::{Layout, alloc, alloc_zeroed},
+    collections::HashMap,
+    convert::Infallible,
+    io::{self, Write},
+    sync::Arc,
+    time::Duration,
+};
 
 use axum::{
     extract::{Path, Query, State},
-    http::{HeaderMap, StatusCode, header::CONTENT_TYPE},
+    http::{HeaderMap, HeaderValue, StatusCode, header::CONTENT_TYPE},
     response::{IntoResponse, Json, Response},
 };
+use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
+#[cfg(test)]
+use std::cell::Cell;
 
 use crate::middleware::auth::validate_admin_secret;
-use crate::server::{EdgeUpstreamHealth, ServerState, ShutdownPhase};
+use crate::server::{
+    EdgeUpstreamHealth, FIXED_CATALOGUE_RESPONSE_LIMIT_BYTES, FORWARDING_APPLICATION_CHUNK_BYTES,
+    MAX_CATALOGUE_REQUEST_BODY_BYTES, ServerState, ShutdownPhase,
+};
 use jazz::tools::public_schema::{ColumnType, Schema, SchemaHash, TableName, TablePolicies, Value};
 use jazz::tools::schema_lens::{Lens, LensOp, LensTransform};
 use jazz::tools::transport_error::ErrorResponse;
@@ -21,6 +34,83 @@ use super::utils::{
     parse_app_id_param, parse_object_id_param, parse_schema_hash_param, permissions_head_view,
     permissions_map_view, unix_timestamp_millis,
 };
+
+#[cfg(test)]
+const FORWARDING_TEST_DEADLINE: Duration = Duration::from_secs(1);
+#[cfg(not(test))]
+const FORWARDING_TEST_DEADLINE: Duration = Duration::from_secs(30);
+
+#[cfg(test)]
+thread_local! {
+    static FAIL_FORWARDING_ALLOCATION_AT: Cell<Option<usize>> = const { Cell::new(None) };
+}
+
+#[cfg(test)]
+fn fail_next_forwarding_allocation_for_test() {
+    fail_forwarding_allocation_at_index_for_test(0);
+}
+
+#[cfg(test)]
+fn fail_forwarding_allocation_at_index_for_test(index: usize) {
+    FAIL_FORWARDING_ALLOCATION_AT.with(|target| target.set(Some(index)));
+}
+
+fn allocation_was_injected_to_fail() -> bool {
+    #[cfg(test)]
+    {
+        return FAIL_FORWARDING_ALLOCATION_AT.with(|target| match target.get() {
+            Some(0) => {
+                target.set(None);
+                true
+            }
+            Some(index) => {
+                target.set(Some(index - 1));
+                false
+            }
+            None => false,
+        });
+    }
+    #[cfg(not(test))]
+    {
+        false
+    }
+}
+
+fn allocate_zeroed_backing(length: usize) -> Result<Vec<u8>, String> {
+    if allocation_was_injected_to_fail() {
+        return Err("catalogue forwarding allocation failed".to_owned());
+    }
+    if length == 0 {
+        return Ok(Vec::new());
+    }
+    let layout = Layout::array::<u8>(length)
+        .map_err(|_| "catalogue forwarding layout invalid".to_owned())?;
+    let pointer = unsafe { alloc_zeroed(layout) };
+    if pointer.is_null() {
+        return Err("catalogue forwarding allocation failed".to_owned());
+    }
+    let boxed = unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(pointer, length)) };
+    Ok(boxed.into_vec())
+}
+
+fn allocate_empty_slots(count: usize) -> Result<Box<[Option<axum::body::Bytes>]>, String> {
+    if allocation_was_injected_to_fail() {
+        return Err("catalogue forwarding allocation failed".to_owned());
+    }
+    if count == 0 {
+        return Ok(Vec::new().into_boxed_slice());
+    }
+    let layout = Layout::array::<Option<axum::body::Bytes>>(count)
+        .map_err(|_| "catalogue forwarding descriptor layout invalid".to_owned())?;
+    let pointer = unsafe { alloc(layout) as *mut Option<axum::body::Bytes> };
+    if pointer.is_null() {
+        return Err("catalogue forwarding descriptor allocation failed".to_owned());
+    }
+    for index in 0..count {
+        unsafe { pointer.add(index).write(None) };
+    }
+    Ok(unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(pointer, count)) })
+}
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -70,6 +160,22 @@ pub(super) struct PublishMigrationRequest {
     from_hash: String,
     to_hash: String,
     forward: Vec<PublishTableLens>,
+}
+#[cfg(test)]
+pub(super) fn oversized_migration_for_test() -> PublishMigrationRequest {
+    PublishMigrationRequest {
+        from_hash: "a".repeat(64),
+        to_hash: "b".repeat(64),
+        forward: (0..200_000)
+            .map(|_| PublishTableLens {
+                table: "t".to_owned(),
+                added: false,
+                removed: false,
+                renamed_from: None,
+                operations: Vec::new(),
+            })
+            .collect(),
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -156,6 +262,12 @@ pub(super) struct ShutdownResponse {
     status: &'static str,
 }
 
+#[derive(Debug)]
+enum RequestBodyError {
+    Oversize,
+    Internal(String),
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct PublishMigrationResponse {
@@ -163,13 +275,163 @@ pub(super) struct PublishMigrationResponse {
     from_hash: String,
     to_hash: String,
 }
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub(super) enum CatalogueRequestBody<'a> {
+    Schema(&'a PublishSchemaRequest),
+    Permissions(&'a PublishPermissionsRequest),
+    Migration(&'a PublishMigrationRequest),
+}
 
-async fn forward_catalogue_request(
+struct CountingWriter {
+    len: usize,
+}
+
+impl Write for CountingWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.len = self
+            .len
+            .checked_add(bytes.len())
+            .ok_or_else(|| io::Error::other("JSON body length overflow"))?;
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct FixedResponseBody {
+    slots: Box<[Option<axum::body::Bytes>]>,
+    used: usize,
+    current: Option<Vec<u8>>,
+    current_len: usize,
+    total_len: usize,
+    limit: usize,
+}
+
+impl FixedResponseBody {
+    fn new(limit: usize) -> Result<Self, String> {
+        let count = limit
+            .checked_div(FORWARDING_APPLICATION_CHUNK_BYTES)
+            .and_then(|whole| {
+                limit
+                    .checked_rem(FORWARDING_APPLICATION_CHUNK_BYTES)
+                    .and_then(|remainder| whole.checked_add(usize::from(remainder != 0)))
+            })
+            .ok_or_else(|| "catalogue upstream response buffering failed".to_owned())?;
+        let slots = allocate_empty_slots(count)
+            .map_err(|_| "catalogue upstream response buffering failed".to_owned())?;
+        Ok(Self {
+            slots,
+            used: 0,
+            current: None,
+            current_len: 0,
+            total_len: 0,
+            limit,
+        })
+    }
+
+    fn append(&mut self, bytes: &[u8]) -> Result<(), ResponseBufferError> {
+        let new_total = self
+            .total_len
+            .checked_add(bytes.len())
+            .ok_or(ResponseBufferError::Internal)?;
+        if new_total > self.limit {
+            return Err(ResponseBufferError::Oversize(self.limit));
+        }
+        let mut offset = 0;
+        while offset < bytes.len() {
+            if self.current.is_none() {
+                if self.used >= self.slots.len() {
+                    return Err(ResponseBufferError::Internal);
+                }
+                let chunk = allocate_zeroed_backing(FORWARDING_APPLICATION_CHUNK_BYTES)
+                    .map_err(|_| ResponseBufferError::Internal)?;
+                self.current = Some(chunk);
+                self.current_len = 0;
+            }
+            let copied =
+                (FORWARDING_APPLICATION_CHUNK_BYTES - self.current_len).min(bytes.len() - offset);
+            self.current.as_mut().expect("current response chunk")
+                [self.current_len..self.current_len + copied]
+                .copy_from_slice(&bytes[offset..offset + copied]);
+            offset += copied;
+            self.current_len += copied;
+            if self.current_len == FORWARDING_APPLICATION_CHUNK_BYTES {
+                self.finish_current()?;
+            }
+        }
+        self.total_len = new_total;
+        Ok(())
+    }
+
+    fn finish_current(&mut self) -> Result<(), ResponseBufferError> {
+        let mut chunk = self.current.take().ok_or(ResponseBufferError::Internal)?;
+        if self.current_len < FORWARDING_APPLICATION_CHUNK_BYTES {
+            chunk.truncate(self.current_len);
+        }
+        if self.used >= self.slots.len() {
+            return Err(ResponseBufferError::Internal);
+        }
+        self.slots[self.used] = Some(axum::body::Bytes::from(chunk));
+        self.used += 1;
+        self.current_len = 0;
+        Ok(())
+    }
+
+    fn finish(mut self) -> Result<axum::body::Body, ResponseBufferError> {
+        if self.current.is_some() {
+            self.finish_current()?;
+        }
+        let stream = futures::stream::iter(
+            self.slots
+                .into_vec()
+                .into_iter()
+                .take(self.used)
+                .flatten()
+                .map(Ok::<_, Infallible>),
+        );
+        Ok(axum::body::Body::from_stream(stream))
+    }
+}
+
+#[derive(Debug)]
+enum ResponseBufferError {
+    Oversize(usize),
+    Internal,
+    Read(String),
+}
+
+fn serialize_request_body(body: CatalogueRequestBody<'_>) -> Result<Vec<u8>, RequestBodyError> {
+    let mut counter = CountingWriter { len: 0 };
+    serde_json::to_writer(&mut counter, &body).map_err(|error| {
+        RequestBodyError::Internal(format!("failed to serialize catalogue request: {error}"))
+    })?;
+    if counter.len > MAX_CATALOGUE_REQUEST_BODY_BYTES {
+        return Err(RequestBodyError::Oversize);
+    }
+    let mut output = allocate_zeroed_backing(counter.len).map_err(|_| {
+        RequestBodyError::Internal("failed to allocate canonical catalogue request body".to_owned())
+    })?;
+    let mut writer = io::Cursor::new(output.as_mut_slice());
+    serde_json::to_writer(&mut writer, &body).map_err(|error| {
+        RequestBodyError::Internal(format!("failed to serialize catalogue request: {error}"))
+    })?;
+    if writer.position() as usize != output.len() {
+        return Err(RequestBodyError::Internal(
+            "failed to serialize canonical catalogue request body".to_owned(),
+        ));
+    }
+    Ok(output)
+}
+
+pub(super) async fn forward_catalogue_request(
     state: &Arc<ServerState>,
     admin_secret: &str,
     method: reqwest::Method,
     path: &str,
-    body: Option<Vec<u8>>,
+    body: Option<CatalogueRequestBody<'_>>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let Some(base_url) = state.upstream_http_url.as_deref() else {
         return Err((
@@ -179,7 +441,22 @@ async fn forward_catalogue_request(
             )),
         ));
     };
-
+    if state.shutdown.is_shutting_down() {
+        return Err(forward_shutdown_error(&method));
+    }
+    let body = body.map(serialize_request_body).transpose().map_err(|error| {
+        match error {
+            RequestBodyError::Oversize => (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                Json(ErrorResponse::bad_request(format!(
+                    "canonical catalogue request body exceeds the {MAX_CATALOGUE_REQUEST_BODY_BYTES}-byte limit"
+                ))),
+            ),
+            RequestBodyError::Internal(message) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorResponse::internal(message)))
+            }
+        }
+    })?;
     let app_scoped_path = format!("/apps/{}/{}", state.app_id, path.trim_start_matches('/'));
     let upstream_url = upstream_endpoint_url(base_url, &app_scoped_path).map_err(|message| {
         (
@@ -187,51 +464,108 @@ async fn forward_catalogue_request(
             Json(ErrorResponse::internal(message)),
         )
     })?;
-
-    let mut request = state
-        .http_client
-        .request(method, upstream_url)
-        .header("X-Jazz-Admin-Secret", admin_secret);
+    let endpoint_limit = if path.trim_start_matches('/').starts_with("schemas") {
+        state.forwarding_policy.list_response_limit_bytes
+    } else {
+        FIXED_CATALOGUE_RESPONSE_LIMIT_BYTES
+    };
+    let mut request = state.http_client.request(method.clone(), upstream_url);
+    request = request.header("X-Jazz-Admin-Secret", admin_secret);
     if let Some(body) = body {
         request = request.header(CONTENT_TYPE, "application/json").body(body);
     }
-
-    let response = request.send().await.map_err(|err| {
-        (
-            StatusCode::BAD_GATEWAY,
-            Json(ErrorResponse::internal(format!(
-                "failed to reach catalogue upstream: {err}"
-            ))),
-        )
-    })?;
-
-    let status =
-        StatusCode::from_u16(response.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
-    let content_type = response.headers().get(CONTENT_TYPE).cloned();
-    let bytes = response.bytes().await.map_err(|err| {
-        (
-            StatusCode::BAD_GATEWAY,
-            Json(ErrorResponse::internal(format!(
-                "failed to read upstream response: {err}"
-            ))),
-        )
-    })?;
-
+    let operation = async move {
+        let response = request.send().await.map_err(|error| {
+            ResponseBufferError::Read(format!("failed to reach catalogue upstream: {error}"))
+        })?;
+        let status =
+            StatusCode::from_u16(response.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+        if response
+            .content_length()
+            .is_some_and(|length| length > endpoint_limit as u64)
+        {
+            return Err(ResponseBufferError::Oversize(endpoint_limit));
+        }
+        let content_type = match response.headers().get(CONTENT_TYPE) {
+            Some(value) if value.as_bytes().len() > 1024 => {
+                return Err(ResponseBufferError::Internal);
+            }
+            Some(value) => HeaderValue::from_bytes(value.as_bytes()).ok(),
+            None => None,
+        };
+        let mut body =
+            FixedResponseBody::new(endpoint_limit).map_err(|_| ResponseBufferError::Internal)?;
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|error| {
+                ResponseBufferError::Read(format!("failed to read upstream response: {error}"))
+            })?;
+            body.append(&chunk)?;
+        }
+        Ok((status, content_type, body.finish()?))
+    };
+    let result = tokio::select! {
+        biased;
+        _ = state.shutdown.wait_requested() => Err(forward_shutdown_error(&method)),
+        _ = tokio::time::sleep(FORWARDING_TEST_DEADLINE) => Err(forward_deadline_error(&method)),
+        result = operation => result.map_err(|error| forward_response_error(&method, error)),
+    };
+    let (status, content_type, body) = result?;
     let mut response_builder = Response::builder().status(status);
     if let Some(content_type) = content_type {
         response_builder = response_builder.header(CONTENT_TYPE, content_type);
     }
+    response_builder.body(body).map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::internal(format!(
+                "failed to build forwarded response: {error}"
+            ))),
+        )
+    })
+}
 
-    response_builder
-        .body(axum::body::Body::from(bytes))
-        .map_err(|err| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::internal(format!(
-                    "failed to build forwarded response: {err}"
-                ))),
-            )
-        })
+fn forward_shutdown_error(method: &reqwest::Method) -> (StatusCode, Json<ErrorResponse>) {
+    let message = if method == reqwest::Method::POST {
+        "catalogue forwarding cancelled during shutdown; the upstream mutation outcome may be unknown; verify catalogue state before retrying"
+    } else {
+        "catalogue forwarding cancelled because the server is shutting down"
+    };
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(ErrorResponse::internal(message)),
+    )
+}
+
+fn forward_deadline_error(method: &reqwest::Method) -> (StatusCode, Json<ErrorResponse>) {
+    let mut message = "catalogue upstream request exceeded the 30-second total deadline".to_owned();
+    if method == reqwest::Method::POST {
+        message.push_str("; the upstream mutation outcome may be unknown; verify catalogue state before retrying");
+    }
+    (
+        StatusCode::BAD_GATEWAY,
+        Json(ErrorResponse::internal(message)),
+    )
+}
+
+fn forward_response_error(
+    method: &reqwest::Method,
+    error: ResponseBufferError,
+) -> (StatusCode, Json<ErrorResponse>) {
+    let mut message = match error {
+        ResponseBufferError::Oversize(limit) => {
+            format!("catalogue upstream response body exceeds the {limit}-byte limit")
+        }
+        ResponseBufferError::Internal => "catalogue upstream response buffering failed".to_owned(),
+        ResponseBufferError::Read(message) => message,
+    };
+    if method == reqwest::Method::POST {
+        message.push_str("; the upstream mutation outcome may be unknown; verify catalogue state before retrying");
+    }
+    (
+        StatusCode::BAD_GATEWAY,
+        Json(ErrorResponse::internal(message)),
+    )
 }
 
 fn upstream_endpoint_url(base_url: &str, path: &str) -> Result<String, String> {
@@ -547,24 +881,12 @@ pub(super) async fn publish_schema_handler(
     }
 
     if state.topology.is_edge() {
-        let body = match serde_json::to_vec(&request) {
-            Ok(body) => body,
-            Err(err) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::internal(format!(
-                        "failed to serialize schema publish request: {err}"
-                    ))),
-                )
-                    .into_response();
-            }
-        };
         return match forward_catalogue_request(
             &state,
             admin_secret.expect("validated admin secret"),
             reqwest::Method::POST,
             "/admin/schemas",
-            Some(body),
+            Some(CatalogueRequestBody::Schema(&request)),
         )
         .await
         {
@@ -758,24 +1080,12 @@ pub(super) async fn publish_permissions_handler(
     }
 
     if state.topology.is_edge() {
-        let body = match serde_json::to_vec(&request) {
-            Ok(body) => body,
-            Err(err) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::internal(format!(
-                        "failed to serialize permissions publish request: {err}"
-                    ))),
-                )
-                    .into_response();
-            }
-        };
         return match forward_catalogue_request(
             &state,
             admin_secret.expect("validated admin secret"),
             reqwest::Method::POST,
             "/admin/permissions",
-            Some(body),
+            Some(CatalogueRequestBody::Permissions(&request)),
         )
         .await
         {
@@ -942,24 +1252,12 @@ pub(super) async fn publish_migration_handler(
     }
 
     if state.topology.is_edge() {
-        let body = match serde_json::to_vec(&request) {
-            Ok(body) => body,
-            Err(err) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::internal(format!(
-                        "failed to serialize migration publish request: {err}"
-                    ))),
-                )
-                    .into_response();
-            }
-        };
         return match forward_catalogue_request(
             &state,
             admin_secret.expect("validated admin secret"),
             reqwest::Method::POST,
             "/admin/migrations",
-            Some(body),
+            Some(CatalogueRequestBody::Migration(&request)),
         )
         .await
         {
@@ -1616,5 +1914,229 @@ mod tests {
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(json, serde_json::json!({ "status": "healthy" }));
+    }
+}
+
+#[cfg(test)]
+mod forwarding_capacity_tests {
+    use super::{
+        CatalogueRequestBody, FORWARDING_APPLICATION_CHUNK_BYTES, FixedResponseBody,
+        PublishMigrationRequest, PublishPermissionsRequest, PublishSchemaRequest, PublishTableLens,
+        ResponseBufferError, Schema, allocate_empty_slots, allocate_zeroed_backing,
+        fail_forwarding_allocation_at_index_for_test, fail_next_forwarding_allocation_for_test,
+        serialize_request_body,
+    };
+
+    #[test]
+    fn canonical_body_is_exact_and_stable() {
+        let request = PublishMigrationRequest {
+            from_hash: "a".repeat(64),
+            to_hash: "b".repeat(64),
+            forward: Vec::new(),
+        };
+        let first = serialize_request_body(CatalogueRequestBody::Migration(&request))
+            .expect("canonical body");
+        let second = serialize_request_body(CatalogueRequestBody::Migration(&request))
+            .expect("canonical body");
+        assert_eq!(first, second);
+        assert_eq!(
+            first,
+            format!(
+                r#"{{"fromHash":"{}","toHash":"{}","forward":[]}}"#,
+                "a".repeat(64),
+                "b".repeat(64)
+            )
+            .into_bytes()
+        );
+        assert_eq!(first.capacity(), first.len());
+    }
+    #[test]
+    fn canonical_body_matches_each_public_dto() {
+        let schema = PublishSchemaRequest {
+            schema: Schema::new(),
+            permissions: None,
+        };
+        assert_eq!(
+            serialize_request_body(CatalogueRequestBody::Schema(&schema)).unwrap(),
+            serde_json::to_vec(&schema).unwrap()
+        );
+
+        let permissions = PublishPermissionsRequest {
+            schema_hash: "a".repeat(64),
+            permissions: std::collections::HashMap::new(),
+            expected_parent_bundle_object_id: None,
+        };
+        assert_eq!(
+            serialize_request_body(CatalogueRequestBody::Permissions(&permissions)).unwrap(),
+            serde_json::to_vec(&permissions).unwrap()
+        );
+
+        let migration = PublishMigrationRequest {
+            from_hash: "a".repeat(64),
+            to_hash: "b".repeat(64),
+            forward: Vec::new(),
+        };
+        assert_eq!(
+            serialize_request_body(CatalogueRequestBody::Migration(&migration)).unwrap(),
+            serde_json::to_vec(&migration).unwrap()
+        );
+    }
+    #[test]
+    fn canonical_request_cap_accepts_exact_limit_and_rejects_one_byte_over() {
+        fn request_with_table_length(length: usize) -> PublishMigrationRequest {
+            PublishMigrationRequest {
+                from_hash: "a".repeat(64),
+                to_hash: "b".repeat(64),
+                forward: vec![PublishTableLens {
+                    table: "t".repeat(length),
+                    added: false,
+                    removed: false,
+                    renamed_from: None,
+                    operations: Vec::new(),
+                }],
+            }
+        }
+
+        let base = serde_json::to_vec(&request_with_table_length(0))
+            .unwrap()
+            .len();
+        let under = serialize_request_body(CatalogueRequestBody::Migration(
+            &request_with_table_length((8 << 20) - 1 - base),
+        ))
+        .expect("body below cap");
+        assert_eq!(under.len(), (8 << 20) - 1);
+        let exact = serialize_request_body(CatalogueRequestBody::Migration(
+            &request_with_table_length((8 << 20) - base),
+        ))
+        .expect("body at cap");
+        assert_eq!(exact.len(), 8 << 20);
+        assert!(
+            serialize_request_body(CatalogueRequestBody::Migration(&request_with_table_length(
+                (8 << 20) + 1 - base
+            )))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn fixed_chunk_capacity_is_bounded_at_each_boundary() {
+        let limit = 8 << 20;
+        for length in [
+            0,
+            1,
+            FORWARDING_APPLICATION_CHUNK_BYTES - 1,
+            FORWARDING_APPLICATION_CHUNK_BYTES,
+            FORWARDING_APPLICATION_CHUNK_BYTES + 1,
+            limit,
+        ] {
+            let mut body = FixedResponseBody::new(limit).expect("fixed response backing");
+            body.append(&vec![0xA5; length]).expect("within-limit body");
+            let retained = body
+                .slots
+                .iter()
+                .filter_map(Option::as_ref)
+                .collect::<Vec<_>>();
+            assert!(retained.len() <= body.slots.len());
+            assert!(
+                retained
+                    .iter()
+                    .all(|chunk| chunk.len() <= FORWARDING_APPLICATION_CHUNK_BYTES)
+            );
+        }
+
+        let mut body = FixedResponseBody::new(limit).expect("fixed response backing");
+        body.append(&vec![0xA5; FORWARDING_APPLICATION_CHUNK_BYTES - 1])
+            .expect("partial response body");
+        assert_eq!(
+            body.current
+                .as_ref()
+                .expect("active response chunk")
+                .capacity(),
+            FORWARDING_APPLICATION_CHUNK_BYTES
+        );
+        let mut body = FixedResponseBody::new(limit).expect("fixed response backing");
+        body.append(b"backing identity").expect("response body");
+        let backing = body
+            .current
+            .as_ref()
+            .expect("active response chunk")
+            .as_ptr();
+        body.finish_current().expect("finish response chunk");
+        assert_eq!(
+            body.slots[0]
+                .as_ref()
+                .expect("retained response chunk")
+                .as_ptr(),
+            backing
+        );
+
+        let mut body = FixedResponseBody::new(limit).expect("fixed response backing");
+        let error = body
+            .append(&vec![0xA5; limit + 1])
+            .expect_err("limit-plus-one response");
+        assert!(matches!(error, ResponseBufferError::Oversize(limit) if limit == 8 << 20));
+        assert!(body.slots.iter().all(Option::is_none));
+    }
+    #[test]
+    fn injected_failure_is_fallible_for_each_response_block_index() {
+        let limit = 6 * FORWARDING_APPLICATION_CHUNK_BYTES;
+        for index in 0..=4 {
+            let mut body = FixedResponseBody::new(limit).expect("response backing");
+            fail_forwarding_allocation_at_index_for_test(index);
+            let input = vec![0x5A; (index + 1) * FORWARDING_APPLICATION_CHUNK_BYTES + 1];
+            assert!(
+                body.append(&input).is_err(),
+                "response block allocation {index} must be fallible"
+            );
+            assert_eq!(body.used, index);
+            assert!(body.slots[..index].iter().all(Option::is_some));
+            assert!(body.slots[index..].iter().all(Option::is_none));
+            assert!(body.current.is_none());
+            assert!(
+                body.current.is_none() || body.current_len <= FORWARDING_APPLICATION_CHUNK_BYTES
+            );
+        }
+    }
+
+    #[test]
+    fn fixed_backing_rejects_layout_overflow_without_partial_allocation() {
+        assert!(allocate_zeroed_backing(usize::MAX).is_err());
+        assert!(allocate_empty_slots(usize::MAX).is_err());
+        let slots = allocate_empty_slots(3).expect("descriptor backing");
+        assert_eq!(
+            std::mem::size_of_val(&*slots),
+            3 * std::mem::size_of::<Option<axum::body::Bytes>>()
+        );
+        assert_eq!(
+            (slots.as_ptr() as usize) % std::mem::align_of::<Option<axum::body::Bytes>>(),
+            0
+        );
+        assert!(FixedResponseBody::new(usize::MAX).is_err());
+    }
+    #[test]
+    fn injected_allocation_failures_are_fallible_at_each_boundary() {
+        let request = PublishMigrationRequest {
+            from_hash: "a".repeat(64),
+            to_hash: "b".repeat(64),
+            forward: Vec::new(),
+        };
+        fail_next_forwarding_allocation_for_test();
+        assert!(
+            serialize_request_body(CatalogueRequestBody::Migration(&request)).is_err(),
+            "request backing allocation must be fallible"
+        );
+
+        fail_next_forwarding_allocation_for_test();
+        assert!(
+            FixedResponseBody::new(8 << 20).is_err(),
+            "descriptor backing allocation must be fallible"
+        );
+
+        let mut body = FixedResponseBody::new(8 << 20).expect("response backing");
+        fail_next_forwarding_allocation_for_test();
+        assert!(
+            body.append(b"response").is_err(),
+            "application chunk allocation must be fallible"
+        );
     }
 }

--- a/crates/jazz-server/src/server/routes/mod.rs
+++ b/crates/jazz-server/src/server/routes/mod.rs
@@ -27,7 +27,7 @@ use axum::{
 use tower_http::cors::{AllowHeaders, CorsLayer};
 use tower_http::trace::TraceLayer;
 
-use crate::server::ServerState;
+use crate::server::{MAX_CATALOGUE_REQUEST_BODY_BYTES, ServerState};
 
 use http::{
     admin_subscription_introspection_handler, health_handler, internal_shutdown_handler,
@@ -37,12 +37,6 @@ use http::{
 };
 use utils::parse_app_id_param;
 use websocket::ws_handler;
-
-/// Admin catalogue uploads are ordinary JSON requests and must be bounded
-/// before an extractor buffers their bodies. Eight MiB accommodates large
-/// schemas and migration bundles without leaving an unauthenticated memory
-/// amplification path.
-const MAX_ADMIN_REQUEST_BODY_BYTES: usize = 8 << 20;
 
 async fn app_id_gate(
     State(state): State<Arc<ServerState>>,
@@ -104,7 +98,7 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
             "/introspection/subscriptions",
             get(admin_subscription_introspection_handler),
         )
-        .layer(DefaultBodyLimit::max(MAX_ADMIN_REQUEST_BODY_BYTES));
+        .layer(DefaultBodyLimit::max(MAX_CATALOGUE_REQUEST_BODY_BYTES));
     let account_routes = Router::new()
         .route("/register", post(accounts::register))
         .route("/found-local-first", post(accounts::found_local_first))
@@ -149,13 +143,14 @@ mod tests {
     use super::*;
 
     use axum::extract::{Path, Query};
-    use axum::http::{HeaderMap, Method, StatusCode, Uri, header};
+    use axum::http::{HeaderMap, HeaderValue, Method, StatusCode, Uri, header};
     use axum::response::Json;
 
     use jazz::tools::AppId;
     use jazz::tools::public_schema::{SchemaHash, TableName};
     use jazz::tools::schema_lens::LensOp;
     use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use crate::server::catalogue::ConnectionSchemaDiagnostics;
     use axum::body;
@@ -170,7 +165,10 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::middleware::AuthConfig;
-    use crate::server::{EdgeUpstreamHealth, ServerBuilder, ServerState, StorageBackend};
+    use crate::server::{
+        EdgeUpstreamHealth, MAX_CATALOGUE_REQUEST_BODY_BYTES, ServerBuilder, ServerState,
+        StorageBackend,
+    };
     use jazz::wire::{
         FEATURE_STRUCTURED_ERRORS, FEATURE_SYNC_MESSAGE_PAYLOAD, WireFrame, WireHello,
         WirePeerRole, decode_frame, encode_frame,
@@ -2911,5 +2909,424 @@ mod tests {
         );
         assert_eq!(state.shutdown.active_app_requests(), 0);
         authority_task.abort();
+    }
+    #[tokio::test]
+    async fn edge_catalogue_forwarding_rejects_expanded_canonical_migration() {
+        let state =
+            make_edge_state_with_schema(Schema::new(), "http://127.0.0.1:9".to_owned()).await;
+        let request = oversized_migration_for_test();
+        let error = forward_catalogue_request(
+            &state,
+            "admin-secret",
+            reqwest::Method::POST,
+            "/admin/migrations",
+            Some(CatalogueRequestBody::Migration(&request)),
+        )
+        .await
+        .expect_err("expanded canonical request must be rejected");
+        assert_eq!(error.0, StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(
+            error.1.0.error,
+            "canonical catalogue request body exceeds the 8388608-byte limit"
+        );
+    }
+
+    #[tokio::test]
+    async fn catalogue_forwarding_policy_validates_default_and_overflow_limits() {
+        let default = ServerBuilder::new(AppId::from_name("policy-default"))
+            .with_storage(StorageBackend::InMemory)
+            .build()
+            .await
+            .expect("default policy");
+        assert_eq!(
+            default.state.forwarding_policy.list_response_limit_bytes,
+            67_108_864
+        );
+        let explicit = ServerBuilder::new(AppId::from_name("policy-explicit"))
+            .with_storage(StorageBackend::InMemory)
+            .with_catalogue_list_response_limit_bytes(1 << 20)
+            .build()
+            .await
+            .expect("explicit policy");
+        assert_eq!(
+            explicit.state.forwarding_policy.list_response_limit_bytes,
+            1 << 20
+        );
+        let overflow = ServerBuilder::new(AppId::from_name("policy-overflow"))
+            .with_storage(StorageBackend::InMemory)
+            .with_catalogue_list_response_limit_bytes(usize::MAX)
+            .build()
+            .await;
+        assert!(overflow.is_err());
+    }
+    #[tokio::test]
+    async fn edge_catalogue_forwarding_uses_http1_for_raw_authority() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind raw authority");
+        let address = listener.local_addr().expect("raw authority address");
+        let authority_task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept raw authority");
+            let mut request = Vec::new();
+            let mut buffer = [0u8; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let read = stream.read(&mut buffer).await.expect("read raw request");
+                assert!(read > 0, "raw client request ended before headers");
+                request.extend_from_slice(&buffer[..read]);
+            }
+            let expected_prefix = format!(
+                "GET /apps/{}/schemas HTTP/1.1\r\n",
+                AppId::from_name("test-app")
+            );
+            assert!(
+                request.starts_with(expected_prefix.as_bytes()),
+                "catalogue forwarding must use HTTP/1.1 on the wire: {request:?}"
+            );
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n[]")
+                .await
+                .expect("write raw response");
+        });
+        let state = make_edge_state_with_schema(Schema::new(), format!("http://{address}")).await;
+        let response = make_test_router(state)
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(test_app_route("/schemas"))
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("response body")
+                .as_ref(),
+            b"[]"
+        );
+        authority_task.await.expect("raw authority task");
+    }
+
+    #[tokio::test]
+    async fn edge_catalogue_forwarding_rejects_h2_preface_on_http1_transport() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind h2 authority");
+        let address = listener.local_addr().expect("h2 authority address");
+        let authority_task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept h2 authority");
+            let mut request = [0u8; 512];
+            let _ = stream.read(&mut request).await.expect("read h1 request");
+            stream
+                .write_all(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+                .await
+                .expect("write h2 preface");
+        });
+        let state = make_edge_state_with_schema(Schema::new(), format!("http://{address}")).await;
+        let response = make_test_router(state)
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(test_app_route("/schemas"))
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert!(
+            body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("h2 rejection body")
+                .windows("failed to reach catalogue upstream".len())
+                .any(|window| window == b"failed to reach catalogue upstream")
+        );
+        authority_task.await.expect("h2 authority task");
+    }
+    #[tokio::test]
+    async fn edge_catalogue_forwarding_rejects_storage_closed_shutdown() {
+        let state =
+            make_edge_state_with_schema(Schema::new(), "http://127.0.0.1:9".to_owned()).await;
+        state.shutdown.request_shutdown();
+        assert_eq!(
+            state.run_shutdown_finalization().await,
+            crate::server::ShutdownPhase::StorageClosed
+        );
+        let error = forward_catalogue_request(
+            &state,
+            "admin-secret",
+            reqwest::Method::POST,
+            "/admin/migrations",
+            None,
+        )
+        .await
+        .expect_err("storage-closed forwarding must be rejected");
+        assert_eq!(error.0, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            error.1.0.error.contains("cancelled during shutdown"),
+            "unexpected shutdown error: {}",
+            error.1.0.error
+        );
+    }
+    #[tokio::test]
+    async fn edge_catalogue_forwarding_validates_content_type_length() {
+        for (length, accepted) in [(1024usize, true), (1025, false)] {
+            let content_type = HeaderValue::from_bytes(&vec![b'x'; length]).unwrap();
+            let authority_app = axum::Router::new().route(
+                &test_app_route("/schema/{hash}"),
+                get(move || {
+                    let content_type = content_type.clone();
+                    async move {
+                        (
+                            StatusCode::OK,
+                            [(header::CONTENT_TYPE, content_type)],
+                            Body::from("ok"),
+                        )
+                    }
+                }),
+            );
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind content-type authority");
+            let address = listener.local_addr().expect("content-type address");
+            let authority_task = tokio::spawn(async move {
+                axum::serve(listener, authority_app)
+                    .await
+                    .expect("serve content-type authority");
+            });
+            let state =
+                make_edge_state_with_schema(Schema::new(), format!("http://{address}")).await;
+            let result = forward_catalogue_request(
+                &state,
+                "admin-secret",
+                reqwest::Method::GET,
+                "/schema/hash",
+                None,
+            )
+            .await;
+            if accepted {
+                let response = result.expect("1024-byte content type is accepted");
+                assert_eq!(response.status(), StatusCode::OK);
+                assert_eq!(
+                    response.headers()[header::CONTENT_TYPE].as_bytes().len(),
+                    length
+                );
+            } else {
+                assert_eq!(
+                    result.expect_err("1025-byte content type is rejected").0,
+                    StatusCode::BAD_GATEWAY
+                );
+            }
+            authority_task.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn edge_catalogue_forwarding_does_not_follow_redirects() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind redirect authority");
+        let address = listener.local_addr().expect("redirect address");
+        let authority_task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept redirect request");
+            let mut request = [0u8; 512];
+            let _ = stream
+                .read(&mut request)
+                .await
+                .expect("read redirect request");
+            stream
+                .write_all(b"HTTP/1.1 302 Found\r\nLocation: /other\r\nContent-Length: 0\r\n\r\n")
+                .await
+                .expect("write redirect response");
+        });
+        let state = make_edge_state_with_schema(Schema::new(), format!("http://{address}")).await;
+        let response = forward_catalogue_request(
+            &state,
+            "admin-secret",
+            reqwest::Method::GET,
+            "/schemas",
+            None,
+        )
+        .await
+        .expect("redirect response");
+        assert_eq!(response.status(), StatusCode::FOUND);
+        authority_task.await.expect("redirect authority task");
+    }
+
+    #[tokio::test]
+    async fn edge_catalogue_forwarding_handles_tiny_raw_writes_across_chunk_boundary() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind tiny-write authority");
+        let address = listener.local_addr().expect("tiny-write address");
+        let authority_task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept tiny-write request");
+            let mut request = [0u8; 512];
+            let _ = stream
+                .read(&mut request)
+                .await
+                .expect("read tiny-write request");
+            let body_length = 2 * 64 * 1024 + 1;
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {body_length}\r\nConnection: close\r\n\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .expect("write tiny-write headers");
+            for _ in 0..body_length {
+                stream.write_all(b"x").await.expect("write tiny body byte");
+            }
+        });
+        let state = make_edge_state_with_schema(Schema::new(), format!("http://{address}")).await;
+        let response = forward_catalogue_request(
+            &state,
+            "admin-secret",
+            reqwest::Method::GET,
+            "/schema/hash",
+            None,
+        )
+        .await
+        .expect("tiny-write response");
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("tiny-write body");
+        assert_eq!(body.len(), 2 * 64 * 1024 + 1);
+        assert!(body.iter().all(|byte| *byte == b'x'));
+        authority_task.await.expect("tiny-write authority task");
+    }
+
+    #[tokio::test]
+    async fn edge_catalogue_forwarding_reuses_one_http1_connection_lease() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind lease authority");
+        let address = listener.local_addr().expect("lease address");
+        let authority_task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept lease connection");
+            for _ in 0..2 {
+                let mut request = Vec::new();
+                let mut buffer = [0u8; 512];
+                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    let read = stream.read(&mut buffer).await.expect("read lease request");
+                    assert!(read > 0, "lease connection closed between requests");
+                    request.extend_from_slice(&buffer[..read]);
+                }
+                stream
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok",
+                    )
+                    .await
+                    .expect("write lease response");
+            }
+        });
+        let state = make_edge_state_with_schema(Schema::new(), format!("http://{address}")).await;
+        for _ in 0..2 {
+            let response = forward_catalogue_request(
+                &state,
+                "admin-secret",
+                reqwest::Method::GET,
+                "/schemas",
+                None,
+            )
+            .await
+            .expect("leased response");
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(
+                body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .expect("leased body")
+                    .as_ref(),
+                b"ok"
+            );
+        }
+        tokio::time::timeout(Duration::from_secs(1), authority_task)
+            .await
+            .expect("lease authority completion")
+            .expect("lease authority task");
+    }
+    #[tokio::test]
+    async fn catalogue_forwarding_without_authority_fails_closed() {
+        let state = make_state_with_schema(Schema::new()).await;
+        let error = forward_catalogue_request(
+            &state,
+            "admin-secret",
+            reqwest::Method::GET,
+            "/schemas",
+            None,
+        )
+        .await
+        .expect_err("core server has no forwarding authority");
+        assert_eq!(error.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(error.1.0.error.contains("without a configured upstream"));
+    }
+    #[tokio::test]
+    async fn edge_catalogue_ingress_cap_blocks_only_oversized_authority_request() {
+        fn padded_migration(length: usize) -> Vec<u8> {
+            let mut value = serde_json::json!({
+                "fromHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "toHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "forward": [],
+                "padding": ""
+            });
+            let base = serde_json::to_vec(&value).unwrap().len();
+            value["padding"] = Value::String("x".repeat(length - base));
+            serde_json::to_vec(&value).unwrap()
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ingress authority");
+        let address = listener.local_addr().expect("ingress authority address");
+        let authority_task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept ingress request");
+            let mut request = [0u8; 1024];
+            let _ = stream
+                .read(&mut request)
+                .await
+                .expect("read ingress request");
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                .await
+                .expect("write ingress response");
+        });
+        let state = make_edge_state_with_schema(Schema::new(), format!("http://{address}")).await;
+        let app = make_test_router(state);
+        let exact = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .method(Method::POST)
+                    .uri(test_app_route("/admin/migrations"))
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(padded_migration(
+                        MAX_CATALOGUE_REQUEST_BODY_BYTES,
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .expect("exact ingress response");
+        assert_eq!(exact.status(), StatusCode::OK);
+        let oversized = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method(Method::POST)
+                    .uri(test_app_route("/admin/migrations"))
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(padded_migration(
+                        MAX_CATALOGUE_REQUEST_BODY_BYTES + 1,
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .expect("oversized ingress response");
+        assert_eq!(oversized.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        authority_task.await.expect("ingress authority task");
     }
 }

--- a/crates/jazz-server/src/server/routes/mod.rs
+++ b/crates/jazz-server/src/server/routes/mod.rs
@@ -2672,4 +2672,244 @@ mod tests {
         let _ = ws.close(None).await;
         server_task.abort();
     }
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn edge_catalogue_forwarding_times_out_before_response_headers() {
+        let authority_app = axum::Router::new().route(
+            &test_app_route("/schemas"),
+            get(|| async { std::future::pending::<Response>().await }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind hanging authority");
+        let address = listener.local_addr().expect("authority address");
+        let authority_task = tokio::spawn(async move {
+            axum::serve(listener, authority_app)
+                .await
+                .expect("serve authority");
+        });
+        let state = make_edge_state_with_schema(Schema::new(), format!("http://{address}")).await;
+        let response = tokio::time::timeout(
+            Duration::from_secs(31),
+            make_test_router(state).oneshot(
+                axum::http::Request::builder()
+                    .uri(test_app_route("/schemas"))
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            ),
+        )
+        .await
+        .expect("forwarding must have a total deadline")
+        .expect("router response");
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("timeout body");
+        let error: Value = serde_json::from_slice(&body).expect("timeout JSON");
+        assert_eq!(
+            error["error"].as_str(),
+            Some("catalogue upstream request exceeded the 30-second total deadline")
+        );
+        authority_task.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn edge_catalogue_forwarding_times_out_while_reading_response_body() {
+        let authority_app = axum::Router::new().route(
+            &test_app_route("/schemas"),
+            get(|| async {
+                let stream = futures::stream::once(async {
+                    Ok::<_, std::convert::Infallible>(axum::body::Bytes::from_static(b"partial"))
+                })
+                .chain(futures::stream::pending::<
+                    Result<axum::body::Bytes, std::convert::Infallible>,
+                >());
+                (
+                    StatusCode::OK,
+                    [(header::CONTENT_TYPE, "application/json")],
+                    Body::from_stream(stream),
+                )
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind partial authority");
+        let address = listener.local_addr().expect("authority address");
+        let authority_task = tokio::spawn(async move {
+            axum::serve(listener, authority_app)
+                .await
+                .expect("serve authority");
+        });
+        let state = make_edge_state_with_schema(Schema::new(), format!("http://{address}")).await;
+        let response = tokio::time::timeout(
+            Duration::from_secs(31),
+            make_test_router(state).oneshot(
+                axum::http::Request::builder()
+                    .uri(test_app_route("/schemas"))
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            ),
+        )
+        .await
+        .expect("forwarding must have a total deadline")
+        .expect("router response");
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("timeout body");
+        let error: Value = serde_json::from_slice(&body).expect("timeout JSON");
+        assert_eq!(
+            error["error"].as_str(),
+            Some("catalogue upstream request exceeded the 30-second total deadline")
+        );
+        authority_task.abort();
+    }
+
+    #[tokio::test]
+    async fn edge_catalogue_forwarding_preserves_invalid_utf8_non_success_response() {
+        let authority_app = axum::Router::new().route(
+            &test_app_route("/schema/{hash}"),
+            get(|| async {
+                (
+                    StatusCode::CONFLICT,
+                    [(header::CONTENT_TYPE, "application/octet-stream")],
+                    Body::from(vec![0xff, 0x00, 0xfe]),
+                )
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind response authority");
+        let address = listener.local_addr().expect("authority address");
+        let authority_task = tokio::spawn(async move {
+            axum::serve(listener, authority_app)
+                .await
+                .expect("serve authority");
+        });
+        let state = make_edge_state_with_schema(Schema::new(), format!("http://{address}")).await;
+        let response = make_test_router(state)
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(test_app_route(
+                        "/schema/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    ))
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/octet-stream"
+        );
+        assert_eq!(
+            body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("response body")
+                .as_ref(),
+            &[0xff, 0x00, 0xfe]
+        );
+        authority_task.abort();
+    }
+
+    #[tokio::test]
+    async fn edge_catalogue_forwarding_rejects_chunked_response_over_limit() {
+        let authority_app = axum::Router::new().route(
+            &test_app_route("/schema/{hash}"),
+            get(|| async {
+                let stream = futures::stream::iter(vec![Ok::<_, std::convert::Infallible>(
+                    axum::body::Bytes::from(vec![b'x'; (8 << 20) + 1]),
+                )]);
+                (StatusCode::OK, Body::from_stream(stream))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind oversized authority");
+        let address = listener.local_addr().expect("authority address");
+        let authority_task = tokio::spawn(async move {
+            axum::serve(listener, authority_app)
+                .await
+                .expect("serve authority");
+        });
+        let state = make_edge_state_with_schema(Schema::new(), format!("http://{address}")).await;
+        let response = make_test_router(state)
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(test_app_route(
+                        "/schema/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    ))
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("oversized response body");
+        let error: Value = serde_json::from_slice(&body).expect("oversized response JSON");
+        assert_eq!(
+            error["error"].as_str(),
+            Some("catalogue upstream response body exceeds the 8388608-byte limit")
+        );
+        authority_task.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn edge_catalogue_forwarding_shutdown_cancels_hanging_mutation() {
+        let authority_app = axum::Router::new().route(
+            &test_app_route("/admin/migrations"),
+            post(|| async { std::future::pending::<Response>().await }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mutation authority");
+        let address = listener.local_addr().expect("authority address");
+        let authority_task = tokio::spawn(async move {
+            axum::serve(listener, authority_app)
+                .await
+                .expect("serve authority");
+        });
+        let state = make_edge_state_with_schema(Schema::new(), format!("http://{address}")).await;
+        let app = make_test_router(state.clone());
+        let request = tokio::spawn(async move {
+            app.oneshot(
+                axum::http::Request::builder()
+                    .method(Method::POST)
+                    .uri(test_app_route("/admin/migrations"))
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{"fromHash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","toHash":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","forward":[]}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .expect("router response")
+        });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        state.shutdown.request_shutdown();
+        let response = tokio::time::timeout(Duration::from_secs(2), request)
+            .await
+            .expect("shutdown must cancel forwarding")
+            .expect("forwarding task");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("shutdown body");
+        let error: Value = serde_json::from_slice(&body).expect("shutdown JSON");
+        assert_eq!(
+            error["error"].as_str(),
+            Some(
+                "catalogue forwarding cancelled during shutdown; the upstream mutation outcome may be unknown; verify catalogue state before retrying"
+            )
+        );
+        assert_eq!(state.shutdown.active_app_requests(), 0);
+        authority_task.abort();
+    }
 }

--- a/docs/content/docs/getting-started/server-setup.mdx
+++ b/docs/content/docs/getting-started/server-setup.mdx
@@ -38,6 +38,21 @@ Your app ID namespaces your data for storage and sync. Click below to generate o
 Local-first auth is enabled by default in development and requires `--allow-local-first-auth` in production. External JWT auth requires either `--jwks-url` or `--jwt-public-key`, but not both.
 Edge mode is enabled by `--upstream-url`; when set, provide `--admin-secret` or `JAZZ_ADMIN_SECRET`. The edge uses that admin secret for its upstream WebSocket connection.
 
+For forwarded catalogue responses, an edge server uses a 67,108,864-byte (64 MiB)
+default limit for `GET /schemas`. You can override it with
+`JAZZ_CATALOGUE_LIST_RESPONSE_LIMIT_BYTES`, using a positive decimal `usize`
+value; startup rejects zero, malformed, overflowing, or otherwise
+allocation-invalid values. This setting is read only when `--upstream-url` is
+configured, affects only forwarded `GET /schemas`, and requires a restart.
+Every other forwarded catalogue response has a fixed 8 MiB limit. Invalid values
+are ignored when starting a direct core server without an upstream URL, so this
+edge-only setting does not change core startup or local catalogue behaviour.
+The edge forwarding client is HTTP/1-only and does not follow redirects. Its
+transport safety is exercised with a raw HTTP/1.1 authority (including tiny
+body writes) and an HTTP/2 connection-preface rejection; these are the local
+equivalent of asserting HTTP/1 ALPN selection without requiring test
+certificates.
+
 Cookie-based WebSocket auth is enabled with `--auth-cookie-name` or `JAZZ_AUTH_COOKIE_NAME`. When no
 explicit auth credential is supplied, the sync server reads that named cookie and validates the JWT
 it contains. If your app uses a separate application session cookie, resolve it in your own app server


### PR DESCRIPTION
## Summary
- Bound edge-to-core catalogue request and response buffering.
- Add a total deadline, shutdown cancellation and a bounded HTTP/1 client.
- Preserve forwarded status, content type and arbitrary body bytes.

## Before
Edges buffered complete authority responses without an application cap or total deadline. Redirects could be followed and shutdown did not cancel hanging forwards.

## After
Canonical requests and ordinary responses are capped at 8 MiB; `GET /schemas` defaults to a configurable 64 MiB. Streaming uses bounded 64 KiB chunks, redirects are disabled, the total deadline is 30 seconds, and shutdown cancels in-flight forwarding. Core catalogue semantics and wire formats remain unchanged.

## Test plan
- [ ] `cargo test -p jazz-server forwarding_capacity_tests`
- [ ] `cargo test -p jazz-server catalogue`