### PR TITLE
Keep Vue clients stable for equivalent configs

### DIFF
--- a/.changeset/vue-config-stability.md
+++ b/.changeset/vue-config-stability.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Keep Vue provider clients stable while mutable configuration changes.

--- a/packages/jazz-tools/src/vue/provider-config-retry.test.ts
+++ b/packages/jazz-tools/src/vue/provider-config-retry.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { createApp, h, nextTick, shallowRef } from "vue";
 import type { AccountDbConfig } from "../accounts/context.js";
+import { makeFakeAccount } from "../react-core/test-utils.js";
 
 const mocks = vi.hoisted(() => ({ createJazzClient: vi.fn() }));
 vi.mock("./create-jazz-client.js", () => ({ createJazzClient: mocks.createJazzClient }));
@@ -30,7 +31,11 @@ beforeEach(() => mocks.createJazzClient.mockReset());
 afterEach(() => cleanups.splice(0).forEach((cleanup) => cleanup()));
 
 function mount() {
-  const config = shallowRef<AccountDbConfig>({ appId: "retry", driver: { type: "memory" } });
+  const config = shallowRef<AccountDbConfig>({
+    appId: "retry",
+    driver: { type: "memory" },
+    account: makeFakeAccount("retry"),
+  });
   const errors: unknown[] = [];
   const app = createApp({
     render: () =>
@@ -61,7 +66,7 @@ it("retries an equivalent config after initialization fails", async () => {
   mocks.createJazzClient.mockRejectedValueOnce(failure).mockResolvedValue(client());
   const { config, errors, element } = mount();
   await vi.waitFor(() => expect(errors).toEqual([failure]));
-  config.value = { driver: { type: "memory" }, appId: "retry" };
+  config.value = { account: config.value.account, driver: { type: "memory" }, appId: "retry" };
   await vi.waitFor(() => expect(element.textContent).toBe("ready"));
   expect(mocks.createJazzClient).toHaveBeenCalledTimes(2);
 });
@@ -73,10 +78,18 @@ it("retries an equivalent replacement after handover shutdown fails", async () =
   mocks.createJazzClient.mockResolvedValueOnce(first).mockResolvedValue(client());
   const { config, errors, element } = mount();
   await vi.waitFor(() => expect(element.textContent).toBe("ready"));
-  config.value = { appId: "replacement", driver: { type: "memory" } };
+  config.value = {
+    account: config.value.account,
+    appId: "replacement",
+    driver: { type: "memory" },
+  };
   await vi.waitFor(() => expect(errors).toEqual([failure]));
   expect(mocks.createJazzClient).toHaveBeenCalledTimes(1);
-  config.value = { driver: { type: "memory" }, appId: "replacement" };
+  config.value = {
+    account: config.value.account,
+    driver: { type: "memory" },
+    appId: "replacement",
+  };
   await vi.waitFor(() => expect(element.textContent).toBe("ready"));
   expect(mocks.createJazzClient).toHaveBeenCalledTimes(2);
 });
@@ -88,15 +101,27 @@ it("a stale failure preserves the newer pending and ready config identity", asyn
   mocks.createJazzClient.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
   const { config, errors, element } = mount();
   await vi.waitFor(() => expect(mocks.createJazzClient).toHaveBeenCalledTimes(1));
-  config.value = { appId: "replacement", driver: { type: "memory" } };
+  config.value = {
+    account: config.value.account,
+    appId: "replacement",
+    driver: { type: "memory" },
+  };
   await nextTick();
   first.reject(new Error("stale initialization failure"));
   await vi.waitFor(() => expect(mocks.createJazzClient).toHaveBeenCalledTimes(2));
-  config.value = { driver: { type: "memory" }, appId: "replacement" };
+  config.value = {
+    account: config.value.account,
+    driver: { type: "memory" },
+    appId: "replacement",
+  };
   await nextTick();
   second.resolve(ready);
   await vi.waitFor(() => expect(element.textContent).toBe("ready"));
-  config.value = { appId: "replacement", driver: { type: "memory" } };
+  config.value = {
+    account: config.value.account,
+    appId: "replacement",
+    driver: { type: "memory" },
+  };
   await nextTick();
   expect(mocks.createJazzClient).toHaveBeenCalledTimes(2);
   expect(ready.shutdown).not.toHaveBeenCalled();

--- a/packages/jazz-tools/src/vue/provider-config-retry.test.ts
+++ b/packages/jazz-tools/src/vue/provider-config-retry.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createApp, h, nextTick, shallowRef } from "vue";
+import type { AccountDbConfig } from "../accounts/context.js";
+
+const mocks = vi.hoisted(() => ({ createJazzClient: vi.fn() }));
+vi.mock("./create-jazz-client.js", () => ({ createJazzClient: mocks.createJazzClient }));
+import { JazzProvider } from "./provider.js";
+
+function client() {
+  return {
+    db: { onAuthChanged: vi.fn(() => () => {}) },
+    session: null,
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+
+const cleanups: (() => void)[] = [];
+beforeEach(() => mocks.createJazzClient.mockReset());
+afterEach(() => cleanups.splice(0).forEach((cleanup) => cleanup()));
+
+function mount() {
+  const config = shallowRef<AccountDbConfig>({ appId: "retry", driver: { type: "memory" } });
+  const errors: unknown[] = [];
+  const app = createApp({
+    render: () =>
+      h(
+        JazzProvider,
+        { config: config.value, autoAttachDevTools: false },
+        {
+          default: () => h("p", "ready"),
+          fallback: () => h("p", "loading"),
+        },
+      ),
+  });
+  app.config.errorHandler = (error) => {
+    errors.push(error);
+  };
+  const element = document.createElement("div");
+  document.body.append(element);
+  app.mount(element);
+  cleanups.push(() => {
+    app.unmount();
+    element.remove();
+  });
+  return { config, errors, element };
+}
+
+it("retries an equivalent config after initialization fails", async () => {
+  const failure = new Error("temporary storage failure");
+  mocks.createJazzClient.mockRejectedValueOnce(failure).mockResolvedValue(client());
+  const { config, errors, element } = mount();
+  await vi.waitFor(() => expect(errors).toEqual([failure]));
+  config.value = { driver: { type: "memory" }, appId: "retry" };
+  await vi.waitFor(() => expect(element.textContent).toBe("ready"));
+  expect(mocks.createJazzClient).toHaveBeenCalledTimes(2);
+});
+
+it("retries an equivalent replacement after handover shutdown fails", async () => {
+  const first = client();
+  const failure = new Error("temporary shutdown failure");
+  first.shutdown.mockRejectedValueOnce(failure);
+  mocks.createJazzClient.mockResolvedValueOnce(first).mockResolvedValue(client());
+  const { config, errors, element } = mount();
+  await vi.waitFor(() => expect(element.textContent).toBe("ready"));
+  config.value = { appId: "replacement", driver: { type: "memory" } };
+  await vi.waitFor(() => expect(errors).toEqual([failure]));
+  expect(mocks.createJazzClient).toHaveBeenCalledTimes(1);
+  config.value = { driver: { type: "memory" }, appId: "replacement" };
+  await vi.waitFor(() => expect(element.textContent).toBe("ready"));
+  expect(mocks.createJazzClient).toHaveBeenCalledTimes(2);
+});
+
+it("a stale failure preserves the newer pending and ready config identity", async () => {
+  const first = deferred<ReturnType<typeof client>>();
+  const second = deferred<ReturnType<typeof client>>();
+  const ready = client();
+  mocks.createJazzClient.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+  const { config, errors, element } = mount();
+  await vi.waitFor(() => expect(mocks.createJazzClient).toHaveBeenCalledTimes(1));
+  config.value = { appId: "replacement", driver: { type: "memory" } };
+  await nextTick();
+  first.reject(new Error("stale initialization failure"));
+  await vi.waitFor(() => expect(mocks.createJazzClient).toHaveBeenCalledTimes(2));
+  config.value = { driver: { type: "memory" }, appId: "replacement" };
+  await nextTick();
+  second.resolve(ready);
+  await vi.waitFor(() => expect(element.textContent).toBe("ready"));
+  config.value = { appId: "replacement", driver: { type: "memory" } };
+  await nextTick();
+  expect(mocks.createJazzClient).toHaveBeenCalledTimes(2);
+  expect(ready.shutdown).not.toHaveBeenCalled();
+  expect(errors).toEqual([]);
+});

--- a/packages/jazz-tools/src/vue/provider.ts
+++ b/packages/jazz-tools/src/vue/provider.ts
@@ -18,6 +18,7 @@ import {
 import type { PublicSession } from "../runtime/context.js";
 import type { Db } from "../runtime/db.js";
 import type { AccountDbConfig as DbConfig } from "../accounts/context.js";
+import { serializeClientConfig } from "../runtime/client-config-key.js";
 import { createJazzClient, type JazzClient as CreatedJazzClient } from "./create-jazz-client.js";
 import { startInspectorOnce } from "../dev-tools/auto-attach.js";
 import { assertNoClassicProviderProps } from "../classic-api.js";
@@ -147,6 +148,45 @@ export const LegacyJazzProvider = defineComponent({
     let lifecycle = Promise.resolve();
     let runId = 0;
     let stopConfigWatch: (() => void) | null = null;
+    const noConfigKey = Symbol("no config key");
+    let lastRequestedConfigKey: string | typeof noConfigKey = noConfigKey;
+
+    const queueConfigRequest = (createClient: () => Promise<CreatedJazzClient>) => {
+      const activeRunId = ++runId;
+      clientRef.value = null;
+      errorRef.value = null;
+
+      lifecycle = lifecycle
+        .then(async () => {
+          if (activeClient) {
+            const previousClient = activeClient;
+            activeClient = null;
+            await previousClient.shutdown();
+          }
+          if (activeRunId !== runId) return;
+          assertNoClassicProviderProps("JazzProvider", attrs);
+
+          const client = await createClient();
+          if (activeRunId !== runId) {
+            await client.shutdown();
+            return;
+          }
+          try {
+            assertNoClassicProviderProps("JazzProvider", attrs);
+          } catch (reason) {
+            await client.shutdown();
+            throw reason;
+          }
+
+          activeClient = client;
+          clientRef.value = client;
+        })
+        .catch((reason) => {
+          if (activeRunId === runId) {
+            errorRef.value = reason instanceof Error ? reason : new Error(String(reason));
+          }
+        });
+    };
 
     // A config-owned client touches browser-only storage.  Do not begin creating
     // it during SSR: rendering the fallback on the server must be side-effect
@@ -155,41 +195,23 @@ export const LegacyJazzProvider = defineComponent({
       stopConfigWatch = watch(
         () => props.config,
         (config) => {
-          const activeRunId = ++runId;
           const configSnapshot = { ...config } as DbConfig;
-          clientRef.value = null;
-          errorRef.value = null;
-
-          lifecycle = lifecycle
-            .then(async () => {
-              if (activeClient) {
-                const previousClient = activeClient;
-                activeClient = null;
-                await previousClient.shutdown();
-              }
-              if (activeRunId !== runId) return;
-              assertNoClassicProviderProps("JazzProvider", attrs);
-
-              const client = await createJazzClient(configSnapshot);
-              if (activeRunId !== runId) {
-                await client.shutdown();
-                return;
-              }
-              try {
-                assertNoClassicProviderProps("JazzProvider", attrs);
-              } catch (reason) {
-                await client.shutdown();
-                throw reason;
-              }
-
-              activeClient = client;
-              clientRef.value = client;
-            })
-            .catch((reason) => {
-              if (activeRunId === runId) {
-                errorRef.value = reason instanceof Error ? reason : new Error(String(reason));
-              }
+          let configKey: string;
+          try {
+            configKey = serializeClientConfig(configSnapshot);
+          } catch (reason) {
+            lastRequestedConfigKey = noConfigKey;
+            queueConfigRequest(async () => {
+              throw reason;
             });
+            return;
+          }
+
+          if (configKey === lastRequestedConfigKey) return;
+          // Record the request before changing lifecycle state so a re-entrant
+          // watcher observes this request as the latest one.
+          lastRequestedConfigKey = configKey;
+          queueConfigRequest(() => createJazzClient(configSnapshot));
         },
         { deep: true, immediate: true },
       );

--- a/packages/jazz-tools/src/vue/provider.ts
+++ b/packages/jazz-tools/src/vue/provider.ts
@@ -183,6 +183,9 @@ export const LegacyJazzProvider = defineComponent({
         })
         .catch((reason) => {
           if (activeRunId === runId) {
+            // Failed requests may be retried with an equivalent config. Stale
+            // failures must preserve the identity of a newer pending request.
+            lastRequestedConfigKey = noConfigKey;
             errorRef.value = reason instanceof Error ? reason : new Error(String(reason));
           }
         });

--- a/packages/jazz-tools/tests/browser/vue-provider.test.ts
+++ b/packages/jazz-tools/tests/browser/vue-provider.test.ts
@@ -81,6 +81,77 @@ describe("Vue Jazz providers", () => {
     await vi.waitFor(() => expect(element.querySelector("#ready")).not.toBeNull());
   });
 
+  it("does not recreate an equivalent config while the client is loading", async () => {
+    let resolveClient!: (client: JazzClient) => void;
+    const first = fakeClient();
+    const creation = new Promise<JazzClient>((resolve) => {
+      resolveClient = resolve;
+    });
+    mocks.createJazzClient.mockReturnValue(creation);
+    const config = ref<DbConfig>({ appId: "loading", driver: { type: "memory" } });
+    const root = defineComponent(
+      () => () =>
+        h(
+          JazzProvider,
+          { config: config.value },
+          {
+            default: () => h("p", { id: "ready" }, "ready"),
+            fallback: () => h("p", { id: "loading" }, "loading"),
+          },
+        ),
+    );
+
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    const app = createApp(root);
+    apps.push(app);
+    app.mount(element);
+    await settle();
+    expect(mocks.createJazzClient).toHaveBeenCalledOnce();
+
+    config.value = { driver: { type: "memory" }, appId: "loading" };
+    await settle();
+    expect(mocks.createJazzClient).toHaveBeenCalledOnce();
+
+    resolveClient(first);
+    await vi.waitFor(() => expect(element.querySelector("#ready")).not.toBeNull());
+    expect(mocks.createJazzClient).toHaveBeenCalledOnce();
+    expect(first.shutdown).not.toHaveBeenCalled();
+  });
+
+  it("does not flicker or recreate an equivalent config after the client is ready", async () => {
+    const client = fakeClient();
+    mocks.createJazzClient.mockResolvedValue(client);
+    const config = ref<DbConfig>({ appId: "ready", driver: { type: "memory" } });
+    const root = defineComponent(
+      () => () =>
+        h(
+          JazzProvider,
+          { config: config.value },
+          {
+            default: () => h("p", { id: "ready" }, "ready"),
+            fallback: () => h("p", { id: "loading" }, "loading"),
+          },
+        ),
+    );
+
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    const app = createApp(root);
+    apps.push(app);
+    app.mount(element);
+    await vi.waitFor(() => expect(element.querySelector("#ready")).not.toBeNull());
+    expect(mocks.createJazzClient).toHaveBeenCalledOnce();
+
+    config.value = { driver: { type: "memory" }, appId: "ready" };
+    await nextTick();
+    expect(element.querySelector("#ready")).not.toBeNull();
+    expect(element.querySelector("#loading")).toBeNull();
+    await settle();
+    expect(mocks.createJazzClient).toHaveBeenCalledOnce();
+    expect(client.shutdown).not.toHaveBeenCalled();
+  });
+
   it("JazzClientProvider never shuts down a caller-owned client", async () => {
     const first = fakeClient();
     const second = fakeClient();


### PR DESCRIPTION
🤖 Equivalent Vue config replacements retain the pending or ready client, avoiding unnecessary shutdown and fallback flicker. Failed attempts can still be retried with equivalent configuration.

Previously, every deep-watch notification recreated the client, even when only object identity or property order changed. The provider now compares the shared canonical client identity. A genuinely different configuration still replaces the client serially: clear the rendered client, shut down the old client, then create its replacement.

Examples:
- Replace a ready configuration with a new object containing the same values: retain the client and rendered content.
- Replace an equivalent configuration while creation is pending: keep the same pending attempt.
- Creation or handover shutdown fails: an equivalent replacement may retry. The current failed attempt clears its remembered identity.
- An older request fails after a newer request was queued: it must not clear the newer request's identity or publish an obsolete error.

The last two cases address the independent review finding. Public Vue interfaces and caller-owned client behavior are unchanged.

Validation:
- Three real Vue/jsdom regressions cover initialization failure, handover failure, and stale failures preserving newer pending/ready identity.
- Before the fix, two retry tests failed; after the fix, all ten focused provider tests passed, including an independent coordinator rerun on the integrated stack.
- Temporarily clearing identity outside the current-generation guard makes the stale-failure regression fail; the mutation was restored.
- The prior integrated stack passed the full local CI-equivalent gate. This amendment received focused provider verification; fresh CI checks the published revision.

The regression fixtures use an account handle. Both the package check and `tsc --project tsconfig.tests.json` pass; the latter is required because the ordinary package check excludes test files and Vitest transpilation alone does not typecheck them.
