### PR TITLE
Retain authoritative reset retry markers

### DIFF
--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -3702,8 +3702,8 @@ where
 {
     let mut retained = Vec::new();
     let mut changed = 0;
-    let pending_authoritative_resets = node.lock().await.take_pending_authoritative_resets();
-    let mut consumed_authoritative_resets = BTreeSet::new();
+    let pending_authoritative_resets = node.lock().await.snapshot_pending_authoritative_resets();
+    let mut reconciled_authoritative_resets = BTreeMap::new();
     node.lock()
         .await
         .drive_ready_query_runtime_with_waker(progress_waker)
@@ -3903,12 +3903,12 @@ where
             );
             let pending_authority_result = delivered_authority_result
                 .as_ref()
-                .filter(|key| pending_authoritative_resets.contains(*key))
+                .filter(|key| pending_authoritative_resets.contains_key(*key))
                 .cloned()
                 .or_else(|| {
                     settled_authority_result
                         .as_ref()
-                        .filter(|key| pending_authoritative_resets.contains(*key))
+                        .filter(|key| pending_authoritative_resets.contains_key(*key))
                         .cloned()
                 });
             let local_overlay_row_keys = BTreeSet::new();
@@ -3979,7 +3979,12 @@ where
                         terminal_layout,
                     )?;
                     materialize_subscription_terminal_records(&mut snapshot, &snapshot_index)?;
-                    consumed_authoritative_resets.insert(authority_result_key);
+                    if let Some(generation) = pending_authoritative_resets
+                        .get(&authority_result_key)
+                        .copied()
+                    {
+                        reconciled_authoritative_resets.insert(authority_result_key, generation);
+                    }
                 }
             }
             let root_occurrence_ids = if shape.query().aggregate.is_some() || terminal_rows {
@@ -4131,12 +4136,12 @@ where
             });
             let authoritative_reset_result = delivered_authority_result
                 .as_ref()
-                .filter(|key| pending_authoritative_resets.contains(*key))
+                .filter(|key| pending_authoritative_resets.contains_key(*key))
                 .cloned()
                 .or_else(|| {
                     settled_authority_result
                         .as_ref()
-                        .filter(|key| pending_authoritative_resets.contains(*key))
+                        .filter(|key| pending_authoritative_resets.contains_key(*key))
                         .cloned()
                 });
             // A propagation receipt is not a replacement input frontier for
@@ -4158,9 +4163,6 @@ where
                 .as_ref()
                 .is_some_and(|key| node.borrow().publication_deferred_for_authority_result(key))
             {
-                if let Some(key) = authoritative_reset_result.as_ref() {
-                    node.borrow_mut().defer_authoritative_reset(key);
-                }
                 retained.push(Rc::downgrade(&state));
                 continue;
             }
@@ -4190,9 +4192,6 @@ where
                 if authorization_mode == QueryAuthorizationMode::ClientLocal
                     && remote_read_tier.is_some()
                 {
-                    if let Some(key) = authoritative_reset_result.as_ref() {
-                        node.borrow_mut().defer_authoritative_reset(key);
-                    }
                     retained.push(Rc::downgrade(&state));
                     continue;
                 }
@@ -4285,9 +4284,6 @@ where
                         Ok(update) => update,
                         Err(crate::node::Error::MissingTransaction(_)) => {
                             node_ref.record_authoritative_reset_missing_payload_fallback();
-                            if let Some(key) = authoritative_reset_result.as_ref() {
-                                node_ref.defer_authoritative_reset(key);
-                            }
                             retained.push(Rc::downgrade(&state));
                             continue;
                         }
@@ -4323,14 +4319,14 @@ where
                         // Missing source descriptors and incomplete coverage
                         // are both pending protocol state, never permission to
                         // reuse the authority's result set or payload.
-                        node.borrow_mut()
-                            .defer_authoritative_reset(authority_result_key);
                         retained.push(Rc::downgrade(&state));
                         continue;
                     }
                 }
