### PR TITLE
Serve SPA deep links from Hono starters

### DIFF
--- a/starters/react-betterauth/e2e/todo-flow.spec.ts
+++ b/starters/react-betterauth/e2e/todo-flow.spec.ts
@@ -53,6 +53,10 @@ test("production server serves the SPA shell for root and deep links", async ({ 
     expect(response.status(), pathname).toBe(200);
     expect(await response.text()).toContain('<div id="root">');
   }
+  const headResponse = await request.head("http://127.0.0.1:3001/dashboard", {
+    headers: { Accept: "text/html" },
+  });
+  expect(headResponse.status(), "HEAD /dashboard").toBe(404);
 });
 
 test("signin with existing account shows todos", async ({ page }) => {

--- a/starters/react-betterauth/e2e/todo-flow.spec.ts
+++ b/starters/react-betterauth/e2e/todo-flow.spec.ts
@@ -43,6 +43,17 @@ test("signup → add todo → reload → todo persists", async ({ page }) => {
   await waitForTodoApp(page);
   await expect(page.getByText(todo, { exact: true })).toHaveCount(1, { timeout: TIMEOUT });
 });
+test("production server serves the SPA shell for root and deep links", async ({ request }) => {
+  test.skip(process.env.JAZZ_E2E_PROD !== "1", "production-only smoke test");
+
+  for (const pathname of ["/", "/dashboard"]) {
+    const response = await request.get(`http://127.0.0.1:3001${pathname}`, {
+      headers: { Accept: "text/html" },
+    });
+    expect(response.status(), pathname).toBe(200);
+    expect(await response.text()).toContain('<div id="root">');
+  }
+});
 
 test("signin with existing account shows todos", async ({ page }) => {
   const runId = Date.now();

--- a/starters/react-betterauth/playwright.config.ts
+++ b/starters/react-betterauth/playwright.config.ts
@@ -1,19 +1,12 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const BASE_URL = "http://localhost:5173";
 const PROD = process.env.JAZZ_E2E_PROD === "1";
+const BASE_URL = PROD ? "http://localhost:3001" : "http://localhost:5173";
 
 const prodApiServer = {
   command: "node --env-file=.env server-dist/index.js",
   env: { PORT: "3001" },
   url: "http://localhost:3001/health",
-  reuseExistingServer: false,
-  timeout: 60_000,
-};
-
-const prodFrontend = {
-  command: "pnpm exec vite preview --port 5173 --strictPort",
-  url: BASE_URL,
   reuseExistingServer: false,
   timeout: 60_000,
 };
@@ -36,7 +29,7 @@ export default defineConfig({
     },
   ],
   webServer: PROD
-    ? [prodApiServer, prodFrontend]
+    ? prodApiServer
     : {
         command: "pnpm dev",
         env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },

--- a/starters/react-betterauth/server/app.ts
+++ b/starters/react-betterauth/server/app.ts
@@ -1,7 +1,43 @@
+import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
 import { auth } from "./auth.js";
 
 export const app = new Hono();
 
+const staticFiles = serveStatic({ root: "./dist" });
+const spaIndex = serveStatic({ root: "./dist", path: "index.html" });
+
 app.get("/health", (c) => c.text("ok"));
 app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw));
+
+app.use("/*", async (c, next) => {
+  if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+    return next();
+  }
+  return staticFiles(c, next);
+});
+
+app.get("*", async (c, next) => {
+  if (c.req.method !== "GET") {
+    return next();
+  }
+  const pathname = c.req.path;
+  if (
+    pathname === "/api" ||
+    pathname.startsWith("/api/") ||
+    pathname === "/assets" ||
+    pathname.startsWith("/assets/")
+  ) {
+    return next();
+  }
+
+  const acceptsHtml = c.req
+    .header("Accept")
+    ?.split(",")
+    .some((value) => value.trim().split(";", 1)[0].toLowerCase() === "text/html");
+  if (!acceptsHtml) {
+    return next();
+  }
+
+  return spaIndex(c, next);
+});

--- a/starters/react-hybrid/e2e/todo-flow.spec.ts
+++ b/starters/react-hybrid/e2e/todo-flow.spec.ts
@@ -54,6 +54,10 @@ test("production server serves the SPA shell for root and deep links", async ({ 
     expect(response.status(), pathname).toBe(200);
     expect(await response.text()).toContain('<div id="root">');
   }
+  const headResponse = await request.head("http://127.0.0.1:3001/dashboard", {
+    headers: { Accept: "text/html" },
+  });
+  expect(headResponse.status(), "HEAD /dashboard").toBe(404);
 });
 
 test("signin with existing account shows todos", async ({ page }) => {

--- a/starters/react-hybrid/e2e/todo-flow.spec.ts
+++ b/starters/react-hybrid/e2e/todo-flow.spec.ts
@@ -44,6 +44,17 @@ test("signup → add todo → reload → todo persists", async ({ page }) => {
   await waitForTodoApp(page);
   await expect(page.getByText(todo, { exact: true })).toHaveCount(1, { timeout: TIMEOUT });
 });
+test("production server serves the SPA shell for root and deep links", async ({ request }) => {
+  test.skip(process.env.JAZZ_E2E_PROD !== "1", "production-only smoke test");
+
+  for (const pathname of ["/", "/dashboard"]) {
+    const response = await request.get(`http://127.0.0.1:3001${pathname}`, {
+      headers: { Accept: "text/html" },
+    });
+    expect(response.status(), pathname).toBe(200);
+    expect(await response.text()).toContain('<div id="root">');
+  }
+});
 
 test("signin with existing account shows todos", async ({ page }) => {
   const runId = Date.now();

--- a/starters/react-hybrid/playwright.config.ts
+++ b/starters/react-hybrid/playwright.config.ts
@@ -1,19 +1,12 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const BASE_URL = "http://localhost:5173";
 const PROD = process.env.JAZZ_E2E_PROD === "1";
+const BASE_URL = PROD ? "http://localhost:3001" : "http://localhost:5173";
 
 const prodApiServer = {
   command: "node --env-file=.env server-dist/index.js",
   env: { PORT: "3001" },
   url: "http://localhost:3001/health",
-  reuseExistingServer: false,
-  timeout: 60_000,
-};
-
-const prodFrontend = {
-  command: "pnpm exec vite preview --port 5173 --strictPort",
-  url: BASE_URL,
   reuseExistingServer: false,
   timeout: 60_000,
 };
@@ -36,7 +29,7 @@ export default defineConfig({
     },
   ],
   webServer: PROD
-    ? [prodApiServer, prodFrontend]
+    ? prodApiServer
     : {
         command: "pnpm dev",
         env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },

--- a/starters/react-hybrid/server/app.ts
+++ b/starters/react-hybrid/server/app.ts
@@ -1,7 +1,43 @@
+import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
 import { auth } from "./auth.js";
 
 export const app = new Hono();
 
+const staticFiles = serveStatic({ root: "./dist" });
+const spaIndex = serveStatic({ root: "./dist", path: "index.html" });
+
 app.get("/health", (c) => c.text("ok"));
 app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw));
+
+app.use("/*", async (c, next) => {
+  if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+    return next();
+  }
+  return staticFiles(c, next);
+});
+
+app.get("*", async (c, next) => {
+  if (c.req.method !== "GET") {
+    return next();
+  }
+  const pathname = c.req.path;
+  if (
+    pathname === "/api" ||
+    pathname.startsWith("/api/") ||
+    pathname === "/assets" ||
+    pathname.startsWith("/assets/")
+  ) {
+    return next();
+  }
+
+  const acceptsHtml = c.req
+    .header("Accept")
+    ?.split(",")
+    .some((value) => value.trim().split(";", 1)[0].toLowerCase() === "text/html");
+  if (!acceptsHtml) {
+    return next();
+  }
+
+  return spaIndex(c, next);
+});

--- a/starters/ts-betterauth/e2e/todo-flow.spec.ts
+++ b/starters/ts-betterauth/e2e/todo-flow.spec.ts
@@ -53,6 +53,10 @@ test("production server serves the SPA shell for root and deep links", async ({ 
     expect(response.status(), pathname).toBe(200);
     expect(await response.text()).toContain('<div id="root">');
   }
+  const headResponse = await request.head("http://127.0.0.1:3001/dashboard", {
+    headers: { Accept: "text/html" },
+  });
+  expect(headResponse.status(), "HEAD /dashboard").toBe(404);
 });
 
 test("signin with existing account shows todos", async ({ page }) => {

--- a/starters/ts-betterauth/e2e/todo-flow.spec.ts
+++ b/starters/ts-betterauth/e2e/todo-flow.spec.ts
@@ -43,6 +43,17 @@ test("signup → add todo → reload → todo persists", async ({ page }) => {
   await waitForTodoApp(page);
   await expect(page.getByText(todo, { exact: true })).toHaveCount(1, { timeout: TIMEOUT });
 });
+test("production server serves the SPA shell for root and deep links", async ({ request }) => {
+  test.skip(process.env.JAZZ_E2E_PROD !== "1", "production-only smoke test");
+
+  for (const pathname of ["/", "/dashboard"]) {
+    const response = await request.get(`http://127.0.0.1:3001${pathname}`, {
+      headers: { Accept: "text/html" },
+    });
+    expect(response.status(), pathname).toBe(200);
+    expect(await response.text()).toContain('<div id="root">');
+  }
+});
 
 test("signin with existing account shows todos", async ({ page }) => {
   const runId = Date.now();

--- a/starters/ts-betterauth/playwright.config.ts
+++ b/starters/ts-betterauth/playwright.config.ts
@@ -1,23 +1,12 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const BASE_URL = "http://localhost:5173";
 const PROD = process.env.JAZZ_E2E_PROD === "1";
+const BASE_URL = PROD ? "http://localhost:3001" : "http://localhost:5173";
 
-// In dev, `pnpm dev` runs the API + vite under concurrently. In prod, we wire
-// the equivalent through playwright's two-server form: the Hono server on
-// 3001 and `vite preview` on 5173 (which proxies /api back to 3001 via the
-// `preview.proxy` config in vite.config.ts).
 const prodApiServer = {
   command: "node --env-file=.env server-dist/index.js",
   env: { PORT: "3001" },
   url: "http://localhost:3001/health",
-  reuseExistingServer: false,
-  timeout: 60_000,
-};
-
-const prodFrontend = {
-  command: "pnpm exec vite preview --port 5173 --strictPort",
-  url: BASE_URL,
   reuseExistingServer: false,
   timeout: 60_000,
 };
@@ -40,7 +29,7 @@ export default defineConfig({
     },
   ],
   webServer: PROD
-    ? [prodApiServer, prodFrontend]
+    ? prodApiServer
     : {
         command: "pnpm dev",
         env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },

--- a/starters/ts-betterauth/server/app.ts
+++ b/starters/ts-betterauth/server/app.ts
@@ -1,7 +1,43 @@
+import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
 import { auth } from "./auth.js";
 
 export const app = new Hono();
 
+const staticFiles = serveStatic({ root: "./dist" });
+const spaIndex = serveStatic({ root: "./dist", path: "index.html" });
+
 app.get("/health", (c) => c.text("ok"));
 app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw));
+
+app.use("/*", async (c, next) => {
+  if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+    return next();
+  }
+  return staticFiles(c, next);
+});
+
+app.get("*", async (c, next) => {
+  if (c.req.method !== "GET") {
+    return next();
+  }
+  const pathname = c.req.path;
+  if (
+    pathname === "/api" ||
+    pathname.startsWith("/api/") ||
+    pathname === "/assets" ||
+    pathname.startsWith("/assets/")
+  ) {
+    return next();
+  }
+
+  const acceptsHtml = c.req
+    .header("Accept")
+    ?.split(",")
+    .some((value) => value.trim().split(";", 1)[0].toLowerCase() === "text/html");
+  if (!acceptsHtml) {
+    return next();
+  }
+
+  return spaIndex(c, next);
+});

--- a/starters/ts-hybrid/e2e/todo-flow.spec.ts
+++ b/starters/ts-hybrid/e2e/todo-flow.spec.ts
@@ -64,6 +64,17 @@ test("signup → add todo → reload → todo persists", async ({ page }) => {
   await expect(page.getByText(localTodo, { exact: true })).toHaveCount(1, { timeout: TIMEOUT });
   await expect(page.getByText(todo, { exact: true })).toHaveCount(1, { timeout: TIMEOUT });
 });
+test("production server serves the SPA shell for root and deep links", async ({ request }) => {
+  test.skip(process.env.JAZZ_E2E_PROD !== "1", "production-only smoke test");
+
+  for (const pathname of ["/", "/dashboard"]) {
+    const response = await request.get(`http://127.0.0.1:3001${pathname}`, {
+      headers: { Accept: "text/html" },
+    });
+    expect(response.status(), pathname).toBe(200);
+    expect(await response.text()).toContain('<div id="root">');
+  }
+});
 
 test("signin with existing account shows todos", async ({ page }) => {
   const runId = Date.now();

--- a/starters/ts-hybrid/e2e/todo-flow.spec.ts
+++ b/starters/ts-hybrid/e2e/todo-flow.spec.ts
@@ -74,6 +74,10 @@ test("production server serves the SPA shell for root and deep links", async ({ 
     expect(response.status(), pathname).toBe(200);
     expect(await response.text()).toContain('<div id="root">');
   }
+  const headResponse = await request.head("http://127.0.0.1:3001/dashboard", {
+    headers: { Accept: "text/html" },
+  });
+  expect(headResponse.status(), "HEAD /dashboard").toBe(404);
 });
 
 test("signin with existing account shows todos", async ({ page }) => {

--- a/starters/ts-hybrid/playwright.config.ts
+++ b/starters/ts-hybrid/playwright.config.ts
@@ -1,19 +1,12 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const BASE_URL = "http://localhost:5173";
 const PROD = process.env.JAZZ_E2E_PROD === "1";
+const BASE_URL = PROD ? "http://localhost:3001" : "http://localhost:5173";
 
 const prodApiServer = {
   command: "node --env-file=.env server-dist/index.js",
   env: { PORT: "3001" },
   url: "http://localhost:3001/health",
-  reuseExistingServer: false,
-  timeout: 60_000,
-};
-
-const prodFrontend = {
-  command: "pnpm exec vite preview --port 5173 --strictPort",
-  url: BASE_URL,
   reuseExistingServer: false,
   timeout: 60_000,
 };
@@ -36,7 +29,7 @@ export default defineConfig({
     },
   ],
   webServer: PROD
-    ? [prodApiServer, prodFrontend]
+    ? prodApiServer
     : {
         command: "pnpm dev",
         env: { BETTER_AUTH_SECRET: "test-secret-do-not-use-in-production" },

--- a/starters/ts-hybrid/server/app.ts
+++ b/starters/ts-hybrid/server/app.ts
@@ -1,7 +1,43 @@
+import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
 import { auth } from "./auth.js";
 
 export const app = new Hono();
 
+const staticFiles = serveStatic({ root: "./dist" });
+const spaIndex = serveStatic({ root: "./dist", path: "index.html" });
+
 app.get("/health", (c) => c.text("ok"));
 app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw));
+
+app.use("/*", async (c, next) => {
+  if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+    return next();
+  }
+  return staticFiles(c, next);
+});
+
+app.get("*", async (c, next) => {
+  if (c.req.method !== "GET") {
+    return next();
+  }
+  const pathname = c.req.path;
+  if (
+    pathname === "/api" ||
+    pathname.startsWith("/api/") ||
+    pathname === "/assets" ||
+    pathname.startsWith("/assets/")
+  ) {
+    return next();
+  }
+
+  const acceptsHtml = c.req
+    .header("Accept")
+    ?.split(",")
+    .some((value) => value.trim().split(";", 1)[0].toLowerCase() === "text/html");
+  if (!acceptsHtml) {
+    return next();
+  }
+
+  return spaIndex(c, next);
+});


### PR DESCRIPTION
## Summary
- Serve the SPA shell for root and deep-link requests from the React and TypeScript Hono starters.
- Keep API and static-asset routing ahead of the fallback.

## Before
Production starter servers could return a missing page for a client-side route that was not the root path.

## After
The four affected starters return the SPA shell for valid client-side deep links while preserving API and asset responses.

## Test plan
- [ ] Review the production-server deep-link smoke test in each affected starter.
- [ ] Run the starter production E2E checks with `JAZZ_E2E_PROD=1`.
- [ ] Run the repository CI checks.