### PR TITLE
Preserve BigInt input precision in Inspector

### DIFF
--- a/.changeset/canonical-bigint-query-decoder.md
+++ b/.changeset/canonical-bigint-query-decoder.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Accept canonical signed-I64 decimal BigInt literals emitted by native query translation.

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.integration.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.integration.test.tsx
@@ -7,6 +7,7 @@ import { MemoryRouter } from "react-router";
 import type * as ReactRouter from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TableDataGrid } from "./TableDataGrid";
+import { GenericQueryBuilder } from "../../utility/generic-query-builder.js";
 
 const issuer = "https://inspector-save.test";
 const userId = "editor";
@@ -15,6 +16,7 @@ const inspectorSaveApp = s.defineApp({
   todos: s.table({
     title: s.string(),
     owner_id: s.uuid(),
+    rank: s.bigint().optional(),
   }),
 });
 const inspectorSavePermissions = s.definePermissions(inspectorSaveApp, ({ policy, session }) => {
@@ -24,8 +26,6 @@ const inspectorSavePermissions = s.definePermissions(inspectorSaveApp, ({ policy
   policy.todos.allowDelete.where({ owner_id: session.user.account });
 });
 
-let currentDb: Db | null = null;
-
 vi.mock("jazz-tools/react", () => ({
   useAll: () => ({ data: [], isLoading: false, error: null }),
   useDb: () => {
@@ -33,6 +33,8 @@ vi.mock("jazz-tools/react", () => ({
     return currentDb;
   },
 }));
+
+let currentDb: Db | null = null;
 
 vi.mock("../../contexts/devtools-context.js", () => ({
   useDevtoolsContext: () => ({
@@ -329,6 +331,82 @@ describe("TableDataGrid real Db save retries", () => {
         id: instrumented.insertIds[0],
         title: "retry same row",
         owner_id: permittedOwner,
+      }),
+    ]);
+  }, 30_000);
+
+  it("persists unsafe-range BigInt mutations exactly through the real Db", async () => {
+    const setup = await createInspectorDb();
+    policyApp = setup.app;
+    const instrumented = instrumentDb(setup.db);
+    currentDb = instrumented.db;
+    const exactValue = 9007199254740993n;
+    renderGrid();
+
+    fireEvent.click(screen.getByRole("button", { name: "Insert row" }));
+    editStagedTextColumn(1, "title", "exact bigint");
+    editStagedTextColumn(2, "owner_id", permittedOwner);
+    editStagedTextColumn(3, "rank", String(exactValue));
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(
+      () => {
+        expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
+      },
+      { timeout: 10_000 },
+    );
+
+    await expect(setup.db.all(inspectorSaveApp.todos, { tier: "edge" })).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "exact bigint",
+          owner_id: permittedOwner,
+          rank: exactValue,
+        }),
+      ]),
+    );
+  }, 30_000);
+
+  it("applies URL-hydrated BigInt filters through the real query runtime", async () => {
+    const setup = await createInspectorDb();
+    policyApp = setup.app;
+    const exactValue = 9007199254740993n;
+    await setup.db
+      .insert(inspectorSaveApp.todos, {
+        title: "exact rank",
+        owner_id: permittedOwner,
+        rank: exactValue,
+      })
+      .wait({ tier: "edge" });
+    await setup.db
+      .insert(inspectorSaveApp.todos, {
+        title: "nearby rank",
+        owner_id: permittedOwner,
+        rank: exactValue - 1n,
+      })
+      .wait({ tier: "edge" });
+
+    const filters = JSON.stringify([
+      { id: "hydrated-rank", column: "rank", operator: "eq", value: String(exactValue) },
+    ]);
+    const url = new URL(
+      `/data-explorer/todos/data?filters=${encodeURIComponent(filters)}`,
+      "https://inspector.test",
+    );
+    const [hydratedFilter] = JSON.parse(url.searchParams.get("filters") ?? "[]") as Array<{
+      column: string;
+      value: string;
+    }>;
+    const query = new GenericQueryBuilder("todos", inspectorSaveApp.wasmSchema).where({
+      [hydratedFilter.column]: hydratedFilter.value,
+    });
+    const rows = await setup.db.all(query, { tier: "edge" });
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        title: "exact rank",
+        owner_id: permittedOwner,
+        rank: exactValue,
       }),
     ]);
   }, 30_000);

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -496,35 +496,6 @@ describe("TableDataGrid", () => {
     });
   });
 
