### PR TITLE
Retry rejected browser configuration on a later explicit API call

### DIFF
--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
@@ -12,6 +12,88 @@ function deferred() {
   return { promise, resolve };
 }
 
+function admissionManager(retryable = true) {
+  let pinned = true;
+  const error = new Error("incompatible persistent browser configuration");
+  const connections: Array<BrowserWorkerConnection & { shutdown: ReturnType<typeof vi.fn> }> = [];
+  const host = {
+    config: {},
+    isShuttingDown: false,
+    runtimeSource: {
+      createBrowserWorkerConnection: vi.fn(() => {
+        const rejected = pinned;
+        const connection = {
+          ready: async () => {
+            if (rejected) throw error;
+          },
+          canRetryInitialConfigurationAdmission: () => rejected && retryable,
+          shutdown: vi.fn(async () => undefined),
+        } as unknown as BrowserWorkerConnection & { shutdown: ReturnType<typeof vi.fn> };
+        connections.push(connection);
+        return connection;
+      }),
+    },
+    clearAuthenticatedInspectorLocalReads: vi.fn(),
+  };
+  const manager = new BrowserConnectionManager(host as unknown as DbForConnection);
+  (manager as unknown as { onClientCreated(input: unknown): void }).onClientCreated({
+    schemaKey: "empty",
+    schema: {},
+    client: {} as JazzClient,
+  });
+  return {
+    manager,
+    host,
+    connections,
+    error,
+    unpin: () => {
+      pinned = false;
+    },
+  };
+}
+
+describe("Browser configuration admission retries", () => {
+  it("rejects each attempt visibly and only reattaches on a later explicit call", async () => {
+    const { manager, connections, error, unpin } = admissionManager();
+    const first = manager.ensureReady("local");
+    const concurrent = manager.ensureReady("local");
+    await expect(first).rejects.toBe(error);
+    await expect(concurrent).rejects.toBe(error);
+    expect(connections).toHaveLength(1);
+    await expect(manager.ensureReady("local")).rejects.toBe(error);
+    expect(connections).toHaveLength(2);
+    expect(connections[0]!.shutdown).toHaveBeenCalledOnce();
+    unpin();
+    await Promise.resolve();
+    expect(connections).toHaveLength(2);
+    await expect(manager.ensureReady("local")).resolves.toBeUndefined();
+    expect(connections).toHaveLength(3);
+    expect(connections[1]!.shutdown).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry other initial failures even with matching error text", async () => {
+    const { manager, connections, error } = admissionManager(false);
+    await expect(manager.ensureReady("local")).rejects.toBe(error);
+    await expect(manager.ensureReady("local")).rejects.toBe(error);
+    expect(connections).toHaveLength(1);
+  });
+
+  it("shares one candidate and cannot reopen while shutdown begins during retirement", async () => {
+    const { manager, host, connections, error } = admissionManager();
+    await expect(manager.ensureReady("local")).rejects.toBe(error);
+    const retirement = deferred();
+    connections[0]!.shutdown.mockImplementation(() => retirement.promise);
+    const retry = manager.ensureReady("local");
+    const concurrent = manager.ensureReady("local");
+    await Promise.resolve();
+    expect(connections[0]!.shutdown).toHaveBeenCalledOnce();
+    host.isShuttingDown = true;
+    retirement.resolve();
+    await Promise.all([retry, concurrent]);
+    expect(connections).toHaveLength(1);
+  });
+});
+
 describe("BrowserConnectionManager.shutdown", () => {
   it("continues teardown after flush fails and preserves the flush error", async () => {
     const flushError = new Error("flush failed");

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -34,6 +34,9 @@ export class BrowserConnectionManager extends ConnectionManager {
   private browserConnectionInput: ConnectionManagerClientInput | null = null;
   /** A failed follower owns no recoverable port; reconnect must mint a new one. */
   private recoverableConnectionFailure = false;
+  private observedConfigurationAdmissionFailure: BrowserWorkerConnection | null = null;
+  private configurationAdmissionRetry: Promise<BrowserWorkerConnection | null> | null = null;
+  private readonly readinessByConnection = new WeakMap<BrowserWorkerConnection, Promise<void>>();
 
   constructor(host: DbForConnection) {
     super(host);
@@ -79,13 +82,16 @@ export class BrowserConnectionManager extends ConnectionManager {
       onStorageInvalidated: () => this.reloadAfterStorageInvalidation(connection),
     });
     this.connection = connection;
+    this.observedConfigurationAdmissionFailure = null;
     this.unregisterInspectorControl?.();
     this.unregisterInspectorControl = registerBrowserInspectorControl(
       () => connection.openInspectorControlPort(),
       () => this.host.config,
     );
     this.initialExplicitOfflineStateKnown = false;
-    this.connectionReady = connection.ready().then(
+    const readiness = connection.ready();
+    this.readinessByConnection.set(connection, readiness);
+    this.connectionReady = readiness.then(
       () => {
         if (this.connection !== connection) return;
         const inspectorPhysicalDbName =
@@ -121,9 +127,25 @@ export class BrowserConnectionManager extends ConnectionManager {
   }
 
   async ensureReady(tier?: DurabilityTier, signal?: AbortSignal): Promise<void> {
-    if (this.host.isShuttingDown) return;
-    await this.storageReset;
-    if (this.connectionError) throw this.connectionError;
+    if (this.host.isShuttingDown || signal?.aborted) return;
+    const reset = this.storageReset;
+    // Capture before yielding: callers already waiting on a rejected attempt
+    // must see that rejection, even if a later API call starts a replacement.
+    let connection = reset ? null : this.connection;
+    const retry = connection !== null && this.observedConfigurationAdmissionFailure === connection;
+    await reset;
+    if (this.host.isShuttingDown || signal?.aborted) return;
+    connection ??= this.connection;
+    if (retry && connection) connection = await this.retryConfigurationAdmission(connection);
+    if (this.host.isShuttingDown || signal?.aborted) return;
+    try {
+      await (connection ? this.readinessByConnection.get(connection) : this.connectionReady);
+    } catch (error) {
+      if (connection === this.connection && connection?.canRetryInitialConfigurationAdmission?.()) {
+        this.observedConfigurationAdmissionFailure = connection;
+      }
+      throw error;
+    }
     await this.connectionReady;
     if (this.host.isShuttingDown) return;
     if (this.connectionError) throw this.connectionError;
@@ -140,6 +162,29 @@ export class BrowserConnectionManager extends ConnectionManager {
     if (this.host.config.serverUrl && tier !== "local") {
       await this.connection?.waitForServerConnection();
     }
+  }
+
+  private retryConfigurationAdmission(
+    failed: BrowserWorkerConnection,
+  ): Promise<BrowserWorkerConnection | null> {
+    if (this.configurationAdmissionRetry) return this.configurationAdmissionRetry;
+    if (failed !== this.connection) return Promise.resolve(this.connection);
+    const retry = (async () => {
+      await failed.shutdown();
+      if (this.host.isShuttingDown || failed !== this.connection) return null;
+      this.connection = null;
+      this.connectionReady = null;
+      this.connectionError = null;
+      this.observedConfigurationAdmissionFailure = null;
+      return this.openBrowserWorkerConnection();
+    })();
+    this.configurationAdmissionRetry = retry;
+    void retry
+      .finally(() => {
+        if (this.configurationAdmissionRetry === retry) this.configurationAdmissionRetry = null;
+      })
+      .catch(() => undefined);
+    return retry;
   }
 
   shouldDeferSubscriptionStart(tier?: DurabilityTier): boolean {

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -359,6 +359,7 @@ export class SharedBrowserForegroundNodeLease implements ForegroundNodeLease {
 export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
   private worker: SharedWorker | null = null;
   private readonly readyPromise: Promise<void>;
+  private initialConfigurationAdmissionRejected = false;
   private readyError: Error | null = null;
   private connection: MessagePortBrowserFollowerConnection | null = null;
   private closed = false;
@@ -480,7 +481,10 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
           // report that rejection before the caller's operation has observed
           // readiness. The outer, constructor-owned state machine turns this
           // into the same explicit error after it has installed containment.
-          resolve({ connected: false, error: deserializeBrowserRelayError(event.data.error) });
+          const error = deserializeBrowserRelayError(event.data.error);
+          this.initialConfigurationAdmissionRejected =
+            error.message === "incompatible persistent browser configuration";
+          resolve({ connected: false, error });
           return;
         }
         if (event.data?.type === "worker-closing") {
@@ -593,6 +597,10 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
   async reconnect(authJson: string, sessionClaims: Record<string, unknown>): Promise<void> {
     await this.ready();
     await this.connection?.reconnect(authJson, sessionClaims);
+  }
+
+  canRetryInitialConfigurationAdmission(): boolean {
+    return this.initialConfigurationAdmissionRejected;
   }
 
   async shutdown(): Promise<void> {

--- a/packages/jazz-tools/src/runtime/runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/runtime-source.ts
@@ -38,6 +38,8 @@ export interface RuntimeTelemetryContext<RuntimeConfig extends DbConfig = DbConf
 }
 
 export interface BrowserWorkerConnection {
+  /** Only a rejected initial configuration admission permits a later API call to retry. */
+  canRetryInitialConfigurationAdmission?(): boolean;
   ready(): Promise<void>;
   waitForServerConnection(): Promise<void>;
   updateAuth(authJson: string, sessionClaims: Record<string, unknown>): Promise<void>;

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -3783,35 +3783,39 @@ describe("SharedWorker bridge with IndexedDB", () => {
     unsubscribe();
   });
 
-  it.fails("surfaces schema mismatch errors and recovers after the pinning tab closes", async () => {
+  it("surfaces schema mismatch errors and recovers after the pinning tab closes", async () => {
     const dbName = uniqueDbName("schema-mismatch-recovery");
+    // Both versions must already be admitted with their lineage lens. Merely
+    // supplying a new schema at reopen is not a catalogue publication.
+    const server = await publishCatalogueSchemaFamily("schema-mismatch-recovery");
+    const nextApp = catalogueAppV2;
     const oldTab = track(
       await createDb({
-        appId: "test-app",
+        appId: server.appId,
+        serverUrl: server.serverUrl,
         driver: { type: "persistent", dbName },
       }),
     );
-    oldTab.insert(todos, { title: "Old schema row", done: false });
+    await withTimeout(
+      oldTab
+        .insert(catalogueAppV1.todos, { title: "Old schema row", completed: false })
+        .wait({ tier: "edge" }),
+      8000,
+      "Old tab should receive the published catalogue before pinning its schema",
+    );
     await waitForCondition(
       async () => {
-        const rows = await oldTab.all(allTodos, { tier: "local" });
+        const rows = await oldTab.all(catalogueAppV1.todos, { tier: "local" });
         return rows.some((row) => row.title === "Old schema row");
       },
       8000,
       "Old tab should be durable-ready with the original schema",
     );
 
-    const nextApp = s.defineApp({
-      todos: s.table({
-        title: s.string(),
-        done: s.boolean(),
-        priority: s.string().optional(),
-      }),
-    });
-
     const newTab = track(
       await createDb({
-        appId: "test-app",
+        appId: server.appId,
+        serverUrl: server.serverUrl,
         driver: { type: "persistent", dbName },
       }),
     );
@@ -3821,7 +3825,31 @@ describe("SharedWorker bridge with IndexedDB", () => {
         8000,
         "Schema-blocked tab query should reject instead of hanging",
       ),
-    ).rejects.toThrow("incompatible persistent browser schema");
+    ).rejects.toThrow("incompatible persistent browser configuration");
+
+    // Each later call gets one fresh admission attempt, and must still fail
+    // visibly while the incompatible worker remains pinned.
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await expect(
+        withTimeout(
+          newTab.all(nextApp.todos, { tier: "local" }),
+          8000,
+          "Repeated schema-blocked query should reject instead of hanging",
+        ),
+      ).rejects.toThrow("incompatible persistent browser configuration");
+    }
+
+    const failedTab = track(
+      await createDb({
+        appId: server.appId,
+        serverUrl: server.serverUrl,
+        driver: { type: "persistent", dbName },
+      }),
+    );
+    await expect(failedTab.all(nextApp.todos, { tier: "local" })).rejects.toThrow(
+      "incompatible persistent browser configuration",
+    );
+    await failedTab.shutdown();
 
     await oldTab.shutdown();
     const rows = await withTimeout(
@@ -3830,6 +3858,7 @@ describe("SharedWorker bridge with IndexedDB", () => {
       "Recovered tab should be able to query with its own schema",
     );
     expect(Array.isArray(rows)).toBe(true);
+    expect(rows.some((row) => row.title === "Old schema row")).toBe(true);
   });
 
   it("keeps explicit-name account caches separate, shared per scope, and destroys only the selected scope", async () => {


### PR DESCRIPTION
🤖 A browser context whose first attachment was rejected for incompatible persistent configuration retained that failure forever. Even after the tab pinning the old configuration closed, a later query on the same context could not attach afresh (#2644).

The first attempt still fails visibly. A later explicit API call may retire that rejected candidate and attempt a fresh attachment. Concurrent callers already attached to the first attempt retain its original failure; later callers share one replacement attempt. Shutdown prevents reopening. This is limited to initial configuration admission: no background retries, silent retries of in-flight operations, or retries of other runtime failures are added.

The regression keeps live configuration mismatch, repeated visible rejection, rejected-tab shutdown, and same-context recovery after the pin closes. It now uses genuinely published schema generations and their lineage-defining migration, and verifies the persisted row survives. The former fixture tried to reopen an unpublished schema, correctly forbidden by the durable catalogue contract. No storage, wire, or core catalogue semantics change. The inherited expected-failure marker is removed only after the corrected real browser scenario passes.

Validation: independent Medium review accepted concurrency, error classification, shutdown, and resource cleanup; its official focused consumer passed 26 tests. The implementation lane independently passed those tests and the actual browser recovery case. Disabling only the later-call retry makes the final recovery assertion fail after the pin closes; restoring it passes. Typecheck, formatting, lint, and sensitive-data guard passed. Coordinator full combined verification at `0b17c853f0` completed with Node exit 0 and browser exit 1: 306 browser tests passed, including this recovery case, while the external cold-recovery fixture failed with “Timed out waiting for edge query coverage”. Exact helper phase and cause are under investigation; this PR remains draft. The failure does not by itself establish a regression caused by this change.

Stacked on Joe's async subscriber-recovery PR #2643, itself based on #2613. The reviewer checked that post-runtime-ready async admission failures remain outside this retry classifier.

