### PR TITLE
Fix payload enum defaults in schema loading

### DIFF
--- a/.changeset/quiet-enum-round-trip.md
+++ b/.changeset/quiet-enum-round-trip.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Preserve payload-enum column and case-field defaults when loading schemas from `wasmSchema` exports.

--- a/packages/jazz-tools/src/schema-loader.test.ts
+++ b/packages/jazz-tools/src/schema-loader.test.ts
@@ -8,6 +8,9 @@ const WITH_DEFAULTS_DIR = fileURLToPath(
   new URL("./testing/fixtures/with-defaults", import.meta.url),
 );
 const WITH_BIGINT_DIR = fileURLToPath(new URL("./testing/fixtures/with-bigint", import.meta.url));
+const WITH_ENUM_PAYLOAD_DEFAULTS_DIR = fileURLToPath(
+  new URL("./testing/fixtures/with-enum-payload-defaults", import.meta.url),
+);
 
 const defaultRemoveTempDirectory = schemaLoaderTestHooks.removeTempDirectory;
 afterEach(() => {
@@ -49,6 +52,21 @@ describe("loadCompiledSchema", () => {
         }),
       }),
     );
+  });
+
+  it("round-trips payload enum defaults from wasm schema exports", async () => {
+    const { app } = (await import("./testing/fixtures/with-enum-payload-defaults/schema.js")) as {
+      app: { wasmSchema: unknown };
+    };
+    const loaded = await loadCompiledSchema(WITH_ENUM_PAYLOAD_DEFAULTS_DIR);
+
+    expect(loaded.schema.tables[0]?.columns[0]?.default).toEqual({
+      type: "ready",
+      count: 7,
+      label: "live",
+      note: null,
+    });
+    expect(schemaToWasm(loaded.schema)).toEqual(app.wasmSchema);
   });
 
   it("loads typed-app BIGINT columns from wasm schema exports", async () => {

--- a/packages/jazz-tools/src/schema-loader.test.ts
+++ b/packages/jazz-tools/src/schema-loader.test.ts
@@ -11,6 +11,12 @@ const WITH_BIGINT_DIR = fileURLToPath(new URL("./testing/fixtures/with-bigint", 
 const WITH_ENUM_PAYLOAD_DEFAULTS_DIR = fileURLToPath(
   new URL("./testing/fixtures/with-enum-payload-defaults", import.meta.url),
 );
+const WITH_ENUM_PAYLOAD_WRONG_TAG_DIR = fileURLToPath(
+  new URL("./testing/fixtures/with-enum-payload-wrong-tag", import.meta.url),
+);
+const WITH_ENUM_PAYLOAD_REQUIRED_NULL_DIR = fileURLToPath(
+  new URL("./testing/fixtures/with-enum-payload-required-null", import.meta.url),
+);
 
 const defaultRemoveTempDirectory = schemaLoaderTestHooks.removeTempDirectory;
 afterEach(() => {
@@ -67,6 +73,18 @@ describe("loadCompiledSchema", () => {
       note: null,
     });
     expect(schemaToWasm(loaded.schema)).toEqual(app.wasmSchema);
+  });
+
+  it("rejects payload enum defaults with a nested value tag mismatch", async () => {
+    await expect(loadCompiledSchema(WITH_ENUM_PAYLOAD_WRONG_TAG_DIR)).rejects.toThrow(
+      "Text default does not match column type.",
+    );
+  });
+
+  it("rejects null defaults for required payload enum fields", async () => {
+    await expect(loadCompiledSchema(WITH_ENUM_PAYLOAD_REQUIRED_NULL_DIR)).rejects.toThrow(
+      "Null default does not match non-nullable column.",
+    );
   });
 
   it("loads typed-app BIGINT columns from wasm schema exports", async () => {

--- a/packages/jazz-tools/src/schema-loader.ts
+++ b/packages/jazz-tools/src/schema-loader.ts
@@ -172,7 +172,9 @@ function columnTypeToSqlType(columnType: ColumnType): SqlType {
             name: field.name,
             sqlType: columnTypeToSqlType(field.column_type),
             nullable: field.nullable,
-            ...(field.default === undefined ? {} : { default: field.default }),
+            ...(field.default === undefined
+              ? {}
+              : { default: wasmValueToDefault(field.default, field.column_type, field.nullable) }),
           })),
         })),
       };
@@ -183,29 +185,95 @@ function columnTypeToSqlType(columnType: ColumnType): SqlType {
   }
 }
 
