### PR TITLE
Explain missing schema during WebSocket admission

### DIFF
--- a/crates/jazz-native-transport/tests/edge_websocket.rs
+++ b/crates/jazz-native-transport/tests/edge_websocket.rs
@@ -514,7 +514,7 @@ async fn dynamic_edge_rejects_client_until_normal_upstream_session_is_attached()
     .await
     .expect_err("downstream admission waits for the normal upstream route");
     assert!(
-        matches!(error, WebSocketClientError::ServerWireError(ref wire) if wire.code == WireErrorCode::NotReady && wire.retry == WireRetry::Later && wire.message.contains("bootstrapping") && wire.message.contains("retry shortly")),
+        matches!(error, WebSocketClientError::ServerWireError(ref wire) if wire.code == WireErrorCode::NotReady && wire.retry == WireRetry::Later),
         "unready dynamic edge must give retryable admission failure: {error}"
     );
 
@@ -634,7 +634,7 @@ async fn blank_dynamic_edge_rejects_downstream_with_retry_later_until_ready() {
     .await
     .expect_err("unready edge must not admit a downstream session");
     assert!(
-        matches!(error, WebSocketClientError::ServerWireError(ref wire) if wire.code == WireErrorCode::NotReady && wire.retry == WireRetry::Later && wire.message.contains("bootstrapping") && wire.message.contains("retry shortly")),
+        matches!(error, WebSocketClientError::ServerWireError(ref wire) if wire.code == WireErrorCode::NotReady && wire.retry == WireRetry::Later),
         "unready edge must return an explicit retry-later diagnosis: {error}"
     );
     task.abort();

--- a/crates/jazz-server/src/server/routes/websocket.rs
+++ b/crates/jazz-server/src/server/routes/websocket.rs
@@ -753,13 +753,21 @@ async fn handle_ws_connection(
     }
 
     let Some(core_server_shell) = state.runtime_for_client() else {
+        let message = if state.shutdown.is_shutting_down() {
+            "runtime is shutting down; retry later"
+        } else if state.topology.is_edge() {
+            "edge runtime is awaiting a complete authoritative catalogue; retry shortly"
+        } else {
+            match state.catalogue.known_schema_hashes(&state.catalogue_store) {
+                Ok(hashes) if hashes.is_empty() => {
+                    "no schema has been published for this app; deploy a schema with `jazz-tools deploy <appId>` before connecting"
+                }
+                _ => "runtime is not ready to accept client connections; retry shortly",
+            }
+        };
         send_ws_error(
             &mut socket,
-            WireError::new(
-                WireErrorCode::NotReady,
-                WireRetry::Later,
-                "runtime is bootstrapping its authoritative catalogue; retry shortly",
-            ),
+            WireError::new(WireErrorCode::NotReady, WireRetry::Later, message),
         )
         .await;
         let _ = socket.close().await;
@@ -2046,6 +2054,71 @@ mod tests {
                 .expect("serve websocket test app");
         });
         addr
+    }
+
+    /// Alice connects to a fresh Core with no published schemas and receives
+    /// actionable deployment guidance while retaining the retryable wire error.
+    #[tokio::test]
+    async fn ws_blank_core_reports_schema_deployment_required() {
+        assert_blank_runtime_diagnostic(
+            false,
+            "no schema has been published for this app; deploy a schema with `jazz-tools deploy <appId>` before connecting",
+        )
+        .await;
+    }
+
+    /// Alice connects to a blank Edge and is told it is awaiting its authority,
+    /// rather than being told to publish a schema directly to that Edge.
+    #[tokio::test]
+    async fn ws_blank_edge_reports_catalogue_wait() {
+        assert_blank_runtime_diagnostic(
+            true,
+            "edge runtime is awaiting a complete authoritative catalogue; retry shortly",
+        )
+        .await;
+    }
+
+    async fn assert_blank_runtime_diagnostic(edge: bool, expected: &str) {
+        let mut builder = ServerBuilder::new(AppId::random())
+            .with_auth_config(AuthConfig {
+                admin_secret: Some("admin-secret".to_owned()),
+                ..Default::default()
+            })
+            .with_storage(StorageBackend::InMemory);
+        if edge {
+            builder = builder.with_upstream_url("ws://127.0.0.1:9");
+        }
+        let server = builder.build().await.expect("build blank server");
+        let state = server.state;
+        let addr = start_ws_test_server(state.clone()).await;
+        let (mut alice, _) = connect_async(ws_url(addr, state.app_id))
+            .await
+            .expect("connect Alice");
+        alice
+            .send(WsMessage::Binary(ws_prelude(AuthorSubject::SYSTEM).into()))
+            .await
+            .expect("send Alice prelude");
+        alice
+            .send(WsMessage::Binary(
+                ws_client_hello_batch_with_features(
+                    FEATURE_SYNC_MESSAGE_PAYLOAD | FEATURE_STRUCTURED_ERRORS,
+                )
+                .into(),
+            ))
+            .await
+            .expect("send Alice hello");
+        let response = tokio::time::timeout(Duration::from_secs(5), alice.next())
+            .await
+            .expect("wait for readiness error")
+            .expect("readiness frame")
+            .expect("readiness response");
+        let frames = decode_ws_message(&response);
+        let [WireFrame::Error(error)] = frames.as_slice() else {
+            panic!("expected readiness error, got {frames:?}");
+        };
+        assert_eq!(error.code, WireErrorCode::NotReady);
+        assert_eq!(error.retry, WireRetry::Later);
+        assert_eq!(error.message, expected);
     }
 
     fn ws_url(addr: std::net::SocketAddr, app_id: AppId) -> String {

--- a/crates/jazz-testkit/src/scenarios.rs
+++ b/crates/jazz-testkit/src/scenarios.rs
@@ -4,6 +4,10 @@ use std::future::Future;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use jazz::query::Query;
+use jazz::tools::native_transport_connector::{
+    NativeCatalogueBootstrapFuture, NativeTransportConnector, NativeTransportError,
+    NativeTransportFuture, NativeTransportRequest,
+};
 use jazz::tools::sync::ClientId;
 use jazz::tools::{
     AppContext, ClientStorage, DurabilityTier, JazzClient, ObjectId, OrderedRowDelta, Schema,
@@ -13,6 +17,49 @@ use jazz_server::{JazzServer, TEST_JWT_AUDIENCE, TEST_JWT_ISSUER};
 use jsonwebtoken::{EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+
+// Retry at the adapter boundary, before JazzClient renders transport errors as
+// diagnostic strings. The native adapter owns code/retry classification.
+struct RetryLaterConnector {
+    deadline: tokio::time::Instant,
+}
+
+impl NativeTransportConnector for RetryLaterConnector {
+    fn validate_catalogue_bootstrap_url(
+        &self,
+        server_url: &str,
+        app_id: jazz::tools::AppId,
+    ) -> Result<(), NativeTransportError> {
+        jazz_native_transport::NativeWebSocketConnector
+            .validate_catalogue_bootstrap_url(server_url, app_id)
+    }
+
+    fn connect(&self, request: NativeTransportRequest) -> NativeTransportFuture {
+        let deadline = self.deadline;
+        Box::pin(async move {
+            loop {
+                match jazz_native_transport::NativeWebSocketConnector
+                    .connect(request.clone())
+                    .await
+                {
+                    Err(error)
+                        if error.is_retryable() && tokio::time::Instant::now() < deadline =>
+                    {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                    result => return result,
+                }
+            }
+        })
+    }
+
+    fn bootstrap_catalogue(
+        &self,
+        request: NativeTransportRequest,
+    ) -> NativeCatalogueBootstrapFuture {
+        jazz_native_transport::NativeWebSocketConnector.bootstrap_catalogue(request)
+    }
+}
 
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 #[allow(dead_code)]
@@ -168,19 +215,12 @@ impl<'a> TestingClient<'a> {
             .expect("enroll public test client");
         let deadline = tokio::time::Instant::now() + timeout;
 
-        let client = loop {
-            match crate::connect(context.clone()).await {
-                Ok(client) => break client,
-                Err(error)
-                    if error.to_string().contains("bootstrapping")
-                        && error.to_string().contains("retry shortly")
-                        && tokio::time::Instant::now() < deadline =>
-                {
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                }
-                Err(error) => panic!("connect test client after retry-later: {error}"),
-            }
-        };
+        let client = JazzClient::connect_with_native_transport(
+            context,
+            std::sync::Arc::new(RetryLaterConnector { deadline }),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("connect test client after retry-later: {error}"));
 
         if let Some(ready_table) = ready_table {
             wait_for_edge_query_ready(


### PR DESCRIPTION
🤖 A fresh core with no published schema rejects WebSocket admission with `not_ready`, but previously described itself as bootstrapping its authoritative catalogue. This made missing deployment look like a stuck refresh.

The diagnostic now identifies a schema-less core and directs the developer to `jazz-tools deploy <appId>`. An edge awaiting its authoritative catalogue keeps an edge-specific waiting message; shutdown and other unavailable-runtime cases receive separate descriptions.

Admission behavior, structured error code, retry advice, and storage/wire encodings are unchanged. For example, connecting before the first schema deployment now explains the required deployment; connecting to an edge before catalogue synchronization still advises waiting. This change diagnoses the current state and does not establish why a previously populated catalogue might be empty.

Validation: two real WebSocket tests pass independently on the committed tree. Restoring the previous diagnostic makes both fail. Formatting and scoped clippy passed. Independent static review passed. CI exposed test-only retry logic coupled to the old English message; the follow-up classifies native retry outcomes before diagnostic formatting, and transport assertions use the structured code/retry. Independent reruns of all 15 native Edge and 27 catalogue integration tests pass. Fresh CI remains pending.
