### PR TITLE
fix: retry unclean native WebSocket connection loss

### DIFF
--- a/.github/workflows/rn-native-artifacts.yml
+++ b/.github/workflows/rn-native-artifacts.yml
@@ -19,6 +19,7 @@ on:
       - "crates/jazz/**"
       - "crates/jazz-compression/**"
       - "crates/jazz-native-relay/**"
+      - "crates/jazz-native-transport/**"
       - "crates/jazz-storage-sqlite/**"
       - "crates/jazz-rn/**"
 
@@ -57,7 +58,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         with:
           rust-cache: "true"
-          rust-cache-key: rn-artifacts-android-${{ env.JAZZ_RN_CARGO_NDK_VERSION }}-ndk-27.1.12297006-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/groove/**', 'crates/idb-tree/**', 'crates/jazz/**', 'crates/jazz-compression/**', 'crates/jazz-native-relay/**', 'crates/jazz-storage-sqlite/**', 'crates/jazz-rn/scripts/build-relay-artifacts.sh') }}
+          rust-cache-key: rn-artifacts-android-${{ env.JAZZ_RN_CARGO_NDK_VERSION }}-ndk-27.1.12297006-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/groove/**', 'crates/idb-tree/**', 'crates/jazz/**', 'crates/jazz-compression/**', 'crates/jazz-native-relay/**', 'crates/jazz-native-transport/**', 'crates/jazz-storage-sqlite/**', 'crates/jazz-rn/scripts/build-relay-artifacts.sh') }}
           rust-cache-bin: "true"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
@@ -99,7 +100,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         with:
           rust-cache: "true"
-          rust-cache-key: rn-artifacts-ios-macos-15-xcode-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/groove/**', 'crates/idb-tree/**', 'crates/jazz/**', 'crates/jazz-compression/**', 'crates/jazz-native-relay/**', 'crates/jazz-storage-sqlite/**', 'crates/jazz-rn/scripts/build-relay-artifacts.sh') }}
+          rust-cache-key: rn-artifacts-ios-macos-15-xcode-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/groove/**', 'crates/idb-tree/**', 'crates/jazz/**', 'crates/jazz-compression/**', 'crates/jazz-native-relay/**', 'crates/jazz-native-transport/**', 'crates/jazz-storage-sqlite/**', 'crates/jazz-rn/scripts/build-relay-artifacts.sh') }}
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.93.1

--- a/crates/jazz-native-transport/src/lib.rs
+++ b/crates/jazz-native-transport/src/lib.rs
@@ -89,6 +89,11 @@ impl std::error::Error for WebSocketClientError {}
 /// NotReady/Later admission response accepted by the browser is retryable.
 fn native_transport_error(error: WebSocketClientError) -> NativeTransportError {
     let retryable = match &error {
+        // A proxy may accept TCP while its upstream is restarting and close
+        // before HTTP upgrade completes. No rejected response was received.
+        WebSocketClientError::Connect(tokio_tungstenite::tungstenite::Error::Protocol(
+            tokio_tungstenite::tungstenite::error::ProtocolError::HandshakeIncomplete,
+        )) => true,
         // Tungstenite represents an established TCP EOF without a Close frame
         // as a protocol error. It is connection loss, unlike malformed frames
         // or rejected authentication, and must not poison the local runtime.
@@ -904,6 +909,48 @@ fn decode_inbound_batch(bytes: &[u8], _bootstrap_catalogue: bool) -> Result<Vec<
 
 #[cfg(test)]
 mod tests {
+    // A proxy can accept TCP while its upstream is down, then close before
+    // completing HTTP upgrade. Observe the real socket error, not its text.
+    #[tokio::test]
+    async fn incomplete_websocket_upgrade_is_retryable() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            use tokio::io::AsyncReadExt;
+            let mut request = Vec::new();
+            while !request.ends_with(b"\r\n\r\n") {
+                let mut byte = [0_u8; 1];
+                stream.read_exact(&mut byte).await.unwrap();
+                request.push(byte[0]);
+                assert!(request.len() < 4096, "bounded upgrade request");
+            }
+            drop(stream);
+        });
+        let error = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            tokio_tungstenite::connect_async(format!("ws://{address}")),
+        )
+        .await
+        .expect("bounded incomplete-upgrade receipt")
+        .expect_err("server never completed HTTP upgrade");
+        assert!(
+            matches!(
+                error,
+                tokio_tungstenite::tungstenite::Error::Protocol(
+                    tokio_tungstenite::tungstenite::error::ProtocolError::HandshakeIncomplete
+                )
+            ),
+            "unexpected incomplete upgrade: {error:?}"
+        );
+        let classified = native_transport_error(WebSocketClientError::Connect(error));
+        assert!(
+            classified.is_retryable(),
+            "incomplete upgrade must reconnect: {classified:?}"
+        );
+        server.await.unwrap();
+    }
+
     // This reproduces the socket library's typed EOF result below the Db API;
     // constructing an error alone would miss the actual abrupt-close category.
     #[tokio::test]
@@ -947,6 +994,12 @@ mod tests {
     #[test]
     fn malformed_websocket_protocol_remains_terminal() {
         use tokio_tungstenite::tungstenite::{Error, error::ProtocolError};
+        assert!(
+            !native_transport_error(WebSocketClientError::Connect(Error::Protocol(
+                ProtocolError::WrongHttpMethod,
+            )))
+            .is_retryable()
+        );
         for error in [
             ProtocolError::UnmaskedFrameFromClient,
             ProtocolError::InvalidOpcode(3),

--- a/crates/jazz-native-transport/src/lib.rs
+++ b/crates/jazz-native-transport/src/lib.rs
@@ -89,6 +89,15 @@ impl std::error::Error for WebSocketClientError {}
 /// NotReady/Later admission response accepted by the browser is retryable.
 fn native_transport_error(error: WebSocketClientError) -> NativeTransportError {
     let retryable = match &error {
+        // Tungstenite represents an established TCP EOF without a Close frame
+        // as a protocol error. It is connection loss, unlike malformed frames
+        // or rejected authentication, and must not poison the local runtime.
+        WebSocketClientError::Send(tokio_tungstenite::tungstenite::Error::Protocol(
+            tokio_tungstenite::tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
+        ))
+        | WebSocketClientError::Receive(tokio_tungstenite::tungstenite::Error::Protocol(
+            tokio_tungstenite::tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
+        )) => true,
         WebSocketClientError::Connect(tokio_tungstenite::tungstenite::Error::Io(error))
         | WebSocketClientError::Send(tokio_tungstenite::tungstenite::Error::Io(error))
         | WebSocketClientError::Receive(tokio_tungstenite::tungstenite::Error::Io(error)) => {
@@ -895,6 +904,67 @@ fn decode_inbound_batch(bytes: &[u8], _bootstrap_catalogue: bool) -> Result<Vec<
 
 #[cfg(test)]
 mod tests {
+    // This reproduces the socket library's typed EOF result below the Db API;
+    // constructing an error alone would miss the actual abrupt-close category.
+    #[tokio::test]
+    async fn established_socket_abrupt_eof_is_retryable() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+            // Drop TCP without sending a WebSocket Close frame, as a proxy
+            // restart or disappearing mobile connection can do.
+            drop(socket);
+        });
+        let (mut socket, _) = tokio_tungstenite::connect_async(format!("ws://{address}"))
+            .await
+            .unwrap();
+        let error = tokio::time::timeout(std::time::Duration::from_secs(5), socket.next())
+            .await
+            .expect("bounded EOF receipt")
+            .expect("typed EOF error")
+            .expect_err("unclean close must produce a socket error");
+        assert!(
+            matches!(
+            error,
+            tokio_tungstenite::tungstenite::Error::Protocol(
+                tokio_tungstenite::tungstenite::error::ProtocolError::ResetWithoutClosingHandshake
+            )
+        ),
+            "unexpected abrupt EOF: {error:?}"
+        );
+        let classified = native_transport_error(WebSocketClientError::Receive(error));
+        assert!(
+            classified.is_retryable(),
+            "abrupt EOF must reconnect: {classified:?}"
+        );
+        server.await.unwrap();
+    }
+
+    // Keep the exception typed and narrow: other protocol failures must still
+    // retire the authenticated connection instead of retrying bad input.
+    #[test]
+    fn malformed_websocket_protocol_remains_terminal() {
+        use tokio_tungstenite::tungstenite::{Error, error::ProtocolError};
+        for error in [
+            ProtocolError::UnmaskedFrameFromClient,
+            ProtocolError::InvalidOpcode(3),
+        ] {
+            assert!(
+                !native_transport_error(WebSocketClientError::Receive(Error::Protocol(error)))
+                    .is_retryable()
+            );
+        }
+        assert!(
+            !native_transport_error(WebSocketClientError::Connect(Error::Protocol(
+                ProtocolError::ResetWithoutClosingHandshake,
+            )))
+            .is_retryable(),
+            "the exception applies only after socket establishment"
+        );
+    }
+
     // This adapter classification has no Db-level API: assert the typed socket
     // and wire boundary, including conflicting error guidance, directly.
     #[test]

--- a/crates/jazz-rn/scripts/build-relay-artifacts.sh
+++ b/crates/jazz-rn/scripts/build-relay-artifacts.sh
@@ -27,7 +27,7 @@ const source = execFileSync(
   [
     "-C", root, "ls-tree", "-r", "--full-tree", "HEAD", "--",
     "Cargo.lock", "Cargo.toml", "crates/groove", "crates/idb-tree",
-    "crates/jazz", "crates/jazz-compression", "crates/jazz-native-relay", "crates/jazz-storage-sqlite",
+    "crates/jazz", "crates/jazz-compression", "crates/jazz-native-relay", "crates/jazz-native-transport", "crates/jazz-storage-sqlite",
     "crates/jazz-rn/scripts/build-relay-artifacts.sh",
   ],
 );

--- a/crates/jazz-rn/scripts/verify-relay-artifacts.mjs
+++ b/crates/jazz-rn/scripts/verify-relay-artifacts.mjs
@@ -57,6 +57,7 @@ const nativeSourceFingerprint = createHash("sha256")
         "crates/jazz",
         "crates/jazz-compression",
         "crates/jazz-native-relay",
+        "crates/jazz-native-transport",
         "crates/jazz-storage-sqlite",
         "crates/jazz-rn/scripts/build-relay-artifacts.sh",
       ],

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -117,6 +117,7 @@ const rnNativeArtifactPushPaths = [
   "crates/jazz/**",
   "crates/jazz-compression/**",
   "crates/jazz-native-relay/**",
+  "crates/jazz-native-transport/**",
   "crates/jazz-storage-sqlite/**",
   "crates/jazz-rn/**",
 ];

--- a/dev/gates/test/jazz-rn-packaging.test.mjs
+++ b/dev/gates/test/jazz-rn-packaging.test.mjs
@@ -2335,6 +2335,7 @@ test("relay verification rejects a manifest-sealed XCFramework without its devic
       "crates/jazz",
       "crates/jazz-compression",
       "crates/jazz-native-relay",
+      "crates/jazz-native-transport",
       "crates/jazz-storage-sqlite",
       "crates/jazz-rn/scripts/build-relay-artifacts.sh",
     ],
@@ -2523,7 +2524,11 @@ ${
       );
     }
 
-    for (const transitiveInput of ["crates/idb-tree/", "crates/jazz-compression/"]) {
+    for (const transitiveInput of [
+      "crates/idb-tree/",
+      "crates/jazz-compression/",
+      "crates/jazz-native-transport/",
+    ]) {
       const entry = nativeSourceInventory
         .split("\n")
         .find((line) => line.includes(transitiveInput));
@@ -2988,6 +2993,7 @@ test("release, preview, and labeled platform gates seal and link the staged rela
     "crates/jazz",
     "crates/jazz-compression",
     "crates/jazz-native-relay",
+    "crates/jazz-native-transport",
     "crates/jazz-storage-sqlite",
   ]) {
     assert.ok(artifactScript.includes(nativeInput), `artifact fingerprint omits ${nativeInput}`);


### PR DESCRIPTION
🤖 A React Native app could terminate when its server disappeared without a WebSocket closing handshake, or when a reconnect attempt lost the connection before completing the HTTP upgrade. Both ordinary connection-loss cases were classified as terminal protocol failures and poisoned the foreground tick.

Retry two narrow typed errors: ResetWithoutClosingHandshake on an established socket's send/receive path, and HandshakeIncomplete while connecting. Complete HTTP/authentication rejections and other malformed-protocol errors remain terminal. The shared native transport change also applies to its other runtime consumers.

Include native transport in RN artifact fingerprints, verification, workflow triggers, cache inputs and the matching CI contract fixture so device artifacts reliably contain transport changes.

Validation: independent correctness review passed; all 18 native transport tests and 22 packaging tests passed, with sensitivity checks detecting removed or overly broad retry handling. The complete CI workflow contract suite passed 206 tests. Clean final Android artifact acceptance passed live server loss, cold app restart while disconnected, persisted identity/data, live convergence after server return, and an offline edit subsequently observed by an independent writer. CI on the final head is pending.

Based on #2668. Fixes #2670.
