### PR TITLE
Make todo CLI storage paths durable

### DIFF
--- a/examples/todo-server-ts/README.md
+++ b/examples/todo-server-ts/README.md
@@ -1,6 +1,6 @@
 # todo-server-ts
 
-Node + Express REST API backed by Jazz as the database. No frontend — pure server-side TypeScript, persistent Fjall storage via the Jazz NAPI bindings.
+Node + Express REST API backed by Jazz as the database. No frontend — pure server-side TypeScript, with persistent Fjall storage via the Jazz NAPI bindings.
 
 ## What it demonstrates
 
@@ -9,7 +9,7 @@ Node + Express REST API backed by Jazz as the database. No frontend — pure ser
 - Request authentication through `client.forRequest(req)`. Every `/todos` request sends `Authorization: Bearer <token>`; Jazz verifies the token and derives the session owner.
 - Server-Sent Events (`/todos/live`) pushing only the authenticated caller's live snapshot on every mutation.
 - Write durability control via `wait({ tier })` (`local`, `edge`, `global`).
-- Persistent Fjall storage rooted in a temp directory on cold start.
+- Explicit persistent or in-memory storage selection for programmatic servers and the CLI.
 
 ## Schema
 
@@ -22,7 +22,15 @@ Node + Express REST API backed by Jazz as the database. No frontend — pure ser
 pnpm dev
 ```
 
-`pnpm dev` runs the server with `tsx watch` against `src/main.ts`. The HTTP API listens on a default port (see `main.ts`); a fresh Fjall database is created in a temp directory.
+`pnpm dev` runs the server with `tsx watch` against `src/main.ts`. The HTTP API listens on a default port (see `main.ts`).
+
+Storage is persistent by default. The CLI resolves its database path in this order:
+
+1. `--data-path <path>` (if supplied).
+2. A non-empty `DB_PATH` environment variable.
+3. `./data/todos/<effective-app-id-base64url>/jazz.db`, relative to the current working directory. The effective app ID is `JAZZ_APP_ID`, or the example's default when it is unset.
+
+`--in-memory` is the only volatile mode. It conflicts with `--data-path` and with any set `DB_PATH`, including an empty value. Unknown options, missing or empty `--data-path` values, and an explicitly empty `DB_PATH` fail before the server listens. Explicit paths are operator-owned: storage-open or lock errors are not redirected to another path.
 
 ## Authentication
 
@@ -44,4 +52,4 @@ The `/health` endpoint remains public.
 pnpm test
 ```
 
-Vitest integration tests cover request authentication, owner-scoped CRUD and live updates, and persistence/cold-start.
+Vitest integration tests cover request authentication, owner-scoped CRUD and live updates, persistence/cold-start, and a real CLI process restart.

--- a/examples/todo-server-ts/src/main.ts
+++ b/examples/todo-server-ts/src/main.ts
@@ -7,13 +7,10 @@
 import express, { Request, Response, NextFunction } from "express";
 import type { Application } from "express";
 import type { Server } from "node:http";
-import { tmpdir } from "node:os";
-import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { createJazzSession, type Db } from "jazz-tools/backend";
 import { app as schemaApp } from "../schema.js";
 import permissions from "../permissions.js";
-
 // ============================================================================
 // Types
 // ============================================================================