-                if let Some(key) = authoritative_reset_result.as_ref() {
-                    consumed_authoritative_resets.insert(key.clone());
+                if let Some(key) = authoritative_reset_result.as_ref()
+                    && let Some(generation) = pending_authoritative_resets.get(key).copied()
+                {
+                    reconciled_authoritative_resets.insert(key.clone(), generation);
                 }
                 if cold_runtime_replacement_pending {
                     let replacement_ready = refresh
@@ -4836,10 +4832,11 @@ where
         }
         retained.push(Rc::downgrade(&state));
     }
-    for pending in pending_authoritative_resets.difference(&consumed_authoritative_resets) {
-        node.borrow_mut().defer_authoritative_reset(pending);
-    }
     *subscriptions.borrow_mut() = retained;
+    for (authority_result_key, generation) in reconciled_authoritative_resets {
+        node.borrow_mut()
+            .acknowledge_authoritative_reset(&authority_result_key, generation);
+    }
     Ok(changed)
 }
 

--- a/crates/jazz/src/db/tests/subscriptions/materialization.rs
+++ b/crates/jazz/src/db/tests/subscriptions/materialization.rs
@@ -310,7 +310,7 @@ fn authoritative_reset_retries_after_refresh_error() {
     }))
     .unwrap();
 
-    seed(&server, "todos", cells("retry after error", false, owner));
+    let first = seed(&server, "todos", cells("retry after error", false, owner));
 
     let (client_transport, server_transport) = duplex();
     let upstream = crate::db::block_on(client.connect_upstream(client_transport));
@@ -336,7 +336,7 @@ fn authoritative_reset_retries_after_refresh_error() {
             },
         })
     ));
-    seed(
+    let second = seed(
         &server,
         "todos",
         cells("second authoritative row", true, owner),
@@ -368,11 +368,34 @@ fn authoritative_reset_retries_after_refresh_error() {
     let retry = subscription
         .try_next_event()
         .expect("the authoritative reset remains pending after refresh error");
-    let SubscriptionEvent::Delta { reset, settled, .. } = retry else {
+    let SubscriptionEvent::Delta {
+        reset,
+        settled,
+        added,
+        updated,
+        removed,
+        ..
+    } = retry
+    else {
         panic!("expected retried authoritative reset");
     };
     assert!(reset);
     assert!(settled);
+    assert_eq!(
+        added
+            .iter()
+            .map(|row| (
+                row.row_uuid(),
+                row.test_cells_by_descriptor()["title"].clone()
+            ))
+            .collect::<Vec<_>>(),
+        vec![
+            (first, Value::String("retry after error".to_owned())),
+            (second, Value::String("second authoritative row".to_owned())),
+        ]
+    );
+    assert!(updated.is_empty());
+    assert!(removed.is_empty());
 }
 
 #[test]
@@ -397,7 +420,7 @@ fn authoritative_reset_retries_after_refresh_cancellation() {
     }))
     .unwrap();
 
-    seed(
+    let first = seed(
         &server,
         "todos",
         cells("retry after cancellation", false, owner),
@@ -427,7 +450,7 @@ fn authoritative_reset_retries_after_refresh_cancellation() {
             },
         })
     ));