-  it("keeps exact BigInt values through cell editing and saving", async () => {
-    mockWasmSchema.todos.columns = [
-      ...initialMockTodoColumns,
-      { name: "rank", column_type: { type: "BigInt" }, nullable: false },
-    ];
-    currentRows = currentRows.map((row) => ({ ...row, rank: 1n }));
-
-    renderGrid();
-
-    const rankCell = screen.getAllByRole("gridcell", { name: "1" })[0] as HTMLElement;
-    fireEvent.doubleClick(rankCell);
-    const rankEditor = screen.getByLabelText("Edit rank") as HTMLInputElement;
-    const exactValue = "9007199254740993";
-    expect(rankEditor.value).toBe("1");
-    fireEvent.change(rankEditor, { target: { value: exactValue } });
-    fireEvent.blur(rankEditor);
-
-    expect(screen.getByText(exactValue)).not.toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
-
-    await waitFor(() => {
-      expect(mockUpdate).toHaveBeenCalledWith(
-        expect.objectContaining({ _table: "todos" }),
-        "row-2",
-        expect.objectContaining({ rank: 9007199254740993n }),
-      );
-    });
-  });
-
   it("edits text cells in place and saves from the banner", async () => {
     renderGrid();
 

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -466,6 +466,65 @@ describe("TableDataGrid", () => {
     });
   });
 
