### PR TITLE
Reject unsupported session claim range operators

### DIFF
--- a/.changeset/reject-session-claim-ranges.md
+++ b/.changeset/reject-session-claim-ranges.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reject unsupported range operators in session claim rules.

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -2368,6 +2368,45 @@ describe("permissions DSL", () => {
     },
   );
 
+  it("prioritizes unsupported session range operators over invalid literals", () => {
+    expect(() =>
+      definePermissions(app, ({ policy, session }) => [
+        policy.todos.allowRead.where(
+          session.where({ "claims.age": { gt: session.claims["sub"] } }),
+        ),
+      ]),
+    ).toThrow(/Unsupported session\.where operator "gt"/);
+  });
+
+  it("omits undefined session range values", () => {
+    const compiled = definePermissions(app, ({ policy, session }) => [
+      policy.todos.allowRead.where(session.where({ "claims.age": { gt: undefined } })),
+    ]);
+
+    expect(compiled.todos!.select?.using).toEqual({ type: "True" });
+  });
+
+  it.each([
+    ["gt", "Gt"],
+    ["gte", "Ge"],
+    ["lt", "Lt"],
+    ["lte", "Le"],
+  ] as const)("preserves ordinary row range operator %s", (operator, expectedOp) => {
+    const compiled = definePermissions(app, ({ policy }) => [
+      policy.todos.allowRead.where({ done: { [operator]: true } } as unknown as TodoWhere),
+    ]);
+
+    expect(compiled.todos!.select?.using).toEqual({
+      type: "Cmp",
+      column: "done",
+      op: expectedOp,
+      value: {
+        type: "Literal",
+        value: true,
+      },
+    });
+  });
+
   it("rejects unsupported where operators and invalid compound combinator inputs", () => {
     expect(() =>
       definePermissions(app, ({ policy }) => [

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -2357,6 +2357,16 @@ describe("permissions DSL", () => {
       ]),
     ).toThrow(/unsupported session\.where operator "startsWith"/i);
   });
+  it.each(["gt", "gte", "lt", "lte"] as const)(
+    "rejects session.where range operator %s synchronously",
+    (operator) => {
+      expect(() =>
+        definePermissions(app, ({ policy, session }) => [
+          policy.todos.allowRead.where(session.where({ "claims.age": { [operator]: 18 } })),
+        ]),
+      ).toThrow(new RegExp(`Unsupported session\\.where operator "${operator}"`));
+    },
+  );
 
   it("rejects unsupported where operators and invalid compound combinator inputs", () => {
     expect(() =>

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -2436,17 +2436,10 @@ function sessionPathFilterToExprs(path: string, raw: unknown): PolicyExpr[] {
         }
         break;
       case "gt":
-        exprs.push(sessionCmpExpr(sessionPath, "Gt", value, path));
-        break;
       case "gte":
-        exprs.push(sessionCmpExpr(sessionPath, "Ge", value, path));
-        break;
       case "lt":
-        exprs.push(sessionCmpExpr(sessionPath, "Lt", value, path));
-        break;
       case "lte":
-        exprs.push(sessionCmpExpr(sessionPath, "Le", value, path));
-        break;
+        throw new Error(`Unsupported session.where operator "${op}" in permissions DSL.`);
       case "isNull":
         if (typeof value !== "boolean") {
           throw new Error(`session.where("${path}.isNull") expects a boolean value.`);


### PR DESCRIPTION
## Summary
- Reject `gt`, `gte`, `lt` and `lte` in `session.where(...)` at definition time.
- Preserve ordinary row range predicates.

## Before
Session range expressions compiled in TypeScript despite core accepting only equality and inequality, then failed later during schema conversion.

## After
Defined session ranges throw a targeted synchronous DSL error. Undefined optional values remain omitted; ordinary row ranges and supported session predicates remain unchanged.

## Test plan
- [ ] `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/permissions/index.test.ts -t "session.*range|ordinary row range"`