### PR TITLE
Preserve recursive join comparison

### DIFF
--- a/crates/groove/src/db/tests/graphs/recursion.rs
+++ b/crates/groove/src/db/tests/graphs/recursion.rs
@@ -6,6 +6,113 @@ use idb_tree::{BoxFuture, Commit, Metadata, PageStore};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::Poll;
+#[futures_test::test]
+async fn recursive_policy_join_hydration_uses_declared_comparison() {
+    let schema = DatabaseSchema::new([
+        TableSchema::new(
+            "seed_left",
+            [
+                ColumnSchema::new("id", ColumnType::U64),
+                ColumnSchema::new("src", ColumnType::U64),
+                ColumnSchema::new("key", ColumnType::U32),
+            ],
+        )
+        .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64)),
+        TableSchema::new(
+            "seed_right",
+            [
+                ColumnSchema::new("id", ColumnType::U64),
+                ColumnSchema::new("key", ColumnType::I64.nullable()),
+                ColumnSchema::new("dst", ColumnType::U32),
+            ],
+        )
+        .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64)),
+        TableSchema::new(
+            "edges",
+            [
+                ColumnSchema::new("id", ColumnType::U64),
+                ColumnSchema::new("src", ColumnType::I64.nullable()),
+                ColumnSchema::new("dst", ColumnType::U32),
+            ],
+        )
+        .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64)),
+    ]);
+    let storage = MemoryStorage::new(&["seed_left", "seed_right", "edges"]).unwrap();
+    let mut database = Database::new(schema, storage).await.unwrap();
+
+    let output = RecordDescriptor::new([
+        ("src", ColumnType::U64.clone()),
+        ("dst", ColumnType::U32.clone()),
+    ]);
+    let seed = GraphBuilder::policy_join(
+        GraphBuilder::table("seed_left"),
+        GraphBuilder::table("seed_right"),
+        ["key"],
+        ["key"],
+    )
+    .project_fields([
+        ProjectField::renamed("left.src", "src"),
+        ProjectField::renamed("right.dst", "dst"),
+    ]);
+    let frontier = GraphBuilder::frontier_source("frontier", output);
+    let step = GraphBuilder::policy_join(frontier, GraphBuilder::table("edges"), ["dst"], ["src"])
+        .project_fields([
+            ProjectField::renamed("left.src", "src"),
+            ProjectField::renamed("right.dst", "dst"),
+        ]);
+    let graph = GraphBuilder::recursive(seed, step, "frontier", 16);
+
+    let mut batch = database.open_batch();
+    batch.insert(
+        "seed_left",
+        vec![Value::U64(1), Value::U64(100), Value::U32(7)],
+    );
+    batch.insert(
+        "seed_right",
+        vec![
+            Value::U64(1),
+            Value::Nullable(Some(Box::new(Value::I64(7)))),
+            Value::U32(8),
+        ],
+    );
+    batch.insert(
+        "edges",
+        vec![
+            Value::U64(1),
+            Value::Nullable(Some(Box::new(Value::I64(8)))),
+            Value::U32(9),
+        ],
+    );
+    database.commit_batch(batch).await.unwrap();
+
+    let subscription = database.subscribe_one_sink(graph).await.unwrap();
+    let mut initial = subscription.recv().unwrap().to_values().unwrap();
+    initial.sort_by_key(|(values, _)| format!("{values:?}"));
+    assert_eq!(
+        initial,
+        vec![
+            (vec![Value::U64(100), Value::U32(8)], 1),
+            (vec![Value::U64(100), Value::U32(9)], 1),
+        ],
+        "recursive hydration must use Policy comparison for seed and step joins",
+    );
+
+    let mut batch = database.open_batch();
+    batch.insert(
+        "edges",
+        vec![
+            Value::U64(2),
+            Value::Nullable(Some(Box::new(Value::I64(9)))),
+            Value::U32(10),
+        ],
+    );
+    database.commit_batch(batch).await.unwrap();
+    assert_eq!(
+        subscription.recv().unwrap().to_values().unwrap(),
+        vec![(vec![Value::U64(100), Value::U32(10)], 1)],
+        "affected recursive frontiers must use the Join comparison",
+    );
+}
 
 #[derive(Clone, Default)]
 struct YieldingPageStore(idb_tree::MemoryPageStore);

--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -878,8 +878,9 @@ pub(super) fn join_keys(
     descriptor: &RecordDescriptor,
     record: &[u8],
     fields: &[String],
+    comparison: ValueComparison,
 ) -> Result<Vec<JoinKey>, IvmRuntimeError> {
-    join_keys_with_comparison(descriptor, record, fields, ValueComparison::Exact)
+    join_keys_with_comparison(descriptor, record, fields, comparison)
 }
 
 fn join_keys_with_comparison(
@@ -1103,8 +1104,8 @@ mod tests {
             "integer and float join keys remain type-exact"
         );
         assert_ne!(
-            join_keys(&u32, &u32_record, &fields).unwrap(),
-            join_keys(&i64, &i64_record, &fields).unwrap(),
+            join_keys(&u32, &u32_record, &fields, ValueComparison::Exact).unwrap(),
+            join_keys(&i64, &i64_record, &fields, ValueComparison::Exact).unwrap(),
             "ordinary arrangement keys retain their exact typed encoding"
         );
     }

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -972,9 +972,12 @@ fn affected_recursive_frontier(
                         Err(error) => return Err(error),
                     }
                     for delta in accumulated {
-                        for key in
-                            super::join::join_keys(&frontier_desc, delta.raw(), &frontier_fields)?
-                        {
+                        for key in super::join::join_keys(
+                            &frontier_desc,
+                            delta.raw(),
+                            &frontier_fields,
+                            join.comparison,
+                        )? {
                             if touched.contains(key.as_slice()) {
                                 selected.insert(delta.record.clone());
                                 break;
@@ -1750,6 +1753,7 @@ impl HydrationEvaluator<'_> {
                             &join.right_descriptor,
                             right_delta.raw(),
                             &right_on,
+                            join.comparison,
                         )? {
                             right_by_key.entry(key).or_default().push(right_delta);
                         }
@@ -1760,6 +1764,7 @@ impl HydrationEvaluator<'_> {
                             &join.left_descriptor,
                             left_delta.raw(),
                             &left_on,
+                            join.comparison,
                         )? {
                             let Some(matches) = right_by_key.get(&key) else {
                                 continue;


### PR DESCRIPTION
## Summary
- Preserve the comparison operator declared by recursive policy joins during hydration.
- Keep recursive closure results aligned with the query's policy semantics.

## Before
Recursive policy join hydration could use a comparison different from the one declared by the query, changing which recursive rows entered the closure.

## After
Hydration carries and applies the declared comparison through recursive join evaluation.

## Test plan
- [ ] Review `recursive_policy_join_hydration_uses_declared_comparison` in `crates/groove/src/db/tests/graphs/recursion.rs`.
- [ ] Run the focused Groove recursion tests.
- [ ] Run the repository CI checks.