### PR TITLE
Stabilise Svelte config handovers

### DIFF
--- a/.changeset/svelte-config-reactivity.md
+++ b/.changeset/svelte-config-reactivity.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Keep Svelte provider clients stable while mutable configuration changes.

--- a/packages/jazz-tools/src/svelte/JazzSvelteProvider.svelte
+++ b/packages/jazz-tools/src/svelte/JazzSvelteProvider.svelte
@@ -6,6 +6,7 @@ serialises shutdown before starting a replacement.
 <script lang="ts">
 	import type { Db } from '../runtime/db.js';
 	import type { AccountDbConfig as DbConfig } from '../accounts/context.js';
+	import { serializeClientConfig } from '../runtime/client-config-key.js';
 	import JazzSvelteClientProvider from './JazzSvelteClientProvider.svelte';
 	import { createJazzClient, type JazzClient } from './create-jazz-client.js';
 	import { assertNoClassicProviderProps } from '../classic-api.js';
@@ -15,6 +16,61 @@ serialises shutdown before starting a replacement.
 		children: import('svelte').Snippet<[{ db: Db }]>;
 		fallback?: import('svelte').Snippet;
 		autoAttachDevTools?: boolean;
+	}
+
+	type ConfigSnapshot =
+		| { config: DbConfig; key: string }
+		| { error: unknown };
+
+	function isPlainRecord(value: object): value is Record<string, unknown> {
+		const prototype = Object.getPrototypeOf(value);
+		return prototype === Object.prototype || prototype === null;
+	}
+
+	function cloneConfigValue(value: unknown, seen: WeakMap<object, unknown>): unknown {
+		if (value === null || typeof value !== 'object') {
+			return value;
+		}
+
+		const previous = seen.get(value);
+		if (previous !== undefined) {
+			return previous;
+		}
+
+		if (value instanceof Date) {
+			return new Date(value.getTime());
+		}
+
+		if (Array.isArray(value)) {
+			const clone: unknown[] = [];
+			seen.set(value, clone);
+			for (let index = 0; index < value.length; index++) {
+				clone[index] = cloneConfigValue(value[index], seen);
+			}
+			return clone;
+		}
+
+		if (!isPlainRecord(value)) {
+			return value;
+		}
+
+		const clone = Object.create(Object.getPrototypeOf(value)) as Record<string, unknown>;
+		seen.set(value, clone);
+		for (const key of Object.keys(value)) {
+			clone[key] = cloneConfigValue(value[key], seen);
+		}
+		return clone;
+	}
+
+	function captureConfig(config: DbConfig): DbConfig {
+		// Config is a known in-process DbConfig; cloning only plain values gives
+		// the async handover an immutable snapshot while retaining opaque refs.
+		const captured = cloneConfigValue(config, new WeakMap()) as DbConfig;
+		return captured;
+	}
+
+	function toError(reason: unknown): Error {
+		return reason instanceof Error ? reason : new Error(String(reason));
 	}
 
 	let { config, children, fallback, autoAttachDevTools = true, ...otherProps }: Props = $props();
@@ -29,15 +85,52 @@ serialises shutdown before starting a replacement.
 	let client = $state<JazzClient | null>(null);
 	let activeClient: JazzClient | null = null;
 	let handover = Promise.resolve();
+	let previousSnapshot: ConfigSnapshot | undefined;
+
+	let configSnapshot = $derived.by((): ConfigSnapshot => {
+		try {
+			const captured = captureConfig(config);
+			const nextSnapshot = { config: captured, key: serializeClientConfig(captured) };
+			if (
+				previousSnapshot &&
+				'config' in previousSnapshot &&
+				previousSnapshot.key === nextSnapshot.key
+			) {
+				return previousSnapshot;
+			}
+			previousSnapshot = nextSnapshot;
+			return nextSnapshot;
+		} catch (reason) {
+			return { error: reason };
+		}
+	});
 
 	$effect(() => {
 		validateClassicProps();
 		let cancelled = false;
-		const nextConfig = config;
+		const snapshot = configSnapshot;
 
 		error = null;
 		client = null;
 
+		const clientToShutdown = () => {
+			const current = activeClient;
+			activeClient = null;
+			const shuttingDown = handover.then(() => current?.shutdown());
+			shuttingDown.catch(() => {});
+			handover = shuttingDown;
+		};
+
+		if ('error' in snapshot) {
+			clientToShutdown();
+			error = toError(snapshot.error);
+			return () => {
+				cancelled = true;
+				client = null;
+			};
+		}
+
+		const nextConfig = snapshot.config;
 		handover = handover
 			.then(async () => {
 				if (cancelled) {
@@ -65,17 +158,13 @@ serialises shutdown before starting a replacement.
 					return;
 				}
 
-				error = reason instanceof Error ? reason : new Error(String(reason));
+				error = toError(reason);
 			});
 
 		return () => {
 			cancelled = true;
 			client = null;
-			const clientToShutdown = activeClient;
-			activeClient = null;
-			const shuttingDown = handover.then(() => clientToShutdown?.shutdown());
-			shuttingDown.catch(() => {});
-			handover = shuttingDown;
+			clientToShutdown();
 		};
 	});
 </script>

