### PR TITLE
Fix typed scalar object where filters

### DIFF
--- a/.changeset/quiet-scalar-filters.md
+++ b/.changeset/quiet-scalar-filters.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Classify typed where values from their declared column types so Date, Uint8Array, JSON-object, and array equality filters lower as a single `eq` condition while operator maps retain their existing validation.

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -26,6 +26,18 @@ const app = s.defineApp({
     }),
   }),
 });
+const scalarApp = s.defineApp({
+  filters: s.table({
+    timestamp: s.timestamp(),
+    bytes: s.bytes(),
+    metadata: s.json(),
+    tags: s.array(s.string()),
+  }),
+});
+
+function translatedConditions(query: { _build(): string }) {
+  return JSON.parse(translateQuery(query._build(), scalarApp.wasmSchema)).conditions;
+}
 
 describe("translateQuery", () => {
   it("uses total structured author equality in both flat and relation predicates", () => {
@@ -524,5 +536,110 @@ describe("translateQuery", () => {
     expect(translated.array_subqueries).toMatchObject([{ requirement: "AtLeastOne" }]);
     expect(translated).not.toHaveProperty("__jazz_client_limit");
     expect(translated).not.toHaveProperty("__jazz_client_offset");
+  });
+
+  it("lowers direct Date values as one equality", () => {
+    const timestamp = new Date("2026-01-02T03:04:05.678Z");
+    expect(translatedConditions(scalarApp.filters.where({ timestamp }))).toEqual([
+      {
+        Cmp: {
+          left: { column: "timestamp" },
+          op: "Eq",
+          right: { Literal: { type: "Timestamp", value: timestamp.getTime() } },
+        },
+      },
+    ]);
+  });
+
+  it("lowers direct Uint8Array values as one equality", () => {
+    expect(
+      translatedConditions(scalarApp.filters.where({ bytes: new Uint8Array([1, 2, 3]) })),
+    ).toEqual([
+      {
+        Cmp: {
+          left: { column: "bytes" },
+          op: "Eq",
+          right: { Literal: { type: "Bytea", value: [1, 2, 3] } },
+        },
+      },
+    ]);
+  });
+
+  it("lowers direct JSON objects as one equality", () => {
+    const metadata = { nested: { answer: 42 } };
+    expect(translatedConditions(scalarApp.filters.where({ metadata }))).toEqual([
+      {
+        Cmp: {
+          left: { column: "metadata" },
+          op: "Eq",
+          right: { Literal: { type: "Text", value: JSON.stringify(metadata) } },
+        },
+      },
+    ]);
+  });
+
+  it("lowers direct arrays as one equality", () => {
+    expect(translatedConditions(scalarApp.filters.where({ tags: ["urgent"] }))).toEqual([
+      {
+        Cmp: {
+          left: { column: "tags" },
+          op: "Eq",
+          right: {
+            Literal: {
+              type: "Array",
+              value: [{ type: "Text", value: "urgent" }],
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("treats typo-only JSON objects as direct equality literals", () => {
+    const metadata = { misspelled: true };
+    expect(translatedConditions(scalarApp.filters.where({ metadata }))).toEqual([
+      {
+        Cmp: {
+          left: { column: "metadata" },
+          op: "Eq",
+          right: { Literal: { type: "Text", value: JSON.stringify(metadata) } },
+        },
+      },
+    ]);
+  });
+
+  it("treats empty JSON objects as direct equality literals", () => {
+    const metadata = {};
+    expect(translatedConditions(scalarApp.filters.where({ metadata }))).toEqual([
+      {
+        Cmp: {
+          left: { column: "metadata" },
+          op: "Eq",
+          right: { Literal: { type: "Text", value: JSON.stringify(metadata) } },
+        },
+      },
+    ]);
+  });
+
+  it("lowers provenance Date fields as direct equality", () => {
+    const createdAt = new Date("2026-02-03T04:05:06.789Z");
+    expect(translatedConditions(scalarApp.filters.where({ $createdAt: createdAt }))).toEqual([
+      {
+        Cmp: {
+          left: { column: "$createdAt" },
+          op: "Eq",
+          right: { Literal: { type: "Timestamp", value: createdAt.getTime() } },
+        },
+      },
+    ]);
+  });
+
+  it("keeps recognized JSON operator maps on the existing validation path", () => {
+    expect(() =>
+      translateQuery(
+        scalarApp.filters.where({ metadata: { gt: 1 } } as never)._build(),
+        scalarApp.wasmSchema,
+      ),
+    ).toThrow('JSON column "metadata" only supports eq/ne/in/isNull operators.');
   });
 });

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -11,13 +11,14 @@ import { blake3 } from "@noble/hashes/blake3.js";
 import { bytesToHex } from "@noble/hashes/utils.js";
 import { hasExternalProvenanceNameAllowance } from "./dsl.js";
 import { schemaToWasm } from "./codegen/schema-reader.js";
-import type { WasmSchema } from "./drivers/types.js";
+import type { ColumnType, WasmSchema } from "./drivers/types.js";
 import {
   PROVENANCE_MAGIC_COLUMNS,
   magicColumnType,
   type ProvenanceMagicColumn,
   assertUserColumnNameAllowed,
 } from "./magic-columns.js";
+import { WHERE_OPERATORS, type WhereOperator } from "./where-operators.js";
 import type { ColumnTransformMap, ColumnTransformRegistry, QueryBuilder } from "./runtime/db.js";
 import type { StreamingValueSource } from "./runtime/client.js";
 import type { Column, Schema as SchemaAst, SqlType, TSTypeFromSqlType } from "./schema.js";
@@ -1297,21 +1298,25 @@ export class TypedTableQueryBuilder<
 
   private _whereConditions(conditions: Record<string, unknown>): BuiltCondition[] {
     const built: BuiltCondition[] = [];
+    const tableSchema = this._schema[this._table];
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
-      const magicType = magicColumnType(key);
-      const recordLiteral =
-        magicType?.type === "Row" &&
-        typeof value === "object" &&
-        value !== null &&
-        magicType.columns.some((column) => Object.hasOwn(value, column.name));
-      if (
-        typeof value === "object" &&
-        value !== null &&
-        !Array.isArray(value) &&
-        !(value instanceof Date) &&
-        !recordLiteral
-      ) {
+      const declaredColumn = tableSchema?.columns.find((column) => column.name === key);
+      const columnType: ColumnType | undefined =
+        key === "id" ? { type: "Uuid" } : (magicColumnType(key) ?? declaredColumn?.column_type);
+      const isObjectValue = typeof value === "object" && value !== null && !Array.isArray(value);
+      const hasRecognizedOperator = isObjectValue
+        ? Object.keys(value).some((op) => WHERE_OPERATORS.includes(op as WhereOperator))
+        : false;
+      const isDirectObjectValue =
+        isObjectValue &&
+        ((columnType?.type === "Json" && !hasRecognizedOperator) ||
+          (columnType?.type === "Timestamp" && value instanceof Date) ||
+          (columnType?.type === "Bytea" && value instanceof Uint8Array) ||
+          (columnType?.type === "Row" &&
+            columnType.columns.some((column) => Object.hasOwn(value, column.name))));
+
+      if (isObjectValue && !isDirectObjectValue) {
         for (const [op, opValue] of Object.entries(value)) {
           if (opValue !== undefined) {
             built.push({ column: key, op, value: opValue });

--- a/packages/jazz-tools/src/where-operators.ts
+++ b/packages/jazz-tools/src/where-operators.ts
@@ -1,16 +1,19 @@
 import type { ColumnDescriptor, ColumnType } from "./drivers/types.js";
 
-export type WhereOperator =
-  | "eq"
-  | "ne"
-  | "gt"
-  | "gte"
-  | "lt"
-  | "lte"
-  | "contains"
-  | "in"
-  | "notIn"
-  | "isNull";
+export const WHERE_OPERATORS = [
+  "eq",
+  "ne",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "contains",
+  "in",
+  "notIn",
+  "isNull",
+] as const;
+
+export type WhereOperator = (typeof WHERE_OPERATORS)[number];
 
 export interface WhereOperatorColumn {
   name: string;


### PR DESCRIPTION
## Summary
- Classify object-shaped typed `where` values using their column type.
- Lower direct Date, byte-array, JSON-object and array values as equality predicates.
- Preserve recognised operator-map validation.

## Before
Every non-array object was treated as operators. Date filters could disappear, byte arrays became numeric operators, and JSON properties became operator names.

## After
Direct timestamp, byte-array, JSON-object and array values lower to one typed `Eq` condition. Provenance timestamps follow the same path. Recognised operator maps keep existing validation and errors.

## Test plan
- [ ] `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/query-adapter.test.ts`
- [ ] `pnpm --filter jazz-tools check`