### PR TITLE
Reject variable spans inside record headers

### DIFF
--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -1667,7 +1667,7 @@ fn record_value_span_for_layout(
             } else {
                 u32_to_usize(read_u32_at(record, fixed_size + variable_idx * 4)?)?
             };
-            if end < start || end > record.len() {
+            if start < variable_start || end < start || end > record.len() {
                 return Err(Error::InvalidOffset);
             }
             Ok(Span { start, end })

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -2135,6 +2135,12 @@ fn lookup_rejects_offset_before_variable_payload_start() {
         descriptor.get_idx(&record, 1).unwrap_err(),
         Error::InvalidOffset
     );
+
+    let later_field_record = vec![2, 0, 0, 0, 0];
+    assert_eq!(
+        descriptor.get_idx(&later_field_record, 2).unwrap_err(),
+        Error::InvalidOffset
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Reject record headers whose variable-field span starts before the variable payload.
- Keep structural validation aligned with full record decoding.

## Before
A malformed record header could point a variable-field span into the fixed header area and reach lookup logic with an invalid payload boundary.

## After
Record validation rejects the impossible span before variable-field lookup, matching the full decoder's safety boundary.

## Test plan
- [ ] Review `lookup_rejects_offset_before_variable_payload_start` in `crates/groove/src/records/tests.rs`.
- [ ] Run the focused Groove records tests.
- [ ] Run the repository CI checks.