### PR TITLE
fix: clarify self-hosted CLI setup diagnostics

### DIFF
--- a/crates/jazz-cli/src/bin/jazz-tools.rs
+++ b/crates/jazz-cli/src/bin/jazz-tools.rs
@@ -427,6 +427,7 @@ mod tests {
 
     #[test]
     fn server_app_id_explains_uuid_requirement() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
         let error = Cli::try_parse_from(["jazz-tools", "server", "my-app"])
             .err()
             .expect("invalid app name must fail");
@@ -497,7 +498,7 @@ mod tests {
         let cli = Cli::try_parse_from([
             "jazz-tools",
             "server",
-            "test-app",
+            "7c5fd0da-4bd1-4ba9-9203-41e1f0da142c",
             "--allow-local-first-auth",
         ])
         .expect("server command should parse");
@@ -517,7 +518,7 @@ mod tests {
         let cli = Cli::try_parse_from([
             "jazz-tools",
             "server",
-            "test-app",
+            "7c5fd0da-4bd1-4ba9-9203-41e1f0da142c",
             "--jwt-public-key",
             r#"{"kty":"oct","kid":"test-kid","alg":"HS256","k":"c2VjcmV0"}"#,
             "--jwt-issuer",
@@ -553,7 +554,7 @@ mod tests {
         let cli = Cli::try_parse_from([
             "jazz-tools",
             "server",
-            "test-app",
+            "7c5fd0da-4bd1-4ba9-9203-41e1f0da142c",
             "--jwks-url",
             "https://issuer.example/.well-known/jwks.json",
         ])
@@ -566,7 +567,7 @@ mod tests {
         let cli = Cli::try_parse_from([
             "jazz-tools",
             "server",
-            "test-app",
+            "7c5fd0da-4bd1-4ba9-9203-41e1f0da142c",
             "--jwks-url",
             "https://issuer.example/.well-known/jwks.json",
             "--jwt-issuer",
@@ -582,8 +583,12 @@ mod tests {
     fn server_command_defaults_shutdown_timeout_secs() {
         let _lock = ENV_LOCK.lock().expect("env lock");
         let _env_guard = EnvVarGuard::remove("JAZZ_SHUTDOWN_TIMEOUT_SECS");
-        let cli = Cli::try_parse_from(["jazz-tools", "server", "test-app"])
-            .expect("server command should parse");
+        let cli = Cli::try_parse_from([
+            "jazz-tools",
+            "server",
+            "7c5fd0da-4bd1-4ba9-9203-41e1f0da142c",
+        ])
+        .expect("server command should parse");
 
         match cli.command {
             Commands::Server {
@@ -600,7 +605,7 @@ mod tests {
         let cli = Cli::try_parse_from([
             "jazz-tools",
             "server",
-            "test-app",
+            "7c5fd0da-4bd1-4ba9-9203-41e1f0da142c",
             "--shutdown-timeout-secs",
             "7",
         ])
@@ -619,8 +624,12 @@ mod tests {
     fn server_command_reads_shutdown_timeout_secs_from_env() {
         let _lock = ENV_LOCK.lock().expect("env lock");
         let _env_guard = EnvVarGuard::set("JAZZ_SHUTDOWN_TIMEOUT_SECS", "11");
-        let cli = Cli::try_parse_from(["jazz-tools", "server", "test-app"])
-            .expect("server command should parse");
+        let cli = Cli::try_parse_from([
+            "jazz-tools",
+            "server",
+            "7c5fd0da-4bd1-4ba9-9203-41e1f0da142c",
+        ])
+        .expect("server command should parse");
 
         match cli.command {
             Commands::Server {
@@ -637,7 +646,7 @@ mod tests {
         let error = match Cli::try_parse_from([
             "jazz-tools",
             "server",
-            "test-app",
+            "7c5fd0da-4bd1-4ba9-9203-41e1f0da142c",
             "--shutdown-timeout-secs",
             "18446744073709551615",
         ]) {

--- a/crates/jazz-cli/src/bin/jazz-tools.rs
+++ b/crates/jazz-cli/src/bin/jazz-tools.rs
@@ -66,6 +66,13 @@ fn resolve_jwt_public_key_input(value: String) -> Result<String, String> {
     Ok(trimmed.to_string())
 }
 
+fn parse_app_id(value: &str) -> Result<String, String> {
+    jazz::tools::AppId::from_string(value).map_err(|_| {
+        "Application ID must be a UUID, not an app name. Generate one with `jazz-tools create app` and reuse it for the server and client.".to_owned()
+    })?;
+    Ok(value.to_owned())
+}
+
 fn parse_shutdown_timeout_secs(value: &str) -> Result<u64, String> {
     let seconds = value
         .parse::<u64>()
@@ -99,7 +106,8 @@ enum Commands {
     },
     /// Run a Jazz server
     Server {
-        /// Application ID (from `jazz-tools create app`)
+        /// Application UUID (from `jazz-tools create app`)
+        #[arg(value_parser = parse_app_id)]
         app_id: String,
 
         /// Port to listen on
@@ -416,6 +424,27 @@ fn shutdown_tracing() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn server_app_id_explains_uuid_requirement() {
+        let error = Cli::try_parse_from(["jazz-tools", "server", "my-app"])
+            .err()
+            .expect("invalid app name must fail");
+        let message = error.to_string();
+        assert!(
+            message.contains("Application ID must be a UUID"),
+            "{message}"
+        );
+        assert!(message.contains("jazz-tools create app"), "{message}");
+        assert!(
+            Cli::try_parse_from([
+                "jazz-tools",
+                "server",
+                "7c5fd0da-4bd1-4ba9-9203-41e1f0da142c",
+            ])
+            .is_ok()
+        );
+    }
 
     // Clap reads env-backed args during parsing, so every Cli::try_parse_from
     // test in this module holds this lock. The tests that mutate env vars keep

--- a/packages/jazz-tools/src/better-auth-adapter/schema.test.ts
+++ b/packages/jazz-tools/src/better-auth-adapter/schema.test.ts
@@ -8,6 +8,21 @@ import {
 } from "./schema.js";
 
 describe("better-auth schema helpers", () => {
+  it("acknowledges adapter timestamps while preserving required and renamed fields", () => {
+    const tables = getAuthTables({});
+    const source = buildJazzSchemaSourceTextFromTables({ tables });
+    expect(source).toContain("createdAt: s.allowExternalProvenanceName(s.timestamp()),");
+    expect(source).toContain("updatedAt: s.allowExternalProvenanceName(s.timestamp()),");
+    expect(source).not.toContain("email: s.allowExternalProvenanceName");
+    const renamed = buildJazzSchemaSourceText({
+      tables,
+      getModelName: (model) => model,
+      getFieldName: ({ field }) => (field === "createdAt" ? "registeredAt" : field),
+    });
+    expect(renamed).toContain("registeredAt: s.timestamp(),");
+    expect(renamed).not.toContain("registeredAt: s.allowExternalProvenanceName");
+  });
+
   it("retains the installed JWT plugin signing-key metadata", () => {
     const tables = getAuthTables({ plugins: [jwt()] });
     const schema = buildJazzSchemaFromTables({ tables });
@@ -197,7 +212,7 @@ describe("better-auth schema helpers", () => {
         "  }),",
         "",
         "  sessions: s.table({",
-        "    createdAt: s.timestamp(),",
+        "    createdAt: s.allowExternalProvenanceName(s.timestamp()),",
         "    retryCounts: s.array(s.int()).optional(),",
         '    userId: s.ref("accountHolders").optional(),',
         "  }),",

--- a/packages/jazz-tools/src/better-auth-adapter/schema.ts
+++ b/packages/jazz-tools/src/better-auth-adapter/schema.ts
@@ -361,7 +361,15 @@ export function buildJazzSchemaSourceText(args: {
         getModelName,
       });
 
-      lines.push(`    ${formatObjectKey(storedFieldName)}: ${expression},`);
+      // Better Auth owns these fields, including its required timestamps.
+      // Keep their domain meaning instead of recommending Jazz provenance columns.
+      lines.push(
+        `    ${formatObjectKey(storedFieldName)}: ${
+          ["createdAt", "createdBy", "updatedAt", "updatedBy"].includes(storedFieldName)
+            ? `s.allowExternalProvenanceName(${expression})`
+            : expression
+        },`,
+      );
     }
 
     lines.push("  }),");

--- a/packages/jazz-tools/src/cli-wrapper.test.ts
+++ b/packages/jazz-tools/src/cli-wrapper.test.ts
@@ -8,6 +8,13 @@ const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const wrapper = join(packageRoot, "bin", "jazz-tools.js");
 
 describe("jazz-tools wrapper", () => {
+  it.each(["--help", "-h"])("shows deploy help before required arguments (%s)", (flag) => {
+    const help = execFileSync(process.execPath, [wrapper, "deploy", flag], { encoding: "utf8" });
+    expect(help).toContain("deploy <appId>");
+    expect(help).toContain("--server-url");
+    expect(help).toContain("--admin-secret");
+  });
+
   it("does not advertise the removed documentation MCP server", () => {
     const help = execFileSync(process.execPath, [wrapper, "--help"], { encoding: "utf8" });
 

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -543,7 +543,69 @@ function isMainModule(): boolean {
   return realpathOrSelf(entry) === realpathOrSelf(fileURLToPath(import.meta.url));
 }
 
+function printHelp(): void {
+  console.log("Usage: node <path-to-jazz-tools>/dist/cli.js <command> [options]");
+  console.log("\nCommands:");
+  console.log("  validate              Validate root schema.ts and optional permissions.ts");
+  console.log("  schema hash           Print the short hash of the current schema.ts");
+  console.log("  schema export         Print the compiled structural schema as JSON");
+  console.log("  deploy <appId>        Publish the current schema.ts and permissions.ts");
+  console.log("  permissions status <appId> Show the current server permissions head for this app");
+  console.log(
+    "  migrations create     Generate a typed structural migration stub between two schema versions",
+  );
+  console.log(
+    "  migrations push <appId> <fromHash> <toHash> Push a reviewed migration edge to the server",
+  );
+  console.log("\nValidation options:");
+  console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
+  console.log("  --strict-provenance   Reject conventional duplicates of Jazz provenance");
+  console.log("\nSchema hash options:");
+  console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
+  console.log("\nSchema export options:");
+  console.log(
+    "  <appId>               Required for server-backed schema export by hash (or set JAZZ_APP_ID / {VITE,PUBLIC,NEXT_PUBLIC,EXPO_PUBLIC}_JAZZ_APP_ID)",
+  );
+  console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
+  console.log("  --schema-hash <hash>  Export a stored structural schema by hash");
+  console.log("  --migrations-dir <p>  Path to migrations directory (default: ./migrations)");
+  console.log(
+    "  --server-url <url>    Jazz server URL (or set JAZZ_SERVER_URL / {VITE,PUBLIC,NEXT_PUBLIC,EXPO_PUBLIC}_JAZZ_SERVER_URL)",
+  );
+  console.log("  --admin-secret <sec>  Admin secret (or set JAZZ_ADMIN_SECRET)");
+  console.log("\nPermissions options:");
+  console.log(
+    "  <appId>               Required (or set JAZZ_APP_ID / {VITE,PUBLIC,NEXT_PUBLIC,EXPO_PUBLIC}_JAZZ_APP_ID)",
+  );
+  console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
+  console.log(
+    "  --server-url <url>    Jazz server URL (or set JAZZ_SERVER_URL / {VITE,PUBLIC,NEXT_PUBLIC,EXPO_PUBLIC}_JAZZ_SERVER_URL)",
+  );
+  console.log("  --admin-secret <sec>  Admin secret (or set JAZZ_ADMIN_SECRET)");
+  console.log("\nMigration options:");
+  console.log(
+    "  <appId>               Required for remote create/push commands (or set JAZZ_APP_ID / {VITE,PUBLIC,NEXT_PUBLIC,EXPO_PUBLIC}_JAZZ_APP_ID)",
+  );
+  console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
+  console.log(
+    "  --server-url <url>    Jazz server URL (or set JAZZ_SERVER_URL / {VITE,PUBLIC,NEXT_PUBLIC,EXPO_PUBLIC}_JAZZ_SERVER_URL)",
+  );
+  console.log("  --admin-secret <sec>  Admin secret (or set JAZZ_ADMIN_SECRET)");
+  console.log("  --migrations-dir <p>  Path to migrations directory (default: ./migrations)");
+  console.log("  --fromHash <hash>     Optional source schema hash (defaults to latest snapshot)");
+  console.log("  --toHash <hash>       Optional target schema hash (defaults to current schema)");
+  console.log("  --name <name>         Optional migration filename label (default: unnamed)");
+  console.log("\nGlobal options:");
+  console.log(
+    "  --env-file <path>     Load env vars from this file (repeatable; first file wins per key). Defaults to .env in cwd.",
+  );
+}
+
 if (isMainModule()) {
+  if (process.argv.slice(2).some((arg) => arg === "--help" || arg === "-h")) {
+    printHelp();
+    process.exit(0);
+  }
   const envFiles = readEnvFiles(process.argv.slice(2));
   if (envFiles.length > 0) {
     for (const file of envFiles) {
@@ -663,65 +725,7 @@ if (isMainModule()) {
       process.exit(1);
     });
   } else {
-    console.log("Usage: node <path-to-jazz-tools>/dist/cli.js <command> [options]");
-    console.log("\nCommands:");
-    console.log("  validate              Validate root schema.ts and optional permissions.ts");
-    console.log("  schema hash           Print the short hash of the current schema.ts");
-    console.log("  schema export         Print the compiled structural schema as JSON");
-    console.log("  deploy <appId>        Publish the current schema.ts and permissions.ts");
-    console.log(
-      "  permissions status <appId> Show the current server permissions head for this app",
-    );
-    console.log(
-      "  migrations create     Generate a typed structural migration stub between two schema versions",
-    );
-    console.log(
-      "  migrations push <appId> <fromHash> <toHash> Push a reviewed migration edge to the server",
-    );
-    console.log("\nValidation options:");
-    console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
-    console.log("  --strict-provenance   Reject conventional duplicates of Jazz provenance");
-    console.log("\nSchema hash options:");
-    console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
-    console.log("\nSchema export options:");
-    console.log(
-      "  <appId>               Required for server-backed schema export by hash (or set JAZZ_APP_ID / {VITE,PUBLIC,NEXT_PUBLIC,EXPO_PUBLIC}_JAZZ_APP_ID)",
-    );
-    console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
-    console.log("  --schema-hash <hash>  Export a stored structural schema by hash");
-    console.log("  --migrations-dir <p>  Path to migrations directory (default: ./migrations)");
-    console.log(
-      "  --server-url <url>    Jazz server URL (or set JAZZ_SERVER_URL / {VITE,PUBLIC,NEXT_PUBLIC,EXPO_PUBLIC}_JAZZ_SERVER_URL)",
-    );
-    console.log("  --admin-secret <sec>  Admin secret (or set JAZZ_ADMIN_SECRET)");
-    console.log("\nPermissions options:");
-    console.log(
-      "  <appId>               Required (or set JAZZ_APP_ID / {VITE,PUBLIC,NEXT_PUBLIC,EXPO_PUBLIC}_JAZZ_APP_ID)",
-    );
-    console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
-    console.log(
-      "  --server-url <url>    Jazz server URL (or set JAZZ_SERVER_URL / {VITE,PUBLIC,NEXT_PUBLIC,EXPO_PUBLIC}_JAZZ_SERVER_URL)",
-    );
-    console.log("  --admin-secret <sec>  Admin secret (or set JAZZ_ADMIN_SECRET)");
-    console.log("\nMigration options:");
-    console.log(
-      "  <appId>               Required for remote create/push commands (or set JAZZ_APP_ID / {VITE,PUBLIC,NEXT_PUBLIC,EXPO_PUBLIC}_JAZZ_APP_ID)",
-    );
-    console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
-    console.log(
-      "  --server-url <url>    Jazz server URL (or set JAZZ_SERVER_URL / {VITE,PUBLIC,NEXT_PUBLIC,EXPO_PUBLIC}_JAZZ_SERVER_URL)",
-    );
-    console.log("  --admin-secret <sec>  Admin secret (or set JAZZ_ADMIN_SECRET)");
-    console.log("  --migrations-dir <p>  Path to migrations directory (default: ./migrations)");
-    console.log(
-      "  --fromHash <hash>     Optional source schema hash (defaults to latest snapshot)",
-    );
-    console.log("  --toHash <hash>       Optional target schema hash (defaults to current schema)");
-    console.log("  --name <name>         Optional migration filename label (default: unnamed)");
-    console.log("\nGlobal options:");
-    console.log(
-      "  --env-file <path>     Load env vars from this file (repeatable; first file wins per key). Defaults to .env in cwd.",
-    );
+    printHelp();
     process.exit(command ? 1 : 0);
   }
 }


### PR DESCRIPTION
🤖 Self-hosted setup exposed three misleading CLI behaviors: deploy --help threw a missing-app-ID error, a descriptive server app name produced an opaque UUID parse failure, and generated BetterAuth timestamps received advice to remove fields BetterAuth requires.

Handle help before argument/environment validation, explain the existing UUID requirement using the unchanged AppId parser, and annotate only generated conventional provenance fields with the existing explicit allowance. Ordinary schema validation and strict provenance diagnostics remain intact.

Validation: independent review, coordinator wrapper/generator tests (16 passed), existing strict-provenance tests, and independent complete Rust CLI binary parser suite (13 passed). Reversible mutations detected both help/allowance and UUID-validation regressions. Full CI pending.

Fixes #2664.
