### PR TITLE
fix: hydrate JSON storage cells in relation includes

### DIFF
--- a/crates/jazz/src/db/tests/reads.rs
+++ b/crates/jazz/src/db/tests/reads.rs
@@ -1989,6 +1989,75 @@ fn relation_snapshot_reverse_array_skips_deleted_children_with_camel_case_ref() 
     );
 }
 
+/// Alice reads a projected reverse include whose parent has an unrelated JSON cell.
+/// The binding hydration boundary must expose the parent and child without physical types.
+#[test]
+fn relation_snapshot_json_parent_binding_hydration() {
+    assert_relation_snapshot_json_binding_hydration(false);
+}
+
+/// Alice includes a child with JSON, so collector anchor and child arms must
+/// agree on the physical JSON descriptor before binding hydration.
+#[test]
+fn relation_snapshot_json_child_binding_hydration() {
+    assert_relation_snapshot_json_binding_hydration(true);
+}
+
+fn assert_relation_snapshot_json_binding_hydration(child_json: bool) {
+    let mut children = PublicTableSchemaBuilder::new("children").fk_column("parentId", "parents");
+    if child_json {
+        children = children.column("metadata", PublicColumnType::Json { schema: None });
+    }
+    let schema = build_public_db_test_schema(
+        PublicSchemaBuilder::new()
+            .table(
+                PublicTableSchemaBuilder::new("parents")
+                    .column("name", PublicColumnType::Text)
+                    .column("metadata", PublicColumnType::Json { schema: None }),
+            )
+            .table(children),
+    );
+    let db = open_db(0xc2, AuthorSubject::for_test_bytes([0xc2; 16]), &schema);
+    // Db's binding-facing API accepts core cells; row_input! is for JazzClient's
+    // public Value algebra and cannot represent this lower-level input type.
+    let parent = db
+        .insert(
+            "parents",
+            BTreeMap::from([
+                ("name".into(), Value::String("alice".into())),
+                ("metadata".into(), Value::String("{}".into())),
+            ]),
+            Default::default(),
+        )
+        .unwrap()
+        .row_uuid();
+    let mut child_cells = BTreeMap::from([("parentId".into(), Value::Uuid(parent.0))]);
+    if child_json {
+        child_cells.insert("metadata".into(), Value::String("{}".into()));
+    }
+    let child = db
+        .insert("children", child_cells, Default::default())
+        .unwrap()
+        .row_uuid();
+    let children = ArraySubquery::new("childrenViaParent", "children", "parentId", "id");
+    let children = if child_json {
+        children
+    } else {
+        children.select(["id"])
+    };
+    let query = Query::from("parents")
+        .select(["id"])
+        .array_subquery(children);
+    let prepared = db.prepare_query(&query).unwrap();
+    let mut snapshot = block_on(db.all_relation_snapshot(&prepared, ReadOpts::default())).unwrap();
+    block_on(db.hydrate_rows_for_binding(&mut snapshot.rows)).unwrap();
+    assert_eq!(row_ids(&snapshot.rows), vec![parent]);
+    assert_eq!(
+        terminal_nested_values(&snapshot, parent, "childrenViaParent", "row_uuid"),
+        vec![Value::Uuid(child.0)]
+    );
+}
+
 #[test]
 fn relation_snapshot_reverse_array_reads_local_nullable_ref_child() {
     let schema = build_public_db_test_schema(

--- a/crates/jazz/src/node/state/lifecycle.rs
+++ b/crates/jazz/src/node/state/lifecycle.rs
@@ -1399,6 +1399,26 @@ where
 
         Box::pin(async move {
             match value_type {
+                // JSON remains string-shaped to callers, but query collectors
+                // retain its distinct storage codec through the binding boundary.
+                ValueType::Internal(_)
+                    if *value_type == groove::large_values::physical_storage_value_type(
+                        groove::large_values::LargeValueKind::Json,
+                    ) =>
+                {
+                    match value {
+                        Value::String(_) => Ok(()),
+                        Value::Large(value_ref)
+                            if value_ref.kind == groove::large_values::LargeValueKind::Json =>
+                        {
+                            *value = self.materialize_large_value(value_ref).await?;
+                            Ok(())
+                        }
+                        _ => Err(Error::InvalidStoredValue(
+                            "binding JSON value does not match its descriptor",
+                        )),
+                    }
+                }
                 ValueType::String => match value {
                     Value::String(_) => Ok(()),
                     Value::Large(value_ref)

--- a/packages/jazz-tools/src/backend/json-include.integration.test.ts
+++ b/packages/jazz-tools/src/backend/json-include.integration.test.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { schema as s } from "../index.js";
+import { deploy, startLocalJazzServer } from "../testing/index.js";
+import { createJazzSession } from "./index.js";
+
+describe("JSON parent includes through the native backend", () => {
+  for (const inMemory of [true, false]) {
+    it(`hydrates projected and full includes with ${inMemory ? "memory" : "persistent"} server storage`, async () => {
+      const app = s.defineApp({
+        parents: s.table({ name: s.string(), metadata: s.json() }),
+        children: s.table({ parentId: s.ref("parents"), name: s.string() }),
+      });
+      const server = await startLocalJazzServer({ appId: randomUUID(), inMemory });
+      let owner: Awaited<ReturnType<typeof createJazzSession>> | undefined;
+      try {
+        await deploy({
+          serverUrl: server.url,
+          appId: server.appId,
+          adminSecret: server.adminSecret,
+          schema: app,
+          permissions: {},
+        });
+        owner = await createJazzSession({
+          appId: server.appId,
+          serverUrl: server.url,
+          app,
+          permissions: {},
+          driver: { type: "memory" },
+          initial: { backendSecret: server.backendSecret },
+        });
+        const db = owner.getSnapshot().client!.db;
+        const parent = await db
+          .insert(app.parents, { name: "Alice", metadata: {} })
+          .wait({ tier: "global" });
+        const child = await db
+          .insert(app.children, { parentId: parent.id, name: "Note" })
+          .wait({ tier: "global" });
+        expect(await db.all(app.parents, { tier: "edge" })).toMatchObject([
+          { id: parent.id, metadata: {} },
+        ]);
+        expect(await db.all(app.children, { tier: "edge" })).toMatchObject([{ id: child.id }]);
+        expect(
+          await db.all(
+            app.parents.select("id").include({ childrenViaParent: app.children.select("id") }),
+            { tier: "edge" },
+          ),
+        ).toEqual([{ id: parent.id, childrenViaParent: [{ id: child.id }] }]);
+        expect(
+          await db.all(app.parents.include({ childrenViaParent: true }), { tier: "edge" }),
+        ).toMatchObject([{ id: parent.id, metadata: {}, childrenViaParent: [{ id: child.id }] }]);
+        const metadata = { body: "x".repeat(100_000) };
+        await db.update(app.parents, parent.id, { metadata }).wait({ tier: "global" });
+        expect(
+          await db.all(app.parents.include({ childrenViaParent: true }), { tier: "edge" }),
+        ).toMatchObject([{ id: parent.id, metadata, childrenViaParent: [{ id: child.id }] }]);
+      } finally {
+        await owner?.close();
+        await server.stop();
+      }
+    }, 30_000);
+  }
+});

--- a/packages/jazz-tools/tests/browser/db.json-includes.test.ts
+++ b/packages/jazz-tools/tests/browser/db.json-includes.test.ts
@@ -1,0 +1,80 @@
+import { expect, it } from "vitest";
+import { schema as s, generateAuthSecret } from "../../src/index.js";
+import { createBrowserTestDb } from "./support.js";
+import { deploy } from "../../src/dev/catalogue.js";
+import { getJazzServerInfo, stopJazzServer } from "./testing-server.js";
+
+const app = s.defineApp({
+  parents: s.table({
+    name: s.string(),
+    state: s.enum("draft", "open", "closed"),
+    summaryId: s.ref("summaries").optional(),
+  }),
+  summaries: s.table({ metadata: s.json() }),
+  children: s.table({ parentId: s.ref("parents"), metadata: s.json() }),
+});
+
+it("reads JSON forward and reverse includes offline before and after persistent reopen", async () => {
+  const server = await getJazzServerInfo(crypto.randomUUID());
+  const permissions = s.definePermissions(app, ({ policy }) => [
+    policy.parents.allowRead.always(),
+    policy.parents.allowInsert.always(),
+    policy.summaries.allowRead.always(),
+    policy.summaries.allowInsert.always(),
+    policy.children.allowRead.always(),
+    policy.children.allowInsert.always(),
+  ]);
+  await deploy({ ...server, schema: app, permissions });
+  const config = {
+    appId: server.appId,
+    serverUrl: server.serverUrl,
+    secret: generateAuthSecret(),
+    driver: { type: "persistent" as const, dbName: `json-includes-${crypto.randomUUID()}` },
+  };
+  let db = await createBrowserTestDb(config);
+  let serverStopped = false;
+  try {
+    const summary = await db
+      .insert(app.summaries, { metadata: { total: 1 } })
+      .wait({ tier: "global" });
+    const parent = await db
+      .insert(app.parents, { name: "Alice", state: "draft", summaryId: summary.id })
+      .wait({ tier: "global" });
+    const child = await db
+      .insert(app.children, { parentId: parent.id, metadata: { title: "Note" } })
+      .wait({ tier: "global" });
+    await db.disconnect();
+    await stopJazzServer(server.serverUrl);
+    serverStopped = true;
+    for (let cycle = 0; cycle < 2; cycle++) {
+      const q = app.parents.where({ id: parent.id });
+      expect(await db.one(q, { tier: "local" })).toMatchObject({ id: parent.id, state: "draft" });
+      expect(await db.one(q.include({ summary: true }), { tier: "local" })).toMatchObject({
+        summary: { id: summary.id, metadata: { total: 1 } },
+      });
+      expect(await db.one(q.include({ childrenViaParent: true }), { tier: "local" })).toMatchObject(
+        { childrenViaParent: [{ id: child.id, metadata: { title: "Note" } }] },
+      );
+      expect(
+        await db.one(
+          q.select("id").include({
+            summary: app.summaries.select("id"),
+            childrenViaParent: app.children.select("id"),
+          }),
+          { tier: "local" },
+        ),
+      ).toEqual({
+        id: parent.id,
+        summary: { id: summary.id },
+        childrenViaParent: [{ id: child.id }],
+      });
+      if (cycle === 0) {
+        await db.shutdown();
+        db = await createBrowserTestDb(config);
+      }
+    }
+  } finally {
+    await db.shutdown();
+    if (!serverStopped) await stopJazzServer(server.serverUrl);
+  }
+}, 60_000);


### PR DESCRIPTION
JSON relation includes now return their requested rows instead of `Protocol: invalid stored value: binding value does not match its descriptor`, including when a parent JSON column is omitted by `select("id")`.

Collectors retain JSON's physical storage descriptor. Binding hydration handled logical strings but rejected that descriptor. This change accepts inline JSON and materializes indirect JSON through the existing asynchronous hydration path. Other descriptor/value mismatches still fail; query semantics and storage/wire encodings are unchanged.

For example, one parent with `metadata: {}` and one child now returns both IDs through a projected reverse include. Full includes also return a 100 KB JSON value. Browser forward/reverse includes continue to work with the server stopped and after persistent reopen.

Fixes #2699. Fixes #2689.

Related: #1844, #1966, #2402.

The older browser report used a different graph-descriptor error. With the matching pre-fix packages from preview run 34280043435 (runtime source `90af64c12`), its original full-schema fixture instead fails all four include probes with the JSON hydration error. The same fixture passes all four probes, update cycles, and offline restart with this change. This does not claim that the older graph error had the same underlying cause.

Validation:

- Jazz core library: 1,914 passed, 2 existing ignored tests.
- All three incremental-delivery canaries passed; the ignored differential oracle also passed with seed 11 and churn depths 10/1,000.
- Native SDK regression passed with memory and persistent server storage, projected/full includes, and large JSON.
- Persistent browser regression covers forward, reverse, and projected includes offline and after reopen.
- Original browser reproduction compared against matching published pre-fix packages.
- Jazz Tools build, TypeScript check, Clippy (`-D warnings`), and formatting/lint hooks passed. Full CI-equivalent gate was not run locally; the optional private sensitive-data guard was unavailable.

## Post-Deploy Monitoring & Validation

On the next preview build, rerun the two linked standalone reproductions. Includes should return the expected rows; either reported descriptor error is a failure signal.