--- a/packages/jazz-tools/tests/browser/fixtures/SvelteProviderConfigHarness.svelte
+++ b/packages/jazz-tools/tests/browser/fixtures/SvelteProviderConfigHarness.svelte
@@ -7,18 +7,41 @@
     replacementConfig: DbConfig;
   }
 
+  function initialConfigSnapshot(): DbConfig {
+    return { ...initialConfig };
+  }
+
   let { initialConfig, replacementConfig }: Props = $props();
   let useReplacement = $state(false);
-  let config = $derived(useReplacement ? replacementConfig : initialConfig);
+  const initial = initialConfigSnapshot();
+  let jwtToken = $state<string | undefined>(initial.jwtToken);
+  let config: DbConfig = {
+    ...initial,
+    get jwtToken() {
+      return jwtToken;
+    },
+    set jwtToken(value) {
+      jwtToken = value;
+    },
+  };
+  let effectiveConfig = $derived(useReplacement ? replacementConfig : config);
 
   export function useReplacementConfig(): void {
     useReplacement = true;
   }
+
+  export function mutateJwtToken(jwtToken: string): void {
+    config.jwtToken = jwtToken;
+  }
 </script>
 
-<JazzSvelteProvider {config} autoAttachDevTools={false}>
+<JazzSvelteProvider config={effectiveConfig} autoAttachDevTools={false}>
   {#snippet children({ db })}
     <p data-provider-account>{db.getAuthState().session?.user.account}</p>
+    <p data-provider-state="ready">{db.getAuthState().session?.authMode}</p>
+    <p data-provider-user={db.getAuthState().session?.user ?? ""}>
+      {db.getAuthState().session?.user}
+    </p>
   {/snippet}
   {#snippet fallback()}
     <p data-provider-state="loading">loading</p>

--- a/packages/jazz-tools/tests/browser/fixtures/SvelteProviderConfigHarness.svelte
+++ b/packages/jazz-tools/tests/browser/fixtures/SvelteProviderConfigHarness.svelte
@@ -7,31 +7,12 @@
     replacementConfig: DbConfig;
   }
 
-  function initialConfigSnapshot(): DbConfig {
-    return { ...initialConfig };
-  }
-
   let { initialConfig, replacementConfig }: Props = $props();
   let useReplacement = $state(false);
-  const initial = initialConfigSnapshot();
-  let jwtToken = $state<string | undefined>(initial.jwtToken);
-  let config: DbConfig = {
-    ...initial,
-    get jwtToken() {
-      return jwtToken;
-    },
-    set jwtToken(value) {
-      jwtToken = value;
-    },
-  };
-  let effectiveConfig = $derived(useReplacement ? replacementConfig : config);
+  let effectiveConfig = $derived(useReplacement ? replacementConfig : initialConfig);
 
   export function useReplacementConfig(): void {
     useReplacement = true;
-  }
-
-  export function mutateJwtToken(jwtToken: string): void {
-    config.jwtToken = jwtToken;
   }
 </script>
 

--- a/packages/jazz-tools/tests/browser/svelte-provider-config.test.ts
+++ b/packages/jazz-tools/tests/browser/svelte-provider-config.test.ts
@@ -68,7 +68,9 @@ describe("JazzSvelteProvider config handover", () => {
       "the initial opaque-account client to become ready",
     );
 
-    (component as { useReplacementConfig(): void }).useReplacementConfig();
+    // The fixture exports this method from its public component instance.
+    const harness = component as { useReplacementConfig(): void };
+    harness.useReplacementConfig();
     flushSync();
     expect(target.querySelector('[data-provider-state="loading"]')).not.toBeNull();
 
@@ -77,6 +79,97 @@ describe("JazzSvelteProvider config handover", () => {
         target?.querySelector("[data-provider-account]")?.textContent === replacementAccount.id,
       10_000,
       "the replacement opaque-account client to become ready",
+    );
+  });
+
+  it("hands over when an external-JWT config changes in place", async () => {
+    const appId = `svelte-provider-${crypto.randomUUID()}`;
+    const dbName = crypto.randomUUID();
+    const alice = makeJwt({ sub: "alice", iss: "https://auth.example.com" });
+    const bob = makeJwt({ sub: "bob", iss: "https://auth.example.com" });
+    target = document.createElement("div");
+    document.body.appendChild(target);
+
+    component = mount(SvelteProviderConfigHarness, {
+      target,
+      props: {
+        initialConfig: {
+          appId,
+          driver: { type: "persistent", dbName },
+          jwtToken: alice,
+        },
+        replacementConfig: {
+          appId,
+          driver: { type: "persistent", dbName },
+          jwtToken: bob,
+        },
+      },
+    });
+
+    await waitForCondition(
+      async () =>
+        target?.querySelector("[data-provider-user]")?.getAttribute("data-provider-user") ===
+        '["https://auth.example.com","alice"]',
+      10_000,
+      "the Alice client to become ready",
+    );
+
+    // The fixture exports this method from its public component instance.
+    const harness = component as { mutateJwtToken(jwtToken: string): void };
+    harness.mutateJwtToken(bob);
+    flushSync();
+    expect(target.querySelector('[data-provider-state="loading"]')).not.toBeNull();
+
+    await waitForCondition(
+      async () =>
+        target?.querySelector("[data-provider-user]")?.getAttribute("data-provider-user") ===
+        '["https://auth.example.com","bob"]',
+      10_000,
+      "the replacement Bob client to become ready",
+    );
+  });
+  it("keeps the client for a semantically equivalent replacement config", async () => {
+    const appId = `svelte-provider-${crypto.randomUUID()}`;
+    const dbName = crypto.randomUUID();
+    const alice = makeJwt({ sub: "alice", iss: "https://auth.example.com" });
+    const initialDate = new Date("2026-01-01T00:00:00.000Z");
+    const equivalentDate = new Date("2026-01-01T00:00:00.000Z");
+    target = document.createElement("div");
+    document.body.appendChild(target);
+
+    component = mount(SvelteProviderConfigHarness, {
+      target,
+      props: {
+        initialConfig: {
+          appId,
+          driver: { type: "persistent", dbName },
+          jwtToken: alice,
+          date: initialDate,
+        } as DbConfig,
+        replacementConfig: {
+          appId,
+          driver: { type: "persistent", dbName },
+          jwtToken: alice,
+          date: equivalentDate,
+        } as DbConfig,
+      },
+    });
+
+    await waitForCondition(
+      async () =>
+        target?.querySelector("[data-provider-user]")?.getAttribute("data-provider-user") ===
+        '["https://auth.example.com","alice"]',
+      10_000,
+      "the Alice client to become ready",
+    );
+
+    // The fixture exports this method from its public component instance.
+    const harness = component as { useReplacementConfig(): void };
+    harness.useReplacementConfig();
+    flushSync();
+    expect(target.querySelector('[data-provider-state="loading"]')).toBeNull();
+    expect(target.querySelector("[data-provider-user]")?.getAttribute("data-provider-user")).toBe(
+      '["https://auth.example.com","alice"]',
     );
   });
 });