-function wasmValueToDefault(value: Value, columnType: ColumnType): unknown {
-  switch (value.type) {
-    case "Null":
-      return null;
+function wasmValueToDefault(value: Value, columnType: ColumnType, nullable = true): unknown {
+  if (value.type === "Null") {
+    if (!nullable) {
+      throw new Error("Null default does not match non-nullable column.");
+    }
+    return null;
+  }
+
+  switch (columnType.type) {
     case "Integer":
+      if (value.type !== "Integer") {
+        throw new Error("Integer default does not match column type.");
+      }
+      return value.value;
     case "BigInt":
+      if (value.type !== "BigInt") {
+        throw new Error("BigInt default does not match column type.");
+      }
+      return value.value;
     case "Double":
+      if (value.type !== "Double") {
+        throw new Error("Double default does not match column type.");
+      }
+      return value.value;
     case "Boolean":
+      if (value.type !== "Boolean") {
+        throw new Error("Boolean default does not match column type.");
+      }
+      return value.value;
     case "Text":
+      if (value.type !== "Text") {
+        throw new Error("Text default does not match column type.");
+      }
+      return value.value;
     case "Timestamp":
+      if (value.type !== "Timestamp") {
+        throw new Error("Timestamp default does not match column type.");
+      }
+      return value.value;
     case "Uuid":
-      if (columnType.type === "Json") {
-        return JSON.parse(String(value.value));
+      if (value.type !== "Uuid") {
+        throw new Error("Uuid default does not match column type.");
       }
       return value.value;
     case "Bytea":
+      if (value.type !== "Bytea") {
+        throw new Error("Bytea default does not match column type.");
+      }
       return new Uint8Array(value.value);
-    case "Array": {
-      if (columnType.type !== "Array") {
+    case "Json":
+      if (value.type !== "Text") {
+        throw new Error("Json default does not match column type.");
+      }
+      return JSON.parse(value.value);
+    case "Enum":
+      if (value.type !== "Text") {
+        throw new Error("Enum default does not match column type.");
+      }
+      return value.value;
+    case "EnumPayload":
+      if (value.type !== "Enum") {
+        throw new Error("Payload enum default does not match column type.");
+      }
+      if (!Array.isArray(value.value.values)) {
+        throw new Error("Payload enum default values must be an array.");
+      }
+      const entry = columnType.cases.find((candidate) => candidate.name === value.value.case);
+      if (!entry) {
+        throw new Error(`Unknown payload enum case "${value.value.case}".`);
+      }
+      if (value.value.values.length !== entry.fields.length) {
+        throw new Error(
+          `Payload enum case "${value.value.case}" default has ${value.value.values.length} values; expected ${entry.fields.length}.`,
+        );
+      }
+      return {
+        type: value.value.case,
+        ...Object.fromEntries(
+          entry.fields.map((field, index) => [
+            field.name,
+            wasmValueToDefault(value.value.values[index]!, field.column_type, field.nullable),
+          ]),
+        ),
+      };
+    case "Array":
+      if (value.type !== "Array") {
         throw new Error("Array default does not match column type.");
       }
       return value.value.map((inner) => wasmValueToDefault(inner, columnType.element));
-    }
     case "Row":
       throw new Error("Root schema loading does not yet support row-valued defaults.");
   }
@@ -232,7 +300,7 @@ function wasmColumnToAst(column: ColumnDescriptor): Column {
     default:
       column.default === undefined
         ? undefined
-        : wasmValueToDefault(column.default, column.column_type),
+        : wasmValueToDefault(column.default, column.column_type, column.nullable),
     references: column.references,
     mergeStrategy: columnMergeStrategyToAst(column.merge_strategy),
   };

--- a/packages/jazz-tools/src/testing/fixtures/with-enum-payload-defaults/schema.ts
+++ b/packages/jazz-tools/src/testing/fixtures/with-enum-payload-defaults/schema.ts
@@ -1,51 +1,18 @@
-export const app = {
-  wasmSchema: {
-    records: {
-      columns: [
-        {
-          name: "state",
-          column_type: {
-            type: "EnumPayload",
-            cases: [
-              {
-                name: "ready",
-                fields: [
-                  {
-                    name: "count",
-                    column_type: { type: "Integer" },
-                    nullable: false,
-                    default: { type: "Integer", value: 3 },
-                  },
-                  {
-                    name: "label",
-                    column_type: { type: "Text" },
-                    nullable: false,
-                    default: { type: "Text", value: "queued" },
-                  },
-                  {
-                    name: "note",
-                    column_type: { type: "Text" },
-                    nullable: true,
-                    default: { type: "Null" },
-                  },
-                ],
-              },
-            ],
-          },
-          nullable: false,
-          default: {
-            type: "Enum",
-            value: {
-              case: "ready",
-              values: [
-                { type: "Integer", value: 7 },
-                { type: "Text", value: "live" },
-                { type: "Null" },
-              ],
-            },
-          },
+import { col } from "../../../dsl.js";
+import { defineApp } from "../../../typed-app.js";
+
+const generatedApp = defineApp({
+  records: {
+    state: col
+      .enum({
+        ready: {
+          count: col.int().default(3),
+          label: col.string().default("queued"),
+          note: col.string().optional().default(null),
         },
-      ],
-    },
+      })
+      .default({ type: "ready", count: 7, label: "live", note: null }),
   },
-};
+});
+
+export const app = { wasmSchema: generatedApp.wasmSchema };

--- a/packages/jazz-tools/src/testing/fixtures/with-enum-payload-defaults/schema.ts
+++ b/packages/jazz-tools/src/testing/fixtures/with-enum-payload-defaults/schema.ts
@@ -1,0 +1,51 @@
+export const app = {
+  wasmSchema: {
+    records: {
+      columns: [
+        {
+          name: "state",
+          column_type: {
+            type: "EnumPayload",
+            cases: [
+              {
+                name: "ready",
+                fields: [
+                  {
+                    name: "count",
+                    column_type: { type: "Integer" },
+                    nullable: false,
+                    default: { type: "Integer", value: 3 },
+                  },
+                  {
+                    name: "label",
+                    column_type: { type: "Text" },
+                    nullable: false,
+                    default: { type: "Text", value: "queued" },
+                  },
+                  {
+                    name: "note",
+                    column_type: { type: "Text" },
+                    nullable: true,
+                    default: { type: "Null" },
+                  },
+                ],
+              },
+            ],
+          },
+          nullable: false,
+          default: {
+            type: "Enum",
+            value: {
+              case: "ready",
+              values: [
+                { type: "Integer", value: 7 },
+                { type: "Text", value: "live" },
+                { type: "Null" },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  },
+};

--- a/packages/jazz-tools/src/testing/fixtures/with-enum-payload-defaults/schema.ts
+++ b/packages/jazz-tools/src/testing/fixtures/with-enum-payload-defaults/schema.ts
@@ -11,8 +11,14 @@ const generatedApp = defineApp({
           note: col.string().optional().default(null),
         },
       })
-      .default({ type: "ready", count: 7, label: "live", note: null }),
+      .default({ type: "ready", count: 7, label: "live", note: "unused" }),
   },
 });
+
+const stateColumn = generatedApp.wasmSchema.records.columns[0]!;
+if (stateColumn.default?.type !== "Enum") {
+  throw new Error("Expected generated payload enum default.");
+}
+stateColumn.default.value.values[2] = { type: "Null" };
 
 export const app = { wasmSchema: generatedApp.wasmSchema };

--- a/packages/jazz-tools/src/testing/fixtures/with-enum-payload-required-null/schema.ts
+++ b/packages/jazz-tools/src/testing/fixtures/with-enum-payload-required-null/schema.ts
@@ -1,0 +1,16 @@
+import { col } from "../../../dsl.js";
+import { defineApp } from "../../../typed-app.js";
+
+const generatedApp = defineApp({
+  records: {
+    state: col.enum({ ready: { label: col.string() } }).default({ type: "ready", label: "live" }),
+  },
+});
+
+const stateColumn = generatedApp.wasmSchema.records.columns[0]!;
+if (stateColumn.default?.type !== "Enum") {
+  throw new Error("Expected generated payload enum default.");
+}
+stateColumn.default.value.values[0] = { type: "Null" };
+
+export const app = { wasmSchema: generatedApp.wasmSchema };

--- a/packages/jazz-tools/src/testing/fixtures/with-enum-payload-wrong-tag/schema.ts
+++ b/packages/jazz-tools/src/testing/fixtures/with-enum-payload-wrong-tag/schema.ts
@@ -1,0 +1,16 @@
+import { col } from "../../../dsl.js";
+import { defineApp } from "../../../typed-app.js";
+
+const generatedApp = defineApp({
+  records: {
+    state: col.enum({ ready: { label: col.string() } }).default({ type: "ready", label: "live" }),
+  },
+});
+
+const stateColumn = generatedApp.wasmSchema.records.columns[0]!;
+if (stateColumn.default?.type !== "Enum") {
+  throw new Error("Expected generated payload enum default.");
+}
+stateColumn.default.value.values[0] = { type: "Integer", value: 7 };
+
+export const app = { wasmSchema: generatedApp.wasmSchema };


### PR DESCRIPTION
## Summary
- Preserve payload-enum column and case-field defaults loaded from `wasmSchema`.
- Reject malformed nested tags and nulls for required payload fields.

## Before
The loader did not decode tagged Enum defaults, losing the column default, and left case-field defaults as tagged runtime values.

## After
Defaults decode recursively according to declared types and re-encode losslessly. Nested tags and nullability are checked; existing scalar, array, JSON and byte default shapes remain unchanged.

## Test plan
- [ ] `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/schema-loader.test.ts`