### PR TITLE
fix: reconnect existing sessions after retryable server shutdown

### DIFF
--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -2396,7 +2396,11 @@ export class NativeRuntimeAdapter implements Runtime {
     // A new transport replaces the old one during a temporary reconnect. Server-tier
     // waits are still meaningful across that transition, so only an explicit runtime
     // shutdown is allowed to reject them.
-    void this.disconnect({ rejectWaiters: false, preservePreHelloRetry: true });
+    void this.disconnect({
+      rejectWaiters: false,
+      preservePreHelloRetry: true,
+      preserveRemoteWaiters: this.networkRetryCount > 0,
+    });
     const generation = ++this.serverConnectionGeneration;
     const transportIdentity = peerIdentityForWebSocketAuth(normalizedAuthJson, this.peerIdentity);
     this.serverTransportError = null;
@@ -2433,6 +2437,11 @@ export class NativeRuntimeAdapter implements Runtime {
       onError: (error) => {
         if (error.code === "not_ready" && error.retry === "later") return;
         if (attempt && this.canRetryNetworkConnection(attempt, error)) return;
+        if (
+          this.serverTransportError &&
+          (error.code === "websocket_closed" || error.code === "websocket_error")
+        )
+          return;
         this.handleServerTransportError(error, generation);
         const reason = wireAuthFailureReason(error);
         if (reason) this.authFailureCallback?.(reason);
@@ -2444,7 +2453,10 @@ export class NativeRuntimeAdapter implements Runtime {
           const recovery = this.retryNetworkConnection(attempt, error);
           if (recovery) return;
         }
-        this.finishServerConnectionAttempt(attempt, new Error(error.message));
+        this.finishServerConnectionAttempt(
+          attempt,
+          this.serverTransportError ?? new Error(error.message),
+        );
       },
     });
     attempt = {
@@ -2559,7 +2571,11 @@ export class NativeRuntimeAdapter implements Runtime {
   }
 
   async disconnect(
-    options: { rejectWaiters?: boolean; preservePreHelloRetry?: boolean } = {},
+    options: {
+      rejectWaiters?: boolean;
+      preservePreHelloRetry?: boolean;
+      preserveRemoteWaiters?: boolean;
+    } = {},
   ): Promise<void> {
     if (this !== this.ownerRuntime) return this.ownerRuntime.disconnect(options);
     if (this.db?.disconnectNativeUpstream) {
@@ -2583,7 +2599,7 @@ export class NativeRuntimeAdapter implements Runtime {
     this.serverTransportError = null;
     if (options.rejectWaiters ?? true) {
       this.resolveServerTransportErrorWaiters(new Error("server transport disconnected"));
-    } else {
+    } else if (!options.preserveRemoteWaiters) {
       this.clearServerTransportErrorWaiters();
     }
     this.resolveServerTransportWorkWaiters();
@@ -3304,17 +3320,13 @@ export class NativeRuntimeAdapter implements Runtime {
       const terminal =
         attempt?.carrier === this.serverCarrier
           ? await Promise.race([pendingConnection.then(() => null), attempt.terminal])
-          : null;
+          : await pendingConnection.then(() => null);
       if (this.closed) return;
       // Reauthentication/reconnect can retire a stalled carrier while this
       // query is waiting. Follow the replacement attempt; only surface a
       // terminal error when this was still the current connection.
       if (terminal) {
-        if (
-          this.serverCarrierPromise !== null &&
-          this.serverCarrierPromise !== pendingConnection &&
-          this.serverConnectionAttempt?.carrier === this.serverCarrier
-        ) {
+        if (this.serverCarrierPromise !== null && this.serverCarrierPromise !== pendingConnection) {
           continue;
         }
         throw terminal;
@@ -4215,6 +4227,7 @@ export class NativeRuntimeAdapter implements Runtime {
   private canRetryNetworkConnection(attempt: ServerConnectionAttempt, error: WireError): boolean {
     return (
       !this.closed &&
+      this.serverTransportError === null &&
       attempt === this.serverConnectionAttempt &&
       attempt.generation === this.serverConnectionGeneration &&
       error.retry === "later" &&
@@ -4239,6 +4252,7 @@ export class NativeRuntimeAdapter implements Runtime {
     this.serverConnectionAttempt = null;
     this.serverCarrier = null;
     this.finishServerConnectionAttempt(attempt, new Error(error.message));
+    const generation = this.serverConnectionGeneration;
     this.resolveServerTransportWorkWaiters();
     const recovery = new Promise<WebSocketCarrier>((resolve, reject) => {
       this.serverReconnectReject = reject;
@@ -4247,7 +4261,12 @@ export class NativeRuntimeAdapter implements Runtime {
         this.serverReconnectReject = null;
         void (async () => {
           await attempt.retirement;
-          if (this.closed || this.serverEndpointUrl !== url || this.serverAuthJson !== authJson) {
+          if (
+            this.closed ||
+            generation !== this.serverConnectionGeneration ||
+            this.serverEndpointUrl !== url ||
+            this.serverAuthJson !== authJson
+          ) {
             throw new Error("server transport disconnected");
           }
           this.connect(url, authJson);

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -77,6 +77,7 @@ import {
   normalizeBackendWebSocketAuth,
   peerIdentityForWebSocketAuth,
   type WebSocketNegotiation,
+  type WireError,
   wireAuthFailureReason,
 } from "./websocket.js";
 import {
@@ -102,6 +103,7 @@ import {
 export { encodeSchema } from "./schema-codec.js";
 
 const SERVER_PUMP_DEBOUNCE_MS = 16;
+const NETWORK_RETRY_LIMIT = 10;
 const PRE_HELLO_RETRY_INITIAL_DELAY_MS = 25;
 const PRE_HELLO_RETRY_MAX_DELAY_MS = 1_000;
 // Amortize scheduler overhead without allowing a ready evaluator to monopolize
@@ -584,6 +586,7 @@ type ServerConnectionAttempt = {
   outcome: Error | null;
   transport: Transport | null;
   retirement: Promise<void> | null;
+  recovery?: Promise<WebSocketCarrier>;
 };
 
 type AuxiliaryRelayTrace = {
@@ -797,6 +800,7 @@ export class NativeRuntimeAdapter implements Runtime {
   private serverReconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private serverReconnectReject: ((error: Error) => void) | null = null;
   private preHelloRetryCount = 0;
+  private networkRetryCount = 0;
   private readonly queuedServerFrames: Uint8Array[] = [];
   private readonly pendingInboundServerFrames: Uint8Array[] = [];
   private serverInboundRouting: Promise<void> = Promise.resolve();
@@ -2428,6 +2432,7 @@ export class NativeRuntimeAdapter implements Runtime {
       },
       onError: (error) => {
         if (error.code === "not_ready" && error.retry === "later") return;
+        if (attempt && this.canRetryNetworkConnection(attempt, error)) return;
         this.handleServerTransportError(error, generation);
         const reason = wireAuthFailureReason(error);
         if (reason) this.authFailureCallback?.(reason);
@@ -2435,6 +2440,10 @@ export class NativeRuntimeAdapter implements Runtime {
       onTerminal: (error) => {
         if (!attempt) return;
         if (error.code === "not_ready" && error.retry === "later") return;
+        if (this.canRetryNetworkConnection(attempt, error)) {
+          const recovery = this.retryNetworkConnection(attempt, error);
+          if (recovery) return;
+        }
         this.finishServerConnectionAttempt(attempt, new Error(error.message));
       },
     });
@@ -2487,6 +2496,7 @@ export class NativeRuntimeAdapter implements Runtime {
           await this.retirePeerTransport(transport);
           return carrier;
         }
+        this.networkRetryCount = 0;
         attempt.transport = transport;
         this.serverTransport = transport;
         transport.setAuxiliaryTraceEnabled?.(this.auxiliaryTraceListeners.size > 0);
@@ -2497,6 +2507,7 @@ export class NativeRuntimeAdapter implements Runtime {
         return carrier;
       })
       .catch((error) => {
+        if (attempt.recovery) return attempt.recovery;
         if (isRetryablePreHelloWireError(error)) {
           const retry = this.retryPreHelloConnection(attempt);
           if (retry) return retry;
@@ -2557,7 +2568,10 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     this.serverConnectionGeneration += 1;
     this.clearServerReconnectTimer();
-    if (!options.preservePreHelloRetry) this.preHelloRetryCount = 0;
+    if (!options.preservePreHelloRetry) {
+      this.preHelloRetryCount = 0;
+      this.networkRetryCount = 0;
+    }
     const attempt = this.serverConnectionAttempt;
     this.serverConnectionAttempt = null;
     if (attempt) {
@@ -4196,6 +4210,59 @@ export class NativeRuntimeAdapter implements Runtime {
     this.failRemoteSubscriptions(this.serverTransportError);
     this.resolveServerTransportErrorWaiters(this.serverTransportError);
     if (isFirstTerminalError) this.serverTransportErrorCallback?.(this.serverTransportError);
+  }
+
+  private canRetryNetworkConnection(attempt: ServerConnectionAttempt, error: WireError): boolean {
+    return (
+      !this.closed &&
+      attempt === this.serverConnectionAttempt &&
+      attempt.generation === this.serverConnectionGeneration &&
+      error.retry === "later" &&
+      (error.code === "websocket_closed" || error.code === "websocket_error") &&
+      (attempt.transport !== null || this.networkRetryCount > 0) &&
+      this.networkRetryCount < NETWORK_RETRY_LIMIT
+    );
+  }
+
+  /** Retry an established upstream without turning a temporary outage into a query failure. */
+  private retryNetworkConnection(
+    attempt: ServerConnectionAttempt,
+    error: WireError,
+  ): Promise<WebSocketCarrier> | null {
+    if (!this.serverEndpointUrl || !this.serverAuthJson) return null;
+    const url = this.serverEndpointUrl;
+    const authJson = this.serverAuthJson;
+    const delay = Math.min(100 * 2 ** this.networkRetryCount++, 1_000);
+    // Retire this generation before any suspended pump or handshake can report
+    // its close as a terminal failure. Native subscriptions survive the detach.
+    this.serverConnectionGeneration += 1;
+    this.serverConnectionAttempt = null;
+    this.serverCarrier = null;
+    this.finishServerConnectionAttempt(attempt, new Error(error.message));
+    this.resolveServerTransportWorkWaiters();
+    const recovery = new Promise<WebSocketCarrier>((resolve, reject) => {
+      this.serverReconnectReject = reject;
+      this.serverReconnectTimer = setTimeout(() => {
+        this.serverReconnectTimer = null;
+        this.serverReconnectReject = null;
+        void (async () => {
+          await attempt.retirement;
+          if (this.closed || this.serverEndpointUrl !== url || this.serverAuthJson !== authJson) {
+            throw new Error("server transport disconnected");
+          }
+          this.connect(url, authJson);
+          if (!this.serverCarrierPromise)
+            throw new Error("server transport reconnect was not started");
+          return await this.serverCarrierPromise;
+        })().then(resolve, reject);
+      }, delay);
+    });
+    attempt.recovery = recovery;
+    this.serverCarrierPromise = recovery;
+    // Each attempt's catch already reports terminal failures. Cancellation by
+    // explicit disconnect/close must not publish a historical transport error.
+    void recovery.catch(() => undefined);
+    return recovery;
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -3309,6 +3309,8 @@ export class NativeRuntimeAdapter implements Runtime {
    */
   private async waitForStrictRemoteQueryTransport(tier: string | null | undefined): Promise<void> {
     if (tier !== "edge" && tier !== "global") return;
+    const endpoint = this.serverEndpointUrl;
+    const identity = peerIdentityForWebSocketAuth(this.serverAuthJson ?? "{}", this.peerIdentity);
     // `connect()` starts its WebSocket handshake before it can admit the
     // native transport. A strict remote read begun in that interval must
     // await the in-flight connection instead of falling through to a local
@@ -3317,11 +3319,24 @@ export class NativeRuntimeAdapter implements Runtime {
       const pendingConnection = this.serverCarrierPromise;
       if (!pendingConnection) return;
       const attempt = this.serverConnectionAttempt;
+      const connectionOutcome = pendingConnection.then(
+        () => null,
+        (error: unknown) => (error instanceof Error ? error : new Error(errorMessage(error))),
+      );
       const terminal =
         attempt?.carrier === this.serverCarrier
-          ? await Promise.race([pendingConnection.then(() => null), attempt.terminal])
-          : await pendingConnection.then(() => null);
+          ? await Promise.race([connectionOutcome, attempt.terminal])
+          : await connectionOutcome;
       if (this.closed) return;
+      if (
+        this.serverCarrierPromise &&
+        (this.serverEndpointUrl !== endpoint ||
+          !bytesEqual(
+            identity,
+            peerIdentityForWebSocketAuth(this.serverAuthJson ?? "{}", this.peerIdentity),
+          ))
+      )
+        throw new Error("server transport scope changed while waiting for remote query");
       // Reauthentication/reconnect can retire a stalled carrier while this
       // query is waiting. Follow the replacement attempt; only surface a
       // terminal error when this was still the current connection.

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -420,7 +420,13 @@ describe("NativeRuntimeAdapter server transport", () => {
     await runtime.close();
   });
 
-  it("lets a strict remote query begun during backoff wait for the replacement", async () => {
+  it.each([
+    "none",
+    "auth-refresh",
+    "disconnect",
+    "authority-replacement",
+    "account-replacement",
+  ] as const)("settles a strict remote query begun during backoff after %s", async (action) => {
     const sockets: FakeWebSocket[] = [];
     globalThis.WebSocket = class extends FakeWebSocket {
       constructor(url: string) {
@@ -457,15 +463,39 @@ describe("NativeRuntimeAdapter server transport", () => {
     // instead of freezing the test process and preventing the retry timer.
     const internal = runtime as unknown as { hasUpstream(): boolean };
     const hasUpstream = internal.hasUpstream.bind(runtime);
+    const entered = deferred<void>();
     let probes = 0;
     internal.hasUpstream = () => {
       if (++probes > 1000) throw new Error("remote gate spun without yielding");
+      entered.resolve();
       return hasUpstream();
     };
-    await expect(runtime.query(JSON.stringify({ table: "todos" }), null, "edge")).resolves.toEqual(
-      [],
-    );
-    expect(sockets).toHaveLength(2);
+    const read = runtime.query(JSON.stringify({ table: "todos" }), null, "edge");
+    const result =
+      action === "disconnect"
+        ? expect(read).rejects.toThrow("server transport disconnected")
+        : action === "authority-replacement" || action === "account-replacement"
+          ? expect(read).rejects.toThrow("server transport scope changed")
+          : expect(read).resolves.toEqual([]);
+    await entered.promise;
+    if (action === "auth-refresh")
+      await runtime.updateAuth(JSON.stringify({ jwt_token: "fresh.jwt" }));
+    if (action === "disconnect") await runtime.disconnect();
+    if (action === "authority-replacement")
+      runtime.connect("ws://127.0.0.1:4200/apps/app-b/ws", "{}");
+    if (action === "account-replacement")
+      await runtime.updateAuth(
+        JSON.stringify({
+          jwt_token:
+            "e30." +
+            Buffer.from(JSON.stringify({ iss: "urn:jazz:test", sub: "another" })).toString(
+              "base64url",
+            ) +
+            ".signature",
+        }),
+      );
+    await result;
+    expect(sockets).toHaveLength(action === "disconnect" ? 1 : 2);
     await runtime.close();
   });
 

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -244,6 +244,86 @@ describe("NativeRuntimeAdapter server transport", () => {
     expect(sockets[1]!.closed).toBe(true);
   });
 
+  it("reconnects an established upstream after a retryable server restart without publishing a terminal error", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+    const transports: FakeTransport[] = [];
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            connectUpstream: () => {
+              const transport = new FakeTransport([]);
+              transports.push(transport);
+              return transport;
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const terminal = vi.fn();
+    runtime.onServerTransportError(terminal);
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    sockets[0]!.emitServerClose();
+    await runtime.waitForUpstreamServerConnection();
+    expect(sockets).toHaveLength(2);
+    expect(transports).toHaveLength(2);
+    expect(transports[0]!.closed).toBe(true);
+    expect(terminal).not.toHaveBeenCalled();
+    await runtime.close();
+  });
+
+  it.each(["disconnect", "close"] as const)(
+    "cancels an established-network retry on %s",
+    async (action) => {
+      const sockets: FakeWebSocket[] = [];
+      globalThis.WebSocket = class extends FakeWebSocket {
+        constructor(url: string) {
+          super(url);
+          sockets.push(this);
+        }
+      } as unknown as typeof WebSocket;
+      const runtime = new NativeRuntimeAdapter(
+        {
+          openMemory: () =>
+            fakeDb({ connectUpstream: () => new FakeTransport([]), tick: () => undefined }),
+          openBrowser: async () => {
+            throw new Error("not used");
+          },
+        } as never,
+        testSchema,
+        new Uint8Array(16),
+        TEST_RUNTIME_AUTHOR,
+        1,
+        true,
+      );
+      const terminal = vi.fn();
+      runtime.onServerTransportError(terminal);
+      runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+      await runtime.waitForUpstreamServerConnection();
+      sockets[0]!.emitServerClose();
+      await runtime[action]();
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(sockets).toHaveLength(1);
+      expect(terminal).not.toHaveBeenCalled();
+      await runtime.close();
+    },
+  );
+
   it("identifies a missing wire mask as a generic native-runtime artifact mismatch", () => {
     const runtime = new NativeRuntimeAdapter(
       {
@@ -1432,6 +1512,7 @@ class FakeWebSocket {
   binaryType: "arraybuffer" | "blob" = "arraybuffer";
   readonly readyState = 1;
   readonly sent: Array<Uint8Array | string> = [];
+  private readonly closeListeners: Array<(event: { data: unknown }) => void> = [];
   private readonly messageListeners: Array<(event: { data: unknown }) => void> = [];
   closed = false;
 
@@ -1460,6 +1541,13 @@ class FakeWebSocket {
 
   addEventListener(type: string, listener: (event: { data: unknown }) => void): void {
     if (type === "message") this.messageListeners.push(listener);
+    if (type === "close") this.closeListeners.push(listener);
+  }
+
+  emitServerClose(): void {
+    this.closed = true;
+    for (const listener of this.closeListeners)
+      listener({ code: 1012, reason: "server shutting down" } as never);
   }
 
   emitMessage(data: Uint8Array): void {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -324,6 +324,198 @@ describe("NativeRuntimeAdapter server transport", () => {
     },
   );
 
+  it("exhausts network retries and rejects an already armed remote wait", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+        if (sockets.length > 1) queueMicrotask(() => this.emitServerClose());
+      }
+    } as unknown as typeof WebSocket;
+    const armed = deferred<void>();
+    const settlement = deferred<void>();
+    const write = {
+      ...fakeWrite(),
+      wait: (tier: string) => {
+        if (tier === "local") return Promise.resolve();
+        armed.resolve();
+        return settlement.promise;
+      },
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            insertEncoded: () => write,
+            connectUpstream: () => new FakeTransport([]),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const terminal = vi.fn();
+    runtime.onServerTransportError(terminal);
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    const txId = await committedTxId(
+      runtime.insert(
+        "todos",
+        { title: { type: "Text", value: "pending during outage" } },
+        null,
+        "00000000-0000-0000-0000-000000000009",
+      ),
+    );
+    const pending = runtime.waitForTransaction(txId, "edge");
+    const rejected = expect(pending).rejects.toThrow("websocket closed");
+    await armed.promise;
+    sockets[0]!.emitServerClose();
+    await expect(runtime.waitForUpstreamServerConnection()).rejects.toThrow("websocket closed");
+    await rejected;
+    expect(sockets).toHaveLength(11);
+    expect(terminal).toHaveBeenCalledTimes(1);
+    settlement.resolve();
+    await runtime.close();
+  }, 15_000);
+
+  it("does not resurrect the previous account transport after replacement", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({ connectUpstream: () => new FakeTransport([]), tick: () => undefined }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    sockets[0]!.emitServerClose();
+    runtime.connect("ws://127.0.0.1:4200/apps/app-b/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(sockets.map((socket) => socket.url)).toEqual([
+      "ws://127.0.0.1:4200/apps/app-a/ws",
+      "ws://127.0.0.1:4200/apps/app-b/ws",
+    ]);
+    await runtime.close();
+  });
+
+  it("lets a strict remote query begun during backoff wait for the replacement", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            all: () => new Uint8Array([0]),
+            prepareQuery: () => ({}),
+            attachQuery: () => ({}),
+            queryAttachmentIsCovered: () => true,
+            detachQuery: () => undefined,
+            connectUpstream: () => new FakeTransport([]),
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    sockets[0]!.emitServerClose();
+    // Bound the historical synchronous-spin regression so it fails this test
+    // instead of freezing the test process and preventing the retry timer.
+    const internal = runtime as unknown as { hasUpstream(): boolean };
+    const hasUpstream = internal.hasUpstream.bind(runtime);
+    let probes = 0;
+    internal.hasUpstream = () => {
+      if (++probes > 1000) throw new Error("remote gate spun without yielding");
+      return hasUpstream();
+    };
+    await expect(runtime.query(JSON.stringify({ table: "todos" }), null, "edge")).resolves.toEqual(
+      [],
+    );
+    expect(sockets).toHaveLength(2);
+    await runtime.close();
+  });
+
+  it.each([
+    [3, 1, "authentication expired"],
+    [2, 0, "malformed protocol frame"],
+  ] as const)(
+    "does not retry a close after terminal wire error %s",
+    async (code, retry, message) => {
+      const sockets: FakeWebSocket[] = [];
+      globalThis.WebSocket = class extends FakeWebSocket {
+        constructor(url: string) {
+          super(url);
+          sockets.push(this);
+        }
+      } as unknown as typeof WebSocket;
+      const runtime = new NativeRuntimeAdapter(
+        {
+          openMemory: () =>
+            fakeDb({ connectUpstream: () => new FakeTransport([]), tick: () => undefined }),
+          openBrowser: async () => {
+            throw new Error("not used");
+          },
+        } as never,
+        testSchema,
+        new Uint8Array(16),
+        TEST_RUNTIME_AUTHOR,
+        1,
+        true,
+      );
+      const terminal = vi.fn();
+      runtime.onServerTransportError(terminal);
+      runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+      await runtime.waitForUpstreamServerConnection();
+      const frame = new PostcardWriter();
+      frame.u64(2);
+      frame.u64(code);
+      frame.u64(retry);
+      frame.string(message);
+      sockets[0]!.emitMessage(encodeWebSocketFrameBatch([frame.finish()]));
+      await vi.waitFor(() => expect(terminal).toHaveBeenCalledTimes(1));
+      sockets[0]!.emitServerClose();
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(sockets).toHaveLength(1);
+      await expect(runtime.waitForUpstreamServerConnection()).rejects.toThrow(message);
+      expect(terminal).toHaveBeenCalledTimes(1);
+      await runtime.close();
+    },
+  );
+
   it("identifies a missing wire mask as a generic native-runtime artifact mismatch", () => {
     const runtime = new NativeRuntimeAdapter(
       {


### PR DESCRIPTION
🤖 Existing browser sessions permanently failed after a self-hosted server restarted with WebSocket close 1012, even though the server retained their data. Retryable network loss now reconnects the upstream with bounded exponential backoff and preserves active subscriptions and remote waits.

A pending strict read waits asynchronously during recovery. Same-endpoint, same-identity credential refresh can replace that connection; changing account or endpoint rejects the old read. Explicit disconnect/shutdown cancels recovery, and terminal authentication or protocol errors remain terminal. Generation fencing prevents a retired connection from replacing a newer one.

Validation: independent review and coordinator rerun of runtime, transport, and WebSocket suites: 223 passed, 1 existing skip. Regression sensitivity checked by reversible local mutations. A realistic collaborative browser app passed offline writes, reload, persistent CLI restart, and continued delivery to already-open clients using candidate TypeScript with the published native artifacts. All substantive CI jobs passed; the final aggregate check is pending. Fresh integrated preview testing remains a follow-up gate for the combined release candidate.

Fixes #2662.