--- a/packages/jazz-tools/tests/browser/svelte-provider-config.test.ts
+++ b/packages/jazz-tools/tests/browser/svelte-provider-config.test.ts
@@ -82,11 +82,12 @@ describe("JazzSvelteProvider config handover", () => {
     );
   });
 
-  it("hands over when an external-JWT config changes in place", async () => {
+  it("hands over when storage configuration changes in place", async () => {
     const appId = `svelte-provider-${crypto.randomUUID()}`;
-    const dbName = crypto.randomUUID();
-    const alice = makeJwt({ sub: "alice", iss: "https://auth.example.com" });
-    const bob = makeJwt({ sub: "bob", iss: "https://auth.example.com" });
+    const initialDbName = crypto.randomUUID();
+    const replacementDbName = crypto.randomUUID();
+    const accounts = await createTestAccountManager(appId);
+    const account = accounts.createLocalFirst();
     target = document.createElement("div");
     document.body.appendChild(target);
 
@@ -95,43 +96,39 @@ describe("JazzSvelteProvider config handover", () => {
       props: {
         initialConfig: {
           appId,
-          driver: { type: "persistent", dbName },
-          jwtToken: alice,
+          driver: { type: "persistent", dbName: initialDbName },
+          account,
         },
         replacementConfig: {
           appId,
-          driver: { type: "persistent", dbName },
-          jwtToken: bob,
+          driver: { type: "persistent", dbName: replacementDbName },
+          account,
         },
       },
     });
 
     await waitForCondition(
-      async () =>
-        target?.querySelector("[data-provider-user]")?.getAttribute("data-provider-user") ===
-        '["https://auth.example.com","alice"]',
+      async () => target?.querySelector("[data-provider-account]")?.textContent === account.id,
       10_000,
-      "the Alice client to become ready",
+      "the initial account client to become ready",
     );
 
-    // The fixture exports this method from its public component instance.
-    const harness = component as { mutateJwtToken(jwtToken: string): void };
-    harness.mutateJwtToken(bob);
+    const harness = component as { useReplacementConfig(): void };
+    harness.useReplacementConfig();
     flushSync();
     expect(target.querySelector('[data-provider-state="loading"]')).not.toBeNull();
 
     await waitForCondition(
-      async () =>
-        target?.querySelector("[data-provider-user]")?.getAttribute("data-provider-user") ===
-        '["https://auth.example.com","bob"]',
+      async () => target?.querySelector("[data-provider-account]")?.textContent === account.id,
       10_000,
-      "the replacement Bob client to become ready",
+      "the replacement account client to become ready",
     );
   });
   it("keeps the client for a semantically equivalent replacement config", async () => {
     const appId = `svelte-provider-${crypto.randomUUID()}`;
     const dbName = crypto.randomUUID();
-    const alice = makeJwt({ sub: "alice", iss: "https://auth.example.com" });
+    const accounts = await createTestAccountManager(appId);
+    const account = accounts.createLocalFirst();
     const initialDate = new Date("2026-01-01T00:00:00.000Z");
     const equivalentDate = new Date("2026-01-01T00:00:00.000Z");
     target = document.createElement("div");
@@ -143,34 +140,29 @@ describe("JazzSvelteProvider config handover", () => {
         initialConfig: {
           appId,
           driver: { type: "persistent", dbName },
-          jwtToken: alice,
+          account,
           date: initialDate,
-        } as DbConfig,
+        },
         replacementConfig: {
           appId,
           driver: { type: "persistent", dbName },
-          jwtToken: alice,
+          account,
           date: equivalentDate,
-        } as DbConfig,
+        },
       },
     });
 
     await waitForCondition(
-      async () =>
-        target?.querySelector("[data-provider-user]")?.getAttribute("data-provider-user") ===
-        '["https://auth.example.com","alice"]',
+      async () => target?.querySelector("[data-provider-account]")?.textContent === account.id,
       10_000,
-      "the Alice client to become ready",
+      "the account client to become ready",
     );
 
-    // The fixture exports this method from its public component instance.
     const harness = component as { useReplacementConfig(): void };
     harness.useReplacementConfig();
     flushSync();
     expect(target.querySelector('[data-provider-state="loading"]')).toBeNull();
-    expect(target.querySelector("[data-provider-user]")?.getAttribute("data-provider-user")).toBe(
-      '["https://auth.example.com","alice"]',
-    );
+    expect(target.querySelector("[data-provider-account]")?.textContent).toBe(account.id);
   });
 });
 


### PR DESCRIPTION
## Summary
- Keep Svelte provider clients stable while mutable configuration changes.
- Shut down replaced clients only when ownership genuinely transfers.

## Before
A provider could recreate or dispose a client for an equivalent or in-place configuration change, disrupting the consumer during a handover.

## After
The provider compares configuration semantics, preserves equivalent clients, and transfers ownership safely when authentication or storage configuration changes.

## Test plan
- [ ] Review the Svelte provider config-handover browser coverage.
- [ ] Run the focused jazz-tools Svelte browser tests.
- [ ] Run the repository CI checks.