### PR TITLE
Fix bundled DSL schema collection isolation

### DIFF
--- a/.changeset/bundled-dsl-collection.md
+++ b/.changeset/bundled-dsl-collection.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Isolate bundled TypeScript schema collection between loader runs.

--- a/packages/jazz-tools/src/schema-loader.test.ts
+++ b/packages/jazz-tools/src/schema-loader.test.ts
@@ -1,12 +1,18 @@
-import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, expect, it, afterEach } from "vitest";
 import { schemaToWasm } from "./codegen/schema-reader.js";
-import { loadCompiledSchema } from "./schema-loader.js";
+import { loadCompiledSchema, schemaLoaderTestHooks } from "./schema-loader.js";
 
 const WITH_DEFAULTS_DIR = fileURLToPath(
   new URL("./testing/fixtures/with-defaults", import.meta.url),
 );
 const WITH_BIGINT_DIR = fileURLToPath(new URL("./testing/fixtures/with-bigint", import.meta.url));
+
+const defaultRemoveTempDirectory = schemaLoaderTestHooks.removeTempDirectory;
+afterEach(() => {
+  schemaLoaderTestHooks.removeTempDirectory = defaultRemoveTempDirectory;
+});
 
 describe("loadCompiledSchema", () => {
   it("keeps typed-app schema and wasm schema losslessly aligned", async () => {
@@ -76,14 +82,63 @@ describe("bundled DSL schema loading", () => {
   });
 
   it("cleans failed bundle state so a retry can load the schema", async () => {
-    process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY = "1";
-    await expect(loadCompiledSchema(fixtureDir("retry-after-failure"))).rejects.toThrow(
-      "intentional schema fixture failure",
-    );
+    const previous = process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY;
+    try {
+      process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY = "1";
+      await expect(loadCompiledSchema(fixtureDir("retry-after-failure"))).rejects.toThrow(
+        "intentional schema fixture failure",
+      );
 
-    delete process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY;
-    const loaded = await loadCompiledSchema(fixtureDir("retry-after-failure"));
-    expect(loaded.schema.tables.map((table) => table.name)).toEqual(["retry_tasks"]);
+      delete process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY;
+      const loaded = await loadCompiledSchema(fixtureDir("retry-after-failure"));
+      expect(loaded.schema.tables.map((table) => table.name)).toEqual(["retry_tasks"]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY;
+      } else {
+        process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY = previous;
+      }
+    }
+  });
+
+  it("cleans temporary bundles and preserves the original load error", async () => {
+    const cleaned: string[] = [];
+    let failCleanup = false;
+    schemaLoaderTestHooks.removeTempDirectory = async (tempDir) => {
+      cleaned.push(tempDir);
+      await defaultRemoveTempDirectory(tempDir);
+      if (failCleanup) throw new Error("intentional cleanup failure");
+    };
+    await loadCompiledSchema(fixtureDir("side-effect-only"));
+
+    const previous = process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY;
+    try {
+      failCleanup = true;
+      process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY = "1";
+      await expect(loadCompiledSchema(fixtureDir("retry-after-failure"))).rejects.toThrow(
+        "intentional schema fixture failure",
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY;
+      } else {
+        process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY = previous;
+      }
+    }
+
+    expect(cleaned).toHaveLength(3);
+    expect(new Set(cleaned).size).toBe(3);
+  });
+
+  it("propagates a cleanup failure after a successful load", async () => {
+    schemaLoaderTestHooks.removeTempDirectory = async (tempDir) => {
+      await defaultRemoveTempDirectory(tempDir);
+      throw new Error("intentional cleanup failure");
+    };
+
+    await expect(loadCompiledSchema(fixtureDir("side-effect-only"))).rejects.toThrow(
+      "intentional cleanup failure",
+    );
   });
 
   it("isolates parallel top-level-await bundles deterministically", async () => {
@@ -96,3 +151,18 @@ describe("bundled DSL schema loading", () => {
     expect(b.schema.tables.map((table) => table.name)).toEqual(["parallel_b"]);
   });
 });
+
+const DIST_SCHEMA_LOADER = fileURLToPath(new URL("../dist/schema-loader.js", import.meta.url).href);
+
+it.skipIf(!existsSync(DIST_SCHEMA_LOADER))(
+  "loads a public bare jazz-tools schema through the built distribution",
+  async () => {
+    // The loader path is runtime-selected because this canary targets the built artifact.
+    const { loadCompiledSchema: loadBuiltSchema } = (await import(
+      pathToFileURL(DIST_SCHEMA_LOADER).href
+    )) as typeof import("./schema-loader.js");
+    const loaded = await loadBuiltSchema(fixtureDir("side-effect-only"));
+
+    expect(loaded.schema.tables.map((table) => table.name)).toEqual(["side_effect_tasks"]);
+  },
+);

--- a/packages/jazz-tools/src/schema-loader.test.ts
+++ b/packages/jazz-tools/src/schema-loader.test.ts
@@ -56,3 +56,43 @@ describe("loadCompiledSchema", () => {
     expect(largeCount?.default).toBe(9007199254740993n);
   });
 });
+const FIXTURES_DIR = fileURLToPath(new URL("../tests/ts-dsl/fixtures", import.meta.url));
+
+const fixtureDir = (name: string) => `${FIXTURES_DIR}/${name}`;
+
+describe("bundled DSL schema loading", () => {
+  it("collects tables from a public bare jazz-tools side-effect import", async () => {
+    const loaded = await loadCompiledSchema(fixtureDir("side-effect-only"));
+
+    expect(loaded.schema.tables.map((table) => table.name)).toEqual(["side_effect_tasks"]);
+  });
+
+  it("preserves explicit schema precedence while consuming side-effect collection", async () => {
+    const explicit = await loadCompiledSchema(fixtureDir("explicit-precedence"));
+    expect(explicit.schema.tables.map((table) => table.name)).toEqual(["explicit_tasks"]);
+
+    const sideEffect = await loadCompiledSchema(fixtureDir("side-effect-only"));
+    expect(sideEffect.schema.tables.map((table) => table.name)).toEqual(["side_effect_tasks"]);
+  });
+
+  it("cleans failed bundle state so a retry can load the schema", async () => {
+    process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY = "1";
+    await expect(loadCompiledSchema(fixtureDir("retry-after-failure"))).rejects.toThrow(
+      "intentional schema fixture failure",
+    );
+
+    delete process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY;
+    const loaded = await loadCompiledSchema(fixtureDir("retry-after-failure"));
+    expect(loaded.schema.tables.map((table) => table.name)).toEqual(["retry_tasks"]);
+  });
+
+  it("isolates parallel top-level-await bundles deterministically", async () => {
+    const [a, b] = await Promise.all([
+      loadCompiledSchema(fixtureDir("parallel-tla-a")),
+      loadCompiledSchema(fixtureDir("parallel-tla-b")),
+    ]);
+
+    expect(a.schema.tables.map((table) => table.name)).toEqual(["parallel_a"]);
+    expect(b.schema.tables.map((table) => table.name)).toEqual(["parallel_b"]);
+  });
+});

--- a/packages/jazz-tools/src/schema-loader.ts
+++ b/packages/jazz-tools/src/schema-loader.ts
@@ -1,10 +1,11 @@
 import { existsSync } from "fs";
-import { access, rm } from "fs/promises";
-import { basename, dirname, join, resolve } from "path";
+import { access, mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { basename, join, resolve } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 import { build, type Plugin } from "esbuild";
 import { schemaToWasm } from "./codegen/schema-reader.js";
-import { getCollectedSchema, resetCollectedState } from "./dsl.js";
+import type { SchemaDefinition } from "./typed-app.js";
 import type { Column, OperationPolicy, Schema, SqlType, TablePolicies } from "./schema.js";
 import type {
   ColumnDescriptor,
@@ -17,11 +18,21 @@ import { schemaDefinitionToAst } from "./migrations.js";
 import type { CompiledPermissionsMap } from "./schema-permissions.js";
 import { validatePermissionsAgainstSchema } from "./schema-permissions.js";
 
-let importCounter = 0;
 const localJazzToolsSourceEntry = fileURLToPath(new URL("./index.ts", import.meta.url));
 const localJazzToolsEntry = existsSync(localJazzToolsSourceEntry)
   ? localJazzToolsSourceEntry
   : fileURLToPath(new URL("./index.js", import.meta.url));
+const schemaLoaderEnvelopeExport = "__jazzSchemaLoaderEnvelope";
+
+async function removeTempDirectory(tempDir: string): Promise<void> {
+  await rm(tempDir, { force: true, recursive: true });
+}
+
+export const schemaLoaderTestHooks: {
+  removeTempDirectory: (tempDir: string) => Promise<void>;
+} = {
+  removeTempDirectory,
+};
 
 export interface LoadedSchemaProject {
   rootDir: string;
@@ -32,12 +43,28 @@ export interface LoadedSchemaProject {
   wasmSchema: WasmSchema;
 }
 
-async function bundleToTempFile(filePath: string): Promise<string> {
-  const sourceDir = dirname(resolve(filePath));
-  const outFile = join(sourceDir, `.jazz-schema-${++importCounter}.mjs`);
+type LoadedTsModule = {
+  module: Record<string, unknown>;
+  collectedSchema: Schema;
+};
+
+async function bundleToTempFile(filePath: string, tempDir: string): Promise<string> {
+  const outFile = join(tempDir, "schema.mjs");
+  const entryFile = join(tempDir, "entry.mjs");
+  const sourceUrl = pathToFileURL(resolve(filePath)).href;
+
+  await writeFile(
+    entryFile,
+    [
+      `import * as module from ${JSON.stringify(sourceUrl)};`,
+      `import { getCollectedSchema } from "jazz-tools";`,
+      `export const ${schemaLoaderEnvelopeExport} = { module, collectedSchema: getCollectedSchema() };`,
+      "",
+    ].join("\n"),
+  );
 
   await build({
-    entryPoints: [resolve(filePath)],
+    entryPoints: [entryFile],
     bundle: true,
     format: "esm",
     platform: "node",
@@ -62,13 +89,46 @@ function localJazzToolsPlugin(): Plugin {
   };
 }
 
-async function loadTsModule(filePath: string): Promise<Record<string, unknown>> {
-  resetCollectedState();
-  const outFile = await bundleToTempFile(filePath);
+async function loadTsModule(filePath: string): Promise<LoadedTsModule> {
+  const tempDir = await mkdtemp(join(tmpdir(), "jazz-schema-loader-"));
+  let loadFailed = false;
   try {
-    return (await import(pathToFileURL(outFile).href)) as Record<string, unknown>;
+    const outFile = await bundleToTempFile(filePath, tempDir);
+    // The output path is unique per load, so runtime import caching cannot
+    // cross-contaminate concurrent schema loads.
+    const loaded = (await import(pathToFileURL(outFile).href)) as Record<string, unknown>;
+    const envelope = loaded[schemaLoaderEnvelopeExport];
+    if (typeof envelope !== "object" || envelope === null) {
+      throw new Error("Schema loader bundle did not return its private result envelope.");
+    }
+    const { module, collectedSchema } = envelope as {
+      module?: unknown;
+      collectedSchema?: unknown;
+    };
+    if (
+      typeof module !== "object" ||
+      module === null ||
+      typeof collectedSchema !== "object" ||
+      collectedSchema === null ||
+      Array.isArray(collectedSchema)
+    ) {
+      throw new Error("Schema loader bundle returned an invalid private result envelope.");
+    }
+    return {
+      module: module as Record<string, unknown>,
+      collectedSchema: collectedSchema as Schema,
+    };
+  } catch (error) {
+    loadFailed = true;
+    throw error;
   } finally {
-    await rm(outFile, { force: true }).catch(() => undefined);
+    try {
+      await schemaLoaderTestHooks.removeTempDirectory(tempDir);
+    } catch (cleanupError) {
+      if (!loadFailed) {
+        throw cleanupError;
+      }
+    }
   }
 }
 
@@ -212,7 +272,10 @@ type LoadedSchemaInput = {
   wasmSchema?: WasmSchema;
 };
 
-function schemaFromLoadedModule(loaded: Record<string, unknown>): LoadedSchemaInput | null {
+function schemaFromLoadedModule(
+  loaded: Record<string, unknown>,
+  collected: Schema,
+): LoadedSchemaInput | null {
   const candidates = [loaded.schema, loaded.schemaDef, loaded.default, loaded.app].filter(
     (candidate): candidate is Record<string, unknown> =>
       typeof candidate === "object" && candidate !== null,
@@ -229,13 +292,12 @@ function schemaFromLoadedModule(loaded: Record<string, unknown>): LoadedSchemaIn
 
   for (const candidate of candidates) {
     try {
-      return { schema: schemaDefinitionToAst(candidate as any) };
+      return { schema: schemaDefinitionToAst(candidate as SchemaDefinition) };
     } catch {
       // Try the next supported export shape.
     }
   }
 
-  const collected = getCollectedSchema();
   if (collected.tables.length > 0) {
     return { schema: collected };
   }
@@ -245,7 +307,7 @@ function schemaFromLoadedModule(loaded: Record<string, unknown>): LoadedSchemaIn
 
 async function loadSchemaInput(filePath: string): Promise<LoadedSchemaInput> {
   const loaded = await loadTsModule(filePath);
-  const directSchema = schemaFromLoadedModule(loaded);
+  const directSchema = schemaFromLoadedModule(loaded.module, loaded.collectedSchema);
   if (directSchema) {
     return directSchema;
   }
@@ -289,7 +351,7 @@ function isPermissionsMap(input: unknown): input is Record<string, TablePolicies
 }
 
 async function loadPermissionsModule(filePath: string): Promise<Record<string, TablePolicies>> {
-  const module = await loadTsModule(filePath);
+  const { module } = await loadTsModule(filePath);
   const candidate = module.default ?? module.permissions ?? null;
   if (!candidate) {
     throw new Error(
@@ -308,7 +370,7 @@ async function loadPermissionsModule(filePath: string): Promise<Record<string, T
 async function tryLoadPermissionsFromSchemaModule(
   filePath: string,
 ): Promise<Record<string, TablePolicies> | undefined> {
-  const module = await loadTsModule(filePath);
+  const { module } = await loadTsModule(filePath);
   const candidate = module.permissions ?? null;
   if (!candidate) {
     return undefined;

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/explicit-precedence/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/explicit-precedence/schema.ts
@@ -1,0 +1,11 @@
+import { col, schema as s, table } from "jazz-tools";
+
+table("discarded_side_effect", {
+  title: col.string(),
+});
+
+export const schema = {
+  explicit_tasks: s.table({
+    title: s.string(),
+  }),
+};

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/parallel-tla-a/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/parallel-tla-a/schema.ts
@@ -1,8 +1,33 @@
 import { col, table } from "jazz-tools";
 
-const { promise, resolve } = Promise.withResolvers<void>();
-setTimeout(resolve, 35);
-await promise;
+type TlaBarrier = {
+  registered: Set<string>;
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+type TlaGlobals = typeof globalThis & {
+  __jazzSchemaLoaderTlaBarrier?: TlaBarrier;
+};
+
+const globals = globalThis as TlaGlobals;
+let barrier = globals.__jazzSchemaLoaderTlaBarrier;
+if (!barrier) {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  barrier = { registered: new Set(), promise, resolve };
+  globals.__jazzSchemaLoaderTlaBarrier = barrier;
+}
+
 table("parallel_a", {
   value: col.string(),
 });
+barrier.registered.add("a");
+if (barrier.registered.size === 2) barrier.resolve();
+
+try {
+  await barrier.promise;
+} finally {
+  if (globals.__jazzSchemaLoaderTlaBarrier === barrier) {
+    delete globals.__jazzSchemaLoaderTlaBarrier;
+  }
+}

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/parallel-tla-a/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/parallel-tla-a/schema.ts
@@ -1,0 +1,8 @@
+import { col, table } from "jazz-tools";
+
+const { promise, resolve } = Promise.withResolvers<void>();
+setTimeout(resolve, 35);
+await promise;
+table("parallel_a", {
+  value: col.string(),
+});

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/parallel-tla-a/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/parallel-tla-a/schema.ts
@@ -13,7 +13,10 @@ type TlaGlobals = typeof globalThis & {
 const globals = globalThis as TlaGlobals;
 let barrier = globals.__jazzSchemaLoaderTlaBarrier;
 if (!barrier) {
-  const { promise, resolve } = Promise.withResolvers<void>();
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
   barrier = { registered: new Set(), promise, resolve };
   globals.__jazzSchemaLoaderTlaBarrier = barrier;
 }

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/parallel-tla-b/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/parallel-tla-b/schema.ts
@@ -1,0 +1,8 @@
+import { col, table } from "jazz-tools";
+
+const { promise, resolve } = Promise.withResolvers<void>();
+setTimeout(resolve, 5);
+await promise;
+table("parallel_b", {
+  value: col.int(),
+});

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/parallel-tla-b/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/parallel-tla-b/schema.ts
@@ -13,7 +13,10 @@ type TlaGlobals = typeof globalThis & {
 const globals = globalThis as TlaGlobals;
 let barrier = globals.__jazzSchemaLoaderTlaBarrier;
 if (!barrier) {
-  const { promise, resolve } = Promise.withResolvers<void>();
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
   barrier = { registered: new Set(), promise, resolve };
   globals.__jazzSchemaLoaderTlaBarrier = barrier;
 }

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/parallel-tla-b/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/parallel-tla-b/schema.ts
@@ -1,8 +1,33 @@
 import { col, table } from "jazz-tools";
 
-const { promise, resolve } = Promise.withResolvers<void>();
-setTimeout(resolve, 5);
-await promise;
+type TlaBarrier = {
+  registered: Set<string>;
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+type TlaGlobals = typeof globalThis & {
+  __jazzSchemaLoaderTlaBarrier?: TlaBarrier;
+};
+
+const globals = globalThis as TlaGlobals;
+let barrier = globals.__jazzSchemaLoaderTlaBarrier;
+if (!barrier) {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  barrier = { registered: new Set(), promise, resolve };
+  globals.__jazzSchemaLoaderTlaBarrier = barrier;
+}
+
 table("parallel_b", {
   value: col.int(),
 });
+barrier.registered.add("b");
+if (barrier.registered.size === 2) barrier.resolve();
+
+try {
+  await barrier.promise;
+} finally {
+  if (globals.__jazzSchemaLoaderTlaBarrier === barrier) {
+    delete globals.__jazzSchemaLoaderTlaBarrier;
+  }
+}

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/retry-after-failure/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/retry-after-failure/schema.ts
@@ -1,0 +1,9 @@
+import { col, table } from "jazz-tools";
+
+table("retry_tasks", {
+  title: col.string(),
+});
+
+if (process.env.JAZZ_SCHEMA_LOADER_FAIL_RETRY === "1") {
+  throw new Error("intentional schema fixture failure");
+}

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/side-effect-only/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/side-effect-only/schema.ts
@@ -1,0 +1,5 @@
+import { col, table } from "jazz-tools";
+
+table("side_effect_tasks", {
+  title: col.string(),
+});


### PR DESCRIPTION
## Summary
- Capture side-effect DSL tables inside the bundle evaluating the schema.
- Isolate concurrent and retrying loads with unique temporary directories.
- Preserve explicit-export precedence and deterministic cleanup errors.

## Before
A public `jazz-tools` side-effect import could register tables in a bundled collector while the loader read a different process-level collector, making a valid schema appear empty. Overlapping or retried loads could share state.

## After
A private entry returns module exports and its in-bundle collected schema together. Explicit exports still win, concurrent loads remain isolated, retries start fresh, and cleanup has defined error precedence. Public schema types and storage formats are unchanged.

## Test plan
- [ ] `corepack pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/schema-loader.test.ts`
- [ ] `corepack pnpm --filter jazz-tools build:runtime && corepack pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/schema-loader.test.ts`