-    seed(
+    let second = seed(
         &server,
         "todos",
         cells("second authoritative row", true, owner),
@@ -478,11 +501,34 @@ fn authoritative_reset_retries_after_refresh_cancellation() {
     let retry = subscription
         .try_next_event()
         .expect("the authoritative reset remains pending after cancellation");
-    let SubscriptionEvent::Delta { reset, settled, .. } = retry else {
+    let SubscriptionEvent::Delta {
+        reset,
+        settled,
+        added,
+        updated,
+        removed,
+        ..
+    } = retry
+    else {
         panic!("expected retried authoritative reset");
     };
     assert!(reset);
     assert!(settled);
+    assert_eq!(
+        added
+            .iter()
+            .map(|row| (
+                row.row_uuid(),
+                row.test_cells_by_descriptor()["title"].clone()
+            ))
+            .collect::<Vec<_>>(),
+        vec![
+            (first, Value::String("retry after cancellation".to_owned())),
+            (second, Value::String("second authoritative row".to_owned())),
+        ]
+    );
+    assert!(updated.is_empty());
+    assert!(removed.is_empty());
 }
 
 #[test]

--- a/crates/jazz/src/db/tests/subscriptions/materialization.rs
+++ b/crates/jazz/src/db/tests/subscriptions/materialization.rs
@@ -289,6 +289,203 @@ fn server_reset_subscription_materializes_without_local_snapshot_eval() {
 }
 
 #[test]
+fn authoritative_reset_retries_after_refresh_error() {
+    let schema = schema();
+    let owner = AuthorSubject::for_test_bytes([0xa3; 16]);
+    let client_author = AuthorSubject::for_test_bytes([0xc3; 16]);
+
+    let server = open_core(0x60, AuthorSubject::SYSTEM, &schema);
+    let families = schema.column_families();
+    let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = groove::storage::TestStorage::controlled(&refs);
+    let eviction = storage.clone();
+    let client = block_on(Db::open(DbConfig {
+        schema: schema.clone(),
+        storage,
+        identity: DbIdentity {
+            node: NodeUuid::from_bytes([0xc3; 16]),
+            author: client_author,
+        },
+        id_source: Some(Box::new(SeededRowIdSource::new(0xc3))),
+    }))
+    .unwrap();
+
+    seed(&server, "todos", cells("retry after error", false, owner));
+
+    let (client_transport, server_transport) = duplex();
+    let upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let _subscriber = server.accept_subscriber(server_transport, client_author);
+    let query = Query::from("todos")
+        .select(["title", "$createdBy"])
+        .order_by("title", OrderDirection::Asc);
+    let mut subscription = prepared_subscribe(&client, &query, global_subscribe_opts()).unwrap();
+    assert!(opened_rows(block_on(subscription.next_raw()).unwrap()).is_empty());
+
+    client.tick().unwrap();
+    server.tick().unwrap();
+    upstream
+        .borrow_mut()
+        .fail_next_subscription_refresh
+        .set(true);
+    block_on(upstream.borrow_mut().tick()).expect("install the reset without refreshing it");
+    assert!(matches!(
+        subscription.try_next_event(),
+        Some(SubscriptionEvent::Rejected {
+            reason: SubscribeRejectReason::ServerFailure {
+                code: SubscribeServerFailureCode::Internal,
+            },
+        })
+    ));
+    seed(
+        &server,
+        "todos",
+        cells("second authoritative row", true, owner),
+    );
+    server.tick().unwrap();
+    upstream
+        .borrow_mut()
+        .fail_next_subscription_refresh
+        .set(true);
+    block_on(upstream.borrow_mut().tick()).expect("install the incremental update");
+    assert!(matches!(
+        subscription.try_next_event(),
+        Some(SubscriptionEvent::Rejected {
+            reason: SubscribeRejectReason::ServerFailure {
+                code: SubscribeServerFailureCode::Internal,
+            },
+        })
+    ));
+    eviction.evict_all();
+    control.fail_next(groove::storage::TestStorageOperation::Get);
+
+    let error = block_on(client.refresh_subscriptions())
+        .expect_err("the injected refresh storage failure must surface");
+    assert!(
+        error.to_string().contains("injected Get failure"),
+        "unexpected refresh failure: {error}"
+    );
+    block_on(client.refresh_subscriptions()).expect("the authoritative reset can be retried");
+    let retry = subscription
+        .try_next_event()
+        .expect("the authoritative reset remains pending after refresh error");
+    let SubscriptionEvent::Delta { reset, settled, .. } = retry else {
+        panic!("expected retried authoritative reset");
+    };
+    assert!(reset);
+    assert!(settled);
+}
+
+#[test]
+fn authoritative_reset_retries_after_refresh_cancellation() {
+    let schema = schema();
+    let owner = AuthorSubject::for_test_bytes([0xa4; 16]);
+    let client_author = AuthorSubject::for_test_bytes([0xc4; 16]);
+
+    let server = open_core(0x61, AuthorSubject::SYSTEM, &schema);
+    let families = schema.column_families();
+    let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = groove::storage::TestStorage::controlled(&refs);
+    let eviction = storage.clone();
+    let client = block_on(Db::open(DbConfig {
+        schema: schema.clone(),
+        storage,
+        identity: DbIdentity {
+            node: NodeUuid::from_bytes([0xc4; 16]),
+            author: client_author,
+        },
+        id_source: Some(Box::new(SeededRowIdSource::new(0xc4))),
+    }))
+    .unwrap();
+
+    seed(
+        &server,
+        "todos",
+        cells("retry after cancellation", false, owner),
+    );
+
+    let (client_transport, server_transport) = duplex();
+    let upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let _subscriber = server.accept_subscriber(server_transport, client_author);
+    let query = Query::from("todos")
+        .select(["title", "$createdBy"])
+        .order_by("title", OrderDirection::Asc);
+    let mut subscription = prepared_subscribe(&client, &query, global_subscribe_opts()).unwrap();
+    assert!(opened_rows(block_on(subscription.next_raw()).unwrap()).is_empty());
+
+    client.tick().unwrap();
+    server.tick().unwrap();
+    upstream
+        .borrow_mut()
+        .fail_next_subscription_refresh
+        .set(true);
+    block_on(upstream.borrow_mut().tick()).expect("install the reset without refreshing it");
+    assert!(matches!(
+        subscription.try_next_event(),
+        Some(SubscriptionEvent::Rejected {
+            reason: SubscribeRejectReason::ServerFailure {
+                code: SubscribeServerFailureCode::Internal,
+            },
+        })
+    ));
+    seed(
+        &server,
+        "todos",
+        cells("second authoritative row", true, owner),
+    );
+    server.tick().unwrap();
+    upstream
+        .borrow_mut()
+        .fail_next_subscription_refresh
+        .set(true);
+    block_on(upstream.borrow_mut().tick()).expect("install the incremental update");
+    assert!(matches!(
+        subscription.try_next_event(),
+        Some(SubscriptionEvent::Rejected {
+            reason: SubscribeRejectReason::ServerFailure {
+                code: SubscribeServerFailureCode::Internal,
+            },
+        })
+    ));
+    eviction.evict_all();
+    control.pause_on(groove::storage::TestStorageOperation::Get);
+    control.pause_on(groove::storage::TestStorageOperation::ScanOpen);
+
+    let mut client_refresh = Box::pin(client.refresh_subscriptions());
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    let mut reached_refresh = false;
+    for _ in 0..128 {
+        assert!(
+            matches!(client_refresh.as_mut().poll(&mut context), Poll::Pending),
+            "refresh must suspend at controlled storage before cancellation"
+        );
+        if control.take_observed().iter().any(|operation| {
+            matches!(
+                operation,
+                groove::storage::TestStorageOperation::Get
+                    | groove::storage::TestStorageOperation::ScanOpen
+            )
+        }) {
+            reached_refresh = true;
+            break;
+        }
+    }
+    assert!(reached_refresh, "refresh did not reach controlled storage");
+    drop(client_refresh);
+    control.resume();
+
+    block_on(client.refresh_subscriptions()).expect("the cancelled refresh can be retried");
+    let retry = subscription
+        .try_next_event()
+        .expect("the authoritative reset remains pending after cancellation");
+    let SubscriptionEvent::Delta { reset, settled, .. } = retry else {
+        panic!("expected retried authoritative reset");
+    };
+    assert!(reset);
+    assert!(settled);
+}
+
+#[test]
 fn runtime_reset_rebuilds_occurrence_sidecar_after_order_change() {
     let schema = schema();
     let client_author = AuthorSubject::for_test_bytes([0xc1; 16]);

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -524,6 +524,9 @@ pub struct NodeState<S> {
     storage_type: std::marker::PhantomData<fn() -> S>,
     /// Process-local identity for runtime-local Groove handles such as prepared shape ids.
     groove_runtime_token: u64,
+    /// Next nonzero process-local identity for an authoritative reset acknowledgement.
+    /// This counter is runtime state only; it never enters protocol or durable data.
+    next_authoritative_reset_generation: u64,
     /// Whether this node has complete settled history for historical reads.
     history_complete: bool,
     /// Host-declared completeness for eager scalar-exit authorization probes.
@@ -1092,7 +1095,7 @@ pub(crate) struct AuthorityResultState {
     known_state_declared: bool,
     initial_hydration: bool,
     deferred_publication: bool,
-    pending_authoritative_reset: bool,
+    pending_authoritative_reset: Option<u64>,
     pending_opening: bool,
 }
 

--- a/crates/jazz/src/node/query_eval/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/subscriptions.rs
@@ -943,6 +943,18 @@ where
             .get(authority_result_key)
             .map_or(0, |state| state.applied_view_update_generation)
     }
+    pub(crate) fn allocate_authoritative_reset_generation(&mut self) -> Result<u64, Error> {
+        let generation = self.next_authoritative_reset_generation;
+        if generation == 0 {
+            return Err(Error::InvalidStoredValue(
+                "authoritative reset generation exhausted",
+            ));
+        }
+        self.next_authoritative_reset_generation = generation.checked_add(1).ok_or(
+            Error::InvalidStoredValue("authoritative reset generation exhausted"),
+        )?;
+        Ok(generation)
+    }
 
     /// Generation of the exact authority-selected source frontier, if this
     /// usage site has claimed one. This is intentionally not the raw
@@ -971,29 +983,41 @@ where
         SUBSCRIPTION_SNAPSHOT_FOR_LINK_CALLS.with(std::cell::Cell::get)
     }
 
-    /// Drain exact authority receipts whose next publication must be a reset.
-    ///
-    /// A binding view is merely a local cache address. It cannot represent a
-    /// lifecycle event once different delegated sessions share that view.
-    pub(crate) fn take_pending_authoritative_resets(&mut self) -> BTreeSet<AuthorityResultKey> {
+    /// Snapshot exact authority receipts whose next publication must be a
+    /// reset. Snapshotting is intentionally non-destructive: an error or
+    /// cancellation leaves the same generation pending for the next refresh.
+    pub(crate) fn snapshot_pending_authoritative_resets(
+        &self,
+    ) -> BTreeMap<AuthorityResultKey, u64> {
         self.query
             .authority_results
-            .iter_mut()
+            .iter()
             .filter_map(|(key, state)| {
-                state.pending_authoritative_reset.then(|| {
-                    state.pending_authoritative_reset = false;
-                    key.clone()
-                })
+                state
+                    .pending_authoritative_reset
+                    .map(|generation| (key.clone(), generation))
             })
             .collect()
     }
 
-    pub(crate) fn defer_authoritative_reset(&mut self, authority_result_key: &AuthorityResultKey) {
-        self.query
-            .authority_results
-            .entry(authority_result_key.clone())
-            .or_default()
-            .pending_authoritative_reset = true;
+    /// Acknowledge one exact reset only if no newer reset superseded it.
+    ///
+    /// Never recreate a retired result: acknowledgement is a receipt for an
+    /// existing exact authority key, not an admission path.
+    pub(crate) fn acknowledge_authoritative_reset(
+        &mut self,
+        authority_result_key: &AuthorityResultKey,
+        generation: u64,
+    ) -> bool {
+        let Some(state) = self.query.authority_results.get_mut(authority_result_key) else {
+            return false;
+        };
+        if state.pending_authoritative_reset == Some(generation) {
+            state.pending_authoritative_reset = None;
+            true
+        } else {
+            false
+        }
     }
 
     pub(crate) fn publication_deferred_for_authority_result(

--- a/crates/jazz/src/node/query_eval/tests/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/tests/subscriptions.rs
@@ -613,12 +613,13 @@ fn interleaved_policy_scoped_lifecycles_keep_reset_and_defer_receipts_separate()
     assert_eq!(relay.applied_authority_result_generation(&alice_key), 1);
     assert_eq!(relay.applied_authority_result_generation(&bob_key), 1);
 
-    let pending = relay.take_pending_authoritative_resets();
+    let pending = relay.snapshot_pending_authoritative_resets();
     assert_eq!(
-        pending,
+        pending.keys().cloned().collect::<BTreeSet<_>>(),
         BTreeSet::from([bob_key.clone()]),
         "Alice's progress marker has not installed a complete reset"
     );
+    let bob_reset_generation = pending[&bob_key];
     // Bob can defer a later publication while Alice's opening continues. That
     // deferred marker is also exact-policy state, not binding-view state.
     relay
@@ -628,13 +629,13 @@ fn interleaved_policy_scoped_lifecycles_keep_reset_and_defer_receipts_separate()
     assert!(relay.publication_deferred_for_authority_result(&bob_key));
     assert!(!relay.publication_deferred_for_authority_result(&alice_key));
 
-    for authority_result_key in &pending {
-        relay.defer_authoritative_reset(authority_result_key);
-    }
     assert_eq!(
-        relay.take_pending_authoritative_resets(),
-        BTreeSet::from([bob_key.clone()]),
-        "Bob's exact reset can be deferred without manufacturing Alice's receipt"
+        relay
+            .snapshot_pending_authoritative_resets()
+            .get(&bob_key)
+            .copied(),
+        Some(bob_reset_generation),
+        "Bob's exact reset remains pending while publication is deferred"
     );
 
     relay
@@ -647,10 +648,18 @@ fn interleaved_policy_scoped_lifecycles_keep_reset_and_defer_receipts_separate()
         .unwrap();
     assert!(!relay.opening_pending_for_authority_result(&alice_key));
     assert!(!relay.publication_deferred_for_authority_result(&bob_key));
+    assert!(
+        relay.acknowledge_authoritative_reset(&bob_key, bob_reset_generation),
+        "Bob's reset is acknowledged only after the healthy completion"
+    );
     assert_eq!(
-        relay.take_pending_authoritative_resets(),
+        relay
+            .snapshot_pending_authoritative_resets()
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>(),
         BTreeSet::from([alice_key.clone()]),
-        "Alice's completed closure now owns its independent reset"
+        "Alice's completed closure owns its independent reset"
     );
     assert!(
         relay.applied_authority_result_generation(&alice_key) > 1,
@@ -660,6 +669,128 @@ fn interleaved_policy_scoped_lifecycles_keep_reset_and_defer_receipts_separate()
         relay.applied_authority_result_generation(&bob_key) > 1,
         "Bob's deferred lifecycle keeps progressing independently"
     );
+}
+
+#[test]
+fn pending_authoritative_reset_acknowledgement_is_generation_checked() {
+    let (_dir, mut relay) = open_node();
+    let shape = Query::from("issues")
+        .validate(&relay.catalogue.schema)
+        .unwrap();
+    register_query_shape(&mut relay, &shape, RegisterShapeOptions::default());
+    let subscribe = Subscribe {
+        shape_id: shape.shape_id(),
+        subscription: SubscriptionKey {
+            shape_id: shape.shape_id(),
+            binding_id: BindingId(uuid::Uuid::from_bytes([0xd4; 16])),
+            read_view: Default::default(),
+        },
+        values: Vec::new(),
+        known_state: None,
+        delegated_session: Some(DelegatedSessionBinding {
+            identity: author(4),
+            claims: BTreeMap::new(),
+        }),
+    };
+    relay
+        .apply_sync_message_settled(SyncMessage::Subscribe(subscribe.clone()))
+        .unwrap();
+    let authority_result_key = relay
+        .authority_result_key_for_subscription(subscribe.subscription)
+        .unwrap();
+    let complete_reset = |subscription| crate::node::ViewUpdateParts {
+        subscription,
+        settled_through: crate::time::GlobalTime(7),
+        defer_settlement: false,
+        reset_result_set: true,
+        version_carriers: Vec::new(),
+        peer_complete_tx_payload_refs: Vec::new(),
+        authorization_progress: Some(3),
+        opening_pending: false,
+        result_member_adds: Vec::new(),
+        result_member_removes: Vec::new(),
+        program_fact_adds: vec![
+            crate::protocol::ProgramFactEntry::ProgramSourceCoverage(
+                crate::protocol::ProgramSourceCoverageEntry {
+                    source: crate::protocol::ProgramSourceId {
+                        table: "issues".to_owned().into(),
+                        path: vec![crate::protocol::ProgramSourceRole::Root],
+                    },
+                    complete: true,
+                },
+            ),
+            crate::protocol::ProgramFactEntry::ProgramSourceCoverage(
+                crate::protocol::ProgramSourceCoverageEntry {
+                    source: crate::protocol::ProgramSourceId {
+                        table: "users".to_owned().into(),
+                        path: vec![
+                            crate::protocol::ProgramSourceRole::Root,
+                            crate::protocol::ProgramSourceRole::Alias(
+                                "reference:assignee".to_owned(),
+                            ),
+                        ],
+                    },
+                    complete: true,
+                },
+            ),
+        ],
+        program_fact_removes: Vec::new(),
+    };
+
+    relay
+        .apply_view_update(complete_reset(subscribe.subscription))
+        .resolve()
+        .unwrap();
+    let first_generation = relay
+        .snapshot_pending_authoritative_resets()
+        .get(&authority_result_key)
+        .copied()
+        .expect("the first complete reset is pending");
+
+    assert!(
+        !relay.acknowledge_authoritative_reset(&authority_result_key, first_generation + 1),
+        "an unrelated generation cannot acknowledge the reset"
+    );
+    assert_eq!(
+        relay
+            .snapshot_pending_authoritative_resets()
+            .get(&authority_result_key)
+            .copied(),
+        Some(first_generation)
+    );
+
+    relay
+        .apply_view_update(complete_reset(subscribe.subscription))
+        .resolve()
+        .unwrap();
+    let second_generation = relay
+        .snapshot_pending_authoritative_resets()
+        .get(&authority_result_key)
+        .copied()
+        .expect("the newer complete reset is pending");
+    assert!(second_generation > first_generation);
+    assert!(
+        !relay.acknowledge_authoritative_reset(&authority_result_key, first_generation),
+        "a stale acknowledgement cannot clear a newer reset"
+    );
+    assert_eq!(
+        relay
+            .snapshot_pending_authoritative_resets()
+            .get(&authority_result_key)
+            .copied(),
+        Some(second_generation)
+    );
+
+    relay
+        .apply_sync_message_settled(SyncMessage::Unsubscribe {
+            subscription: subscribe.subscription,
+        })
+        .unwrap();
+    assert!(
+        !relay.acknowledge_authoritative_reset(&authority_result_key, second_generation),
+        "retired results reject acknowledgements without recreating state"
+    );
+    assert!(relay.snapshot_pending_authoritative_resets().is_empty());
 }
 
 /// Storage-backed scalar membership ships the exact deletion-register winner

--- a/crates/jazz/src/node/query_eval/tests/subscriptions.rs
+++ b/crates/jazz/src/node/query_eval/tests/subscriptions.rs
@@ -702,7 +702,7 @@ fn pending_authoritative_reset_acknowledgement_is_generation_checked() {
         subscription,
         settled_through: crate::time::GlobalTime(7),
         defer_settlement: false,
-        reset_result_set: true,
+        reset_input_set: true,
         version_carriers: Vec::new(),
         peer_complete_tx_payload_refs: Vec::new(),
         authorization_progress: Some(3),
@@ -735,6 +735,7 @@ fn pending_authoritative_reset_acknowledgement_is_generation_checked() {
             ),
         ],
         program_fact_removes: Vec::new(),
+        wire_rows: None,
     };
 
     relay

--- a/crates/jazz/src/node/state/lifecycle.rs
+++ b/crates/jazz/src/node/state/lifecycle.rs
@@ -661,6 +661,7 @@ where
             content_runtime_provider,
             storage_type: std::marker::PhantomData,
             groove_runtime_token: next_groove_runtime_token(),
+            next_authoritative_reset_generation: 1,
             history_complete,
             authored_commit_durability: DurabilityTier::Local,
             authoritative_scalar_exit_refresh: false,

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -2178,6 +2178,15 @@ where
         // policy-scoped authority identity captured when that subscription was
         // admitted; never reconstruct or share it through BindingViewKey.
         let authority_result_key = self.authority_result_key_for_subscription(subscription)?;
+        let reset_cleared_shared_state = Self::reset_replaces_authority_source_closure(
+            reset_input_set,
+            !program_fact_adds.is_empty() || !program_fact_removes.is_empty(),
+            opening_pending,
+            self.query.authority_results.get(&authority_result_key),
+        );
+        let pending_authoritative_reset_generation = reset_cleared_shared_state
+            .then(|| self.allocate_authoritative_reset_generation())
+            .transpose()?;
         let preflight = if preloaded_tx_ids.is_none() {
             Some(
                 self.preflight_view_bundle_conflicts(&version_bundle_refs)
@@ -2261,12 +2270,7 @@ where
         }
         let persisted_fact_adds = program_fact_adds.clone();
         let persisted_fact_removes = program_fact_removes.clone();
-        let reset_cleared_shared_state = Self::reset_replaces_authority_source_closure(
-            reset_input_set,
-            !program_fact_adds.is_empty() || !program_fact_removes.is_empty(),
-            opening_pending,
-            self.query.authority_results.get(&authority_result_key),
-        );
+
         if reset_cleared_shared_state {
             self.clear_settled_result_view(authority_result_key.clone());
         }
@@ -2316,12 +2320,8 @@ where
             // it carries retractions. The public subscription materializes its
             // replacement snapshot below, rather than attempting to apply a
             // removal after the reset has cleared the cached result set.
-            if reset_cleared_shared_state {
-                self.query
-                    .authority_results
-                    .entry(authority_result_key.clone())
-                    .or_default()
-                    .pending_authoritative_reset = true;
+            if let Some(generation) = pending_authoritative_reset_generation {
+                state.pending_authoritative_reset = Some(generation);
             }
         }
         if !defer_settlement && !opening_pending {


### PR DESCRIPTION
## Summary
- Preserve authoritative reset markers while refresh retries fail, cancel, or advance generations.
- Keep reset acknowledgement state isolated per policy-scoped lifecycle.

## Before
A refresh error or cancellation could lose the pending authoritative reset marker, allowing a stale acknowledgement or incomplete materialisation to escape.

## After
Reset markers survive retryable failures and are generation-checked before acknowledgement, while policy-scoped lifecycles retain separate state.

## Test plan
- [ ] Review the refresh error, cancellation, and generation-check regressions in the Jazz subscription materialisation tests.
- [ ] Run the focused Jazz subscription and query-evaluation subscription tests.
- [ ] Run the repository CI checks.