+  it("preserves exact BigInt filter values through URL and query serialization", async () => {
+    mockWasmSchema.todos.columns = [
+      ...initialMockTodoColumns,
+      { name: "rank", column_type: { type: "BigInt" }, nullable: false },
+    ];
+    currentRows = currentRows.map((row) => ({ ...row, rank: 1n }));
+
+    renderGrid();
+
+    fireEvent.change(screen.getByLabelText("Column"), { target: { value: "rank" } });
+    fireEvent.change(screen.getByLabelText("Operator"), { target: { value: "in" } });
+    fireEvent.change(screen.getByLabelText("Value"), {
+      target: { value: "9007199254740993, -9007199254740993" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add where clause" }));
+
+    await waitFor(() => {
+      const filteredQuery = getLastTodosQuery();
+      expect(JSON.parse(filteredQuery._build())).toMatchObject({
+        conditions: [
+          {
+            column: "rank",
+            op: "in",
+            value: ["9007199254740993", "-9007199254740993"],
+          },
+        ],
+      });
+    });
+  });
+
+  it("keeps exact BigInt values through cell editing and saving", async () => {
+    mockWasmSchema.todos.columns = [
+      ...initialMockTodoColumns,
+      { name: "rank", column_type: { type: "BigInt" }, nullable: false },
+    ];
+    currentRows = currentRows.map((row) => ({ ...row, rank: 1n }));
+
+    renderGrid();
+
+    const rankCell = screen.getAllByRole("gridcell", { name: "1" })[0] as HTMLElement;
+    fireEvent.doubleClick(rankCell);
+    const rankEditor = screen.getByLabelText("Edit rank") as HTMLInputElement;
+    const exactValue = "9007199254740993";
+    expect(rankEditor.value).toBe("1");
+    fireEvent.change(rankEditor, { target: { value: exactValue } });
+    fireEvent.blur(rankEditor);
+
+    expect(screen.getByText(exactValue)).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ _table: "todos" }),
+        "row-2",
+        expect.objectContaining({ rank: 9007199254740993n }),
+      );
+    });
+  });
+
   it("edits text cells in place and saves from the banner", async () => {
     renderGrid();
 

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -64,6 +64,12 @@ function formatCellValue(value: unknown): string {
   return String(value);
 }
 
+function serializeFilterClauses(clauses: TableFilterClause[]): string {
+  return JSON.stringify(clauses, (_key, value) =>
+    typeof value === "bigint" ? value.toString() : value,
+  );
+}
+
 const RELATION_LABEL_COLUMN_PRIORITY = [
   "name",
   "title",
@@ -895,7 +901,7 @@ export function TableDataGrid() {
       (prev) => {
         const p = new URLSearchParams(prev);
         if (next.length > 0) {
-          p.set("filters", JSON.stringify(next));
+          p.set("filters", serializeFilterClauses(next));
         } else {
           p.delete("filters");
         }

--- a/packages/inspector/src/components/data-explorer/TableFilterBuilder.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableFilterBuilder.test.tsx
@@ -232,4 +232,25 @@ describe("TableFilterBuilder", () => {
 
     expect(screen.getAllByText("rank eq 9007199254740993").length).toBeGreaterThan(0);
   });
+
+  it("renders BigInt membership filters as exact decimal text", () => {
+    render(
+      <TableFilterBuilder
+        schemaColumns={bigintSchemaColumns}
+        clauses={[
+          {
+            id: "rank-membership-filter",
+            column: "rank",
+            operator: "in",
+            value: [9007199254740993n, -9007199254740993n],
+          },
+        ]}
+        onClausesChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getAllByText('rank in ["9007199254740993","-9007199254740993"]').length,
+    ).toBeGreaterThan(0);
+  });
 });

--- a/packages/inspector/src/components/data-explorer/TableFilterBuilder.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableFilterBuilder.test.tsx
@@ -12,6 +12,11 @@ const schemaColumns = [
   { name: "meta", column_type: { type: "Row", columns: [] }, nullable: true },
 ] satisfies ColumnDescriptor[];
 
+const bigintSchemaColumns = [
+  ...schemaColumns,
+  { name: "rank", column_type: { type: "BigInt" }, nullable: false },
+] satisfies ColumnDescriptor[];
+
 describe("TableFilterBuilder", () => {
   afterEach(() => {
     cleanup();
@@ -214,5 +219,17 @@ describe("TableFilterBuilder", () => {
     expect(screen.getAllByRole("button", { name: /Remove filter on/ })[0]?.textContent).toBe("×");
     expect(screen.getAllByText("title contains alpha").length).toBeGreaterThan(0);
     expect(screen.getAllByText("count gt 1").length).toBeGreaterThan(0);
+  });
+
+  it("renders BigInt filter values as exact decimal text", () => {
+    render(
+      <TableFilterBuilder
+        schemaColumns={bigintSchemaColumns}
+        clauses={[{ id: "rank-filter", column: "rank", operator: "eq", value: 9007199254740993n }]}
+        onClausesChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText("rank eq 9007199254740993").length).toBeGreaterThan(0);
   });
 });

--- a/packages/inspector/src/components/data-explorer/TableFilterBuilder.tsx
+++ b/packages/inspector/src/components/data-explorer/TableFilterBuilder.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, type ChangeEvent, type FormEvent, type ReactNode } from "react";
+import { parseSignedBigInt64 } from "./parse-signed-bigint.js";
 import type { ColumnDescriptor, ColumnType } from "jazz-tools";
 import {
   getSupportedWhereOperatorsForColumn,
@@ -83,7 +84,6 @@ function parseScalarValue(columnType: ColumnType, value: string): unknown {
       return parsed;
     }
     case "Integer":
-    case "BigInt":
     case "Double": {
       const parsed = Number(trimmed);
       if (!Number.isFinite(parsed)) {
@@ -91,6 +91,8 @@ function parseScalarValue(columnType: ColumnType, value: string): unknown {
       }
       return parsed;
     }
+    case "BigInt":
+      return parseSignedBigInt64(trimmed);
     case "Bytea":
       return parseBytea(trimmed);
     case "Json":
@@ -140,8 +142,11 @@ function parseFilterValue(
 
 function formatClauseValue(value: unknown): string {
   if (value instanceof Uint8Array) return `[${Array.from(value).join(", ")}]`;
+  if (typeof value === "bigint") return value.toString();
   if (typeof value === "string") return value;
-  return JSON.stringify(value);
+  return JSON.stringify(value, (_key, candidate) =>
+    typeof candidate === "bigint" ? candidate.toString() : candidate,
+  );
 }
 
 function createClauseId(): string {

--- a/packages/inspector/src/components/data-explorer/parse-signed-bigint.ts
+++ b/packages/inspector/src/components/data-explorer/parse-signed-bigint.ts
@@ -1,0 +1,16 @@
+const SIGNED_I64_MIN = -(1n << 63n);
+const SIGNED_I64_MAX = (1n << 63n) - 1n;
+const SIGNED_DECIMAL_INTEGER = /^[+-]?\d+$/;
+
+export function parseSignedBigInt64(value: string): bigint {
+  if (!SIGNED_DECIMAL_INTEGER.test(value)) {
+    throw new Error("Value must be a signed 64-bit integer.");
+  }
+
+  const parsed = BigInt(value);
+  if (parsed < SIGNED_I64_MIN || parsed > SIGNED_I64_MAX) {
+    throw new Error("Value must be a signed 64-bit integer.");
+  }
+
+  return parsed;
+}

--- a/packages/inspector/src/components/data-explorer/row-mutation-form.test.ts
+++ b/packages/inspector/src/components/data-explorer/row-mutation-form.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseMutationFieldValue } from "./row-mutation-form";
+import { formatMutationFieldValue, parseMutationFieldValue } from "./row-mutation-form";
 
 describe("parseMutationFieldValue", () => {
   it("rejects empty integer input", () => {
@@ -13,5 +13,30 @@ describe("parseMutationFieldValue", () => {
   it("still parses explicit zero for numeric fields", () => {
     expect(parseMutationFieldValue({ type: "Integer" }, "0")).toBe(0);
     expect(parseMutationFieldValue({ type: "Double" }, "0")).toBe(0);
+  });
+
+  it("parses BigInt values exactly and formats them as decimal text", () => {
+    const parsed = parseMutationFieldValue({ type: "BigInt" }, "9007199254740993");
+
+    expect(parsed).toBe(9007199254740993n);
+    expect(formatMutationFieldValue(parsed)).toBe("9007199254740993");
+    expect(parseMutationFieldValue({ type: "BigInt" }, "-9223372036854775808")).toBe(
+      -9223372036854775808n,
+    );
+    expect(parseMutationFieldValue({ type: "BigInt" }, "9223372036854775807")).toBe(
+      9223372036854775807n,
+    );
+  });
+
+  it("rejects non-decimal and out-of-range BigInt values", () => {
+    expect(() => parseMutationFieldValue({ type: "BigInt" }, "1e3")).toThrow(
+      "Value must be a signed 64-bit integer.",
+    );
+    expect(() => parseMutationFieldValue({ type: "BigInt" }, "9223372036854775808")).toThrow(
+      "Value must be a signed 64-bit integer.",
+    );
+    expect(() => parseMutationFieldValue({ type: "BigInt" }, "-9223372036854775809")).toThrow(
+      "Value must be a signed 64-bit integer.",
+    );
   });
 });

--- a/packages/inspector/src/components/data-explorer/row-mutation-form.ts
+++ b/packages/inspector/src/components/data-explorer/row-mutation-form.ts
@@ -1,4 +1,5 @@
 import type { ColumnDescriptor, ColumnType } from "jazz-tools";
+import { parseSignedBigInt64 } from "./parse-signed-bigint.js";
 
 export type MutationFormMode = "edit" | "insert";
 
@@ -45,8 +46,7 @@ export function parseMutationFieldValue(columnType: ColumnType, valueText: strin
       }
       return parsed;
     }
-    case "Integer":
-    case "BigInt": {
+    case "Integer": {
       if (trimmed.length === 0) {
         throw new Error("Value is required.");
       }
@@ -55,6 +55,12 @@ export function parseMutationFieldValue(columnType: ColumnType, valueText: strin
         throw new Error("Value must be an integer.");
       }
       return parsed;
+    }
+    case "BigInt": {
+      if (trimmed.length === 0) {
+        throw new Error("Value is required.");
+      }
+      return parseSignedBigInt64(trimmed);
     }
     case "Double": {
       if (trimmed.length === 0) {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -104,6 +104,8 @@ import {
 } from "../../magic-columns.js";
 
 export { encodeSchema } from "./schema-codec.js";
+const MAX_CANONICAL_SIGNED_I64_LENGTH = 20;
+const CANONICAL_SIGNED_I64_DECIMAL = /^(?:0|[1-9][0-9]*|-[1-9][0-9]*)$/;
 
 const SERVER_PUMP_DEBOUNCE_MS = 16;
 const NETWORK_RETRY_LIMIT = 10;
@@ -5756,12 +5758,24 @@ function readLiteral(value: unknown): QueryLiteral | null {
   ) {
     return { type: "Integer", value: record.value };
   }
-  if (
-    record.type === "BigInt" &&
-    (typeof record.value === "bigint" ||
-      (typeof record.value === "number" && Number.isSafeInteger(record.value)))
-  ) {
-    return { type: "BigInt", value: BigInt(record.value) };
+  if (record.type === "BigInt") {
+    if (
+      typeof record.value === "string" &&
+      record.value.length <= MAX_CANONICAL_SIGNED_I64_LENGTH &&
+      CANONICAL_SIGNED_I64_DECIMAL.test(record.value)
+    ) {
+      try {
+        return { type: "BigInt", value: exactSignedI64(BigInt(record.value), "BigInt value") };
+      } catch {
+        return null;
+      }
+    }
+    if (
+      typeof record.value === "bigint" ||
+      (typeof record.value === "number" && Number.isSafeInteger(record.value))
+    ) {
+      return { type: "BigInt", value: BigInt(record.value) };
+    }
   }
   if (
     record.type === "Timestamp" &&

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -2,7 +2,6 @@ import { schema as s } from "../../schema-namespace.js";
 import { authorColumnType } from "../../magic-columns.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { performance } from "node:perf_hooks";
-import { schema as s } from "../../schema-namespace.js";
 import type {
   ColumnDescriptor,
   RuntimeSubscriptionDelta,

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -2945,7 +2945,7 @@ describe("NativeRuntimeAdapter server transport", () => {
     });
   });
 
-  it("rejects malformed, noncanonical, oversized, and out-of-range BigInt strings", () => {
+  it("rejects malformed, noncanonical, oversized, and out-of-range BigInt strings", async () => {
     const invalidValues = [
       "",
       " 1",
@@ -2959,21 +2959,43 @@ describe("NativeRuntimeAdapter server transport", () => {
       "-9223372036854775809",
     ];
 
-    for (const value of invalidValues) {
-      expect(() =>
-        prepareNativeQuery(bigintQuerySchema, {
-          table: "metrics",
-          conditions: [
-            {
-              Cmp: {
-                left: { column: "largeCount" },
-                op: "Eq",
-                right: { Literal: { type: "BigInt", value } },
-              },
-            },
-          ],
-        }),
-      ).toThrow("Native runtime cannot encode this query shape");
+    const prepareQuery = vi.fn(() => ({}));
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () => fakeDb({ prepareQuery, tick: () => undefined }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      bigintQuerySchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    try {
+      for (const value of invalidValues) {
+        await expect(
+          runtime.query(
+            JSON.stringify({
+              table: "metrics",
+              conditions: [
+                {
+                  Cmp: {
+                    left: { column: "largeCount" },
+                    op: "Eq",
+                    right: { Literal: { type: "BigInt", value } },
+                  },
+                },
+              ],
+            }),
+          ),
+        ).rejects.toThrow();
+        expect(prepareQuery).not.toHaveBeenCalled();
+      }
+    } finally {
+      await runtime.close();
     }
   });
 
@@ -6894,7 +6916,7 @@ const bigintQuerySchema = s.defineApp({
   }),
 }).wasmSchema;
 
-// Exercise the serialized adapter interface, including deliberately invalid literals.
+// Capture native bytes for valid queries through the serialized adapter interface.
 function prepareNativeQuery(schema: WasmSchema, query: object): Uint8Array {
   let preparedBytes: Uint8Array | undefined;
   const runtime = new NativeRuntimeAdapter(

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime.test.ts
@@ -2,6 +2,7 @@ import { schema as s } from "../../schema-namespace.js";
 import { authorColumnType } from "../../magic-columns.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { performance } from "node:perf_hooks";
+import { schema as s } from "../../schema-namespace.js";
 import type {
   ColumnDescriptor,
   RuntimeSubscriptionDelta,
@@ -2856,6 +2857,124 @@ describe("NativeRuntimeAdapter server transport", () => {
           { column: "largeCount", op: "Eq", value: { type: "BigInt", value } },
         ]),
       ).toThrow("BigInt value must be a signed 64-bit integer");
+    }
+  });
+
+  it("decodes canonical BigInt query strings into exact native i64 literals", () => {
+    const preparedBytes = prepareNativeQuery(bigintQuerySchema, {
+      table: "metrics",
+      conditions: [
+        {
+          Cmp: {
+            left: { column: "largeCount" },
+            op: "Ge",
+            right: {
+              Literal: { type: "BigInt", value: "-9223372036854775808" },
+            },
+          },
+        },
+        {
+          Cmp: {
+            left: { column: "largeCount" },
+            op: "Eq",
+            right: {
+              Literal: { type: "BigInt", value: "-9007199254740993" },
+            },
+          },
+        },
+        {
+          Cmp: {
+            left: { column: "largeCount" },
+            op: "Le",
+            right: {
+              Literal: { type: "BigInt", value: "9223372036854775807" },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(readPreparedComparisonLiterals(preparedBytes)).toEqual([
+      {
+        predicateTag: 7,
+        column: "largeCount",
+        literal: { tag: 14, value: -9223372036854775808n },
+      },
+      {
+        predicateTag: 3,
+        column: "largeCount",
+        literal: { tag: 14, value: -9007199254740993n },
+      },
+      {
+        predicateTag: 9,
+        column: "largeCount",
+        literal: { tag: 14, value: 9223372036854775807n },
+      },
+    ]);
+  });
+
+  it("decodes canonical BigInt strings recursively inside array literals", () => {
+    const preparedBytes = prepareNativeQuery(bigintQuerySchema, {
+      table: "metrics",
+      conditions: [
+        {
+          Cmp: {
+            left: { column: "largeCounts" },
+            op: "Eq",
+            right: {
+              Literal: {
+                type: "Array",
+                value: [
+                  { type: "BigInt", value: "9223372036854775807" },
+                  { type: "BigInt", value: "-9007199254740993" },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(readPreparedArrayComparison(preparedBytes)).toEqual({
+      predicateTag: 3,
+      column: "largeCounts",
+      literalTag: 12,
+      values: [
+        { tag: 14, value: 9223372036854775807n },
+        { tag: 14, value: -9007199254740993n },
+      ],
+    });
+  });
+
+  it("rejects malformed, noncanonical, oversized, and out-of-range BigInt strings", () => {
+    const invalidValues = [
+      "",
+      " 1",
+      "-0",
+      "01",
+      "+1",
+      "1e3",
+      "0x10",
+      "9".repeat(21),
+      "9223372036854775808",
+      "-9223372036854775809",
+    ];
+
+    for (const value of invalidValues) {
+      expect(() =>
+        prepareNativeQuery(bigintQuerySchema, {
+          table: "metrics",
+          conditions: [
+            {
+              Cmp: {
+                left: { column: "largeCount" },
+                op: "Eq",
+                right: { Literal: { type: "BigInt", value } },
+              },
+            },
+          ],
+        }),
+      ).toThrow("Native runtime cannot encode this query shape");
     }
   });
 
@@ -6769,6 +6888,44 @@ const testSchema = {
   },
 } satisfies WasmSchema;
 
+const bigintQuerySchema = s.defineApp({
+  metrics: s.table({
+    largeCount: s.bigint(),
+    largeCounts: s.array(s.bigint()),
+  }),
+}).wasmSchema;
+
+// Exercise the serialized adapter interface, including deliberately invalid literals.
+function prepareNativeQuery(schema: WasmSchema, query: object): Uint8Array {
+  let preparedBytes: Uint8Array | undefined;
+  const runtime = new NativeRuntimeAdapter(
+    {
+      openMemory: () =>
+        fakeDb({
+          prepareQuery: (prepared: Uint8Array) => {
+            preparedBytes = prepared;
+            return {};
+          },
+          subscribe: () => new ReadableStream(),
+          tick: () => undefined,
+        }),
+      openBrowser: async () => {
+        throw new Error("not used");
+      },
+    } as never,
+    schema,
+    new Uint8Array(16),
+    TEST_RUNTIME_AUTHOR,
+    1,
+    true,
+  );
+  runtime.createSubscription(JSON.stringify(query));
+  if (preparedBytes === undefined) {
+    throw new Error("native query was not prepared");
+  }
+  return preparedBytes;
+}
+
 function emptyNativeRuntime(): NativeRuntimeAdapter {
   return new NativeRuntimeAdapter(
     {
@@ -7001,6 +7158,27 @@ function readPreparedComparisonLiterals(query: Uint8Array): Array<{
     expect(predicateReader.u64()).toBe(3);
     return { predicateTag, column, literal: readPreparedNumericLiteral(predicateReader) };
   });
+}
+
+function readPreparedArrayComparison(query: Uint8Array): {
+  predicateTag: number;
+  column: string;
+  literalTag: number;
+  values: Array<{ tag: number; value: number | bigint }>;
+} {
+  const reader = new PostcardReader(query);
+  reader.string();
+  const predicateCount = reader.u64();
+  expect(predicateCount).toBe(1);
+  const predicateTag = reader.u64();
+  expect(predicateTag).toBe(3);
+  expect(reader.u64()).toBe(0);
+  const column = reader.string();
+  expect(reader.u64()).toBe(3);
+  const literalTag = reader.u64();
+  expect(literalTag).toBe(12);
+  const values = reader.readVec((valueReader) => readPreparedNumericLiteral(valueReader));
+  return { predicateTag, column, literalTag, values };
 }
 
 function readPreparedNumericLiteral(reader: PostcardReader): {


### PR DESCRIPTION
## Summary
- Preserve signed-I64 BigInt values through Inspector filters, URL state, mutations, and native query lowering.
- Accept canonical signed-I64 decimal literals without lossy JavaScript number conversion.

## Before
Inspector query and mutation paths could coerce large integer values through JavaScript number handling, losing precision before the native runtime received them.

## After
BigInt values are parsed, serialised, validated, and lowered as exact signed-I64 decimal values across the Inspector surfaces.

## Test plan
- [ ] Review the Inspector filter, mutation, URL, and native-runtime BigInt regressions.
- [ ] Run the focused Inspector and jazz-tools test targets.
- [ ] Run the repository CI checks.