### PR TITLE
Diagnose Android restart fixture metadata failures

### DIFF
--- a/dev/rn-device-acceptance/App.tsx
+++ b/dev/rn-device-acceptance/App.tsx
@@ -55,7 +55,8 @@ async function observeTrustedAdmissionLifecycleInner(
   // retained app data from an old install unable to satisfy this run's reopen
   // assertion.
   markFailure("fixture-metadata-failed");
-  const receipt = await deviceReceiptContext();
+  const receipt = await deviceReceiptContext(markFailure);
+  markFailure("fixture-phase-failed");
   const phase = await nativeAcceptancePhase();
   if (phase === "verify") {
     // This is intentionally a new JS and native process. The row was committed

--- a/dev/rn-device-acceptance/android/app/src/main/java/dev/jazz/rndeviceacceptance/JazzDeviceFixtureModule.kt
+++ b/dev/rn-device-acceptance/android/app/src/main/java/dev/jazz/rndeviceacceptance/JazzDeviceFixtureModule.kt
@@ -23,6 +23,9 @@ import org.json.JSONObject
 class JazzDeviceFixtureModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(context) {
   private val diagnosticCodes = setOf(
     "fixture-metadata-failed",
+    "fixture-receipt-call-failed",
+    "fixture-receipt-validation-failed",
+    "fixture-phase-failed",
     "native-admission-failed",
     "relay-command-abi-failed",
     "relay-open-failed",
@@ -181,33 +184,51 @@ class JazzDeviceFixtureModule(context: ReactApplicationContext) : ReactContextBa
   }
 
   @ReactMethod fun receiptContext(promise: Promise) {
+    var stage = "activity"
+    Log.e("JazzFixtureMetadata", "receipt-started")
     try {
       val activity = reactApplicationContext.currentActivity
         ?: error("acceptance activity is unavailable")
+      stage = "nonce"
       val nonce = activity.intent.getStringExtra("jazzDeviceRunNonce")
         ?: error("acceptance launch did not include a run nonce")
       // Hash the installed package itself, rather than echoing an adb extra.
+      stage = "package-hash"
+      Log.e("JazzFixtureMetadata", "package-hash-started")
       val buildFingerprint = sha256File(reactApplicationContext.applicationInfo.sourceDir)
+      stage = "device-identity"
       val deviceIdentifier = Build.FINGERPRINT.takeIf(String::isNotBlank)
         ?: error("Android build fingerprint is unavailable")
+      stage = "resolve"
       promise.resolve(Arguments.createMap().apply {
         putString("platform", "android")
         putString("deviceIdentifier", deviceIdentifier)
         putString("buildFingerprint", buildFingerprint)
         putString("runNonce", nonce)
       })
-    } catch (error: Throwable) { promise.reject("E_JAZZ_DEVICE_RECEIPT_CONTEXT", error) }
+      Log.e("JazzFixtureMetadata", "receipt-resolved")
+    } catch (_: Throwable) {
+      // Fixed internal stages only; never log intent data or exception text.
+      Log.e("JazzFixtureMetadata", "receipt-failed-$stage")
+      promise.reject("E_JAZZ_DEVICE_RECEIPT_CONTEXT", "Fixture receipt metadata unavailable")
+    }
   }
 
   /** Only the host's bounded acceptance phase crosses this boundary.  It
    * cannot select a relay scope, identity, or filesystem path. */
   @ReactMethod fun acceptancePhase(promise: Promise) {
+    Log.e("JazzFixtureMetadata", "phase-started")
     try {
-      val phase = reactApplicationContext.currentActivity
-        ?.intent?.getStringExtra("jazzDeviceAcceptancePhase") ?: "seed"
+      val activity = reactApplicationContext.currentActivity
+      if (activity == null) Log.e("JazzFixtureMetadata", "phase-activity-unavailable")
+      val phase = activity?.intent?.getStringExtra("jazzDeviceAcceptancePhase") ?: "seed"
       require(phase == "seed" || phase == "verify") { "invalid acceptance phase" }
       promise.resolve(phase)
-    } catch (error: Throwable) { promise.reject("E_JAZZ_DEVICE_FIXTURE", error) }
+      Log.e("JazzFixtureMetadata", if (phase == "seed") "phase-seed-resolved" else "phase-verify-resolved")
+    } catch (_: Throwable) {
+      Log.e("JazzFixtureMetadata", "phase-failed")
+      promise.reject("E_JAZZ_DEVICE_FIXTURE", "Fixture acceptance phase unavailable")
+    }
   }
 
   private fun sha256File(path: String): String {

--- a/dev/rn-device-acceptance/ios/JazzDeviceFixture.mm
+++ b/dev/rn-device-acceptance/ios/JazzDeviceFixture.mm
@@ -24,6 +24,9 @@ static NSURL *JazzDeviceDiagnosticURL(void) {
 static NSSet<NSString *> *JazzDeviceDiagnosticCodes(void) {
   return [NSSet setWithArray:@[
     @"fixture-metadata-failed",
+    @"fixture-receipt-call-failed",
+    @"fixture-receipt-validation-failed",
+    @"fixture-phase-failed",
     @"native-admission-failed",
     @"relay-command-abi-failed",
     @"relay-open-failed",

--- a/dev/rn-device-acceptance/native/android/JazzDeviceFixtureModule.kt
+++ b/dev/rn-device-acceptance/native/android/JazzDeviceFixtureModule.kt
@@ -23,6 +23,9 @@ import org.json.JSONObject
 class JazzDeviceFixtureModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(context) {
   private val diagnosticCodes = setOf(
     "fixture-metadata-failed",
+    "fixture-receipt-call-failed",
+    "fixture-receipt-validation-failed",
+    "fixture-phase-failed",
     "native-admission-failed",
     "relay-command-abi-failed",
     "relay-open-failed",
@@ -181,33 +184,51 @@ class JazzDeviceFixtureModule(context: ReactApplicationContext) : ReactContextBa
   }
 
   @ReactMethod fun receiptContext(promise: Promise) {
+    var stage = "activity"
+    Log.e("JazzFixtureMetadata", "receipt-started")
     try {
       val activity = reactApplicationContext.currentActivity
         ?: error("acceptance activity is unavailable")
+      stage = "nonce"
       val nonce = activity.intent.getStringExtra("jazzDeviceRunNonce")
         ?: error("acceptance launch did not include a run nonce")
       // Hash the installed package itself, rather than echoing an adb extra.
+      stage = "package-hash"
+      Log.e("JazzFixtureMetadata", "package-hash-started")
       val buildFingerprint = sha256File(reactApplicationContext.applicationInfo.sourceDir)
+      stage = "device-identity"
       val deviceIdentifier = Build.FINGERPRINT.takeIf(String::isNotBlank)
         ?: error("Android build fingerprint is unavailable")
+      stage = "resolve"
       promise.resolve(Arguments.createMap().apply {
         putString("platform", "android")
         putString("deviceIdentifier", deviceIdentifier)
         putString("buildFingerprint", buildFingerprint)
         putString("runNonce", nonce)
       })
-    } catch (error: Throwable) { promise.reject("E_JAZZ_DEVICE_RECEIPT_CONTEXT", error) }
+      Log.e("JazzFixtureMetadata", "receipt-resolved")
+    } catch (_: Throwable) {
+      // Fixed internal stages only; never log intent data or exception text.
+      Log.e("JazzFixtureMetadata", "receipt-failed-$stage")
+      promise.reject("E_JAZZ_DEVICE_RECEIPT_CONTEXT", "Fixture receipt metadata unavailable")
+    }
   }
 
   /** Only the host's bounded acceptance phase crosses this boundary.  It
    * cannot select a relay scope, identity, or filesystem path. */
   @ReactMethod fun acceptancePhase(promise: Promise) {
+    Log.e("JazzFixtureMetadata", "phase-started")
     try {
-      val phase = reactApplicationContext.currentActivity
-        ?.intent?.getStringExtra("jazzDeviceAcceptancePhase") ?: "seed"
+      val activity = reactApplicationContext.currentActivity
+      if (activity == null) Log.e("JazzFixtureMetadata", "phase-activity-unavailable")
+      val phase = activity?.intent?.getStringExtra("jazzDeviceAcceptancePhase") ?: "seed"
       require(phase == "seed" || phase == "verify") { "invalid acceptance phase" }
       promise.resolve(phase)
-    } catch (error: Throwable) { promise.reject("E_JAZZ_DEVICE_FIXTURE", error) }
+      Log.e("JazzFixtureMetadata", if (phase == "seed") "phase-seed-resolved" else "phase-verify-resolved")
+    } catch (_: Throwable) {
+      Log.e("JazzFixtureMetadata", "phase-failed")
+      promise.reject("E_JAZZ_DEVICE_FIXTURE", "Fixture acceptance phase unavailable")
+    }
   }
 
   private fun sha256File(path: String): String {

--- a/dev/rn-device-acceptance/native/ios/JazzDeviceFixture.mm
+++ b/dev/rn-device-acceptance/native/ios/JazzDeviceFixture.mm
@@ -24,6 +24,9 @@ static NSURL *JazzDeviceDiagnosticURL(void) {
 static NSSet<NSString *> *JazzDeviceDiagnosticCodes(void) {
   return [NSSet setWithArray:@[
     @"fixture-metadata-failed",
+    @"fixture-receipt-call-failed",
+    @"fixture-receipt-validation-failed",
+    @"fixture-phase-failed",
     @"native-admission-failed",
     @"relay-command-abi-failed",
     @"relay-open-failed",

--- a/dev/rn-device-acceptance/scripts/android-diagnostics.mjs
+++ b/dev/rn-device-acceptance/scripts/android-diagnostics.mjs
@@ -16,6 +16,19 @@ const THREADTIME_FOREGROUND_WAKE =
 const THREADTIME_CORE_OBSERVATION =
   /^\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d+\s+\d+\s+\d+\s+E\s+JazzCoreObservation\s*:\s*(request-started|request-sent|promise-resolved|js-(?:before-core-await|core-await-returned|before-unsubscribe|after-unsubscribe|before-shutdown|after-shutdown)|http-status-(?:[1-5]\d{2}|invalid)|failure-(?:setup|request|response|promise)-(?:timeout|connection|dns|tls|protocol|io|state|other))\s*$/;
 
+// Separate from the JS stage: its final retry must not hide native causality.
+const THREADTIME_FIXTURE_METADATA =
+  /^\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d+\s+\d+\s+\d+\s+E\s+JazzFixtureMetadata\s*:\s*(receipt-started|package-hash-started|receipt-resolved|receipt-failed-(?:activity|nonce|package-hash|device-identity|resolve)|phase-started|phase-activity-unavailable|phase-seed-resolved|phase-verify-resolved|phase-failed)\s*$/;
+
+export function androidFixtureMetadataDiagnostic(output) {
+  const codes = new Set();
+  for (const line of String(output).split(/\r?\n/)) {
+    const code = THREADTIME_FIXTURE_METADATA.exec(line)?.[1];
+    if (code) codes.add(code);
+  }
+  return codes.size ? [...codes].join(",") : undefined;
+}
+
 export function androidCoreObservationDiagnostic(output) {
   const codes = new Set();
   for (const line of String(output).split(/\r?\n/)) {
@@ -70,9 +83,11 @@ export function androidAcceptanceFailure(kind, phase, output) {
         : undefined;
   if (!summary) throw new Error("invalid Android acceptance failure kind");
   const diagnostic = androidDeviceDiagnostic(output);
+  const metadata = androidFixtureMetadataDiagnostic(output);
+  const metadataSummary = metadata ? `${summary}; fixture metadata: ${metadata}` : summary;
   const stage = diagnostic
-    ? `${summary}; device stage: ${diagnostic}`
-    : `${summary}; no device stage`;
+    ? `${metadataSummary}; device stage: ${diagnostic}`
+    : `${metadataSummary}; no device stage`;
   const coreObservation = androidCoreObservationDiagnostic(output);
   const writerRead =
     diagnostic === "scope-isolation-writer-read-failed"

--- a/dev/rn-device-acceptance/scripts/android-diagnostics.test.mjs
+++ b/dev/rn-device-acceptance/scripts/android-diagnostics.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   androidAcceptanceFailure,
+  androidFixtureMetadataDiagnostic,
   androidDeviceDiagnostic,
   androidCoreObservationDiagnostic,
   androidScopeWriterReadDiagnostic,
@@ -170,4 +171,41 @@ test("synchronous seed boundaries survive alongside native acknowledgement witho
     line("js-before-unsubscribe", "ReactNativeJS"),
   ].join("\n");
   assert.equal(androidCoreObservationDiagnostic(output), codes.join(","));
+});
+
+test("metadata causality survives JS retry and rejects secret-bearing near matches", () => {
+  const line = (code, tag = "JazzFixtureMetadata") =>
+    `08-29 22:52:21.495  4268  4288 E ${tag}: ${code}`;
+  const output = [
+    line("receipt-started"),
+    line("receipt-failed-activity"),
+    line("fixture-receipt-call-failed", "JazzDeviceAcceptance"),
+    line("receipt-failed-nonce secret-token"),
+    line("receipt-failed-secret-token"),
+    line("phase-verify-resolved", "ReactNativeJS"),
+    line("phase-verify-resolved", "OtherNativeTag"),
+  ].join("\n");
+  assert.equal(androidFixtureMetadataDiagnostic(output), "receipt-started,receipt-failed-activity");
+  const failure = androidAcceptanceFailure("timeout", "verify", output);
+  assert.match(failure, /fixture metadata: receipt-started,receipt-failed-activity/);
+  assert.match(failure, /device stage: fixture-receipt-call-failed/);
+  assert.doesNotMatch(failure, /secret-token|phase-verify-resolved/);
+});
+
+test("metadata distinguishes an unresolved package hash from resolved native metadata", () => {
+  const line = (code) => `08-29 22:52:21.495  4268  4288 E JazzFixtureMetadata: ${code}`;
+  for (const codes of [
+    ["receipt-started", "package-hash-started"],
+    ["receipt-started", "package-hash-started", "receipt-failed-package-hash"],
+    [
+      "receipt-started",
+      "package-hash-started",
+      "receipt-resolved",
+      "phase-started",
+      "phase-activity-unavailable",
+      "phase-seed-resolved",
+    ],
+    ["phase-started", "phase-failed"],
+  ])
+    assert.equal(androidFixtureMetadataDiagnostic(codes.map(line).join("\n")), codes.join(","));
 });

--- a/dev/rn-device-acceptance/scripts/native-host-contract.test.mjs
+++ b/dev/rn-device-acceptance/scripts/native-host-contract.test.mjs
@@ -1536,3 +1536,19 @@ test("both platforms use the shared Rust-generated schema through account admiss
   ])
     assert.doesNotMatch(read(file), /JAZZ_DEVICE_SCHEMA_JSON|NSString \*schema/);
 });
+
+test("Android metadata diagnostics survive host filtering and generated source copies", () => {
+  const fixture = read("native/android/JazzDeviceFixtureModule.kt");
+  assert.equal(
+    fixture,
+    read("android/app/src/main/java/dev/jazz/rndeviceacceptance/JazzDeviceFixtureModule.kt"),
+  );
+  assert.match(read("scripts/run-android.mjs"), /"JazzFixtureMetadata:E"/);
+  const metadata = fixture.slice(
+    fixture.indexOf("@ReactMethod fun receiptContext"),
+    fixture.indexOf("private fun sha256File"),
+  );
+  assert.doesNotMatch(metadata, /Log\.e\([^\n]*(?:error|nonce|intent|buildFingerprint)/);
+  assert.doesNotMatch(metadata, /promise\.reject\([^\n]*error/);
+  assert.match(metadata, /receipt-failed-\$stage/);
+});

--- a/dev/rn-device-acceptance/scripts/run-android.mjs
+++ b/dev/rn-device-acceptance/scripts/run-android.mjs
@@ -37,6 +37,7 @@ const acceptanceLogcat = () =>
     "JazzScopeWriterRead:E",
     "JazzForegroundWake:E",
     "JazzCoreObservation:E",
+    "JazzFixtureMetadata:E",
     "*:S",
   ]);
 const startedAt = Date.now();

--- a/dev/rn-device-acceptance/src/device-diagnostics.ts
+++ b/dev/rn-device-acceptance/src/device-diagnostics.ts
@@ -1,5 +1,8 @@
 export const DEVICE_DIAGNOSTIC_CODES = [
   "fixture-metadata-failed",
+  "fixture-receipt-call-failed",
+  "fixture-receipt-validation-failed",
+  "fixture-phase-failed",
   "native-admission-failed",
   "relay-command-abi-failed",
   "relay-open-failed",

--- a/dev/rn-device-acceptance/src/native-fixture.ts
+++ b/dev/rn-device-acceptance/src/native-fixture.ts
@@ -125,8 +125,12 @@ export async function switchNativeRelayAuthScope(): Promise<AdmittedRelay> {
 }
 
 /** Trusted package/launch identity used solely to bind observed device receipts. */
-export async function deviceReceiptContext(): Promise<DeviceReceiptContext> {
+export async function deviceReceiptContext(
+  markFailure: (code: DeviceDiagnosticCode) => void = () => {},
+): Promise<DeviceReceiptContext> {
+  markFailure("fixture-receipt-call-failed");
   const context = await fixtureModule().receiptContext();
+  markFailure("fixture-receipt-validation-failed");
   if (
     !(["android", "ios"] as const).includes(context.platform) ||
     !context.deviceIdentifier ||


### PR DESCRIPTION
🤖 Android restart acceptance on the account-system stack timed out before database admission, but its single metadata failure code could not distinguish the native receipt call, receipt validation, or launch-phase lookup (#2645).

This diagnostic change separates those boundaries and retains fixed native categories for missing activity/nonce, package hashing, device identity, promise resolution, and phase lookup. The host accepts only exact allowlisted log tags and values; credentials, intents, arbitrary exception messages, and near-matching payloads are excluded. A later generic JavaScript failure cannot overwrite the native evidence.

This is not a claimed fix. Receipt validation, process restart, server shutdown, and database assertions stay intact. A new installed Android run must identify the cause before this blocker is called resolved.

Validation: coordinator independently ran 41 focused diagnostic, native-host, and network-policy tests; all passed. Lane typecheck and commit guards passed. Removing native metadata parsing makes both new diagnostic regressions fail; restored tests pass. This draft is based on the account-system integration branch, not main.