@@ -69,6 +66,8 @@ interface ServerLifecycle {
 const serverLifecycles = new WeakMap<Application, ServerLifecycle>();
 const stopPromises = new WeakMap<Server, Promise<void>>();
 
+export type TodoServerStorage = { type: "persistent"; dataPath: string } | { type: "memory" };
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -76,17 +75,24 @@ const stopPromises = new WeakMap<Server, Promise<void>>();
 /**
  * Create a todo server.
  *
- * @param dataPath Optional path to local Fjall database file. If omitted, uses a temp directory.
+ * @param storage Explicit persistent path or in-memory storage selector.
  * @returns TodoServer with the Express app, administrative database handle, and lifecycle functions
  */
 export async function createServer(
-  dataPath?: string,
+  storage: TodoServerStorage,
   options: TodoServerOptions = {},
 ): Promise<TodoServer> {
-  const dbPath = dataPath ?? join(mkdtempSync(join(tmpdir(), "jazz-todo-")), "jazz.db");
   const appId = options.appId ?? process.env.JAZZ_APP_ID ?? "019d4349-244c-74d4-8573-8e1b24cf21e2";
   const serverUrl = options.serverUrl ?? process.env.JAZZ_SERVER_URL;
   const backendSecret = options.backendSecret ?? process.env.JAZZ_BACKEND_SECRET;
+  const driver =
+    storage.type === "persistent"
+      ? { type: "persistent" as const, dataPath: storage.dataPath }
+      : { type: "memory" as const };
+
+  if (storage.type === "persistent" && storage.dataPath.trim() === "") {
+    throw new Error("Persistent storage requires a non-empty dataPath");
+  }
 
   if (!serverUrl || !backendSecret) {
     throw new Error("JAZZ_SERVER_URL and JAZZ_BACKEND_SECRET are required");
@@ -96,7 +102,7 @@ export async function createServer(
     appId,
     app: schemaApp,
     permissions,
-    driver: { type: "persistent", dataPath: dbPath },
+    driver,
     serverUrl,
     initial: { backendSecret },
     env: "dev",
@@ -438,8 +444,60 @@ export async function stopServer(server: RunningServer): Promise<void> {
 // CLI Entry Point
 // ============================================================================
 
+const DEFAULT_APP_ID = "019d4349-244c-74d4-8573-8e1b24cf21e2";
+
+function resolveStorage(argv: string[], env: NodeJS.ProcessEnv): TodoServerStorage {
+  let dataPath: string | undefined;
+  let inMemory = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--data-path") {
+      if (dataPath !== undefined) {
+        throw new Error("The --data-path option may only be provided once");
+      }
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith("--") || value.trim() === "") {
+        throw new Error("--data-path requires a non-empty path");
+      }
+      dataPath = value;
+      index += 1;
+    } else if (argument === "--in-memory") {
+      if (inMemory) {
+        throw new Error("The --in-memory option may only be provided once");
+      }
+      inMemory = true;
+    } else {
+      throw new Error(`Unknown option: ${argument}`);
+    }
+  }
+
+  const environmentPath = env.DB_PATH;
+  if (environmentPath !== undefined && environmentPath.trim() === "") {
+    throw new Error("DB_PATH must be non-empty when set");
+  }
+  if (inMemory && (dataPath !== undefined || environmentPath !== undefined)) {
+    throw new Error("--in-memory conflicts with --data-path and DB_PATH");
+  }
+  if (dataPath !== undefined) {
+    return { type: "persistent", dataPath };
+  }
+  if (environmentPath !== undefined) {
+    return { type: "persistent", dataPath: environmentPath };
+  }
+  if (inMemory) {
+    return { type: "memory" };
+  }
+
+  const appId = env.JAZZ_APP_ID ?? DEFAULT_APP_ID;
+  const encodedAppId = Buffer.from(appId, "utf8").toString("base64url");
+  return {
+    type: "persistent",
+    dataPath: join("data", "todos", encodedAppId, "jazz.db"),
+  };
+}
 async function main() {
-  const todoServer = await createServer();
+  const todoServer = await createServer(resolveStorage(process.argv.slice(2), process.env));
 
   // Start server
   const port = parseInt(process.env.PORT ?? "3000", 10);

--- a/examples/todo-server-ts/tests/authentication.test.ts
+++ b/examples/todo-server-ts/tests/authentication.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { randomUUID } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createAccountManager } from "jazz-tools";
 import {
   deploy,
@@ -85,13 +88,19 @@ describe("Todo Server request authentication", () => {
     alice = await createIdentity(jwtIssuer, upstream, "todo-rest-auth-alice");
     bob = await createIdentity(jwtIssuer, upstream, "todo-rest-auth-bob");
     server = await startServer(
-      await createServer(undefined, {
-        jwksUrl: jwtIssuer.jwksUrl,
-        appId: upstream.appId,
-        serverUrl: upstream.url,
-        backendSecret: upstream.backendSecret,
-        adminSecret: upstream.adminSecret,
-      }),
+      await createServer(
+        {
+          type: "persistent",
+          dataPath: join(mkdtempSync(join(tmpdir(), "jazz-auth-")), "jazz.db"),
+        },
+        {
+          jwksUrl: jwtIssuer.jwksUrl,
+          appId: upstream.appId,
+          serverUrl: upstream.url,
+          backendSecret: upstream.backendSecret,
+          adminSecret: upstream.adminSecret,
+        },
+      ),
       0,
     );
     baseUrl = server.baseUrl;

--- a/examples/todo-server-ts/tests/cli.test.ts
+++ b/examples/todo-server-ts/tests/cli.test.ts
@@ -5,7 +5,15 @@ import { once } from "node:events";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { startTestJwtIssuer, type TestJwtIssuerHandle } from "jazz-tools/testing";
+import {
+  deploy,
+  startLocalJazzServer,
+  startTestJwtIssuer,
+  type LocalJazzServerHandle,
+  type TestJwtIssuerHandle,
+} from "jazz-tools/testing";
+import permissions from "../permissions.js";
+import { app } from "../schema.js";
 
 const EXTERNAL_ISSUER = "https://todo-server.example.test";
 const APP_ID = "todo-cli-durable-restart";
@@ -18,12 +26,30 @@ type RunningChild = {
 };
 
 let jwtIssuer: TestJwtIssuerHandle;
-
+let upstream: LocalJazzServerHandle;
+async function startUpstream(): Promise<void> {
+  jwtIssuer = await startTestJwtIssuer();
+  upstream = await startLocalJazzServer({
+    appId: APP_ID,
+    jwksUrl: jwtIssuer.jwksUrl,
+    jwtIssuer: EXTERNAL_ISSUER,
+    jwtAudience: jwtIssuer.audience,
+  });
+  await deploy({
+    serverUrl: upstream.url,
+    appId: upstream.appId,
+    adminSecret: upstream.adminSecret,
+    schema: app,
+    permissions,
+  });
+}
 async function startChild(cwd: string): Promise<RunningChild> {
   const childEnv = {
     ...process.env,
     PORT: "0",
     JAZZ_APP_ID: APP_ID,
+    JAZZ_SERVER_URL: upstream.url,
+    JAZZ_BACKEND_SECRET: upstream.backendSecret,
     JAZZ_JWKS_URL: jwtIssuer.jwksUrl,
   };
   delete childEnv.DB_PATH;
@@ -73,6 +99,8 @@ async function runCli(
     ...process.env,
     PORT: "0",
     JAZZ_APP_ID: APP_ID,
+    JAZZ_SERVER_URL: upstream.url,
+    JAZZ_BACKEND_SECRET: upstream.backendSecret,
     JAZZ_JWKS_URL: jwtIssuer.jwksUrl,
   };
   if (dbPath === undefined) delete childEnv.DB_PATH;
@@ -108,10 +136,11 @@ const invalidCliCases = [
 
 describe("Todo server CLI", () => {
   beforeAll(async () => {
-    jwtIssuer = await startTestJwtIssuer();
+    await startUpstream();
   });
 
   afterAll(async () => {
+    await upstream?.stop();
     await jwtIssuer?.stop();
   });
 

--- a/examples/todo-server-ts/tests/cli.test.ts
+++ b/examples/todo-server-ts/tests/cli.test.ts
@@ -5,6 +5,8 @@ import { once } from "node:events";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createAccountManager } from "jazz-tools";
+
 import {
   deploy,
   startLocalJazzServer,
@@ -43,6 +45,24 @@ async function startUpstream(): Promise<void> {
     permissions,
   });
 }
+async function registerToken(token: string): Promise<void> {
+  let stored: string | null = null;
+  const accounts = await createAccountManager({
+    appId: APP_ID,
+    serverUrl: upstream.url,
+    env: `todo-cli-${crypto.randomUUID()}`,
+    store: {
+      async read() {
+        return stored;
+      },
+      async update(transform) {
+        stored = transform(stored);
+      },
+    },
+  });
+  await accounts.registerJWT(token);
+}
+
 async function startChild(cwd: string): Promise<RunningChild> {
   const childEnv = {
     ...process.env,
@@ -151,6 +171,7 @@ describe("Todo server CLI", () => {
     let second: RunningChild | undefined;
 
     try {
+      await registerToken(token);
       first = await startChild(cwd);
       const createResponse = await fetch(`${first.baseUrl}/todos`, {
         method: "POST",

--- a/examples/todo-server-ts/tests/cli.test.ts
+++ b/examples/todo-server-ts/tests/cli.test.ts
@@ -1,0 +1,108 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, rmSync } from "node:fs";
+import { once } from "node:events";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startTestJwtIssuer, type TestJwtIssuerHandle } from "jazz-tools/testing";
+
+const EXTERNAL_ISSUER = "https://todo-server.example.test";
+const APP_ID = "todo-cli-durable-restart";
+const exampleRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const tsxLauncher = join(exampleRoot, "node_modules", ".bin", "tsx");
+
+type RunningChild = {
+  process: ChildProcess;
+  baseUrl: string;
+};
+
+let jwtIssuer: TestJwtIssuerHandle;
+
+async function startChild(cwd: string): Promise<RunningChild> {
+  const childEnv = {
+    ...process.env,
+    PORT: "0",
+    JAZZ_APP_ID: APP_ID,
+    JAZZ_JWKS_URL: jwtIssuer.jwksUrl,
+  };
+  delete childEnv.DB_PATH;
+  const child = spawn(tsxLauncher, [join(exampleRoot, "src", "main.ts")], {
+    cwd,
+    env: childEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let output = "";
+  let errorOutput = "";
+  const ready = new Promise<string>((resolve, reject) => {
+    const onOutput = (chunk: Buffer) => {
+      output += chunk.toString();
+      const match = output.match(/Todo server listening on (http:\/\/localhost:\d+)/);
+      if (match) resolve(match[1]!);
+    };
+    child.stdout?.on("data", onOutput);
+    child.stderr?.on("data", (chunk: Buffer) => {
+      errorOutput += chunk.toString();
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      reject(
+        new Error(
+          `Server exited before readiness (code=${code}, signal=${signal}). Output:\n${output}\n${errorOutput}`,
+        ),
+      );
+    });
+  });
+
+  return { process: child, baseUrl: await ready };
+}
+
+async function stopChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGINT");
+  await once(child, "exit");
+}
+
+describe("Todo server CLI", () => {
+  beforeAll(async () => {
+    jwtIssuer = await startTestJwtIssuer();
+  });
+
+  afterAll(async () => {
+    await jwtIssuer?.stop();
+  });
+
+  it("persists authenticated todos across fresh CLI processes with the default path", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "jazz-todo-cli-restart-"));
+    const token = jwtIssuer.jwtForUser("todo-cli-restart-user", {}, { issuer: EXTERNAL_ISSUER });
+    let first: RunningChild | undefined;
+    let second: RunningChild | undefined;
+
+    try {
+      first = await startChild(cwd);
+      const createResponse = await fetch(`${first.baseUrl}/todos`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ title: "survives process restart" }),
+      });
+      expect(createResponse.status).toBe(201);
+      await stopChild(first.process);
+
+      second = await startChild(cwd);
+      const listResponse = await fetch(`${second.baseUrl}/todos`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      expect(listResponse.status).toBe(200);
+      const todos = (await listResponse.json()) as Array<{ title: string }>;
+      expect(todos.some((todo) => todo.title === "survives process restart")).toBe(true);
+    } finally {
+      if (first) await stopChild(first.process);
+      if (second) await stopChild(second.process);
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/examples/todo-server-ts/tests/cli.test.ts
+++ b/examples/todo-server-ts/tests/cli.test.ts
@@ -64,6 +64,48 @@ async function stopChild(child: ChildProcess): Promise<void> {
   await once(child, "exit");
 }
 
+async function runCli(
+  cwd: string,
+  args: string[],
+  dbPath: string | undefined,
+): Promise<{ code: number | null; output: string }> {
+  const childEnv = {
+    ...process.env,
+    PORT: "0",
+    JAZZ_APP_ID: APP_ID,
+    JAZZ_JWKS_URL: jwtIssuer.jwksUrl,
+  };
+  if (dbPath === undefined) delete childEnv.DB_PATH;
+  else childEnv.DB_PATH = dbPath;
+  const child = spawn(tsxLauncher, [join(exampleRoot, "src", "main.ts"), ...args], {
+    cwd,
+    env: childEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let output = "";
+  child.stdout?.on("data", (chunk: Buffer) => {
+    output += chunk.toString();
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    output += chunk.toString();
+  });
+  const [code] = await once(child, "exit");
+  return { code: code as number | null, output };
+}
+
+const invalidCliCases = [
+  { name: "unknown options", args: ["--unknown"], dbPath: undefined },
+  { name: "missing data path", args: ["--data-path"], dbPath: undefined },
+  { name: "empty data path", args: ["--data-path", ""], dbPath: undefined },
+  {
+    name: "in-memory and data path conflict",
+    args: ["--in-memory", "--data-path", "/tmp/todo.db"],
+    dbPath: undefined,
+  },
+  { name: "empty DB_PATH", args: [], dbPath: "" },
+] as const;
+
 describe("Todo server CLI", () => {
   beforeAll(async () => {
     jwtIssuer = await startTestJwtIssuer();
@@ -102,6 +144,17 @@ describe("Todo server CLI", () => {
     } finally {
       if (first) await stopChild(first.process);
       if (second) await stopChild(second.process);
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+  it.each(invalidCliCases)("$name fails before listening", async ({ args, dbPath }) => {
+    const cwd = mkdtempSync(join(tmpdir(), "jazz-todo-cli-invalid-"));
+    try {
+      const result = await runCli(cwd, args, dbPath);
+      expect(result.code).not.toBe(0);
+      expect(result.output).toContain("Fatal error:");
+      expect(result.output).not.toContain("Todo server listening");
+    } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
   });

--- a/examples/todo-server-ts/tests/integration.test.ts
+++ b/examples/todo-server-ts/tests/integration.test.ts
@@ -229,7 +229,7 @@ describe("Todo Server Integration", () => {
       const address = occupied.address();
       if (!address || typeof address === "string") throw new Error("expected TCP listener");
 
-      const candidate = await createServer(undefined, jazzOptions());
+      const candidate = await createServer({ type: "memory" }, jazzOptions());
       try {
         await expect(startServer(candidate, address.port)).rejects.toMatchObject({
           code: "EADDRINUSE",
@@ -327,10 +327,7 @@ describe("Todo Server Integration", () => {
 
       // --- First boot: create some todos ---
       const server1 = await startServer(
-        await createServer(
-          { type: "persistent", dataPath: dbPath },
-          jazzOptions(),
-        ),
+        await createServer({ type: "persistent", dataPath: dbPath }, jazzOptions()),
         0,
       );
 
@@ -356,10 +353,7 @@ describe("Todo Server Integration", () => {
 
       // --- Second boot: same data path, fresh server ---
       const server2 = await startServer(
-        await createServer(
-          { type: "persistent", dataPath: dbPath },
-          jazzOptions(),
-        ),
+        await createServer({ type: "persistent", dataPath: dbPath }, jazzOptions()),
         0,
       );
 
@@ -392,7 +386,10 @@ describe("Todo Server Integration", () => {
     it("returns the current value after dense update history and a restart", async () => {
       const dataDir = mkdtempSync(join(tmpdir(), "jazz-dense-history-"));
       const dbPath = join(dataDir, "jazz.db");
-      const server1 = await startServer(await createServer(dbPath, jazzOptions()), 0);
+      const server1 = await startServer(
+        await createServer({ type: "persistent", dataPath: dbPath }, jazzOptions()),
+        0,
+      );
 
       let todoId: string | undefined;
       try {
@@ -417,7 +414,10 @@ describe("Todo Server Integration", () => {
         await stopServer(server1);
       }
 
-      const server2 = await startServer(await createServer(dbPath, jazzOptions()), 0);
+      const server2 = await startServer(
+        await createServer({ type: "persistent", dataPath: dbPath }, jazzOptions()),
+        0,
+      );
       try {
         const response = await authenticatedFetch(`${server2.baseUrl}/todos/${todoId}`);
         expect(response.status).toBe(200);

--- a/examples/todo-server-ts/tests/integration.test.ts
+++ b/examples/todo-server-ts/tests/integration.test.ts
@@ -555,7 +555,10 @@ describe("Todo Server Integration", () => {
       }
     });
     it("rejects todo requests admitted after draining begins", async () => {
-      const drainingServer = await startServer(await createServer(undefined, jazzOptions()), 0);
+      const drainingServer = await startServer(
+        await createServer({ type: "memory" }, jazzOptions()),
+        0,
+      );
       const originalClose = drainingServer.server.close.bind(drainingServer.server);
       let closeCallback: ((error?: Error) => void) | undefined;
       drainingServer.server.close = vi.fn((callback?: (error?: Error) => void) => {
@@ -590,7 +593,7 @@ describe("Todo Server Integration", () => {
     });
 
     it("gracefully closes active SSE connections during shutdown", async () => {
-      const sseServer = await startServer(await createServer(undefined, jazzOptions()), 0);
+      const sseServer = await startServer(await createServer({ type: "memory" }, jazzOptions()), 0);
       const sseBaseUrl = sseServer.baseUrl;
       let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
       let shutdown: Promise<void> | undefined;

--- a/examples/todo-server-ts/tests/integration.test.ts
+++ b/examples/todo-server-ts/tests/integration.test.ts
@@ -110,8 +110,14 @@ describe("Todo Server Integration", () => {
       permissions,
     });
     primaryIdentity = await createIdentity(jwtIssuer, upstream, "todo-rest-integration");
-    // Create server with Fjall-backed storage (temp directory)
-    const todoServer = await createServer(undefined, jazzOptions());
+    // Create an isolated persistent server for the CRUD suite.
+    const todoServer = await createServer(
+      {
+        type: "persistent",
+        dataPath: join(mkdtempSync(join(tmpdir(), "jazz-integration-")), "jazz.db"),
+      },
+      jazzOptions(),
+    );
 
     // Start on random available port
     server = await startServer(todoServer, 0);
@@ -320,7 +326,13 @@ describe("Todo Server Integration", () => {
       const dbPath = join(dataDir, "jazz.db");
 
       // --- First boot: create some todos ---
-      const server1 = await startServer(await createServer(dbPath, jazzOptions()), 0);
+      const server1 = await startServer(
+        await createServer(
+          { type: "persistent", dataPath: dbPath },
+          jazzOptions(),
+        ),
+        0,
+      );
 
       const createRes1 = await authenticatedFetch(`${server1.baseUrl}/todos`, {
         method: "POST",
@@ -343,7 +355,13 @@ describe("Todo Server Integration", () => {
       await stopServer(server1);
 
       // --- Second boot: same data path, fresh server ---
-      const server2 = await startServer(await createServer(dbPath, jazzOptions()), 0);
+      const server2 = await startServer(
+        await createServer(
+          { type: "persistent", dataPath: dbPath },
+          jazzOptions(),
+        ),
+        0,
+      );
 
       // The server's public authenticated route must be able to serve the
       // persisted current state immediately after reopening, rather than only
@@ -416,7 +434,16 @@ describe("Todo Server Integration", () => {
   describe("SSE Live Endpoint", () => {
     it("streams only the authenticated caller's todos and updates on changes", async () => {
       // Use an isolated server instance so this test has an independent persistence context.
-      const sseServer = await startServer(await createServer(undefined, jazzOptions()), 0);
+      const sseServer = await startServer(
+        await createServer(
+          {
+            type: "persistent",
+            dataPath: join(mkdtempSync(join(tmpdir(), "jazz-sse-")), "jazz.db"),
+          },
+          jazzOptions(),
+        ),
+        0,
+      );
       const sseBaseUrl = sseServer.baseUrl;
       let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
       try {


### PR DESCRIPTION
## Summary
- Give the todo server CLI an explicit durable storage-path mode.
- Keep memory storage available for ephemeral operation and tests.

## Before
Fresh CLI processes could lose authenticated todos because the default server path did not select durable storage consistently.

## After
The CLI uses a durable default path across process restarts, while callers can still select memory storage explicitly.

## Test plan
- [ ] Review the fresh-process persistence regression in `examples/todo-server-ts/tests/cli.test.ts`.
- [ ] Run the focused todo-server authentication, integration, and CLI tests.
- [ ] Run the repository CI checks.