### PR TITLE
fix: support vanilla React Native session bootstrap without app shims

### DIFF
--- a/.changeset/tidy-native-bootstrap.md
+++ b/.changeset/tidy-native-bootstrap.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Support native account and row decoding without browser TextDecoder globals, preserve canonical account authority URLs on React Native, and isolate telemetry environment lookup from browser-only module syntax.

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -17,6 +17,11 @@
     "./dist/runtime/native-runtime/node-foreground-node-lease.js": "./dist/runtime/native-runtime/node-foreground-node-lease.browser.js"
   },
   "types": "dist/index.d.ts",
+  "react-native": {
+    "./dist/runtime/platform-url.js": "./dist/runtime/platform-url.native.js",
+    "./dist/runtime/telemetry-env.js": "./dist/runtime/telemetry-env.native.js",
+    "./dist/runtime/browser-worker-assets.js": "./dist/runtime/browser-worker-assets.native.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -180,8 +185,9 @@
     "jose": "^6.2.1",
     "json-schema-to-ts": "^3.1.1",
     "pluralize-esm": "^9.0.5",
-    "react-native-url-polyfill": "^3.0.0",
-    "web-streams-polyfill": "^4.2.0"
+    "tr46": "5.1.1",
+    "web-streams-polyfill": "^4.2.0",
+    "whatwg-url-without-unicode": "8.0.0-3"
   },
   "devDependencies": {
     "@better-auth/test-utils": "^1.7.1",

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -180,6 +180,7 @@
     "jose": "^6.2.1",
     "json-schema-to-ts": "^3.1.1",
     "pluralize-esm": "^9.0.5",
+    "react-native-url-polyfill": "^3.0.0",
     "web-streams-polyfill": "^4.2.0"
   },
   "devDependencies": {

--- a/packages/jazz-tools/src/accounts/context.ts
+++ b/packages/jazz-tools/src/accounts/context.ts
@@ -1,3 +1,4 @@
+import { PlatformURL } from "../runtime/platform-url.js";
 import { admitAccountConfig } from "./config-capability.js";
 import type { AccountHandle } from "./state.js";
 import {
@@ -25,7 +26,7 @@ export type AccountDbConfig = Omit<
 
 /** One canonical application endpoint for enrollment and context scope validation. */
 export function accountRegistryUrl(serverUrl: string, appId: string): string {
-  const url = new URL(serverUrl);
+  const url = new PlatformURL(serverUrl);
   if (url.protocol === "ws:") url.protocol = "http:";
   if (url.protocol === "wss:") url.protocol = "https:";
   if (url.protocol !== "http:" && url.protocol !== "https:")
@@ -51,7 +52,7 @@ function accountContextScope(config: AccountDbConfig): string {
   const registry = accountRegistry(account);
   // Offline creation still has a configured registry authority; no request is made.
   if (
-    !new URL(registry).pathname.endsWith(`/apps/${accountAppId(config.appId)}/accounts`) ||
+    !new PlatformURL(registry).pathname.endsWith(`/apps/${accountAppId(config.appId)}/accounts`) ||
     (config.serverUrl !== undefined &&
       accountRegistryUrl(config.serverUrl, config.appId) !== registry)
   ) {

--- a/packages/jazz-tools/src/react-native/create-account-manager.test.ts
+++ b/packages/jazz-tools/src/react-native/create-account-manager.test.ts
@@ -55,6 +55,31 @@ describe("React Native account preparation", () => {
     expect(native.openAttached).not.toHaveBeenCalled();
   });
 
+  it("retains and restores native account identity without browser decoder or Node Buffer globals", async () => {
+    const subject = "native-café-🧭";
+    const jwt = `e30.${Buffer.from(JSON.stringify({ iss: "urn:jazz:local-first", sub: subject })).toString("base64url")}.signature`;
+    vi.stubGlobal("TextDecoder", undefined);
+    vi.stubGlobal("Buffer", undefined);
+    mocks.install.mockReturnValue({
+      accountSecret: () => new Uint8Array(32).fill(7),
+      mintLocalFirstToken: () => jwt,
+    });
+    const config = {
+      appId: "native-missing-globals",
+      serverUrl: "https://core.example",
+      store: store(),
+    };
+    const manager = await createAccountManager(config);
+    const account = manager.createLocalFirst();
+    expect(account.identity.subject).toBe(subject);
+    await expect(
+      accountToken(account, accountRegistryUrl(config.serverUrl, config.appId)),
+    ).resolves.toBe(jwt);
+    const restored = await createAccountManager(config);
+    expect(restored.getLoggedIn()?.id).toBe(account.id);
+    expect(restored.getLoggedIn()?.identity.subject).toBe(subject);
+  });
+
   it("rejects a native build without account crypto during preparation", async () => {
     mocks.install.mockReturnValue({ abiVersion: 1, openAttached: vi.fn() });
     await expect(

--- a/packages/jazz-tools/src/react-native/platform-url.test.ts
+++ b/packages/jazz-tools/src/react-native/platform-url.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, expect, it, vi } from "vitest";
-vi.mock("react-native", () => ({ NativeModules: {}, Platform: { OS: "android", Version: 35 } }));
 vi.mock("../runtime/platform-url.js", () => import("../runtime/platform-url.native.js"));
 import { accountRegistryUrl } from "../accounts/context.js";
 import { PlatformURL } from "../runtime/platform-url.native.js";
@@ -27,5 +26,43 @@ it("uses canonical account authority URLs even when the native global adds trail
     "file:///core",
   ]) {
     expect(() => accountRegistryUrl(base, appId)).toThrow("invalid_registry_url");
+  }
+});
+
+it("matches standard server authority canonicalization and rejection", () => {
+  const valid = [
+    "https://CORE.EXAMPLE/base",
+    "https://%41.example/base",
+    "https://café.example/base",
+    "https://日本語.example",
+    "https://xn--caf-dma.example",
+    "https://CORE.EXAMPLE:443/base/",
+    "http://127.1:80",
+    "http://0x7f.0.0.1",
+    "https://０１２.０.０.１",
+    "https://[2001:0db8::1]:443/base",
+    "https://name:secret@CORE.EXAMPLE/base?query=value#fragment",
+    "https://core.example/a/../b",
+    "https://example.0xg",
+    "https://core.example./",
+    "https://faß.example",
+  ];
+  for (const input of valid) expect(new PlatformURL(input).href).toBe(new URL(input).href);
+  for (const input of [
+    "https://%FF",
+    "https://%C0%AF.example",
+    "https://%00.example",
+    "https://%23.example",
+    "https://xn--",
+    "https://a.1",
+    "https://example.123",
+    "https://example.09",
+    "https://example.0x",
+    "https://[not-ipv6]",
+    "https://core.example:99999",
+    "https://\u200d.example",
+  ]) {
+    expect(() => new URL(input)).toThrow();
+    expect(() => new PlatformURL(input)).toThrow();
   }
 });

--- a/packages/jazz-tools/src/react-native/platform-url.test.ts
+++ b/packages/jazz-tools/src/react-native/platform-url.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, expect, it, vi } from "vitest";
+vi.mock("react-native", () => ({ NativeModules: {}, Platform: { OS: "android", Version: 35 } }));
+vi.mock("../runtime/platform-url.js", () => import("../runtime/platform-url.native.js"));
+import { accountRegistryUrl } from "../accounts/context.js";
+import { PlatformURL } from "../runtime/platform-url.native.js";
+afterEach(() => vi.unstubAllGlobals());
+
+it("uses canonical account authority URLs even when the native global adds trailing slashes", () => {
+  const HostURL = globalThis.URL;
+  vi.stubGlobal(
+    "URL",
+    class extends HostURL {
+      get pathname() {
+        return super.pathname.replace(/\/?$/, "/");
+      }
+    },
+  );
+  const appId = "a1510000-0000-4000-8000-000000000001";
+  const expected = `https://core.example/base/apps/${appId}/accounts`;
+  expect(accountRegistryUrl("wss://core.example/base/", appId)).toBe(expected);
+  expect(new PlatformURL(expected).pathname).toBe(`/base/apps/${appId}/accounts`);
+  expect(accountRegistryUrl("https://other.example/base", appId)).not.toBe(expected);
+  for (const base of [
+    "https://name:secret@core.example",
+    "https://core.example?tenant=other",
+    "https://core.example#other",
+    "file:///core",
+  ]) {
+    expect(() => accountRegistryUrl(base, appId)).toThrow("invalid_registry_url");
+  }
+});

--- a/packages/jazz-tools/src/runtime/author-id.ts
+++ b/packages/jazz-tools/src/runtime/author-id.ts
@@ -1,7 +1,8 @@
+import { Utf8Decoder } from "./utf8.js";
 import type { Value } from "../drivers/types.js";
 import type { PublicSession, Session } from "./context.js";
 
-const canonicalAuthorDecoder = new TextDecoder("utf-8", { fatal: true });
+const canonicalAuthorDecoder = new Utf8Decoder({ fatal: true });
 const STORED_SCALAR_INLINE_TAG = 2;
 const CANONICAL_AUTHOR_OPEN_BRACKET = 0x5b;
 const publicSessions = new WeakMap<Session, PublicSession>();

--- a/packages/jazz-tools/src/runtime/browser-worker-assets.native.ts
+++ b/packages/jazz-tools/src/runtime/browser-worker-assets.native.ts
@@ -1,0 +1,5 @@
+function unsupported(): never {
+  throw new Error("Browser worker assets are unavailable on React Native");
+}
+export const browserRuntimeModuleUrl = unsupported;
+export const bundledBrowserWorkerUrl = unsupported;

--- a/packages/jazz-tools/src/runtime/browser-worker-assets.ts
+++ b/packages/jazz-tools/src/runtime/browser-worker-assets.ts
@@ -1,0 +1,7 @@
+/** Keep browser asset literals visible to bundlers, outside native imports. */
+export function browserRuntimeModuleUrl(): string {
+  return import.meta.url;
+}
+export function bundledBrowserWorkerUrl(): string {
+  return new URL("../worker/jazz-broker-worker.js", import.meta.url).href;
+}

--- a/packages/jazz-tools/src/runtime/browser-worker-config.ts
+++ b/packages/jazz-tools/src/runtime/browser-worker-config.ts
@@ -1,3 +1,4 @@
+import { browserRuntimeModuleUrl, bundledBrowserWorkerUrl } from "./browser-worker-assets.js";
 import type { RuntimeSourcesConfig } from "./context.js";
 import type { DbConfig } from "./db.js";
 import { resolveClientInternalSessionSync } from "./client-session.js";
@@ -20,13 +21,13 @@ const inMemoryWasmAssetIds = new WeakMap<object, string>();
 export function resolveBrowserWorkerUrl(runtimeSources?: RuntimeSourcesConfig): string {
   if (runtimeSources?.brokerWorkerUrl || runtimeSources?.baseUrl) {
     return resolveRuntimeConfigBrokerWorkerUrl(
-      import.meta.url,
+      browserRuntimeModuleUrl(),
       typeof location !== "undefined" ? location.href : undefined,
       runtimeSources,
     );
   }
   // Keep this literal statically analyzable so bundlers emit the worker asset.
-  const bundledUrl = new URL("../worker/jazz-broker-worker.js", import.meta.url).href;
+  const bundledUrl = bundledBrowserWorkerUrl();
   return versionRuntimeAssetUrl(
     resolveConfiguredUrl(bundledUrl, typeof location !== "undefined" ? location.href : undefined),
     runtimeSources,
@@ -62,7 +63,7 @@ export function resolveBrowserWorkerRuntimeSources(
   }
 
   const wasmUrl = resolveRuntimeConfigWasmUrl(
-    import.meta.url,
+    browserRuntimeModuleUrl(),
     typeof location !== "undefined" ? location.href : undefined,
     runtimeSources,
   );

--- a/packages/jazz-tools/src/runtime/client-session.ts
+++ b/packages/jazz-tools/src/runtime/client-session.ts
@@ -1,3 +1,4 @@
+import { Utf8Decoder } from "./utf8.js";
 import { runtimeRandomBytes } from "./runtime-entropy.js";
 import type { PublicSession, Session } from "./context.js";
 import { attachPublicSessionClaims, isUsableSubject, withCanonicalUser } from "./author-id.js";
@@ -197,7 +198,7 @@ function decodeBase64ToUtf8(base64: string): string | null {
       for (let i = 0; i < binary.length; i += 1) {
         bytes[i] = binary.charCodeAt(i);
       }
-      return new TextDecoder().decode(bytes);
+      return new Utf8Decoder().decode(bytes);
     } catch {
       return null;
     }

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1,3 +1,4 @@
+import { Utf8Decoder } from "./utf8.js";
 import { runtimeRandomBytes } from "./runtime-entropy.js";
 import type { AccountHandle } from "../accounts/state.js";
 import { GracefulShutdownSyncError } from "./graceful-shutdown-error.js";
@@ -877,7 +878,7 @@ function applyPartialValueSelections<T>(
       ) {
         throw new Error(`UTF-8 range for "${column}" splits a code point or is out of bounds.`);
       }
-      projected[column] = new TextDecoder("utf-8", { fatal: true }).decode(
+      projected[column] = new Utf8Decoder({ fatal: true }).decode(
         bytes.slice(selection.fromUtf8, selection.toUtf8),
       );
       continue;

--- a/packages/jazz-tools/src/runtime/native-runtime/native-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-codec.ts
@@ -1,3 +1,4 @@
+import { Utf8Decoder } from "../utf8.js";
 import {
   type NativeRowBatch,
   type NativeRelationSubscriptionSnapshot,
@@ -16,7 +17,7 @@ import { parseCanonicalAuthorSubject } from "../author-id.js";
 import { exactSignedI64 } from "./exact-integer.js";
 import { encodeRelationQueryPostcard, type RelExpr } from "../../ir.js";
 
-const fatalUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+const fatalUtf8Decoder = new Utf8Decoder({ fatal: true });
 
 export {
   createRecord,

--- a/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-row-codec.ts
@@ -1,3 +1,4 @@
+import { Utf8Decoder } from "../utf8.js";
 import type {
   ColumnDescriptor,
   ColumnType,
@@ -9,8 +10,8 @@ import { isProvenanceMagicColumn } from "../../magic-columns.js";
 import { validateStructuredAuthorValue } from "../author-id.js";
 import { exactSignedI64 } from "./exact-integer.js";
 
-const textDecoder = new TextDecoder("utf-8", { fatal: true });
-const fatalUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+const textDecoder = new Utf8Decoder({ fatal: true });
+const fatalUtf8Decoder = new Utf8Decoder({ fatal: true });
 
 export type ValueType = {
   tag: number;
@@ -431,7 +432,7 @@ export function decodeRecordString(
   raw: Uint8Array,
   logicalIndex: number,
 ): string {
-  return new TextDecoder().decode(decodeRecordBytes(descriptor, raw, logicalIndex));
+  return new Utf8Decoder().decode(decodeRecordBytes(descriptor, raw, logicalIndex));
 }
 
 export function decodeRecordBytes(

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1,3 +1,4 @@
+import { Utf8Decoder } from "../utf8.js";
 import { runtimeRandomBytes } from "../runtime-entropy.js";
 import { stripColumnQualifier } from "../query-column-name.js";
 import type {
@@ -668,7 +669,7 @@ type NativeRowFieldPlan = {
   includeInValues: boolean;
 };
 
-const textDecoder = new TextDecoder("utf-8", { fatal: true });
+const textDecoder = new Utf8Decoder({ fatal: true });
 const byteHex = Array.from({ length: 256 }, (_, byte) => byte.toString(16).padStart(2, "0"));
 const nativeRowFieldPlanCache = new WeakMap<WasmSchema, Map<string, NativeRowFieldPlan[]>>();
 const MAX_DEFERRED_PLACEHOLDER_CHUNKS = 16;
@@ -1188,7 +1189,7 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     const result = await this.db.readTextUtf16Range(table, parseUuid(objectId), column, start, end);
     return isPendingNativeRead(result)
-      ? new TextDecoder().decode(await this.awaitNativeRead(result))
+      ? new Utf8Decoder().decode(await this.awaitNativeRead(result))
       : result;
   }
 
@@ -1204,7 +1205,7 @@ export class NativeRuntimeAdapter implements Runtime {
     if (!this.db.readJsonPointer) throw new Error("Native runtime does not expose JSON pointers");
     let value = await this.db.readJsonPointer(table, parseUuid(objectId), column, pointer);
     if (isPendingNativeRead(value)) {
-      value = new TextDecoder().decode(await this.awaitNativeRead(value));
+      value = new Utf8Decoder().decode(await this.awaitNativeRead(value));
     }
     return typeof value === "string" ? JSON.parse(value) : value;
   }
@@ -3361,7 +3362,7 @@ export class NativeRuntimeAdapter implements Runtime {
     this.db.admitLocalFirstSession(
       token,
       appId,
-      new TextDecoder().decode(authorBytesForSession(session)),
+      new Utf8Decoder().decode(authorBytesForSession(session)),
     );
   }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
@@ -1,3 +1,4 @@
+import { Utf8Decoder } from "../utf8.js";
 import { httpUrlToWs } from "../url.js";
 import { mapAuthReason } from "../auth-state.js";
 import type { AuthFailureReason } from "../auth-state.js";
@@ -475,7 +476,7 @@ export function encodeWebSocketPrelude(
   requestedLink?: "scope_isolated_client_relay",
 ): string {
   const auth = JSON.parse(authJson) as Record<string, unknown>;
-  const peerAuthor = new TextDecoder().decode(peerIdentity);
+  const peerAuthor = new Utf8Decoder().decode(peerIdentity);
   const sub = authSub(auth) ?? canonicalAuthorSubjectPart(peerAuthor) ?? peerAuthor;
   return JSON.stringify({
     peer_identity: peerAuthor,
@@ -521,7 +522,7 @@ export function peerIdentityForWebSocketAuth(
   let existing: ReturnType<typeof parseCanonicalAuthorSubject> = null;
   try {
     existing = parseCanonicalAuthorSubject(
-      new TextDecoder("utf-8", { fatal: true }).decode(fallbackIdentity),
+      new Utf8Decoder({ fatal: true }).decode(fallbackIdentity),
     );
   } catch {
     // Non-author transport identities have no account association to preserve.

--- a/packages/jazz-tools/src/runtime/native-url-types.d.ts
+++ b/packages/jazz-tools/src/runtime/native-url-types.d.ts
@@ -1,0 +1,17 @@
+declare module "whatwg-url-without-unicode" {
+  export const URL: typeof globalThis.URL;
+}
+declare module "tr46" {
+  export function toASCII(
+    domain: string,
+    options: {
+      checkHyphens: boolean;
+      checkBidi: boolean;
+      checkJoiners: boolean;
+      useSTD3ASCIIRules: boolean;
+      transitionalProcessing: boolean;
+      verifyDNSLength: boolean;
+      ignoreInvalidPunycode: boolean;
+    },
+  ): string | null;
+}

--- a/packages/jazz-tools/src/runtime/platform-url.native.ts
+++ b/packages/jazz-tools/src/runtime/platform-url.native.ts
@@ -1,3 +1,32 @@
-// Metro selects this emitted .native.js file. Import the constructor only:
-// application globals and React Native's own URL implementation remain intact.
-export { URL as PlatformURL } from "react-native-url-polyfill";
+import { URL as NativeURL } from "whatwg-url-without-unicode";
+import { toASCII } from "tr46";
+
+/** The native URL parser needs the WHATWG domain-to-ASCII step restored. */
+export class PlatformURL extends NativeURL {
+  constructor(input: string | URL, base?: string | URL) {
+    super(input, base);
+    if (!this.hostname || this.hostname.startsWith("[")) return;
+    const domain = toASCII(this.hostname, {
+      checkHyphens: false,
+      checkBidi: true,
+      checkJoiners: true,
+      useSTD3ASCIIRules: false,
+      transitionalProcessing: false,
+      verifyDNSLength: false,
+      ignoreInvalidPunycode: false,
+    });
+    if (!domain || /[\u0000-\u0020#%/:<>?@[\\\]^|\u007f]/.test(domain)) {
+      throw new TypeError("Invalid URL hostname");
+    }
+    // The setter runs IPv4 parsing after IDNA (including fullwidth digits).
+    this.hostname = domain;
+    const parts = domain.split(".");
+    if (parts.at(-1) === "") parts.pop();
+    const last = parts.at(-1) ?? "";
+    const endsInNumber = /^[0-9]+$/.test(last) || /^0x[0-9a-f]*$/i.test(last);
+    const ipv4 = /^(?:[0-9]+\.){3}[0-9]+$/.test(this.hostname);
+    if ((endsInNumber && !ipv4) || (!ipv4 && this.hostname !== domain)) {
+      throw new TypeError("Invalid URL hostname");
+    }
+  }
+}

--- a/packages/jazz-tools/src/runtime/platform-url.native.ts
+++ b/packages/jazz-tools/src/runtime/platform-url.native.ts
@@ -15,7 +15,15 @@ export class PlatformURL extends NativeURL {
       verifyDNSLength: false,
       ignoreInvalidPunycode: false,
     });
-    if (!domain || /[\u0000-\u0020#%/:<>?@[\\\]^|\u007f]/.test(domain)) {
+    if (
+      !domain ||
+      Array.from(domain).some(
+        (char) =>
+          char.charCodeAt(0) <= 0x20 ||
+          char.charCodeAt(0) === 0x7f ||
+          "#%/:<>?@[\\]^|".includes(char),
+      )
+    ) {
       throw new TypeError("Invalid URL hostname");
     }
     // The setter runs IPv4 parsing after IDNA (including fullwidth digits).

--- a/packages/jazz-tools/src/runtime/platform-url.native.ts
+++ b/packages/jazz-tools/src/runtime/platform-url.native.ts
@@ -1,0 +1,3 @@
+// Metro selects this emitted .native.js file. Import the constructor only:
+// application globals and React Native's own URL implementation remain intact.
+export { URL as PlatformURL } from "react-native-url-polyfill";

--- a/packages/jazz-tools/src/runtime/platform-url.ts
+++ b/packages/jazz-tools/src/runtime/platform-url.ts
@@ -1,0 +1,2 @@
+/** Browser and server hosts provide a standards-compliant URL implementation. */
+export const PlatformURL = globalThis.URL;

--- a/packages/jazz-tools/src/runtime/subscription-manager.ts
+++ b/packages/jazz-tools/src/runtime/subscription-manager.ts
@@ -1,3 +1,4 @@
+import { Utf8Decoder } from "./utf8.js";
 /**
  * Manage subscription state and compute deltas.
  *
@@ -12,7 +13,7 @@ import type {
   WasmRow,
 } from "../drivers/types.js";
 
-const fatalUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+const fatalUtf8Decoder = new Utf8Decoder({ fatal: true });
 
 export const RowChangeKind = {
   Added: 0 as const,

--- a/packages/jazz-tools/src/runtime/sync-telemetry.ts
+++ b/packages/jazz-tools/src/runtime/sync-telemetry.ts
@@ -1,3 +1,5 @@
+import { resolveTelemetryCollectorUrlFromEnv } from "./telemetry-env.js";
+export { resolveTelemetryCollectorUrlFromEnv } from "./telemetry-env.js";
 import type { TimeInput, Tracer } from "@opentelemetry/api";
 
 export const DEFAULT_TELEMETRY_COLLECTOR_URL = "http://localhost:4318";
@@ -31,9 +33,6 @@ export type WasmTraceEntry =
       kind: "dropped";
       count: number;
     };
-type ImportMetaWithEnv = ImportMeta & {
-  env?: Record<string, string | undefined>;
-};
 
 type WasmTelemetryModule = {
   setTraceEntryCollectionEnabled(enabled: boolean): void;
@@ -78,25 +77,6 @@ export function resolveTelemetryCollectorUrl(
   if (telemetry === true) return DEFAULT_TELEMETRY_COLLECTOR_URL;
   if (typeof telemetry !== "string") return undefined;
   return telemetry.trim() || undefined;
-}
-
-// Bundlers (Vite, Next/Webpack DefinePlugin, esbuild) only inline
-// `process.env.X` / `import.meta.env.X` when both the object chain and the
-// property name are literal in the source — computed keys, aliased env
-// objects, and dynamic indexing all defeat static replacement.
-export function resolveTelemetryCollectorUrlFromEnv(): string | undefined {
-  const hasProcess = typeof process !== "undefined";
-  return (
-    trim(hasProcess ? process.env.VITE_JAZZ_TELEMETRY_COLLECTOR_URL : undefined) ??
-    trim(hasProcess ? process.env.NEXT_PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL : undefined) ??
-    trim(hasProcess ? process.env.PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL : undefined) ??
-    trim(hasProcess ? process.env.EXPO_PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL : undefined) ??
-    trim((import.meta as ImportMetaWithEnv).env?.VITE_JAZZ_TELEMETRY_COLLECTOR_URL)
-  );
-}
-
-function trim(value: string | undefined): string | undefined {
-  return value?.trim() || undefined;
 }
 
 export function normalizeOtlpEndpoint(collectorUrl: string, signal: TelemetrySignal): string {

--- a/packages/jazz-tools/src/runtime/telemetry-env.native.ts
+++ b/packages/jazz-tools/src/runtime/telemetry-env.native.ts
@@ -1,0 +1,5 @@
+/** Metro/Hermes has no import.meta. Keep Expo's statically replaced env access. */
+export function resolveTelemetryCollectorUrlFromEnv(): string | undefined {
+  if (typeof process === "undefined") return undefined;
+  return process.env.EXPO_PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL?.trim() || undefined;
+}

--- a/packages/jazz-tools/src/runtime/telemetry-env.ts
+++ b/packages/jazz-tools/src/runtime/telemetry-env.ts
@@ -1,0 +1,22 @@
+type ImportMetaWithEnv = ImportMeta & {
+  env?: Record<string, string | undefined>;
+};
+
+// Bundlers (Vite, Next/Webpack DefinePlugin, esbuild) only inline
+// `process.env.X` / `import.meta.env.X` when both the object chain and the
+// property name are literal in the source — computed keys, aliased env
+// objects, and dynamic indexing all defeat static replacement.
+export function resolveTelemetryCollectorUrlFromEnv(): string | undefined {
+  const hasProcess = typeof process !== "undefined";
+  return (
+    trim(hasProcess ? process.env.VITE_JAZZ_TELEMETRY_COLLECTOR_URL : undefined) ??
+    trim(hasProcess ? process.env.NEXT_PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL : undefined) ??
+    trim(hasProcess ? process.env.PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL : undefined) ??
+    trim(hasProcess ? process.env.EXPO_PUBLIC_JAZZ_TELEMETRY_COLLECTOR_URL : undefined) ??
+    trim((import.meta as ImportMetaWithEnv).env?.VITE_JAZZ_TELEMETRY_COLLECTOR_URL)
+  );
+}
+
+function trim(value: string | undefined): string | undefined {
+  return value?.trim() || undefined;
+}

--- a/packages/jazz-tools/src/runtime/url.ts
+++ b/packages/jazz-tools/src/runtime/url.ts
@@ -1,3 +1,4 @@
+import { PlatformURL } from "./platform-url.js";
 /**
  * Build an app-scoped URL under `/apps/<appId>`.
  *
@@ -52,7 +53,7 @@ function parseServerUrl(serverUrl: string): URL {
   let parsed: URL;
 
   try {
-    parsed = new URL(serverUrl.trim());
+    parsed = new PlatformURL(serverUrl.trim());
   } catch {
     throw invalidServerUrl(serverUrl);
   }

--- a/packages/jazz-tools/src/runtime/utf8.test.ts
+++ b/packages/jazz-tools/src/runtime/utf8.test.ts
@@ -43,6 +43,13 @@ describe("UTF-8 decoding on a host without TextDecoder", () => {
     }
   });
 
+  it("decodes large text across bounded output chunks without losing code points", () => {
+    const text = "\ufeff" + "Field notes café 🧭 日本語\n".repeat(100_000);
+    const bytes = encoder.encode(text);
+    vi.stubGlobal("TextDecoder", undefined);
+    expect(new Utf8Decoder({ fatal: true }).decode(bytes)).toBe(text.slice(1));
+  });
+
   it("agrees with the host decoder across every one- and two-byte input", () => {
     vi.stubGlobal("TextDecoder", undefined);
     const fallback = new Utf8Decoder();

--- a/packages/jazz-tools/src/runtime/utf8.test.ts
+++ b/packages/jazz-tools/src/runtime/utf8.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Utf8Decoder } from "./utf8.js";
+const HostDecoder = globalThis.TextDecoder;
+const encoder = new TextEncoder();
+afterEach(() => vi.unstubAllGlobals());
+
+describe("UTF-8 decoding on a host without TextDecoder", () => {
+  it("preserves Unicode and initial BOM handling across independent calls", () => {
+    vi.stubGlobal("TextDecoder", undefined);
+    const decoder = new Utf8Decoder({ fatal: true });
+    for (const text of [
+      "",
+      "plain ASCII",
+      "café 日本語 🧭",
+      "\ufeffnote",
+      "a\ufeffb",
+      "\ufeff\ufeffnote",
+    ]) {
+      const bytes = encoder.encode(text);
+      expect(decoder.decode(bytes)).toBe(new HostDecoder("utf-8", { fatal: true }).decode(bytes));
+    }
+  });
+
+  it("rejects invalid UTF-8 and preserves nonfatal maximal-subpart replacements", () => {
+    vi.stubGlobal("TextDecoder", undefined);
+    const invalid = [
+      [0x80],
+      [0xc0, 0xaf],
+      [0xc2],
+      [0xe0, 0x80, 0xaf],
+      [0xed, 0xa0, 0x80],
+      [0xf4, 0x90, 0x80, 0x80],
+      [0xf5, 0x80, 0x80, 0x80],
+      [0xe2, 0x82],
+      [0xe2, 0x41, 0xc2, 0xa2],
+      [0xf0, 0x90, 0x41],
+      [0xff, 0xef, 0xbb, 0xbf],
+    ];
+    for (const data of invalid) {
+      const bytes = Uint8Array.from(data);
+      expect(() => new Utf8Decoder({ fatal: true }).decode(bytes)).toThrow(TypeError);
+      expect(new Utf8Decoder().decode(bytes)).toBe(new HostDecoder().decode(bytes));
+    }
+  });
+
+  it("agrees with the host decoder across every one- and two-byte input", () => {
+    vi.stubGlobal("TextDecoder", undefined);
+    const fallback = new Utf8Decoder();
+    const native = new HostDecoder();
+    for (let first = 0; first <= 255; first++) {
+      expect(fallback.decode(Uint8Array.of(first))).toBe(native.decode(Uint8Array.of(first)));
+      for (let second = 0; second <= 255; second++) {
+        const bytes = Uint8Array.of(first, second);
+        expect(fallback.decode(bytes)).toBe(native.decode(bytes));
+      }
+    }
+  });
+});

--- a/packages/jazz-tools/src/runtime/utf8.ts
+++ b/packages/jazz-tools/src/runtime/utf8.ts
@@ -15,9 +15,23 @@ export class Utf8Decoder {
     if (this.native) return this.native.decode(input);
     const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
     const output: string[] = [];
+    let chunk: string[] = [];
+    let started = false;
+    const emit = (value: string) => {
+      // Default TextDecoder BOM handling applies only to the first code point.
+      if (!started) {
+        started = true;
+        if (value === "\ufeff") return;
+      }
+      chunk.push(value);
+      if (chunk.length === 4096) {
+        output.push(chunk.join(""));
+        chunk = [];
+      }
+    };
     const invalid = () => {
       if (this.fatal) throw new TypeError("The encoded data was not valid UTF-8");
-      output.push("\ufffd");
+      emit("\ufffd");
     };
     let codePoint = 0;
     let remaining = 0;
@@ -28,7 +42,7 @@ export class Utf8Decoder {
     for (let index = 0; index < bytes.length; index++) {
       const byte = bytes[index]!;
       if (remaining === 0) {
-        if (byte <= 0x7f) output.push(String.fromCharCode(byte));
+        if (byte <= 0x7f) emit(String.fromCharCode(byte));
         else if (byte >= 0xc2 && byte <= 0xdf) {
           remaining = 1;
           codePoint = byte & 0x1f;
@@ -53,12 +67,11 @@ export class Utf8Decoder {
         lower = 0x80;
         upper = 0xbf;
         codePoint = (codePoint << 6) | (byte & 0x3f);
-        if (--remaining === 0) output.push(String.fromCodePoint(codePoint));
+        if (--remaining === 0) emit(String.fromCodePoint(codePoint));
       }
     }
     if (remaining !== 0) invalid();
-    // TextDecoder's default ignoreBOM=false strips only an initial UTF-8 BOM.
-    if (output[0] === "\ufeff") output.shift();
+    if (chunk.length) output.push(chunk.join(""));
     return output.join("");
   }
 }

--- a/packages/jazz-tools/src/runtime/utf8.ts
+++ b/packages/jazz-tools/src/runtime/utf8.ts
@@ -1,0 +1,64 @@
+/** Internal UTF-8 decoding without requiring browser globals on native hosts. */
+export class Utf8Decoder {
+  private readonly native: TextDecoder | undefined;
+  private readonly fatal: boolean;
+
+  constructor(options: { fatal?: boolean } = {}) {
+    this.fatal = options.fatal ?? false;
+    this.native =
+      typeof globalThis.TextDecoder === "function"
+        ? new globalThis.TextDecoder("utf-8", options)
+        : undefined;
+  }
+
+  decode(input: Uint8Array | ArrayBuffer = new Uint8Array()): string {
+    if (this.native) return this.native.decode(input);
+    const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
+    const output: string[] = [];
+    const invalid = () => {
+      if (this.fatal) throw new TypeError("The encoded data was not valid UTF-8");
+      output.push("\ufffd");
+    };
+    let codePoint = 0;
+    let remaining = 0;
+    let lower = 0x80;
+    let upper = 0xbf;
+    // WHATWG UTF-8 decoding: an invalid continuation is reprocessed as a new
+    // leading byte. This preserves replacement behavior as well as strict mode.
+    for (let index = 0; index < bytes.length; index++) {
+      const byte = bytes[index]!;
+      if (remaining === 0) {
+        if (byte <= 0x7f) output.push(String.fromCharCode(byte));
+        else if (byte >= 0xc2 && byte <= 0xdf) {
+          remaining = 1;
+          codePoint = byte & 0x1f;
+        } else if (byte >= 0xe0 && byte <= 0xef) {
+          remaining = 2;
+          codePoint = byte & 0x0f;
+          if (byte === 0xe0) lower = 0xa0;
+          if (byte === 0xed) upper = 0x9f;
+        } else if (byte >= 0xf0 && byte <= 0xf4) {
+          remaining = 3;
+          codePoint = byte & 0x07;
+          if (byte === 0xf0) lower = 0x90;
+          if (byte === 0xf4) upper = 0x8f;
+        } else invalid();
+      } else if (byte < lower || byte > upper) {
+        remaining = 0;
+        lower = 0x80;
+        upper = 0xbf;
+        invalid();
+        index--;
+      } else {
+        lower = 0x80;
+        upper = 0xbf;
+        codePoint = (codePoint << 6) | (byte & 0x3f);
+        if (--remaining === 0) output.push(String.fromCodePoint(codePoint));
+      }
+    }
+    if (remaining !== 0) invalid();
+    // TextDecoder's default ignoreBOM=false strips only an initial UTF-8 BOM.
+    if (output[0] === "\ufeff") output.shift();
+    return output.join("");
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1829,6 +1829,9 @@ importers:
       react-native:
         specifier: '>=0.76'
         version: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4)
+      react-native-url-polyfill:
+        specifier: ^3.0.0
+        version: 3.0.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))
       web-streams-polyfill:
         specifier: ^4.2.0
         version: 4.2.0
@@ -11883,6 +11886,11 @@ packages:
 
   react-native-monorepo-config@0.3.5:
     resolution: {integrity: sha512-Xdu7k0s4V2FHn2OGnlr3D22Dgt5ij0ek9yzloPoLkHh3rL/jUQbPrawieKsAbkqoenv/7pfPJwMlPT27bvN1fg==}
+
+  react-native-url-polyfill@3.0.0:
+    resolution: {integrity: sha512-aA5CiuUCUb/lbrliVCJ6lZ17/RpNJzvTO/C7gC/YmDQhTUoRD5q5HlJfwLWcxz4VgAhHwXKzhxH+wUN24tAdqg==}
+    peerDependencies:
+      react-native: '*'
 
   react-native@0.81.5:
     resolution: {integrity: sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==}
@@ -25000,6 +25008,11 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  react-native-url-polyfill@3.0.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4)):
+    dependencies:
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4)
+      whatwg-url-without-unicode: 8.0.0-3
 
   react-refresh@0.14.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1829,12 +1829,15 @@ importers:
       react-native:
         specifier: '>=0.76'
         version: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4)
-      react-native-url-polyfill:
-        specifier: ^3.0.0
-        version: 3.0.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))
       web-streams-polyfill:
         specifier: ^4.2.0
         version: 4.2.0
+      whatwg-url-without-unicode:
+        specifier: 8.0.0-3
+        version: 8.0.0-3
+      tr46:
+        specifier: 5.1.1
+        version: 5.1.1
     devDependencies:
       '@better-auth/test-utils':
         specifier: ^1.7.1
@@ -11886,11 +11889,6 @@ packages:
 
   react-native-monorepo-config@0.3.5:
     resolution: {integrity: sha512-Xdu7k0s4V2FHn2OGnlr3D22Dgt5ij0ek9yzloPoLkHh3rL/jUQbPrawieKsAbkqoenv/7pfPJwMlPT27bvN1fg==}
-
-  react-native-url-polyfill@3.0.0:
-    resolution: {integrity: sha512-aA5CiuUCUb/lbrliVCJ6lZ17/RpNJzvTO/C7gC/YmDQhTUoRD5q5HlJfwLWcxz4VgAhHwXKzhxH+wUN24tAdqg==}
-    peerDependencies:
-      react-native: '*'
 
   react-native@0.81.5:
     resolution: {integrity: sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==}
@@ -25008,11 +25006,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  react-native-url-polyfill@3.0.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4)):
-    dependencies:
-      react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4)
-      whatwg-url-without-unicode: 8.0.0-3
 
   react-refresh@0.14.2: {}
 


### PR DESCRIPTION
🤖 A vanilla React Native app could not create a local-first session: Hermes lacks TextDecoder, its built-in URL behavior changed account authority paths, and native-reachable browser modules contained import.meta. The SDK now supplies internal portable UTF-8 decoding and explicitly maps native URL, telemetry, and worker helpers through its published package configuration. App-side global shims are unnecessary.

UTF-8 fatal/replacement and BOM behavior is preserved. Native authority parsing restores standard host canonicalization, including IDNA and IPv4, without relaxing account/application checks. Browser worker asset literals remain in the browser implementation. No wire or storage encoding changes are intended.

Independent review checked 2,319 authority cases against standard URL, all valid Unicode scalar values and 300,000 malformed UTF-8 inputs, plus regression-sensitive mutations. Focused suites passed 159 tests and TypeScript checks. Vanilla Android bootstrap and live server delivery worked in the candidate app; the final exact-commit package, offline persistence/restart receipt, integrated gates and fresh preview are still in progress. Draft pending those gates.

Fixes #2661.
