### PR TITLE
Fix refined query type compatibility

### DIFF
--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -1359,6 +1359,11 @@ export interface Query<
   TSchema extends SchemaLike = SchemaLike,
   TRequired extends boolean = false,
 > extends TypedTableQueryBuilder<SchemaMeta<TTable, TSchema>, TInclude, TSelection, TRequired> {
+  /** @internal Phantom used by `Db.update` to retain column-specific diff shapes. */
+  readonly _largeValueUpdateType: TableLargeValueUpdate<
+    TSchema,
+    Extract<TTable, TableName<TSchema>>
+  >;
   where(
     conditions: TableWhereInput<TSchema, Extract<TTable, TableName<TSchema>>>,
   ): Query<TTable, TInclude, TSelection, TSchema, TRequired>;
@@ -1406,13 +1411,7 @@ export interface Table<TTable extends string, TSchema extends SchemaLike> extend
   {},
   DefaultTableSelection<SchemaMeta<TTable, TSchema>>,
   TSchema
-> {
-  /** @internal Phantom used by `Db.update` to retain column-specific diff shapes. */
-  readonly _largeValueUpdateType: TableLargeValueUpdate<
-    TSchema,
-    Extract<TTable, TableName<TSchema>>
-  >;
-}
+> {}
 
 export type QueryHandle<
   TTable extends string,

--- a/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
@@ -123,6 +123,16 @@ const largeSchema = {
 };
 
 describe("typed app prototype", () => {
+  it("allows a table-inferred variable to be reassigned to a refined query", () => {
+    let query = app.todos;
+
+    query = query.where({ done: true });
+
+    expect(JSON.parse(query._build()).conditions).toEqual([
+      { column: "done", op: "eq", value: true },
+    ]);
+  });
+
   it("serializes select/include metadata without codegen", () => {
     expect(JSON.parse(app.todos.select("title").include({ project: true })._build())).toEqual({
       table: "todos",


### PR DESCRIPTION
## Before

Table objects carried the required _largeValueUpdateType phantom, while refined Query values returned by where did not. TypeScript therefore rejected reassigning a table-inferred variable after refinement:

    let query = app.todos;
    query = query.where({ done: true });

## After

The phantom lives on Query, whose generic parameters retain the originating table and schema. Table continues to extend Query, so both table roots and refined queries retain the column-specific large-value update type.

The example above now compiles, and a regression test exercises both the assignment and the serialized condition.

## Invariants

- Db.update continues to infer table-specific large-value diff shapes.
- Query refinements preserve the originating table and schema metadata.
- A Table remains usable everywhere its corresponding Query is accepted.

## Non-goals

- No runtime query behavior or serialization changes.
- No changes to large-value update semantics.
- No broader Rust/TypeScript Db API refactoring.

## Validation

- jazz-tools TypeScript test compilation passed.
- typed-app focused suite passed: 15 tests.
- root pnpm build passed: 48 of 48 final Turbo tasks.
- pre-commit oxfmt and oxlint hooks passed.