### PR TITLE
Harden browser worker lifecycle and reset cleanup

### DIFF
--- a/.changeset/browser-worker-lifecycle.md
+++ b/.changeset/browser-worker-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Keep browser worker readiness, follower liveness, and foreground lease reset and shutdown ownership consistent across worker generations.

--- a/docs/content/docs/getting-started/client-setup.mdx
+++ b/docs/content/docs/getting-started/client-setup.mdx
@@ -121,6 +121,8 @@ While control requests are waiting for worker replies, Jazz probes the connectio
 
 An unresponsive-worker error does not prove that an outstanding operation failed. It may already have completed. Jazz does not automatically retry operations with an unknown outcome or clear IndexedDB. Use the existing [client and session lifecycle](/docs/auth/lifecycle) to recover, and establish a mutation's outcome before retrying it. Terminal shutdown reports the causal failure without waiting indefinitely for an unresponsive worker; it does not claim that an unacknowledged durable handoff succeeded.
 
+An intentional storage reset releases the old foreground identity without returning it to the erased store. `deleteClientStorage()` waits for a fresh identity before the same application client can be used again. If shutdown starts during that acquisition, Jazz retires the unused identity instead. Inspector attachments are session-scoped: after a reset, open a new attachment rather than reusing the old one.
+
 #### Browser storage eviction
 
 `{ type: "persistent" }` writes to [IndexedDB](https://developer.mozilla.org/docs/Web/API/IndexedDB_API). By default browsers treat this as **best-effort** storage&hairsp;—&hairsp;under disk pressure, or after long inactivity, the browser can clear it without warning. For a local-first app that means a returning user can find their identity (the local-first secret) and any data owned only by that user wiped.

--- a/docs/content/docs/getting-started/client-setup.mdx
+++ b/docs/content/docs/getting-started/client-setup.mdx
@@ -113,6 +113,14 @@ Browser clients default to `driver: { type: "persistent" }`, which stores data l
 
 When you supply `driver: { type: "persistent", dbName }`, the name is a logical base. Jazz derives the physical root from registry, app, environment, and account. Linked identities share that account's durable root while opening distinct live authorization sessions. A root whose recorded scope does not match is rejected.
 
+#### Browser worker failures
+
+After the shared worker acknowledges startup, runtime initialisation has a five-minute grace period. If it does not become ready, startup reports an error instead of leaving the client pending indefinitely. Suspended tabs receive fresh grace when they resume.
+
+While control requests are waiting for worker replies, Jazz probes the connection every 30 seconds and allows 30 seconds for a response. These are connection-health checks, not query or storage-operation timeouts: a responsive worker can continue a long operation, and idle connections are not continuously probed.
+
+An unresponsive-worker error does not prove that an outstanding operation failed. It may already have completed. Jazz does not automatically retry operations with an unknown outcome or clear IndexedDB. Use the existing [client and session lifecycle](/docs/auth/lifecycle) to recover, and establish a mutation's outcome before retrying it. Terminal shutdown reports the causal failure without waiting indefinitely for an unresponsive worker; it does not claim that an unacknowledged durable handoff succeeded.
+
 #### Browser storage eviction
 
 `{ type: "persistent" }` writes to [IndexedDB](https://developer.mozilla.org/docs/Web/API/IndexedDB_API). By default browsers treat this as **best-effort** storage&hairsp;—&hairsp;under disk pressure, or after long inactivity, the browser can clear it without warning. For a local-first app that means a returning user can find their identity (the local-first secret) and any data owned only by that user wiped.

--- a/packages/jazz-tools/scripts/bundle-broker-worker.mjs
+++ b/packages/jazz-tools/scripts/bundle-broker-worker.mjs
@@ -40,7 +40,7 @@ function assertOutputMayBePublished(outputDir) {
     );
 }
 
-export async function bundleBrokerWorker(outputDir = canonicalOutputDir) {
+export async function bundleBrokerWorker(outputDir = canonicalOutputDir, entryPoint = entry) {
   assertOutputMayBePublished(outputDir);
   await mkdir(outputDir, { recursive: true });
   // Prepare the complete pair privately. Publication below only renames fully
@@ -53,7 +53,7 @@ export async function bundleBrokerWorker(outputDir = canonicalOutputDir) {
   const wasmOutfile = resolve(outputDir, "jazz_wasm_bg.wasm");
   try {
     await build({
-      entryPoints: [entry],
+      entryPoints: [entryPoint],
       outfile: stagedWorker,
       // Correctness consumers pin both wasm-bindgen glue and the binary.  A
       // binary-only override would still let esbuild follow a mutable package

--- a/packages/jazz-tools/src/runtime/browser-worker-config.test.ts
+++ b/packages/jazz-tools/src/runtime/browser-worker-config.test.ts
@@ -84,27 +84,6 @@ describe("browser SharedWorker asset handoff", () => {
     expect(freshRealmIdentity).not.toBe(sourceIdentity);
   });
 
-  it("does not collapse distinct assets that collide under the retired 32-bit scope hash", () => {
-    const first = {
-      wasmUrl: "https://assets.test/jazz_wasm_bg.wasm",
-      brokerWorkerUrl: "https://assets.test/worker/jazz-broker-worker.js",
-      wasmVersion: "build-2826",
-    };
-    const second = {
-      wasmUrl: "https://assets.test/jazz_wasm_bg.wasm",
-      brokerWorkerUrl: "https://assets.test/worker/jazz-broker-worker.js",
-      wasmVersion: "build-290d",
-    };
-
-    // These full canonical identities have the same FNV-1a 32-bit hash. The
-    // worker scope retains the identity itself, so the collision cannot alias
-    // their process-global wasm-bindgen initialization.
-    expect(retiredScopeHash(createBrowserWorkerAssetScope(first))).toBe(
-      retiredScopeHash(createBrowserWorkerAssetScope(second)),
-    );
-    expect(createBrowserWorkerAssetScope(first)).not.toBe(createBrowserWorkerAssetScope(second));
-  });
-
   it("requires an immutable version when browser asset URLs are configured", () => {
     expect(() => resolveBrowserWorkerRuntimeSources({ wasmUrl: "/assets/jazz.wasm" })).toThrow(
       "runtimeSources.wasmVersion",
@@ -134,15 +113,6 @@ describe("browser SharedWorker asset handoff", () => {
     expect(new URL(workerUrl).searchParams.get("jazz-runtime-version")).toBe("deploy-42");
   });
 });
-
-function retiredScopeHash(value: string): string {
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < value.length; index += 1) {
-    hash ^= value.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return (hash >>> 0).toString(16).padStart(8, "0");
-}
 
 describe("account storage and principal runtime isolation", () => {
   it("reopens the same account root without sharing live authorization between linked identities", async () => {

--- a/packages/jazz-tools/src/runtime/browser-worker-config.ts
+++ b/packages/jazz-tools/src/runtime/browser-worker-config.ts
@@ -13,7 +13,7 @@ import {
 
 import { normalizeOtlpEndpoint } from "./sync-telemetry.js";
 
-const SHARED_RUNTIME_PROTOCOL_VERSION = "jazz-shared-runtime-v1";
+const SHARED_RUNTIME_PROTOCOL_VERSION = "jazz-shared-runtime-v2";
 // Coupled to IndexedDbPageStore's durable epoch. Keeping it in the database
 // scope prevents an old worker from opening incompatible root metadata.
 const BROWSER_STORAGE_FORMAT_VERSION = "idbtree-v1";
@@ -86,6 +86,7 @@ export function resolveBrowserWorkerRuntimeSources(
 export function createBrowserWorkerAssetScope(runtimeSources?: RuntimeSourcesConfig): string {
   const resolvedSources = resolveBrowserWorkerRuntimeSources(runtimeSources);
   return JSON.stringify({
+    protocolVersion: SHARED_RUNTIME_PROTOCOL_VERSION,
     workerUrl: resolveBrowserWorkerUrl(resolvedSources),
     wasmAsset: workerWasmAssetIdentity(resolvedSources),
   });

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
@@ -14,7 +14,7 @@ function deferred() {
   return { promise, resolve };
 }
 
-async function leasedManagerFixture(admissionError?: Error) {
+async function foregroundLeaseFixture() {
   const messages: string[] = [];
   const leaseEvents = new EventTarget();
   const emit = (data: unknown) => leaseEvents.dispatchEvent(new MessageEvent("message", { data }));
@@ -47,6 +47,25 @@ async function leasedManagerFixture(admissionError?: Error) {
     port as unknown as MessagePort,
     { dbName: "terminal-lease-controls", storageOwner: "owner" },
   );
+  return {
+    lease,
+    port,
+    messages,
+    finishStarted,
+    acknowledge: () => emit({ type: "foreground-node-lease-result" }),
+    allowFinish: () => {
+      acknowledgeFinish = true;
+    },
+    setClientLive: (live: boolean) => {
+      clientLive = live;
+    },
+    liveClientAtRetirement: () => liveClientAtRetirement,
+  };
+}
+
+async function leasedManagerFixture(admissionError?: Error, inspectorAttachment = false) {
+  const leaseFixture = await foregroundLeaseFixture();
+  const { lease } = leaseFixture;
   const connection: BrowserWorkerConnection = {
     ready: vi.fn(async () => {
       if (admissionError) throw admissionError;
@@ -65,16 +84,18 @@ async function leasedManagerFixture(admissionError?: Error) {
     onMutationError: vi.fn(),
     getRuntime: () => undefined,
     discard: vi.fn(() => {
-      clientLive = false;
+      leaseFixture.setClientLive(false);
     }),
   } as unknown as JazzClient;
   let onFailure!: BrowserWorkerConnectionContext["onFailure"];
+  const contexts: BrowserWorkerConnectionContext[] = [];
   const disposeTelemetry = vi.fn();
   const createClient = vi.fn(() => {
-    clientLive = true;
+    leaseFixture.setClientLive(true);
     return client;
   });
   const createConnection = vi.fn((context: BrowserWorkerConnectionContext) => {
+    contexts.push(context);
     onFailure = context.onFailure;
     return { ...connection };
   });
@@ -82,10 +103,20 @@ async function leasedManagerFixture(admissionError?: Error) {
     config: {
       serverUrl: "https://example.test",
       telemetryCollectorUrl: "https://example.test/telemetry",
+      runtimeSources: inspectorAttachment
+        ? {
+            inspectorBinding: {
+              appId: "app",
+              physicalDbName: "root",
+              authSessionKey: "session",
+              storageOwner: "owner",
+            },
+          }
+        : undefined,
     },
     isShuttingDown: false,
     runtimeSource: {
-      acquireBrowserForegroundNodeLease: async () => lease,
+      acquireBrowserForegroundNodeLease: vi.fn(async () => lease),
       createClient,
       installTelemetry: () => disposeTelemetry,
       createBrowserWorkerConnection: createConnection,
@@ -102,23 +133,153 @@ async function leasedManagerFixture(admissionError?: Error) {
   return {
     manager,
     host,
-    lease,
-    port,
-    messages,
+    ...leaseFixture,
+    contexts,
     connection,
     client,
     disposeTelemetry,
     createClient,
     createConnection,
-    finishStarted,
     fail: (error: Error) => onFailure(error),
-    acknowledge: () => emit({ type: "foreground-node-lease-result" }),
-    allowFinish: () => {
-      acknowledgeFinish = true;
-    },
-    liveClientAtRetirement: () => liveClientAtRetirement,
   };
 }
+
+describe("BrowserConnectionManager acknowledged storage reset", () => {
+  it.each([false, true])(
+    "cancels an obsolete pending lease finish without losing an earlier flush error (%s)",
+    async (flushFailed) => {
+      vi.useFakeTimers();
+      const fixture = await leasedManagerFixture();
+      const flushError = new Error("independent flush failure");
+      if (flushFailed) vi.mocked(fixture.connection.flushLocal).mockRejectedValue(flushError);
+      fixture.host.isShuttingDown = true;
+      let outcome: unknown = "pending";
+      const shutdown = fixture.manager.shutdown().then(
+        () => {
+          outcome = "fulfilled";
+        },
+        (error) => {
+          outcome = error;
+        },
+      );
+      try {
+        await fixture.finishStarted.promise;
+        const terminalMessages = fixture.messages.slice();
+        fixture.contexts[0]!.onStorageReset?.(1);
+        fixture.contexts[0]!.onStorageReset?.(1);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(outcome).toBe(flushFailed ? flushError : "fulfilled");
+        expect(fixture.port.close).toHaveBeenCalledOnce();
+        expect(fixture.messages).toEqual(terminalMessages);
+        fixture.acknowledge();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(outcome).toBe(flushFailed ? flushError : "fulfilled");
+        await expect(fixture.lease.retire()).rejects.toThrow(/reset/i);
+        expect(fixture.port.close).toHaveBeenCalledOnce();
+      } finally {
+        fixture.acknowledge();
+        await shutdown;
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("waits for a new lease before same-Db reuse and ignores an old reset callback", async () => {
+    vi.useFakeTimers();
+    const fixture = await leasedManagerFixture();
+    const successor = await foregroundLeaseFixture();
+    successor.allowFinish();
+    const acquire = deferred();
+    fixture.host.runtimeSource.acquireBrowserForegroundNodeLease.mockImplementation(async () => {
+      await acquire.promise;
+      return successor.lease;
+    });
+    fixture.contexts[0]!.onStorageReset?.(1);
+    let resetFinished = false;
+    const reset = fixture.manager.deleteClientStorage().then(() => {
+      resetFinished = true;
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      expect(resetFinished).toBe(false);
+      expect(() => fixture.manager.getClient({})).toThrow(/reset/i);
+      acquire.resolve();
+      await reset;
+      fixture.manager.getClient({});
+      await fixture.manager.ensureReady("local");
+      const discards = vi.mocked(fixture.client.discard).mock.calls.length;
+      fixture.contexts[0]!.onStorageReset?.(2);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fixture.client.discard).toHaveBeenCalledTimes(discards);
+      await fixture.manager.shutdown();
+      expect(fixture.messages).not.toContain("return-foreground-node-lease");
+      expect(successor.messages).toContain("return-foreground-node-lease");
+      expect(successor.port.close).toHaveBeenCalledOnce();
+    } finally {
+      acquire.resolve();
+      fixture.allowFinish();
+      fixture.acknowledge();
+      successor.acknowledge();
+      await reset;
+      await fixture.manager.shutdown();
+      vi.useRealTimers();
+    }
+  });
+
+  it("retires an acquired but unpublished successor when shutdown wins", async () => {
+    vi.useFakeTimers();
+    const fixture = await leasedManagerFixture();
+    const successor = await foregroundLeaseFixture();
+    successor.allowFinish();
+    const acquire = deferred();
+    fixture.host.runtimeSource.acquireBrowserForegroundNodeLease.mockImplementation(async () => {
+      await acquire.promise;
+      return successor.lease;
+    });
+    fixture.contexts[0]!.onStorageReset?.(1);
+    await vi.advanceTimersByTimeAsync(0);
+    let outcome = "pending";
+    const shutdown = fixture.manager.shutdown().then(() => {
+      outcome = "fulfilled";
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      expect(outcome).toBe("pending");
+      acquire.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(outcome).toBe("fulfilled");
+      expect(successor.messages).toContain("retire-foreground-node-lease");
+      expect(successor.messages).not.toContain("return-foreground-node-lease");
+      expect(successor.port.close).toHaveBeenCalledOnce();
+      expect(fixture.messages).not.toContain("return-foreground-node-lease");
+      expect(() => fixture.manager.getClient({})).toThrow("shut down");
+    } finally {
+      acquire.resolve();
+      fixture.acknowledge();
+      successor.acknowledge();
+      await shutdown;
+      vi.useRealTimers();
+    }
+  });
+  it("requires a fresh Inspector attachment after an acknowledged reset", async () => {
+    const fixture = await leasedManagerFixture(undefined, true);
+    fixture.contexts[0]!.onStorageReset?.(1);
+    await fixture.manager.deleteClientStorage();
+    let resetError: unknown;
+    try {
+      fixture.manager.getClient({});
+    } catch (error) {
+      resetError = error;
+    }
+    expect(resetError).toBeInstanceOf(Error);
+    await expect(fixture.manager.ensureReady("local")).rejects.toBe(resetError);
+    expect(fixture.host.runtimeSource.acquireBrowserForegroundNodeLease).toHaveBeenCalledOnce();
+    expect(fixture.port.close).toHaveBeenCalledOnce();
+    fixture.host.isShuttingDown = true;
+    await fixture.manager.shutdown();
+    expect(fixture.messages).not.toContain("return-foreground-node-lease");
+  });
+});
 
 function admissionManager(retryable = true) {
   let pinned = true;
@@ -666,7 +827,7 @@ describe("BrowserConnectionManager explicit transport transitions", () => {
       openInspectorControlPort: vi.fn(async () => ({}) as MessagePort),
       getAuthenticatedInspectorAttachmentPhysicalDbName: vi.fn(() => "authenticated-root"),
     } as unknown as BrowserWorkerConnection;
-    let onStorageReset: (() => void) | undefined;
+    let onStorageReset: BrowserWorkerConnectionContext["onStorageReset"];
     const host = {
       config: { serverUrl: "https://example.test" },
       isShuttingDown: false,
@@ -695,7 +856,7 @@ describe("BrowserConnectionManager explicit transport transitions", () => {
       expect(host.enableAuthenticatedInspectorLocalReads).toHaveBeenCalledOnce(),
     );
 
-    onStorageReset?.();
+    onStorageReset?.(1);
     await vi.waitFor(() =>
       expect(host.clearAuthenticatedInspectorLocalReads).toHaveBeenCalledTimes(2),
     );

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import type { JazzClient } from "../client.js";
-import type { BrowserWorkerConnection } from "../runtime-source.js";
+import { SharedBrowserForegroundNodeLease } from "../native-runtime/browser-shared-worker-connection.js";
+import { BrowserWorkerUnresponsiveError } from "../native-runtime/browser-worker-protocol.js";
+import type { BrowserWorkerConnection, BrowserWorkerConnectionContext } from "../runtime-source.js";
 import { BrowserConnectionManager } from "./browser-connection-manager.js";
 import type { DbForConnection } from "./types.js";
 
@@ -10,6 +12,112 @@ function deferred() {
     resolve = resolvePromise;
   });
   return { promise, resolve };
+}
+
+async function leasedManagerFixture(admissionError?: Error) {
+  const messages: string[] = [];
+  const leaseEvents = new EventTarget();
+  const emit = (data: unknown) => leaseEvents.dispatchEvent(new MessageEvent("message", { data }));
+  const finishStarted = deferred();
+  let acknowledgeFinish = false;
+  let liveClientAtRetirement: boolean | undefined;
+  let clientLive = false;
+  const port = Object.assign(leaseEvents, {
+    start() {},
+    close: vi.fn(),
+    postMessage(message: { type: string; attemptId?: string }) {
+      messages.push(message.type);
+      if (message.type === "probe-foreground-node-lease-worker") {
+        emit({ type: "foreground-node-lease-worker-alive", attemptId: message.attemptId });
+      } else if (message.type === "acquire-foreground-node-lease") {
+        emit({
+          type: "foreground-node-lease-ready",
+          leaseId: "00000000-0000-4000-8000-000000000002",
+          node: new Uint8Array(16),
+          confirmedTxTime: "0",
+        });
+      } else {
+        if (message.type === "retire-foreground-node-lease") liveClientAtRetirement = clientLive;
+        finishStarted.resolve();
+        if (acknowledgeFinish) emit({ type: "foreground-node-lease-result" });
+      }
+    },
+  });
+  const lease = await SharedBrowserForegroundNodeLease.acquireFromPort(
+    port as unknown as MessagePort,
+    { dbName: "terminal-lease-controls", storageOwner: "owner" },
+  );
+  const connection: BrowserWorkerConnection = {
+    ready: vi.fn(async () => {
+      if (admissionError) throw admissionError;
+    }),
+    waitForServerConnection: vi.fn(async () => undefined),
+    waitForPendingWrites: vi.fn(async () => undefined),
+    updateAuth: vi.fn(async () => undefined),
+    disconnect: vi.fn(async () => undefined),
+    reconnect: vi.fn(async () => undefined),
+    deleteStorage: vi.fn(async () => undefined),
+    flushLocal: vi.fn(async () => undefined),
+    openInspectorControlPort: vi.fn(async () => ({}) as MessagePort),
+    shutdown: vi.fn(async () => undefined),
+  };
+  const client = {
+    onMutationError: vi.fn(),
+    getRuntime: () => undefined,
+    discard: vi.fn(() => {
+      clientLive = false;
+    }),
+  } as unknown as JazzClient;
+  let onFailure!: BrowserWorkerConnectionContext["onFailure"];
+  const disposeTelemetry = vi.fn();
+  const createClient = vi.fn(() => {
+    clientLive = true;
+    return client;
+  });
+  const createConnection = vi.fn((context: BrowserWorkerConnectionContext) => {
+    onFailure = context.onFailure;
+    return { ...connection };
+  });
+  const host = {
+    config: {
+      serverUrl: "https://example.test",
+      telemetryCollectorUrl: "https://example.test/telemetry",
+    },
+    isShuttingDown: false,
+    runtimeSource: {
+      acquireBrowserForegroundNodeLease: async () => lease,
+      createClient,
+      installTelemetry: () => disposeTelemetry,
+      createBrowserWorkerConnection: createConnection,
+    },
+    markUnauthenticated: vi.fn(),
+    clearAuthError: vi.fn(),
+    onMutationError: vi.fn(),
+    clearAuthenticatedInspectorLocalReads: vi.fn(),
+  };
+  const manager = new BrowserConnectionManager(host as unknown as DbForConnection);
+  await manager.start();
+  manager.getClient({});
+  if (!admissionError) await manager.ensureReady("local");
+  return {
+    manager,
+    host,
+    lease,
+    port,
+    messages,
+    connection,
+    client,
+    disposeTelemetry,
+    createClient,
+    createConnection,
+    finishStarted,
+    fail: (error: Error) => onFailure(error),
+    acknowledge: () => emit({ type: "foreground-node-lease-result" }),
+    allowFinish: () => {
+      acknowledgeFinish = true;
+    },
+    liveClientAtRetirement: () => liveClientAtRetirement,
+  };
 }
 
 function admissionManager(retryable = true) {
@@ -95,6 +203,192 @@ describe("Browser configuration admission retries", () => {
 });
 
 describe("BrowserConnectionManager.shutdown", () => {
+  it("preserves a lease persistence failure while completing fallback and remaining teardown", async () => {
+    const fixture = await leasedManagerFixture();
+    vi.mocked(fixture.connection.shutdown).mockRejectedValue(
+      new Error("later worker close failure"),
+    );
+    fixture.host.isShuttingDown = true;
+    const shutdown = fixture.manager.shutdown();
+    const rejected = expect(shutdown).rejects.toThrow("high-water persistence failed");
+    await fixture.finishStarted.promise;
+    fixture.port.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          type: "foreground-node-lease-result",
+          error: { name: "Error", message: "high-water persistence failed" },
+        },
+      }),
+    );
+    await rejected;
+    expect(fixture.client.discard).toHaveBeenCalledOnce();
+    expect(fixture.disposeTelemetry).toHaveBeenCalledOnce();
+    expect(fixture.connection.shutdown).toHaveBeenCalledOnce();
+    expect(fixture.port.close).toHaveBeenCalledOnce();
+  });
+
+  it.each(["established follower", "initialization"] as const)(
+    "abandons a latched %s failure only after disabling the foreground lifetime",
+    async (phase) => {
+      const error = new BrowserWorkerUnresponsiveError("worker stopped responding");
+      const fixture = await leasedManagerFixture(phase === "initialization" ? error : undefined);
+      if (phase === "established follower") fixture.fail(error);
+      await expect(fixture.manager.ensureReady("local")).rejects.toBe(error);
+      expect(fixture.client.discard).not.toHaveBeenCalled();
+      expect(fixture.messages).not.toContain("retire-foreground-node-lease");
+      fixture.host.isShuttingDown = true;
+      let outcome: unknown = "pending";
+      const shutdown = fixture.manager.shutdown().then(
+        () => {
+          outcome = "fulfilled";
+        },
+        (failure) => {
+          outcome = failure;
+        },
+      );
+      vi.useFakeTimers();
+      try {
+        await vi.advanceTimersByTimeAsync(0);
+        expect(outcome).toBe(error);
+        expect(fixture.liveClientAtRetirement()).toBe(false);
+        expect(fixture.connection.flushLocal).not.toHaveBeenCalled();
+        expect(fixture.connection.shutdown).toHaveBeenCalledOnce();
+        expect(fixture.disposeTelemetry).toHaveBeenCalledOnce();
+        expect(fixture.messages).not.toContain("return-foreground-node-lease");
+        expect(() => fixture.manager.getClient({})).toThrow("shut down");
+        expect(fixture.createClient).toHaveBeenCalledOnce();
+        expect(fixture.port.close).not.toHaveBeenCalled();
+      } finally {
+        fixture.acknowledge();
+        await shutdown;
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("interrupts an in-flight lease finish when the shutdown connection fails", async () => {
+    const fixture = await leasedManagerFixture();
+    const error = new BrowserWorkerUnresponsiveError("worker died during lease cleanup");
+    fixture.host.isShuttingDown = true;
+    let outcome: unknown = "pending";
+    const shutdown = fixture.manager.shutdown().then(
+      () => {
+        outcome = "fulfilled";
+      },
+      (failure) => {
+        outcome = failure;
+      },
+    );
+    vi.useFakeTimers();
+    try {
+      await fixture.finishStarted.promise;
+      expect(fixture.messages).toContain("return-foreground-node-lease");
+      fixture.fail(error);
+      fixture.fail(new BrowserWorkerUnresponsiveError("duplicate failure"));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(outcome).toBe(error);
+      expect(fixture.messages.filter((type) => type.endsWith("-foreground-node-lease"))).toEqual([
+        "acquire-foreground-node-lease",
+        "return-foreground-node-lease",
+      ]);
+      expect(fixture.client.discard).toHaveBeenCalledOnce();
+      expect(fixture.disposeTelemetry).toHaveBeenCalledOnce();
+      expect(fixture.connection.shutdown).toHaveBeenCalledOnce();
+      expect(fixture.port.close).not.toHaveBeenCalled();
+      await expect(fixture.lease.returnWithHighWater(0n)).rejects.toBe(error);
+      await expect(fixture.lease.retire()).rejects.toBe(error);
+    } finally {
+      fixture.acknowledge();
+      await shutdown;
+      vi.useRealTimers();
+    }
+    expect(fixture.port.close).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the same foreground lease live across an explicit follower reconnect", async () => {
+    const fixture = await leasedManagerFixture();
+    fixture.fail(new BrowserWorkerUnresponsiveError("replace only this follower"));
+    await fixture.manager.reconnect();
+    expect(fixture.createConnection).toHaveBeenCalledTimes(2);
+    expect(fixture.manager.getClient({})).toBe(fixture.client);
+    expect(fixture.createClient).toHaveBeenCalledOnce();
+    expect(fixture.client.discard).not.toHaveBeenCalled();
+    expect(fixture.messages).not.toContain("retire-foreground-node-lease");
+    fixture.allowFinish();
+    fixture.host.isShuttingDown = true;
+    await fixture.manager.shutdown();
+    expect(fixture.messages).toContain("return-foreground-node-lease");
+    expect(fixture.messages).not.toContain("retire-foreground-node-lease");
+  });
+
+  it("returns the lease normally after a configuration error even with a lifecycle error name", async () => {
+    const error = new Error("incompatible persistent browser configuration");
+    error.name = "BrowserWorkerUnresponsiveError";
+    const fixture = await leasedManagerFixture(error);
+    await expect(fixture.manager.ensureReady("local")).rejects.toBe(error);
+    fixture.allowFinish();
+    fixture.host.isShuttingDown = true;
+    await fixture.manager.shutdown();
+    expect(fixture.connection.flushLocal).not.toHaveBeenCalled();
+    expect(fixture.messages).toContain("return-foreground-node-lease");
+    expect(fixture.messages).not.toContain("retire-foreground-node-lease");
+    expect(fixture.client.discard).toHaveBeenCalledOnce();
+  });
+
+  it("awaits retirement after a responsive flush error before completing teardown", async () => {
+    const fixture = await leasedManagerFixture();
+    const flushError = new Error("local settlement failed");
+    vi.mocked(fixture.connection.flushLocal).mockRejectedValue(flushError);
+    const getRuntime = vi.spyOn(fixture.client, "getRuntime").mockImplementation(() => {
+      throw new Error("foreground runtime cannot capture its high-water");
+    });
+    vi.mocked(fixture.connection.shutdown).mockRejectedValue(new Error("later close failure"));
+    const abandon = vi.spyOn(fixture.lease, "abandonAfterWorkerFailure");
+    fixture.host.isShuttingDown = true;
+    let outcome: unknown = "pending";
+    const shutdown = fixture.manager.shutdown().then(
+      () => {
+        outcome = "fulfilled";
+      },
+      (failure) => {
+        outcome = failure;
+      },
+    );
+    vi.useFakeTimers();
+    try {
+      // Drain without awaiting shutdown: premature abandonment must fail here,
+      // rather than a withheld retirement result timing out the test.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(outcome).toBe("pending");
+      expect(abandon).not.toHaveBeenCalled();
+      expect(fixture.messages.filter((type) => type.endsWith("-foreground-node-lease"))).toEqual([
+        "acquire-foreground-node-lease",
+        "retire-foreground-node-lease",
+      ]);
+      expect(fixture.client.discard).not.toHaveBeenCalled();
+      expect(fixture.connection.shutdown).not.toHaveBeenCalled();
+      expect(fixture.disposeTelemetry).not.toHaveBeenCalled();
+      expect(fixture.port.close).not.toHaveBeenCalled();
+
+      fixture.acknowledge();
+      await shutdown;
+      expect(outcome).toBe(flushError);
+      expect(abandon).not.toHaveBeenCalled();
+      expect(fixture.port.close).toHaveBeenCalledOnce();
+      expect(fixture.client.discard).toHaveBeenCalledOnce();
+      expect(fixture.disposeTelemetry).toHaveBeenCalledOnce();
+      expect(fixture.connection.shutdown).toHaveBeenCalledOnce();
+    } finally {
+      // Always release the real lease adapter after observing the held result.
+      fixture.allowFinish();
+      fixture.acknowledge();
+      await shutdown;
+      getRuntime.mockRestore();
+      abandon.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("continues teardown after flush fails and preserves the flush error", async () => {
     const flushError = new Error("flush failed");
     const workerShutdownError = new Error("worker shutdown failed");
@@ -133,6 +427,131 @@ describe("BrowserConnectionManager.shutdown", () => {
     expect(client.discard).toHaveBeenCalledOnce();
     expect(disposeRuntimeTelemetry).toHaveBeenCalledOnce();
     expect(connection.shutdown).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a shutdown flush failure without waiting for the silent companion lease", async () => {
+    const leaseMessages: string[] = [];
+    const leaseEvents = new EventTarget();
+    const emitLeaseMessage = (data: unknown) =>
+      leaseEvents.dispatchEvent(new MessageEvent("message", { data }));
+    const leasePort = Object.assign(leaseEvents, {
+      start() {},
+      close: vi.fn(),
+      postMessage(message: { type: string; attemptId?: string }) {
+        leaseMessages.push(message.type);
+        if (message.type === "probe-foreground-node-lease-worker") {
+          emitLeaseMessage({
+            type: "foreground-node-lease-worker-alive",
+            attemptId: message.attemptId,
+          });
+        } else if (message.type === "acquire-foreground-node-lease") {
+          emitLeaseMessage({
+            type: "foreground-node-lease-ready",
+            leaseId: "00000000-0000-4000-8000-000000000001",
+            node: new Uint8Array(16),
+            confirmedTxTime: "0",
+          });
+        }
+        // The companion channel supplies neither a finish result nor messageerror.
+      },
+    });
+    const lease = await SharedBrowserForegroundNodeLease.acquireFromPort(
+      leasePort as unknown as MessagePort,
+      { dbName: "shutdown-flush-failure", storageOwner: "owner" },
+    );
+    const flushError = new BrowserWorkerUnresponsiveError(
+      "worker became unresponsive during shutdown flush",
+    );
+    const flushStarted = deferred();
+    const finishFlush = deferred();
+    let onFailure!: BrowserWorkerConnectionContext["onFailure"];
+    const connection: BrowserWorkerConnection = {
+      ready: vi.fn(async () => undefined),
+      waitForServerConnection: vi.fn(async () => undefined),
+      waitForPendingWrites: vi.fn(async () => undefined),
+      updateAuth: vi.fn(async () => undefined),
+      disconnect: vi.fn(async () => undefined),
+      reconnect: vi.fn(async () => undefined),
+      deleteStorage: vi.fn(async () => undefined),
+      flushLocal: vi.fn(async () => {
+        flushStarted.resolve();
+        await finishFlush.promise;
+        onFailure(flushError);
+        throw flushError;
+      }),
+      openInspectorControlPort: vi.fn(async () => ({}) as MessagePort),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const client = {
+      onMutationError: vi.fn(),
+      getRuntime: () => undefined,
+      discard: vi.fn(),
+    } as unknown as JazzClient;
+    const disposeRuntimeTelemetry = vi.fn();
+    const host = {
+      config: { telemetryCollectorUrl: "https://example.test/telemetry" },
+      isShuttingDown: false,
+      runtimeSource: {
+        acquireBrowserForegroundNodeLease: async () => lease,
+        createClient: () => client,
+        installTelemetry: () => disposeRuntimeTelemetry,
+        createBrowserWorkerConnection: (context: BrowserWorkerConnectionContext) => {
+          onFailure = context.onFailure;
+          return connection;
+        },
+      },
+      markUnauthenticated: vi.fn(),
+      clearAuthError: vi.fn(),
+      onMutationError: vi.fn(),
+      clearAuthenticatedInspectorLocalReads: vi.fn(),
+    };
+    const manager = new BrowserConnectionManager(host as unknown as DbForConnection);
+    await manager.start();
+    manager.getClient({});
+    await manager.ensureReady("local");
+    expect(leasePort.close).not.toHaveBeenCalled();
+    expect(leaseMessages).not.toContain("return-foreground-node-lease");
+    expect(leaseMessages).not.toContain("retire-foreground-node-lease");
+
+    host.isShuttingDown = true;
+    let outcome: { status: "pending" | "fulfilled" } | { status: "rejected"; error: unknown } = {
+      status: "pending",
+    };
+    void manager.shutdown().then(
+      () => {
+        outcome = { status: "fulfilled" };
+      },
+      (error: unknown) => {
+        outcome = { status: "rejected", error };
+      },
+    );
+    vi.useFakeTimers();
+    try {
+      await flushStarted.promise;
+      expect(leasePort.close).not.toHaveBeenCalled();
+      expect(leaseMessages).not.toContain("retire-foreground-node-lease");
+      finishFlush.resolve();
+      // Drain the synchronous fixture's cleanup promises without awaiting shutdown:
+      // a missing lease result must fail this assertion, not time out the test.
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(outcome).toEqual({ status: "rejected", error: flushError });
+      expect("error" in outcome ? outcome.error : undefined).toBe(flushError);
+      expect(manager.getCurrentClient()).toBeNull();
+      expect(client.discard).toHaveBeenCalledOnce();
+      expect(disposeRuntimeTelemetry).toHaveBeenCalledOnce();
+      expect(connection.shutdown).toHaveBeenCalledOnce();
+      expect(leaseMessages).not.toContain("return-foreground-node-lease");
+    } finally {
+      // Release the baseline's pending finish only after observing shutdown.
+      // This fixture acknowledgement is not evidence of durable return/retirement.
+      finishFlush.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      emitLeaseMessage({ type: "foreground-node-lease-result" });
+      await vi.advanceTimersByTimeAsync(0);
+      leasePort.close();
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -18,6 +18,13 @@ import { registerBrowserInspectorControl } from "../../dev/inspector-overlay/bro
 import { assertBrowserStorageOwnerUnchanged } from "../browser-worker-config.js";
 import { waitForInspectorOpening } from "../native-runtime/inspector-control-lifecycle.js";
 
+interface BrowserConnectionScope {
+  readonly connection: BrowserWorkerConnection;
+  readonly lease: BrowserForegroundNodeLease | undefined;
+  readonly inspectorAttachment: boolean;
+  resetReason: Error | null;
+}
+
 /**
  * Every persistent browser tab is an in-memory client of one SharedWorker
  * runtime. There are no tab roles, elections, or follower handoffs. SharedWorker
@@ -33,6 +40,8 @@ export class BrowserConnectionManager extends ConnectionManager {
   private readonly reconnectWaiters = new Set<() => void>();
   private transportTransition: Promise<void> = Promise.resolve();
   private storageReset: Promise<void> | null = null;
+  private storageResetError: Error | null = null;
+  private connectionScope: BrowserConnectionScope | null = null;
   private unregisterInspectorControl: (() => void) | null = null;
   private browserConnectionInput: ConnectionManagerClientInput | null = null;
   /** A failed follower owns no recoverable port; reconnect must mint a new one. */
@@ -44,6 +53,8 @@ export class BrowserConnectionManager extends ConnectionManager {
   private shutdownStarted = false;
   private shutdownFailure: {
     connection: BrowserWorkerConnection | null;
+    scope: BrowserConnectionScope | null;
+    reset: () => void;
     abandon: (error: Error) => void;
   } | null = null;
 
@@ -62,6 +73,8 @@ export class BrowserConnectionManager extends ConnectionManager {
 
   override getClient(schema: WasmSchema): JazzClient {
     if (this.shutdownStarted) throw new Error("Browser connection manager is shut down");
+    if (this.storageResetError) throw this.storageResetError;
+    if (this.storageReset) throw new Error("Browser storage reset is still in progress");
     return super.getClient(schema);
   }
 
@@ -81,6 +94,7 @@ export class BrowserConnectionManager extends ConnectionManager {
     const workerConfig = { ...this.host.config };
     copyAccountConfigAdmission(this.host.config, workerConfig);
     setTrustedReservedSession(workerConfig, getTrustedReservedSession(this.host.config));
+    let scope: BrowserConnectionScope;
     const connection = this.host.runtimeSource.createBrowserWorkerConnection({
       config: workerConfig,
       schema: input.schema,
@@ -89,9 +103,16 @@ export class BrowserConnectionManager extends ConnectionManager {
       onAuthRestored: () => this.host.clearAuthError(),
       onExplicitOfflineChange: (offline) => this.setExplicitOffline(connection, offline),
       onFailure: (error) => this.observeConnectionFailure(connection, asError(error)),
-      onStorageReset: () => this.beginStorageReset(connection),
+      onStorageReset: (resetId) => this.beginStorageReset(scope, resetId),
       onStorageInvalidated: () => this.reloadAfterStorageInvalidation(connection),
     });
+    scope = {
+      connection,
+      lease: this.foregroundNodeLease,
+      inspectorAttachment: workerConfig.runtimeSources?.inspectorBinding !== undefined,
+      resetReason: null,
+    };
+    this.connectionScope = scope;
     this.connection = connection;
     this.observedConfigurationAdmissionFailure = null;
     this.unregisterInspectorControl?.();
@@ -154,6 +175,7 @@ export class BrowserConnectionManager extends ConnectionManager {
     let connection = reset ? null : this.connection;
     const retry = connection !== null && this.observedConfigurationAdmissionFailure === connection;
     await reset;
+    if (this.storageResetError) throw this.storageResetError;
     if (this.host.isShuttingDown || signal?.aborted) return;
     connection ??= this.connection;
     if (retry && connection) connection = await this.retryConfigurationAdmission(connection);
@@ -303,21 +325,53 @@ export class BrowserConnectionManager extends ConnectionManager {
     return this.connection.openInspectorControlPort(signal);
   }
 
-  private beginStorageReset(connection: BrowserWorkerConnection): void {
-    if (this.connection !== connection || this.storageReset) return;
+  private beginStorageReset(scope: BrowserConnectionScope, resetId: number): void {
+    if (
+      scope.resetReason ||
+      (this.connectionScope !== scope && this.shutdownFailure?.scope !== scope)
+    )
+      return;
+    scope.resetReason = new Error(
+      `Browser foreground lease released after storage reset ${resetId}`,
+    );
     this.host.clearAuthenticatedInspectorLocalReads();
     this.connection = null;
     this.connectionReady = null;
+    this.foregroundNodeLease = undefined;
     this.initialExplicitOfflineStateKnown = false;
     const client = this.detachClient();
-    client?.discard();
-    this.storageReset = connection
-      .shutdown()
-      .then(() => undefined)
-      .finally(() => {
-        this.connectionError = null;
-        this.storageReset = null;
-      });
+    const reset = runCleanupSteps([
+      () => client?.discard(),
+      () => scope.lease?.releaseAfterStorageReset(scope.resetReason!),
+      () => {
+        if (this.shutdownFailure?.scope === scope) this.shutdownFailure.reset();
+      },
+      () => scope.connection.shutdown(),
+      async () => {
+        if (this.shutdownStarted || this.connectionScope !== scope) return;
+        if (scope.inspectorAttachment) {
+          this.storageResetError = new Error(
+            "Inspector storage was reset; a new attachment is required",
+          );
+          return;
+        }
+        const successor = await this.host.runtimeSource.acquireBrowserForegroundNodeLease(
+          this.host.config,
+        );
+        if (this.shutdownStarted || this.connectionScope !== scope) await successor.retire();
+        else this.foregroundNodeLease = successor;
+      },
+    ]).finally(() => {
+      if (this.storageReset !== reset) return;
+      this.storageReset = null;
+      if (this.connectionScope === scope) this.connectionScope = null;
+    });
+    this.storageReset = reset;
+    // A reset received by another tab has no direct promise consumer yet.
+    // Retain its failure for subsequent synchronous client access/readiness.
+    void reset.catch((error: unknown) => {
+      this.storageResetError ??= asError(error);
+    });
   }
 
   /**
@@ -350,6 +404,7 @@ export class BrowserConnectionManager extends ConnectionManager {
     if (this.shutdownStarted) return;
     this.shutdownStarted = true;
     const connection = this.connection;
+    const scope = this.connectionScope;
     const admissionError = this.connectionError;
     this.connection = null;
     this.connectionReady = null;
@@ -382,7 +437,7 @@ export class BrowserConnectionManager extends ConnectionManager {
         notifyAbandoned();
       }
     };
-    this.shutdownFailure = { connection, abandon };
+    this.shutdownFailure = { connection, scope, abandon, reset: notifyAbandoned };
     if (admissionError instanceof BrowserWorkerUnresponsiveError) abandon(admissionError);
 
     try {
@@ -391,13 +446,20 @@ export class BrowserConnectionManager extends ConnectionManager {
           if (workerFailure) throw workerFailure;
         },
         () => unregisterInspectorControl?.(),
+        () => this.storageReset ?? undefined,
         async () => {
           if (workerFailure) throw workerFailure;
+          if (scope?.resetReason) return;
           // Configuration rejection is not a dead realm: skip the absent follower
           // flush, but retain the lease's ordinary clean-return semantics.
           if (admissionError) return;
           try {
-            await connection?.flushLocal();
+            await Promise.race([
+              connection?.flushLocal(),
+              abandoned.then(() => {
+                if (workerFailure) throw workerFailure;
+              }),
+            ]);
           } catch (error) {
             flushFailed = true;
             if (workerFailure) throw workerFailure;
@@ -407,6 +469,7 @@ export class BrowserConnectionManager extends ConnectionManager {
         },
         async () => {
           if (workerFailure) throw workerFailure;
+          if (scope?.resetReason) return;
           if (!lease) return;
           let finishFailed = false;
           let finishError: unknown;
@@ -423,10 +486,12 @@ export class BrowserConnectionManager extends ConnectionManager {
                 // and drain started writes before releasing this identity. A
                 // failed flush cannot establish a clean durable handoff.
                 const highWater = await runtime.quiesceForegroundTxTimeHighWater();
+                if (scope?.resetReason) return;
                 if (flushFailed) await lease.retire();
                 else await lease.returnWithHighWater(highWater);
               }
             } catch (error) {
+              if (error === scope?.resetReason) return;
               finishFailed = true;
               finishError = workerFailure ?? error;
               // Abandonment rejects this fallback too; never replace the first
@@ -440,7 +505,8 @@ export class BrowserConnectionManager extends ConnectionManager {
           await Promise.race([
             finish(),
             abandoned.then(() => {
-              throw finishFailed ? finishError : workerFailure;
+              if (finishFailed) throw finishError;
+              if (workerFailure) throw workerFailure;
             }),
           ]);
         },
@@ -449,13 +515,15 @@ export class BrowserConnectionManager extends ConnectionManager {
           this.detachClient()?.discard();
         },
         () => super.shutdown(),
-        () => connection?.shutdown(),
+        () => (scope?.resetReason ? undefined : connection?.shutdown()),
+        () => this.storageReset ?? undefined,
         () => {
           if (workerFailure) throw workerFailure;
         },
       ]);
     } finally {
       this.shutdownFailure = null;
+      if (this.connectionScope === scope) this.connectionScope = null;
     }
   }
 

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -1,12 +1,14 @@
 import { copyAccountConfigAdmission } from "../../accounts/config-capability.js";
-import type { DurabilityTier } from "../client.js";
+import type { WasmSchema } from "../../drivers/types.js";
+import type { DurabilityTier, JazzClient } from "../client.js";
 import { resolveClientInternalSessionSync } from "../client-session.js";
 import type { Session } from "../context.js";
 import { getTrustedReservedSession, setTrustedReservedSession } from "../db-internal-session.js";
-import type { BrowserWorkerConnection } from "../runtime-source.js";
+import type { BrowserForegroundNodeLease, BrowserWorkerConnection } from "../runtime-source.js";
 import { reloadAfterStorageInvalidation } from "../browser-storage-invalidation.js";
 import { runCleanupSteps } from "../run-cleanup-steps.js";
 import { NativeRuntimeAdapter } from "../native-runtime/native-runtime-adapter.js";
+import { BrowserWorkerUnresponsiveError } from "../native-runtime/browser-worker-protocol.js";
 import {
   ConnectionManager,
   type ConnectionManagerClientInput,
@@ -38,6 +40,12 @@ export class BrowserConnectionManager extends ConnectionManager {
   private observedConfigurationAdmissionFailure: BrowserWorkerConnection | null = null;
   private configurationAdmissionRetry: Promise<BrowserWorkerConnection | null> | null = null;
   private readonly readinessByConnection = new WeakMap<BrowserWorkerConnection, Promise<void>>();
+  declare protected foregroundNodeLease: BrowserForegroundNodeLease | undefined;
+  private shutdownStarted = false;
+  private shutdownFailure: {
+    connection: BrowserWorkerConnection | null;
+    abandon: (error: Error) => void;
+  } | null = null;
 
   constructor(host: DbForConnection) {
     super(host);
@@ -52,12 +60,18 @@ export class BrowserConnectionManager extends ConnectionManager {
     );
   }
 
+  override getClient(schema: WasmSchema): JazzClient {
+    if (this.shutdownStarted) throw new Error("Browser connection manager is shut down");
+    return super.getClient(schema);
+  }
+
   protected override onClientCreated(input: ConnectionManagerClientInput): void {
     this.browserConnectionInput = input;
     this.openBrowserWorkerConnection();
   }
 
   private openBrowserWorkerConnection(): BrowserWorkerConnection {
+    if (this.shutdownStarted) throw new Error("Browser connection manager is shut down");
     const input = this.browserConnectionInput;
     if (!input) throw new Error("Browser worker connection requires an initialized client");
     // An Inspector receipt authenticates one worker connection, not a durable
@@ -74,11 +88,7 @@ export class BrowserConnectionManager extends ConnectionManager {
       onAuthFailure: (reason) => this.host.markUnauthenticated(reason),
       onAuthRestored: () => this.host.clearAuthError(),
       onExplicitOfflineChange: (offline) => this.setExplicitOffline(connection, offline),
-      onFailure: (error) => {
-        if (this.connection !== connection) return;
-        this.connectionError = asError(error);
-        this.recoverableConnectionFailure = true;
-      },
+      onFailure: (error) => this.observeConnectionFailure(connection, asError(error)),
       onStorageReset: () => this.beginStorageReset(connection),
       onStorageInvalidated: () => this.reloadAfterStorageInvalidation(connection),
     });
@@ -108,9 +118,8 @@ export class BrowserConnectionManager extends ConnectionManager {
         this.recoverableConnectionFailure = false;
       },
       (error: unknown) => {
+        this.observeConnectionFailure(connection, asError(error));
         if (this.connection !== connection) return;
-        this.connectionError = asError(error);
-        this.recoverableConnectionFailure = true;
         // `connectionReady` is also observed by passive readiness consumers
         // (for example the initial offline-state probe). Keep it a settled
         // notification, not a detached rejected promise. Public operations
@@ -125,6 +134,16 @@ export class BrowserConnectionManager extends ConnectionManager {
       }).catch(() => undefined);
     }
     return connection;
+  }
+
+  private observeConnectionFailure(connection: BrowserWorkerConnection, error: Error): void {
+    if (this.shutdownFailure?.connection === connection) {
+      if (error instanceof BrowserWorkerUnresponsiveError) this.shutdownFailure.abandon(error);
+      return;
+    }
+    if (this.connection !== connection) return;
+    this.connectionError = error;
+    this.recoverableConnectionFailure = true;
   }
 
   async ensureReady(tier?: DurabilityTier, signal?: AbortSignal): Promise<void> {
@@ -233,6 +252,7 @@ export class BrowserConnectionManager extends ConnectionManager {
       throw new Error("Db.reconnect() requires a configured serverUrl.");
     }
     await this.enqueueTransportTransition(async () => {
+      if (this.shutdownStarted) throw new Error("Browser connection manager is shut down");
       if (this.recoverableConnectionFailure) this.reopenFailedFollower();
       await this.connectionReady;
       if (this.connectionError) throw this.connectionError;
@@ -327,10 +347,13 @@ export class BrowserConnectionManager extends ConnectionManager {
   }
 
   override async shutdown(): Promise<void> {
+    if (this.shutdownStarted) return;
+    this.shutdownStarted = true;
     const connection = this.connection;
-    const admissionFailed = this.connectionError !== null;
+    const admissionError = this.connectionError;
     this.connection = null;
     this.connectionReady = null;
+    this.browserConnectionInput = null;
     this.initialExplicitOfflineStateKnown = false;
     this.resolveReconnectWaiters();
     const unregisterInspectorControl = this.unregisterInspectorControl;
@@ -339,43 +362,101 @@ export class BrowserConnectionManager extends ConnectionManager {
     const lease = this.foregroundNodeLease;
     this.foregroundNodeLease = undefined;
     const client = this.getCurrentClient();
-    await runCleanupSteps([
-      () => unregisterInspectorControl?.(),
-      // A rejected physical-root admission created no follower and therefore
-      // has nothing to flush. Shutdown remains idempotent after a caller has
-      // already received that operation-level error.
-      () => (admissionFailed ? undefined : connection?.flushLocal()),
-      async () => {
-        if (!lease) return;
-        // The native value includes identities minted for rolled-back and
-        // unsubmitted writes. Any failure in this readout or its atomic worker
-        // persistence retires the node rather than risking reuse.
-        try {
-          const runtime = client?.getRuntime();
-          if (!runtime) {
-            // No foreground client existed, hence no transaction identity was
-            // minted after the lease was acquired.
-            await lease.returnWithHighWater(lease.confirmedTxTime);
-            return;
-          } else if (!(runtime instanceof NativeRuntimeAdapter)) {
-            await lease.retire();
-            return;
-          }
-          await lease.returnWithHighWater(await runtime.quiesceForegroundTxTimeHighWater());
-        } catch {
-          await lease.retire().catch(() => undefined);
-        }
-      },
-      () => {
-        // The tab runtime is explicitly non-durable; once its worker peer has
-        // flushed, graceful evaluator teardown cannot add durability and may wait
-        // on suspended recursive/include work. Abandon that view and let the
-        // durable worker own orderly persistence shutdown.
+    let workerFailure: Error | null = null;
+    let flushFailed = false;
+    let notifyAbandoned!: () => void;
+    const abandoned = new Promise<void>((resolve) => {
+      notifyAbandoned = resolve;
+    });
+    const abandon = (error: Error) => {
+      if (workerFailure) return;
+      workerFailure = error;
+      // Shutdown owns this lifetime now. Disable minting before even a best-effort
+      // retirement can transfer ownership; a mere reconnect never reaches here.
+      try {
         this.detachClient()?.discard();
-      },
-      () => super.shutdown(),
-      () => connection?.shutdown(),
-    ]);
+      } catch {
+        // The causal worker failure remains first even if local disposal fails.
+      } finally {
+        lease?.abandonAfterWorkerFailure(error);
+        notifyAbandoned();
+      }
+    };
+    this.shutdownFailure = { connection, abandon };
+    if (admissionError instanceof BrowserWorkerUnresponsiveError) abandon(admissionError);
+
+    try {
+      await runCleanupSteps([
+        () => {
+          if (workerFailure) throw workerFailure;
+        },
+        () => unregisterInspectorControl?.(),
+        async () => {
+          if (workerFailure) throw workerFailure;
+          // Configuration rejection is not a dead realm: skip the absent follower
+          // flush, but retain the lease's ordinary clean-return semantics.
+          if (admissionError) return;
+          try {
+            await connection?.flushLocal();
+          } catch (error) {
+            flushFailed = true;
+            if (workerFailure) throw workerFailure;
+            if (error instanceof BrowserWorkerUnresponsiveError) abandon(error);
+            throw error;
+          }
+        },
+        async () => {
+          if (workerFailure) throw workerFailure;
+          if (!lease) return;
+          let finishFailed = false;
+          let finishError: unknown;
+          const finish = async () => {
+            try {
+              const runtime = client?.getRuntime();
+              if (!runtime) {
+                if (flushFailed) await lease.retire();
+                else await lease.returnWithHighWater(lease.confirmedTxTime);
+              } else if (!(runtime instanceof NativeRuntimeAdapter)) {
+                await lease.retire();
+              } else {
+                // Even after an ordinary flush failure, close mutation admission
+                // and drain started writes before releasing this identity. A
+                // failed flush cannot establish a clean durable handoff.
+                const highWater = await runtime.quiesceForegroundTxTimeHighWater();
+                if (flushFailed) await lease.retire();
+                else await lease.returnWithHighWater(highWater);
+              }
+            } catch (error) {
+              finishFailed = true;
+              finishError = workerFailure ?? error;
+              // Abandonment rejects this fallback too; never replace the first
+              // failure or retry an unknown clean return.
+              await lease.retire().catch(() => undefined);
+              throw finishError;
+            }
+          };
+          // A causal failure may arrive while high-water capture or lease finish
+          // is already in flight. Its background work cannot hold shutdown open.
+          await Promise.race([
+            finish(),
+            abandoned.then(() => {
+              throw finishFailed ? finishError : workerFailure;
+            }),
+          ]);
+        },
+        () => {
+          // The tab view is non-durable; only its worker owns persistence shutdown.
+          this.detachClient()?.discard();
+        },
+        () => super.shutdown(),
+        () => connection?.shutdown(),
+        () => {
+          if (workerFailure) throw workerFailure;
+        },
+      ]);
+    } finally {
+      this.shutdownFailure = null;
+    }
   }
 
   private resolveReconnectWaiters(): void {

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { MessagePortBrowserFollowerConnection } from "./browser-follower-connection.js";
 import {
+  BrowserWorkerUnresponsiveError,
   serializeBrowserRelayError,
   type BrowserFollowerPortEvent,
   type BrowserFollowerPortRequest,
@@ -33,6 +34,35 @@ class TestPort {
       listener({ data: event } as MessageEvent);
     }
   }
+}
+
+async function createWatchdogFollower(port = new TestPort()) {
+  const transport = {
+    recvWireFrames: () => [],
+    sendWireFrame: () => undefined,
+    tick: () => 0,
+  };
+  const runtime = {
+    connectUpstreamPeer: vi.fn(() => transport),
+    onPeerTransportWork: vi.fn(() => () => undefined),
+    progressPeerTransport: vi.fn(async () => undefined),
+    retirePeerTransport: vi.fn(async () => undefined),
+    reportRemoteServerTransportError: vi.fn(),
+    flushLocalSettlements: vi.fn(async () => undefined),
+  };
+  const onFailure = vi.fn();
+  const connection = new MessagePortBrowserFollowerConnection(
+    runtime as never,
+    port as unknown as MessagePort,
+    {},
+    null,
+    { onAuthFailure: vi.fn(), onAuthRestored: vi.fn(), onFailure },
+  );
+  const init = port.sent[port.sent.length - 1];
+  if (!init || init.type !== "init") throw new Error("follower did not initialize");
+  port.emit({ type: "result", id: init.id });
+  await connection.ready();
+  return { connection, port, runtime, onFailure };
 }
 
 describe("MessagePortBrowserFollowerConnection", () => {
@@ -88,6 +118,215 @@ describe("MessagePortBrowserFollowerConnection", () => {
       }
     },
   );
+
+  it("rejects a pending control operation when the established worker channel stays silent", async () => {
+    vi.useFakeTimers();
+    let connection: MessagePortBrowserFollowerConnection | undefined;
+    try {
+      const port = new TestPort();
+      const transport = {
+        recvWireFrames: () => [],
+        sendWireFrame: () => undefined,
+        tick: () => 0,
+      };
+      const runtime = {
+        connectUpstreamPeer: vi.fn(() => transport),
+        onPeerTransportWork: vi.fn(() => () => undefined),
+        progressPeerTransport: vi.fn(async () => undefined),
+        retirePeerTransport: vi.fn(async () => undefined),
+        reportRemoteServerTransportError: vi.fn(),
+      };
+      const onFailure = vi.fn();
+      connection = new MessagePortBrowserFollowerConnection(
+        runtime as never,
+        port as unknown as MessagePort,
+        {},
+        null,
+        { onAuthFailure: vi.fn(), onAuthRestored: vi.fn(), onFailure },
+      );
+      const init = port.sent[0];
+      if (!init || init.type !== "init") throw new Error("follower did not initialize");
+      port.emit({ type: "result", id: init.id });
+      await connection.ready();
+
+      const outcome: {
+        status: "pending" | "resolved" | "rejected";
+        error?: unknown;
+      } = { status: "pending" };
+      void connection.waitForServerConnection().then(
+        () => {
+          outcome.status = "resolved";
+        },
+        (error: unknown) => {
+          outcome.status = "rejected";
+          outcome.error = error;
+        },
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(port.sent).toContainEqual({
+        type: "wait-server",
+        id: expect.any(Number),
+      });
+
+      // The channel supplies neither a result nor a messageerror. Allow the
+      // pending-only probe interval and its full response window to elapse.
+      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(outcome.status).toBe("pending");
+      expect(onFailure).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(outcome.status).toBe("rejected");
+      expect(outcome.error).toBeInstanceOf(Error);
+      expect(onFailure).toHaveBeenCalledExactlyOnceWith(outcome.error);
+    } finally {
+      // Release an unanswered baseline RPC only after observing its outcome.
+      // Shutdown would send another unanswered request on this silent port.
+      connection?.detachForReconnect();
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["wait-server", "flush-pending-writes"] as const)(
+    "keeps a long %s operation alive with pongs and stops probing once idle",
+    async (operation) => {
+      vi.useFakeTimers();
+      const { connection, port, onFailure } = await createWatchdogFollower();
+      try {
+        await vi.advanceTimersByTimeAsync(120_000);
+        expect(port.sent.filter((message) => message.type === "runtime-probe")).toEqual([]);
+        port.onPostMessage = (message) => {
+          if (message.type === "runtime-probe") port.emit({ ...message, type: "runtime-pong" });
+          if (message.type === "flush-local") port.emit({ type: "result", id: message.id });
+        };
+        const settled = vi.fn();
+        const wait = (
+          operation === "wait-server"
+            ? connection.waitForServerConnection()
+            : connection.waitForPendingWrites()
+        ).then(settled);
+        await vi.advanceTimersByTimeAsync(180_000);
+        expect(settled).not.toHaveBeenCalled();
+        expect(onFailure).not.toHaveBeenCalled();
+        expect(port.sent.filter((message) => message.type === "runtime-probe")).toHaveLength(6);
+        const request = port.sent.find((message) => message.type === operation);
+        if (!request || !("id" in request) || request.id === undefined)
+          throw new Error("missing pending operation");
+        port.emit({ type: "result", id: request.id });
+        await wait;
+        expect(settled).toHaveBeenCalledOnce();
+        await vi.advanceTimersByTimeAsync(120_000);
+        expect(port.sent.filter((message) => message.type === "runtime-probe")).toHaveLength(6);
+      } finally {
+        connection.detachForReconnect();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("rejects all pending controls once and fences a prior connection's pong", async () => {
+    vi.useFakeTimers();
+    const first = await createWatchdogFollower();
+    let successorConnection: MessagePortBrowserFollowerConnection | undefined;
+    try {
+      const firstWait = first.connection.waitForServerConnection().catch((error) => error);
+      await vi.advanceTimersByTimeAsync(30_000);
+      const oldProbe = first.port.sent.find((message) => message.type === "runtime-probe")!;
+      first.connection.detachForReconnect();
+      await firstWait;
+      const successor = await createWatchdogFollower(first.port);
+      successorConnection = successor.connection;
+      const failed = vi.fn();
+      const firstPending = successor.connection.waitForServerConnection().catch(failed);
+      const secondPending = successor.connection.disconnect().catch(failed);
+      await vi.advanceTimersByTimeAsync(30_000);
+      first.port.emit({ ...oldProbe, type: "runtime-pong" });
+      await vi.advanceTimersByTimeAsync(30_000);
+      await Promise.all([firstPending, secondPending]);
+      expect(failed).toHaveBeenCalledTimes(2);
+      const error = failed.mock.calls[0]![0];
+      expect(error).toBeInstanceOf(BrowserWorkerUnresponsiveError);
+      expect(error.message).toMatch(/outcomes are unknown.*not retried/);
+      expect(failed.mock.calls[1]![0]).toBe(error);
+      expect(successor.onFailure).toHaveBeenCalledExactlyOnceWith(error);
+      expect(successor.runtime.retirePeerTransport).toHaveBeenCalledOnce();
+      expect(first.port.close).toHaveBeenCalledTimes(2);
+      for (const message of first.port.sent) {
+        if (message.type === "runtime-probe") first.port.emit({ ...message, type: "runtime-pong" });
+        if ("id" in message && message.id !== undefined)
+          first.port.emit({ type: "result", id: message.id });
+      }
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(failed).toHaveBeenCalledTimes(2);
+      expect(successor.onFailure).toHaveBeenCalledOnce();
+      expect(first.port.sent.filter((message) => message.type === "wait-server")).toHaveLength(2);
+      expect(first.port.sent.filter((message) => message.type === "disconnect")).toHaveLength(1);
+    } finally {
+      first.connection.detachForReconnect();
+      successorConnection?.detachForReconnect();
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives a delayed expiry a fresh identified probe and a full reply grace", async () => {
+    vi.useFakeTimers();
+    const { connection, port, onFailure } = await createWatchdogFollower();
+    try {
+      const rejected = vi.fn();
+      const wait = connection.waitForServerConnection().catch(rejected);
+      await vi.advanceTimersByTimeAsync(30_000);
+      const oldProbe = port.sent.find((message) => message.type === "runtime-probe")!;
+      // Wall time passes without timer or message dispatch, as during sleep.
+      vi.setSystemTime(Date.now() + 300_000);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(onFailure).not.toHaveBeenCalled();
+      const probes = port.sent.filter((message) => message.type === "runtime-probe");
+      expect(probes).toHaveLength(2);
+      expect(probes[1]!.nonce).not.toBe(oldProbe.nonce);
+      port.emit({ ...oldProbe, type: "runtime-pong" });
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(rejected).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      await wait;
+      expect(rejected).toHaveBeenCalledOnce();
+      expect(onFailure).toHaveBeenCalledOnce();
+    } finally {
+      connection.detachForReconnect();
+      vi.useRealTimers();
+    }
+  });
+
+  it("starts a fresh reply grace when a hidden page becomes visible", async () => {
+    vi.useFakeTimers();
+    const page = Object.assign(new EventTarget(), { visibilityState: "hidden" });
+    vi.stubGlobal("document", page);
+    const { connection, port, onFailure } = await createWatchdogFollower();
+    try {
+      const rejected = vi.fn();
+      const wait = connection.waitForServerConnection().catch(rejected);
+      await vi.advanceTimersByTimeAsync(30_000);
+      const oldProbe = port.sent.find((message) => message.type === "runtime-probe")!;
+      await vi.advanceTimersByTimeAsync(29_000);
+      page.visibilityState = "visible";
+      page.dispatchEvent(new Event("visibilitychange"));
+      port.emit({ ...oldProbe, type: "runtime-pong" });
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(rejected).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      await wait;
+      expect(rejected).toHaveBeenCalledOnce();
+      expect(onFailure).toHaveBeenCalledOnce();
+      connection.detachForReconnect();
+      const sent = port.sent.length;
+      page.dispatchEvent(new Event("visibilitychange"));
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(port.sent).toHaveLength(sent);
+    } finally {
+      connection.detachForReconnect();
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
 
   it("clears a remote peer failure after the worker confirms reconnect", async () => {
     const port = new TestPort();

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
@@ -407,7 +407,7 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
         type: "storage-reset-observed",
         resetId: message.resetId,
       } satisfies BrowserFollowerPortRequest);
-      this.callbacks.onStorageReset?.();
+      this.callbacks.onStorageReset?.(message.resetId);
       return;
     }
     if (message.type === "storage-invalidated") {

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
@@ -195,7 +195,6 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
       if (controlClosed) return;
       controlClosed = true;
       closeInspectorControlPort(channel.port1);
-      channel.port2.close();
     };
     const onAbort = () => {
       if (!this.pending.delete(id)) return;
@@ -214,6 +213,7 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
         [channel.port2],
       );
     } catch (error) {
+      channel.port2.close();
       this.fail(asError(error));
     }
     try {

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-follower-connection.ts
@@ -5,6 +5,7 @@ import type {
 } from "../runtime-source.js";
 import { BrowserWorkerTransportPump, transferableFrames } from "./browser-worker-transport.js";
 import {
+  BrowserWorkerUnresponsiveError,
   deserializeBrowserRelayError,
   type BrowserFollowerPortEvent,
   type BrowserFollowerPortRequest,
@@ -40,6 +41,12 @@ type BrowserFollowerPortRpcRequest =
   | { type: "abort-storage-reset" }
   | { type: "reconnect"; authJson: string; sessionClaims: Record<string, unknown> };
 
+// Connection policy, not an operation deadline. A matching pong keeps even
+// an indefinitely pending server/durability wait alive.
+const PROBE_INTERVAL_MS = 30_000;
+const PROBE_REPLY_MS = 30_000;
+const CALLBACK_SUSPENSION_SLACK_MS = 1_000;
+
 /** Connects one tab's non-durable in-memory runtime to the elected worker. */
 export class MessagePortBrowserFollowerConnection implements BrowserFollowerConnection {
   private pump: BrowserWorkerTransportPump | null = null;
@@ -52,6 +59,11 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
   private closed = false;
   private failed: Error | null = null;
   private readonly disposeQueryCoverageTrace: (() => void) | null;
+  private readonly connectionId = crypto.randomUUID();
+  private nextProbeNonce = 1;
+  private probeNonce: number | null = null;
+  private watchdogTimer: number | NodeJS.Timeout | null = null;
+  private watchdogEpoch = 0;
 
   constructor(
     private readonly runtime: NativeRuntimeAdapter,
@@ -73,6 +85,8 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
     port.addEventListener("message", this.onMessage);
     port.addEventListener("messageerror", this.onMessageError);
     port.start();
+    globalThis.addEventListener?.("pageshow", this.onResume);
+    globalThis.document?.addEventListener("visibilitychange", this.onVisibilityChange);
     this.disposeQueryCoverageTrace = traceRelay
       ? runtime.onQueryCoverageTrace((entry) => {
           if (this.closed) return;
@@ -181,6 +195,7 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
       if (controlClosed) return;
       controlClosed = true;
       closeInspectorControlPort(channel.port1);
+      channel.port2.close();
     };
     const onAbort = () => {
       if (!this.pending.delete(id)) return;
@@ -188,6 +203,7 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
       rejectPending(inspectorControlAbortError());
     };
     signal?.addEventListener("abort", onAbort, { once: true });
+    this.armWatchdog();
     try {
       this.port.postMessage(
         {
@@ -197,6 +213,10 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
         } satisfies BrowserFollowerPortRequest,
         [channel.port2],
       );
+    } catch (error) {
+      this.fail(asError(error));
+    }
+    try {
       await promise;
       if (signal?.aborted) {
         closeControl();
@@ -267,12 +287,87 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
     const promise = new Promise<void>((resolve, reject) => {
       this.pending.set(id, { type: request.type, resolve, reject });
     });
-    this.port.postMessage(message satisfies BrowserFollowerPortRequest);
+    this.armWatchdog();
+    try {
+      this.port.postMessage(message satisfies BrowserFollowerPortRequest);
+    } catch (error) {
+      this.fail(asError(error));
+    }
     return promise;
   }
 
+  private clearWatchdog(): void {
+    if (this.watchdogTimer !== null) clearTimeout(this.watchdogTimer);
+    this.watchdogTimer = null;
+    this.probeNonce = null;
+    this.watchdogEpoch++;
+  }
+
+  private armWatchdog(): void {
+    if (this.closed || this.failed || this.pending.size === 0 || this.watchdogTimer !== null)
+      return;
+    this.scheduleWatchdog(PROBE_INTERVAL_MS, false);
+  }
+
+  private scheduleWatchdog(delay: number, awaitingReply: boolean): void {
+    const epoch = ++this.watchdogEpoch;
+    const deadline = Date.now() + delay;
+    this.watchdogTimer = setTimeout(() => {
+      if (epoch !== this.watchdogEpoch || this.closed || this.failed) return;
+      this.watchdogTimer = null;
+      if (this.pending.size === 0) {
+        this.clearWatchdog();
+        return;
+      }
+      // A suspended page must not consume a reply grace during time in which
+      // it could not dispatch messages. Fence the old reply and probe afresh.
+      if (!awaitingReply || Date.now() > deadline + CALLBACK_SUSPENSION_SLACK_MS) {
+        this.sendProbe();
+        return;
+      }
+      const error = new BrowserWorkerUnresponsiveError(
+        "Browser worker connection is unresponsive. Pending operation outcomes are unknown; operations were not retried.",
+      );
+      this.runtime.reportRemoteServerTransportError(error);
+      this.fail(error);
+    }, delay);
+  }
+
+  private sendProbe(): void {
+    this.clearWatchdog();
+    if (this.closed || this.failed || this.pending.size === 0) return;
+    const nonce = this.nextProbeNonce++;
+    this.probeNonce = nonce;
+    // Arm first so a synchronous adapter reply cannot leave an expiry behind.
+    this.scheduleWatchdog(PROBE_REPLY_MS, true);
+    try {
+      this.port.postMessage({
+        type: "runtime-probe",
+        connectionId: this.connectionId,
+        nonce,
+      } satisfies BrowserFollowerPortRequest);
+    } catch (error) {
+      this.fail(asError(error));
+    }
+  }
+
+  private readonly onResume = (): void => {
+    this.sendProbe();
+  };
+
+  private readonly onVisibilityChange = (): void => {
+    if (globalThis.document?.visibilityState === "visible") this.onResume();
+  };
+
   private readonly onMessage = (event: MessageEvent<BrowserFollowerPortEvent>): void => {
+    if (this.closed || this.failed) return;
     const message = event.data;
+    if (message.type === "runtime-pong") {
+      if (message.connectionId !== this.connectionId || message.nonce !== this.probeNonce) return;
+      this.clearWatchdog();
+      this.armWatchdog();
+      return;
+    }
     if (message.type === "frames") {
       if (this.pump) this.pump.receive(message.frames);
       else this.pendingFrames.push(message.frames);
@@ -307,6 +402,7 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
         this.pending.delete(id);
         pending.resolve();
       }
+      if (this.pending.size === 0) this.clearWatchdog();
       this.port.postMessage({
         type: "storage-reset-observed",
         resetId: message.resetId,
@@ -331,6 +427,7 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
     const pending = this.pending.get(message.id);
     if (!pending) return;
     this.pending.delete(message.id);
+    if (this.pending.size === 0) this.clearWatchdog();
     if (message.error) {
       pending.reject(deserializeBrowserRelayError(message.error));
     } else {
@@ -354,13 +451,19 @@ export class MessagePortBrowserFollowerConnection implements BrowserFollowerConn
     } catch {
       // The port may already be unusable; disposal below is still required.
     }
-    this.callbacks.onFailure(error);
-    this.dispose(error);
+    try {
+      this.callbacks.onFailure(error);
+    } finally {
+      this.dispose(error);
+    }
   }
 
   private dispose(error: Error): void {
     if (this.closed) return;
     this.closed = true;
+    this.clearWatchdog();
+    globalThis.removeEventListener?.("pageshow", this.onResume);
+    globalThis.document?.removeEventListener("visibilitychange", this.onVisibilityChange);
     this.port.removeEventListener("message", this.onMessage);
     this.port.removeEventListener("messageerror", this.onMessageError);
     this.disposeQueryCoverageTrace?.();

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.test.ts
@@ -5,6 +5,7 @@ import {
   SharedBrowserForegroundNodeLease,
   SharedBrowserWorkerConnection,
 } from "./browser-shared-worker-connection.js";
+import { BrowserWorkerUnresponsiveError } from "./browser-worker-protocol.js";
 
 type LeaseMessage =
   | { type: "probe-foreground-node-lease-worker"; attemptId: string }
@@ -117,7 +118,9 @@ class ScriptedRuntimePort {
   private readonly listeners = new Map<string, Set<(event: MessageEvent) => void>>();
   closed = false;
 
-  constructor(private readonly onPost: (message: { type?: string; id?: number }) => void) {}
+  constructor(
+    private readonly onPost: (message: { type?: string; id?: number; attemptId?: string }) => void,
+  ) {}
 
   start(): void {}
 
@@ -135,7 +138,7 @@ class ScriptedRuntimePort {
     this.listeners.get(type)?.delete(listener);
   }
 
-  postMessage(message: { type?: string; id?: number }): void {
+  postMessage(message: { type?: string; id?: number; attemptId?: string }): void {
     this.onPost(message);
   }
 
@@ -143,6 +146,58 @@ class ScriptedRuntimePort {
     for (const listener of this.listeners.get("message") ?? [])
       listener({ data: message } as MessageEvent);
   }
+
+  emitMessageError(): void {
+    for (const listener of this.listeners.get("messageerror") ?? [])
+      listener(new MessageEvent("messageerror"));
+  }
+}
+
+function runtimeBootstrapFixture() {
+  const sent: Array<{ type?: string; id?: number }> = [];
+  const port = new ScriptedRuntimePort((message) => {
+    sent.push(message);
+    if (message.type === "connect-runtime") port.emit({ type: "worker-alive" });
+    if (message.type === "init") port.emit({ type: "result", id: message.id });
+  });
+  vi.stubGlobal(
+    "SharedWorker",
+    class {
+      readonly port = port;
+    },
+  );
+  const connection = new SharedBrowserWorkerConnection(
+    {
+      connectUpstreamPeer: () => ({ recvWireFrames: () => [] }),
+      onPeerTransportWork: () => () => undefined,
+      progressPeerTransport: async () => undefined,
+      retirePeerTransport: async () => undefined,
+      reportRemoteServerTransportError: vi.fn(),
+      reportRemoteMutationError: vi.fn(),
+      flushLocalSettlements: async () => undefined,
+    } as never,
+    {
+      schema: {},
+      dbName: "runtime-budget-controls",
+      author: new Uint8Array(16),
+      initialSyncFlushEvery: 1,
+      appId: "app",
+      storageOwner: "owner",
+      authSessionKey: "scope",
+      authJson: "{}",
+      sessionClaims: {},
+    },
+    "runtime-fingerprint",
+    {
+      onAuthFailure: vi.fn(),
+      onAuthRestored: vi.fn(),
+      onExplicitOfflineChange: vi.fn(),
+      onFailure: vi.fn(),
+      onStorageReset: vi.fn(),
+      onStorageInvalidated: vi.fn(),
+    },
+  );
+  return { connection, port, sent };
 }
 
 class InspectorPort {
@@ -160,6 +215,140 @@ class InspectorPort {
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
+});
+
+describe("browser foreground lease terminal abandonment", () => {
+  async function acquireLease(retirePostError?: Error) {
+    const sent: string[] = [];
+    const port = new ScriptedRuntimePort((message) => {
+      sent.push(message.type!);
+      if (message.type === "probe-foreground-node-lease-worker") {
+        port.emit({ type: "foreground-node-lease-worker-alive", attemptId: message.attemptId });
+      } else if (message.type === "acquire-foreground-node-lease") {
+        port.emit({
+          type: "foreground-node-lease-ready",
+          leaseId: "00000000-0000-4000-8000-000000000003",
+          node: new Uint8Array(16),
+          confirmedTxTime: "0",
+        });
+      } else if (message.type === "retire-foreground-node-lease" && retirePostError) {
+        throw retirePostError;
+      }
+    });
+    const close = vi.spyOn(port, "close");
+    const lease = await SharedBrowserForegroundNodeLease.acquireFromPort(
+      port as unknown as MessagePort,
+      { dbName: "abandoned-foreground-root", storageOwner: "owner" },
+    );
+    return { lease, port, sent, close };
+  }
+
+  it.each(["before finish", "during retirement"] as const)(
+    "rejects local finish %s without awaiting a retirement receipt",
+    async (phase) => {
+      const { lease, port, sent, close } = await acquireLease();
+      const error = new BrowserWorkerUnresponsiveError("worker realm stopped responding");
+      const pending = phase === "before finish" ? undefined : lease.retire();
+      const rejected = pending && expect(pending).rejects.toBe(error);
+      lease.abandonAfterWorkerFailure(error);
+      lease.abandonAfterWorkerFailure(new Error("duplicate must not replace the cause"));
+      await rejected;
+      await expect(lease.returnWithHighWater(99n)).rejects.toBe(error);
+      await expect(lease.retire()).rejects.toBe(error);
+      expect(sent.filter((type) => type === "retire-foreground-node-lease")).toHaveLength(1);
+      expect(sent).not.toContain("return-foreground-node-lease");
+      expect(close).not.toHaveBeenCalled();
+      port.emit({ type: "unrelated-result" });
+      expect(close).not.toHaveBeenCalled();
+      port.emit({ type: "foreground-node-lease-result" });
+      expect(close).toHaveBeenCalledOnce();
+      port.emit({ type: "foreground-node-lease-result" });
+      lease.abandonAfterWorkerFailure(new Error("late failure"));
+      await expect(lease.returnWithHighWater(0n)).rejects.toBe(error);
+      expect(close).toHaveBeenCalledOnce();
+      expect(sent.filter((type) => type === "retire-foreground-node-lease")).toHaveLength(1);
+    },
+  );
+
+  it("retains only the already-posted return when abandonment rejects its local caller", async () => {
+    const { lease, port, sent, close } = await acquireLease();
+    const post = vi.spyOn(port, "postMessage");
+    const error = new BrowserWorkerUnresponsiveError("worker realm stopped responding");
+    let outcome: unknown = "pending";
+    const returned = lease.returnWithHighWater(42n).then(
+      () => {
+        outcome = "fulfilled";
+      },
+      (failure) => {
+        outcome = failure;
+      },
+    );
+    vi.useFakeTimers();
+    try {
+      expect(post).toHaveBeenCalledExactlyOnceWith({
+        type: "return-foreground-node-lease",
+        confirmedTxTime: "42",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(outcome).toBe("pending");
+      lease.abandonAfterWorkerFailure(error);
+      lease.abandonAfterWorkerFailure(new Error("duplicate must not replace the cause"));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(outcome).toBe(error);
+      expect(sent.filter((type) => type.endsWith("-foreground-node-lease"))).toEqual([
+        "acquire-foreground-node-lease",
+        "return-foreground-node-lease",
+      ]);
+      expect(close).not.toHaveBeenCalled();
+      port.emit({ type: "unrelated-result" });
+      expect(close).not.toHaveBeenCalled();
+
+      // The original result releases the port, not the caller's unknown outcome.
+      port.emit({ type: "foreground-node-lease-result" });
+      await returned;
+      expect(close).toHaveBeenCalledOnce();
+      expect(outcome).toBe(error);
+      await expect(lease.returnWithHighWater(99n)).rejects.toBe(error);
+      await expect(lease.retire()).rejects.toBe(error);
+      port.emit({ type: "foreground-node-lease-result" });
+      expect(close).toHaveBeenCalledOnce();
+      expect(post).toHaveBeenCalledOnce();
+    } finally {
+      // Release this actual adapter's controlled port after the observations,
+      // including on the baseline's contradictory second-request assertion.
+      port.emit({ type: "foreground-node-lease-result" });
+      await returned;
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["result error", "messageerror"] as const)(
+    "releases retained cleanup on a late %s without changing the causal failure",
+    async (event) => {
+      const { lease, port, close } = await acquireLease();
+      const error = new BrowserWorkerUnresponsiveError("original worker failure");
+      lease.abandonAfterWorkerFailure(error);
+      if (event === "messageerror") port.emitMessageError();
+      else
+        port.emit({
+          type: "foreground-node-lease-result",
+          error: { name: "Error", message: "late durable retirement failure" },
+        });
+      expect(close).toHaveBeenCalledOnce();
+      await expect(lease.retire()).rejects.toBe(error);
+    },
+  );
+
+  it("keeps the causal failure when best-effort retirement cannot be posted", async () => {
+    const { lease, sent, close } = await acquireLease(new Error("port is gone"));
+    const error = new BrowserWorkerUnresponsiveError("original worker failure");
+    lease.abandonAfterWorkerFailure(error);
+    lease.abandonAfterWorkerFailure(error);
+    await expect(lease.returnWithHighWater(0n)).rejects.toBe(error);
+    await expect(lease.retire()).rejects.toBe(error);
+    expect(sent.filter((type) => type === "retire-foreground-node-lease")).toHaveLength(1);
+    expect(close).toHaveBeenCalledOnce();
+  });
 });
 
 describe("browser SharedWorker realm identity", () => {
@@ -390,6 +579,148 @@ describe("browser SharedWorker realm identity", () => {
     await retired;
   });
 
+  it("rejects readiness when an alive runtime never finishes its five-minute startup grace", async () => {
+    vi.useFakeTimers();
+    const port = new ScriptedRuntimePort((message) => {
+      if (message.type === "connect-runtime") port.emit({ type: "worker-alive" });
+    });
+    vi.stubGlobal(
+      "SharedWorker",
+      class {
+        readonly port = port;
+      },
+    );
+    const runtime = {
+      connectUpstreamPeer: () => ({ recvWireFrames: () => [] }),
+      onPeerTransportWork: () => () => undefined,
+      progressPeerTransport: async () => undefined,
+      retirePeerTransport: async () => undefined,
+      reportRemoteServerTransportError: vi.fn(),
+      reportRemoteMutationError: vi.fn(),
+      flushLocalSettlements: async () => undefined,
+    };
+    const callbacks = {
+      onAuthFailure: vi.fn(),
+      onAuthRestored: vi.fn(),
+      onExplicitOfflineChange: vi.fn(),
+      onFailure: vi.fn(),
+      onStorageReset: vi.fn(),
+      onStorageInvalidated: vi.fn(),
+    };
+    const connection = new SharedBrowserWorkerConnection(
+      runtime as never,
+      {
+        schema: {},
+        dbName: "runtime-startup-grace-root",
+        author: new Uint8Array(16),
+        initialSyncFlushEvery: 1,
+        appId: "app",
+        storageOwner: "owner",
+        authSessionKey: "scope-a",
+        authJson: "{}",
+        sessionClaims: {},
+      },
+      "runtime-fingerprint",
+      callbacks,
+    );
+    let outcome = "pending";
+    void connection.ready().then(
+      () => {
+        outcome = "resolved";
+      },
+      () => {
+        outcome = "rejected";
+      },
+    );
+
+    try {
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1_000);
+      expect(outcome).toBe("rejected");
+      await expect(connection.ready()).rejects.toBeInstanceOf(BrowserWorkerUnresponsiveError);
+    } finally {
+      // Release the stalled baseline only after observing public readiness.
+      // This terminal reply also completes retained timeout cleanup.
+      port.emit({
+        type: "runtime-error",
+        error: { name: "Error", message: "Runtime fixture finished" },
+      });
+      await connection.shutdown();
+    }
+  });
+
+  it("admits a healthy runtime that initializes beyond the old one-second probe", async () => {
+    vi.useFakeTimers();
+    const { connection, port, sent } = runtimeBootstrapFixture();
+    await vi.advanceTimersByTimeAsync(1_100);
+    port.emit({ type: "runtime-ready" });
+    await expect(connection.ready()).resolves.toBeUndefined();
+    const shutdown = connection.shutdown();
+    await vi.advanceTimersByTimeAsync(0);
+    // The follower has finished admission and owns normal close acknowledgement.
+    port.emit({ type: "result", id: sent.find((message) => message.type === "close")?.id });
+    await shutdown;
+    expect(port.closed).toBe(true);
+  });
+
+  it("does not let duplicate alive messages extend runtime startup", async () => {
+    vi.useFakeTimers();
+    const { connection, port, sent } = runtimeBootstrapFixture();
+    const rejected = expect(connection.ready()).rejects.toThrow("five minutes");
+    await vi.advanceTimersByTimeAsync(299_000);
+    port.emit({ type: "worker-alive" });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await rejected;
+    expect(sent.filter((message) => message.type === "cancel-runtime-bootstrap")).toHaveLength(1);
+    await connection.shutdown();
+    expect(port.closed).toBe(false);
+    port.emit({ type: "runtime-bootstrap-cancelled" });
+    expect(port.closed).toBe(true);
+  });
+
+  it("settles shutdown without a cancellation ack and releases a late attached peer", async () => {
+    vi.useFakeTimers();
+    const { connection, port, sent } = runtimeBootstrapFixture();
+    const rejected = expect(connection.ready()).rejects.toThrow("closed");
+    await connection.shutdown();
+    await rejected;
+    await connection.shutdown();
+    expect(sent.filter((message) => message.type === "cancel-runtime-bootstrap")).toHaveLength(1);
+    expect(port.closed).toBe(false);
+    port.emit({ type: "runtime-ready" });
+    expect(sent).toContainEqual({ type: "close", id: 0, releaseContext: true });
+    expect(port.closed).toBe(false);
+    port.emit({ type: "result", id: 0 });
+    expect(port.closed).toBe(true);
+    const settledCount = sent.length;
+    port.emit({ type: "runtime-ready" });
+    expect(sent).toHaveLength(settledCount);
+  });
+
+  it("gives a suspended page fresh startup grace before expiring a delayed timer", async () => {
+    vi.useFakeTimers();
+    const { connection, port } = runtimeBootstrapFixture();
+    let outcome = "pending";
+    void connection.ready().then(
+      () => {
+        outcome = "ready";
+      },
+      () => {
+        outcome = "failed";
+      },
+    );
+    // Advance wall time without running scheduled tasks: the first resumed
+    // task must not treat time spent asleep as evidence of worker failure.
+    vi.setSystemTime(Date.now() + 10 * 60_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(outcome).toBe("pending");
+    await vi.advanceTimersByTimeAsync(299_000);
+    expect(outcome).toBe("pending");
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(outcome).toBe("failed");
+    port.emit({ type: "runtime-bootstrap-cancelled" });
+    await connection.shutdown();
+  });
+
   it("moves a runtime bootstrap out of an inspector-terminating realm", async () => {
     const dbName = "runtime-closing-root";
     const workers: Array<{ name: string; port: ScriptedRuntimePort }> = [];
@@ -609,5 +940,6 @@ describe("browser SharedWorker realm identity", () => {
     );
 
     expect(current).not.toBe(next);
+    expect(current).toContain('"protocolVersion":"jazz-shared-runtime-v2"');
   });
 });

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -88,7 +88,7 @@ export class SharedBrowserForegroundNodeLease implements BrowserForegroundNodeLe
   private worker: Pick<SharedWorker, "port"> | null = null;
   private port: MessagePort | null = null;
   private closed = false;
-  private abandonedError: Error | null = null;
+  private terminalError: Error | null = null;
   private finishPromise: Promise<void> | null = null;
   private finishWaiter: { resolve: () => void; reject: (error: Error) => void } | null = null;
   private listeningForFinish = false;
@@ -322,7 +322,7 @@ export class SharedBrowserForegroundNodeLease implements BrowserForegroundNodeLe
   }
 
   async returnWithHighWater(highWater: bigint): Promise<void> {
-    if (this.abandonedError) throw this.abandonedError;
+    if (this.terminalError) throw this.terminalError;
     if (highWater < 0n) throw new Error("Invalid foreground transaction high-water");
     await this.finish({
       type: "return-foreground-node-lease",
@@ -331,14 +331,14 @@ export class SharedBrowserForegroundNodeLease implements BrowserForegroundNodeLe
   }
 
   async retire(): Promise<void> {
-    if (this.abandonedError) throw this.abandonedError;
+    if (this.terminalError) throw this.terminalError;
     if (this.closed) return;
     await this.finish({ type: "retire-foreground-node-lease" });
   }
 
   abandonAfterWorkerFailure(error: Error): void {
-    if (this.abandonedError) return;
-    this.abandonedError = error;
+    if (this.terminalError) return;
+    this.terminalError = error;
     this.finishWaiter?.reject(error);
     this.finishWaiter = null;
     if (this.closed || !this.port) return;
@@ -356,8 +356,18 @@ export class SharedBrowserForegroundNodeLease implements BrowserForegroundNodeLe
     // The late result only releases this background witness, not durable success.
   }
 
+  releaseAfterStorageReset(reason: Error): void {
+    this.failFinish(reason);
+  }
+
+  private failFinish(error: Error): void {
+    this.terminalError ??= error;
+    this.finishWaiter?.reject(this.terminalError);
+    this.closeFinishPort();
+  }
+
   private finish(message: BrowserForegroundNodeLeasePortRequest): Promise<void> {
-    if (this.abandonedError) return Promise.reject(this.abandonedError);
+    if (this.terminalError) return Promise.reject(this.terminalError);
     if (this.closed)
       return Promise.reject(new Error("Shared browser foreground lease is already closed"));
     if (this.finishPromise) return this.finishPromise;
@@ -372,8 +382,7 @@ export class SharedBrowserForegroundNodeLease implements BrowserForegroundNodeLe
     try {
       port.postMessage(message);
     } catch (error) {
-      this.finishWaiter?.reject(error instanceof Error ? error : new Error(String(error)));
-      this.closeFinishPort();
+      this.failFinish(error instanceof Error ? error : new Error(String(error)));
     }
     return this.finishPromise;
   }
@@ -388,14 +397,15 @@ export class SharedBrowserForegroundNodeLease implements BrowserForegroundNodeLe
   private readonly onFinishResult = (event: MessageEvent<BrowserForegroundNodeLeasePortEvent>) => {
     const result = event.data;
     if (result?.type !== "foreground-node-lease-result") return;
-    if (result.error) this.finishWaiter?.reject(deserializeBrowserRelayError(result.error));
-    else this.finishWaiter?.resolve();
-    this.closeFinishPort();
+    if (result.error) this.failFinish(deserializeBrowserRelayError(result.error));
+    else {
+      this.finishWaiter?.resolve();
+      this.closeFinishPort();
+    }
   };
 
   private readonly onFinishError = () => {
-    this.finishWaiter?.reject(new Error("Shared browser foreground lease port message error"));
-    this.closeFinishPort();
+    this.failFinish(new Error("Shared browser foreground lease port message error"));
   };
 
   private closeFinishPort(): void {

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -4,18 +4,21 @@ import {
   resolveBrowserWorkerUrl,
 } from "../browser-worker-config.js";
 import {
+  BrowserWorkerUnresponsiveError,
   deserializeBrowserRelayError,
   type BrowserSharedWorkerConnectRequest,
   type BrowserSharedWorkerConnectResponse,
+  type BrowserSharedWorkerBootstrapCancelRequest,
   type BrowserForegroundNodeLeaseAcquireResponse,
   type BrowserForegroundNodeLeasePortEvent,
   type BrowserForegroundNodeLeasePortRequest,
+  type BrowserFollowerPortEvent,
   type BrowserFollowerPortRequest,
   type BrowserInspectorControlEvent,
   type BrowserWorkerInitOptions,
 } from "./browser-worker-protocol.js";
 import type {
-  ForegroundNodeLease,
+  BrowserForegroundNodeLease,
   BrowserWorkerConnection,
   BrowserWorkerConnectionContext,
 } from "../runtime-source.js";
@@ -41,6 +44,8 @@ const MAX_SHARED_WORKER_GENERATION_ATTEMPTS = 8;
 const MAX_FOREGROUND_NODE_LEASE_BUSY_ATTEMPTS = 8;
 const FOREGROUND_NODE_LEASE_RETRY_INITIAL_DELAY_MS = 25;
 const FOREGROUND_NODE_LEASE_RETRY_MAX_DELAY_MS = 250;
+const RUNTIME_STARTUP_TIMEOUT_MS = 5 * 60_000;
+const RUNTIME_STARTUP_CLOCK_INTERVAL_MS = 1_000;
 
 type ForegroundNodeLeaseAttemptOutcome =
   | { type: "ready"; lease: SharedBrowserForegroundNodeLease }
@@ -79,10 +84,15 @@ function foregroundLeaseCleanupKey(workerName: string, storageOwner: string): st
  * exists. Its port stays open as the durable owner's liveness witness until
  * explicit clean return or retirement.
  */
-export class SharedBrowserForegroundNodeLease implements ForegroundNodeLease {
+export class SharedBrowserForegroundNodeLease implements BrowserForegroundNodeLease {
   private worker: Pick<SharedWorker, "port"> | null = null;
   private port: MessagePort | null = null;
   private closed = false;
+  private abandonedError: Error | null = null;
+  private finishPromise: Promise<void> | null = null;
+  private finishWaiter: { resolve: () => void; reject: (error: Error) => void } | null = null;
+  private listeningForFinish = false;
+  private terminalRequestSent = false;
 
   private constructor(
     readonly node: Uint8Array,
@@ -312,6 +322,7 @@ export class SharedBrowserForegroundNodeLease implements ForegroundNodeLease {
   }
 
   async returnWithHighWater(highWater: bigint): Promise<void> {
+    if (this.abandonedError) throw this.abandonedError;
     if (highWater < 0n) throw new Error("Invalid foreground transaction high-water");
     await this.finish({
       type: "return-foreground-node-lease",
@@ -320,40 +331,81 @@ export class SharedBrowserForegroundNodeLease implements ForegroundNodeLease {
   }
 
   async retire(): Promise<void> {
+    if (this.abandonedError) throw this.abandonedError;
     if (this.closed) return;
     await this.finish({ type: "retire-foreground-node-lease" });
   }
 
-  private async finish(message: BrowserForegroundNodeLeasePortRequest): Promise<void> {
-    if (this.closed) throw new Error("Shared browser foreground lease is already closed");
+  abandonAfterWorkerFailure(error: Error): void {
+    if (this.abandonedError) return;
+    this.abandonedError = error;
+    this.finishWaiter?.reject(error);
+    this.finishWaiter = null;
+    if (this.closed || !this.port) return;
+    this.listenForFinish();
+    // A quiesced return may already have committed. Retain its one outcome;
+    // another command cannot retrospectively retire an identity already reused.
+    if (this.terminalRequestSent) return;
+    this.terminalRequestSent = true;
+    try {
+      this.port.postMessage({ type: "retire-foreground-node-lease" });
+    } catch {
+      this.closeFinishPort();
+    }
+    // Do not close after posting: WebKit can discard a queued retirement.
+    // The late result only releases this background witness, not durable success.
+  }
+
+  private finish(message: BrowserForegroundNodeLeasePortRequest): Promise<void> {
+    if (this.abandonedError) return Promise.reject(this.abandonedError);
+    if (this.closed)
+      return Promise.reject(new Error("Shared browser foreground lease is already closed"));
+    if (this.finishPromise) return this.finishPromise;
     const port = this.port;
-    if (!port) throw new Error("Shared browser foreground lease port is unavailable");
-    await new Promise<void>((resolve, reject) => {
-      const cleanup = () => {
-        port.removeEventListener("message", onMessage);
-        port.removeEventListener("messageerror", onMessageError);
-      };
-      const onMessage = (event: MessageEvent<BrowserForegroundNodeLeasePortEvent>) => {
-        const result = event.data;
-        if (result?.type !== "foreground-node-lease-result") return;
-        cleanup();
-        if (result.error) reject(deserializeBrowserRelayError(result.error));
-        else resolve();
-      };
-      const onMessageError = () => {
-        cleanup();
-        reject(new Error("Shared browser foreground lease port message error"));
-      };
-      port.addEventListener("message", onMessage);
-      port.addEventListener("messageerror", onMessageError);
-      port.postMessage(message);
-    }).finally(() => {
-      this.closed = true;
-      this.port?.close();
-      this.port = null;
-      this.worker?.port.close();
-      this.worker = null;
+    if (!port)
+      return Promise.reject(new Error("Shared browser foreground lease port is unavailable"));
+    this.listenForFinish();
+    this.finishPromise = new Promise<void>((resolve, reject) => {
+      this.finishWaiter = { resolve, reject };
     });
+    this.terminalRequestSent = true;
+    try {
+      port.postMessage(message);
+    } catch (error) {
+      this.finishWaiter?.reject(error instanceof Error ? error : new Error(String(error)));
+      this.closeFinishPort();
+    }
+    return this.finishPromise;
+  }
+
+  private listenForFinish(): void {
+    if (this.listeningForFinish) return;
+    this.listeningForFinish = true;
+    this.port?.addEventListener("message", this.onFinishResult);
+    this.port?.addEventListener("messageerror", this.onFinishError);
+  }
+
+  private readonly onFinishResult = (event: MessageEvent<BrowserForegroundNodeLeasePortEvent>) => {
+    const result = event.data;
+    if (result?.type !== "foreground-node-lease-result") return;
+    if (result.error) this.finishWaiter?.reject(deserializeBrowserRelayError(result.error));
+    else this.finishWaiter?.resolve();
+    this.closeFinishPort();
+  };
+
+  private readonly onFinishError = () => {
+    this.finishWaiter?.reject(new Error("Shared browser foreground lease port message error"));
+    this.closeFinishPort();
+  };
+
+  private closeFinishPort(): void {
+    this.finishWaiter = null;
+    this.closed = true;
+    this.port?.removeEventListener("message", this.onFinishResult);
+    this.port?.removeEventListener("messageerror", this.onFinishError);
+    this.worker?.port.close();
+    this.port = null;
+    this.worker = null;
   }
 }
 
@@ -366,6 +418,7 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
   private closed = false;
   private readonly workerName: string;
   private connectedGeneration: number | null = null;
+  private cancelBootstrap: (() => void) | null = null;
 
   constructor(
     runtime: NativeRuntimeAdapter,
@@ -439,8 +492,8 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
         generationName,
         createWorker,
       );
-      if (this.closed) return;
       if (outcome.error) throw outcome.error;
+      if (this.closed) return;
       if (outcome.connected) {
         this.connectedGeneration = generation;
         return;
@@ -462,50 +515,136 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
     const port = worker.port;
     port.start();
     return new Promise<{ connected: boolean; error?: Error }>((resolve) => {
-      let bootstrapTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
-        cleanup();
-        port.close();
+      let settled = false;
+      let cancelled = false;
+      let closingLatePeer = false;
+      let alive = false;
+      let lastTick = Date.now();
+      let deadline = lastTick + 1_000;
+      let suspended = typeof document !== "undefined" && document.hidden;
+      let bootstrapTimer: ReturnType<typeof setTimeout> | undefined;
+      const settle = (outcome: { connected: boolean; error?: Error }) => {
+        if (settled) return;
+        settled = true;
+        stopClock();
+        if (this.cancelBootstrap === cancelForShutdown) this.cancelBootstrap = null;
+        resolve(outcome);
+      };
+      const cancel = (outcome: { connected: boolean; error?: Error }) => {
+        if (settled) return;
+        cancelled = true;
+        settle(outcome);
+        // Keep the listener until the worker fences admission or publishes a
+        // late peer. Public readiness/shutdown must not await this cleanup.
         if (this.worker === worker) this.worker = null;
-        resolve({ connected: false });
-      }, 1000);
-      const onMessage = (event: MessageEvent<BrowserSharedWorkerConnectResponse>) => {
+        try {
+          port.postMessage({
+            type: "cancel-runtime-bootstrap",
+          } satisfies BrowserSharedWorkerBootstrapCancelRequest);
+        } catch {
+          cleanup();
+          port.close();
+        }
+      };
+      const cancelForShutdown = () =>
+        cancel({
+          connected: false,
+          error: new Error("Shared browser runtime connection is closed"),
+        });
+      this.cancelBootstrap = cancelForShutdown;
+      const refreshGrace = () => {
+        lastTick = Date.now();
+        deadline = lastTick + (alive ? RUNTIME_STARTUP_TIMEOUT_MS : 1_000);
+      };
+      const onVisibilityChange = () => {
+        const hidden = typeof document !== "undefined" && document.hidden;
+        if (suspended && !hidden) refreshGrace();
+        suspended = hidden;
+      };
+      const onPageShow = () => refreshGrace();
+      const tick = () => {
+        const now = Date.now();
+        // A delayed task cannot distinguish a dead worker from a suspended
+        // page. Give a resumed page one fresh complete admission grace.
+        if (suspended || now - lastTick > RUNTIME_STARTUP_CLOCK_INTERVAL_MS * 2) refreshGrace();
+        lastTick = now;
+        if (now >= deadline) {
+          cancel(
+            alive
+              ? {
+                  connected: false,
+                  error: new BrowserWorkerUnresponsiveError(
+                    "Shared browser runtime did not finish initialization within five minutes",
+                  ),
+                }
+              : { connected: false },
+          );
+          return;
+        }
+        bootstrapTimer = setTimeout(
+          tick,
+          Math.min(RUNTIME_STARTUP_CLOCK_INTERVAL_MS, deadline - now),
+        );
+      };
+      const stopClock = () => {
+        clearTimeout(bootstrapTimer);
+        bootstrapTimer = undefined;
+        if (typeof document !== "undefined")
+          document.removeEventListener("visibilitychange", onVisibilityChange);
+        if (typeof window !== "undefined") window.removeEventListener("pageshow", onPageShow);
+      };
+      const onMessage = (
+        event: MessageEvent<BrowserSharedWorkerConnectResponse | BrowserFollowerPortEvent>,
+      ) => {
+        if (cancelled) {
+          if (event.data?.type === "runtime-ready") {
+            if (closingLatePeer) return;
+            closingLatePeer = true;
+            port.postMessage({
+              type: "close",
+              id: 0,
+              releaseContext: true,
+            } satisfies BrowserFollowerPortRequest);
+            return;
+          } else if (
+            event.data?.type !== "runtime-bootstrap-cancelled" &&
+            event.data?.type !== "runtime-error" &&
+            event.data?.type !== "worker-closing" &&
+            !(event.data?.type === "result" && event.data.id === 0)
+          )
+            return;
+          cleanup();
+          port.close();
+          return;
+        }
         if (event.data?.type === "worker-alive") {
-          if (bootstrapTimer) clearTimeout(bootstrapTimer);
-          bootstrapTimer = null;
+          if (!alive) {
+            alive = true;
+            refreshGrace();
+          }
           return;
         }
         if (event.data?.type === "runtime-error") {
           cleanup();
           port.close();
           if (this.worker === worker) this.worker = null;
-          // Do not reject a bare MessagePort callback promise. A browser can
-          // report that rejection before the caller's operation has observed
-          // readiness. The outer, constructor-owned state machine turns this
-          // into the same explicit error after it has installed containment.
           const error = deserializeBrowserRelayError(event.data.error);
           this.initialConfigurationAdmissionRejected =
             error.message === "incompatible persistent browser configuration";
-          resolve({ connected: false, error });
+          settle({ connected: false, error });
           return;
         }
         if (event.data?.type === "worker-closing") {
           cleanup();
           port.close();
           if (this.worker === worker) this.worker = null;
-          resolve({ connected: false });
+          settle({ connected: false });
           return;
         }
         if (event.data?.type !== "runtime-ready") return;
         cleanup();
-        if (this.closed) {
-          port.postMessage({
-            type: "close",
-            releaseContext: true,
-          } satisfies BrowserFollowerPortRequest);
-          port.close();
-          resolve({ connected: true });
-          return;
-        }
+        // The installed follower owns liveness from this synchronous handoff.
+        if (this.cancelBootstrap === cancelForShutdown) this.cancelBootstrap = null;
         const connection = new MessagePortBrowserFollowerConnection(
           runtime,
           port,
@@ -523,12 +662,12 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
         );
         this.connection = connection;
         void connection.ready().then(
-          () => resolve({ connected: true }),
+          () => settle({ connected: true }),
           (error: unknown) => {
             port.close();
             if (this.connection === connection) this.connection = null;
             if (this.worker === worker) this.worker = null;
-            resolve({
+            settle({
               connected: false,
               error: error instanceof Error ? error : new Error(String(error)),
             });
@@ -539,19 +678,22 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
         cleanup();
         port.close();
         if (this.worker === worker) this.worker = null;
-        resolve({
+        settle({
           connected: false,
           error: new Error("Shared browser runtime port message error"),
         });
       };
       const cleanup = () => {
-        if (bootstrapTimer) clearTimeout(bootstrapTimer);
-        bootstrapTimer = null;
+        stopClock();
         port.removeEventListener("message", onMessage);
         port.removeEventListener("messageerror", onMessageError);
       };
       port.addEventListener("message", onMessage);
       port.addEventListener("messageerror", onMessageError);
+      if (typeof document !== "undefined")
+        document.addEventListener("visibilitychange", onVisibilityChange);
+      if (typeof window !== "undefined") window.addEventListener("pageshow", onPageShow);
+      bootstrapTimer = setTimeout(tick, 1_000);
       try {
         port.postMessage({
           type: "connect-runtime",
@@ -563,7 +705,7 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
         cleanup();
         port.close();
         if (this.worker === worker) this.worker = null;
-        resolve({
+        settle({
           connected: false,
           error: error instanceof Error ? error : new Error(String(error)),
         });
@@ -607,7 +749,7 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
   async shutdown(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
-    await this.readyPromise.catch(() => undefined);
+    this.cancelBootstrap?.();
     await this.connection?.shutdown(true);
     this.connection = null;
     this.worker?.port.close();

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-worker-protocol.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-worker-protocol.ts
@@ -3,6 +3,11 @@ import type { RuntimeSourcesConfig } from "../context.js";
 import type { MutationErrorEvent } from "../client.js";
 import type { NativeSelfSignedClientProof } from "./native-codec.js";
 
+/** Local lifecycle classification, never inferred from a relayed error's name or message. */
+export class BrowserWorkerUnresponsiveError extends Error {
+  override readonly name = "BrowserWorkerUnresponsiveError";
+}
+
 /**
  * Structured-clone-safe Error representation used across browser worker
  * MessagePorts. Error's own fields are not consistently enumerable or retained
@@ -293,6 +298,11 @@ export interface BrowserSharedWorkerConnectRequest {
   options: BrowserWorkerInitOptions;
 }
 
+/** Cancel only this port's runtime admission, never shared initialization. */
+export interface BrowserSharedWorkerBootstrapCancelRequest {
+  type: "cancel-runtime-bootstrap";
+}
+
 /**
  * Liveness handshake sent before a foreground lease request. The worker must
  * acknowledge this without touching durable state; only then may the client
@@ -372,6 +382,8 @@ export type BrowserForegroundNodeLeasePortEvent = {
 export type BrowserSharedWorkerConnectResponse =
   | { type: "worker-alive" }
   | { type: "runtime-ready" }
+  /** The admission is fenced; the client may release its retained port. */
+  | { type: "runtime-bootstrap-cancelled" }
   | { type: "runtime-error"; error: BrowserRelayError }
   /** The realm has acknowledged inspector-directed termination. */
   | { type: "worker-closing" };
@@ -394,6 +406,8 @@ export type InspectorStagedEdit = {
 };
 
 export type BrowserFollowerPortRequest =
+  /** Connection liveness only; never acknowledges an operation's outcome. */
+  | { type: "runtime-probe"; connectionId: string; nonce: number }
   | {
       type: "inspect-commit";
       id: number;
@@ -531,6 +545,7 @@ export type BrowserInspectorControlEvent =
 
 export type BrowserFollowerPortEvent =
   | { type: "inspector-query-result"; id: number; value?: unknown; error?: BrowserRelayError }
+  | { type: "runtime-pong"; connectionId: string; nonce: number }
   | { type: "inspector-binding"; id: number; binding: InspectorAttachmentBinding }
   | { type: "frames"; frames: Uint8Array[] }
   /**

--- a/packages/jazz-tools/src/runtime/runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/runtime-source.ts
@@ -35,6 +35,8 @@ export interface ForegroundNodeLease {
 export interface BrowserForegroundNodeLease extends ForegroundNodeLease {
   /** The caller must first disable the foreground lifetime that can mint this node's TxIds. */
   abandonAfterWorkerFailure(error: Error): void;
+  /** Locally releases an erased epoch after its worker-authored reset receipt; never writes a handoff. */
+  releaseAfterStorageReset(reason: Error): void;
 }
 
 export interface RuntimeTelemetryContext<RuntimeConfig extends DbConfig = DbConfig> {
@@ -79,7 +81,7 @@ export interface BrowserWorkerConnectionContext<RuntimeConfig extends DbConfig =
   /** The worker namespace's explicit offline state changed. */
   onExplicitOfflineChange?: (offline: boolean) => void;
   onFailure: (error: unknown) => void;
-  onStorageReset?: () => void;
+  onStorageReset?: (resetId: number) => void;
   onStorageInvalidated?: () => void;
 }
 
@@ -92,7 +94,7 @@ export interface BrowserFollowerConnectionContext<RuntimeConfig extends DbConfig
   /** The worker namespace's explicit offline state changed. */
   onExplicitOfflineChange?: (offline: boolean) => void;
   onFailure: (error: unknown) => void;
-  onStorageReset?: () => void;
+  onStorageReset?: (resetId: number) => void;
   onStorageInvalidated?: () => void;
 }
 

--- a/packages/jazz-tools/src/runtime/runtime-source.ts
+++ b/packages/jazz-tools/src/runtime/runtime-source.ts
@@ -31,6 +31,12 @@ export interface ForegroundNodeLease {
   retire(): Promise<void>;
 }
 
+/** Browser-only terminal cleanup; the durable retirement outcome remains unknown. */
+export interface BrowserForegroundNodeLease extends ForegroundNodeLease {
+  /** The caller must first disable the foreground lifetime that can mint this node's TxIds. */
+  abandonAfterWorkerFailure(error: Error): void;
+}
+
 export interface RuntimeTelemetryContext<RuntimeConfig extends DbConfig = DbConfig> {
   config: RuntimeConfig;
   collectorUrl: string;
@@ -162,7 +168,7 @@ export abstract class RuntimeSource<RuntimeConfig extends DbConfig = DbConfig> {
     return undefined;
   }
 
-  acquireBrowserForegroundNodeLease(_config: RuntimeConfig): Promise<ForegroundNodeLease> {
+  acquireBrowserForegroundNodeLease(_config: RuntimeConfig): Promise<BrowserForegroundNodeLease> {
     return Promise.reject(
       new Error("Db runtime source does not support browser foreground leases"),
     );

--- a/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
@@ -27,6 +27,7 @@ import {
   type BrowserWorkerLifecycleTrace,
   type BrowserSharedWorkerConnectRequest,
   type BrowserSharedWorkerConnectResponse,
+  type BrowserSharedWorkerBootstrapCancelRequest,
   type BrowserWorkerInitOptions,
 } from "../runtime/native-runtime/browser-worker-protocol.js";
 // Worker failures cross a MessagePort boundary, so retain enough WASM frames to
@@ -93,6 +94,8 @@ type RuntimeContext = {
   fingerprint: string;
   options: BrowserWorkerInitOptions;
   peers: Map<string, TabPeer>;
+  admissionClaims: Set<symbol>;
+  pendingAdmissionTasks: number;
   runtime: NativeRuntimeAdapter | null;
   initialize: Promise<void>;
   closing: Promise<void> | null;
@@ -200,6 +203,7 @@ const workerGlobal = globalThis as SharedWorkerGlobal;
 const workerRealmId = crypto.randomUUID();
 let foregroundLeaseTestHooks: ForegroundLeaseTestHooks | null = null;
 const contexts = new Map<string, RuntimeContext>();
+const pendingRuntimeOwnerRetirements = new Map<string, PhysicalDatabaseOwner>();
 const foregroundLeaseOwners = new Map<string, ForegroundLeaseOwner>();
 const physicalDatabaseOwners = new Map<string, PhysicalDatabaseOwner>();
 const physicalDatabaseOwnerAdmissions = new Map<string, Promise<PhysicalDatabaseOwner>>();
@@ -377,6 +381,9 @@ async function releasePhysicalDatabaseOwner(dbName: string): Promise<void> {
         owner.disposeInvalidation = null;
         owner.pageStore.close();
         await owner.epoch.release();
+        if (pendingRuntimeOwnerRetirements.get(dbName) === owner) {
+          pendingRuntimeOwnerRetirements.delete(dbName);
+        }
         physicalDatabaseOwners.delete(dbName);
       }
     })();
@@ -417,23 +424,26 @@ function attachBootstrapPort(
   // new liveness claim before any message task can run; otherwise that old
   // close can terminate this exact admission mid-flight. Do not merely
   // cancel the old close token here: the bootstrap reservation is the
-  // durable fact that remains true until this port has either completed its
-  // first operation or failed it.
+  // durable fact that remains true until this port has completed its first
+  // operation, failed it, or expired without starting one.
   pendingBootstrapOperations += 1;
   let bootstrapFinished = false;
   let bootstrapPortClosed = false;
   let probedLeaseAttemptId: string | null = null;
   let operationStarted = false;
+  let runtimeAdmission = false;
   const parentLifetime = new AbortController();
-  // A vanished iframe may never deliver a close message. Only expire the
-  // unclaimed bootstrap; allocation has its own cancellation protocol.
-  const idleTimer = scope ? setTimeout(() => closeBootstrapPort(), 30_000) : undefined;
+  // A vanished page or iframe may never deliver a close message. Probe-only
+  // ports remain unclaimed; starting runtime admission or lease allocation
+  // clears this timer and uses that operation's own cancellation protocol.
+  const idleTimer = setTimeout(() => closeBootstrapPort(), 30_000);
   const finishBootstrap = () => {
     if (bootstrapFinished) return;
     bootstrapFinished = true;
     clearTimeout(idleTimer);
     pendingBootstrapOperations -= 1;
     maybeCloseWorker();
+    retireUnclaimedRuntimeOwners();
   };
   const detachBootstrapListeners = () => {
     port.removeEventListener("message", onBootstrapMessage);
@@ -442,6 +452,7 @@ function attachBootstrapPort(
   const closeBootstrapPort = () => {
     if (bootstrapPortClosed) return;
     bootstrapPortClosed = true;
+    parentLifetime.abort();
     detachBootstrapListeners();
     finishBootstrap();
     port.close();
@@ -449,12 +460,23 @@ function attachBootstrapPort(
   function onBootstrapMessage(
     messageEvent: MessageEvent<
       | BrowserSharedWorkerConnectRequest
+      | BrowserSharedWorkerBootstrapCancelRequest
       | BrowserForegroundNodeLeaseProbeRequest
       | BrowserForegroundNodeLeaseAcquireRequest
       | BrowserForegroundNodeLeaseCancelRequest
     >,
   ) {
     const message = messageEvent.data;
+    if (message?.type === "cancel-runtime-bootstrap" && runtimeAdmission) {
+      // Fence this attempt synchronously. Shared initialization is not aborted;
+      // its eventual completion still owns retirement of an unclaimed context.
+      parentLifetime.abort();
+      post(port, { type: "runtime-bootstrap-cancelled" });
+      detachBootstrapListeners();
+      finishBootstrap();
+      return;
+    }
+    if (operationStarted) return;
     if (
       scope &&
       (message.type === "connect-runtime" ||
@@ -507,16 +529,20 @@ function attachBootstrapPort(
     }
     operationStarted = true;
     clearTimeout(idleTimer);
-    detachBootstrapListeners();
     if (message.type === "connect-runtime") {
+      runtimeAdmission = true;
       recordWorkerLifecycle(
         "bootstrap-start",
         message.options.dbName,
         message.options.authSessionKey,
       );
       post(port, { type: "worker-alive" });
-      void connectTab(port, message, finishBootstrap);
+      void connectTab(port, message, parentLifetime.signal, () => {
+        detachBootstrapListeners();
+        finishBootstrap();
+      });
     } else {
+      detachBootstrapListeners();
       if (probedLeaseAttemptId !== null && message.attemptId !== probedLeaseAttemptId) {
         finishBootstrap();
         post(port, {
@@ -877,12 +903,56 @@ async function retireForegroundNodeLease(
   }
 }
 
+/**
+ * Lease bootstraps also claim physical owners before their lease bookkeeping
+ * exists. Wait for those reservations, then retire only the captured owner,
+ * never a replacement or an owner adopted by another admission.
+ */
+function retireUnclaimedRuntimeOwners(): void {
+  if (pendingBootstrapOperations !== 0) return;
+  for (const [dbName, owner] of pendingRuntimeOwnerRetirements) {
+    pendingRuntimeOwnerRetirements.delete(dbName);
+    if (physicalDatabaseOwners.get(dbName) !== owner) continue;
+    if (contexts.has(dbName)) continue;
+    const leaseOwner = foregroundLeaseOwners.get(dbName);
+    if (
+      leaseOwner &&
+      (leaseOwner.activeLeaseIds.size > 0 ||
+        leaseOwner.pendingLeaseAllocations > 0 ||
+        leaseOwner.pendingLeaseFinalizations > 0)
+    )
+      continue;
+    foregroundLeaseOwners.delete(dbName);
+    void releasePhysicalDatabaseOwner(dbName).catch(() => undefined);
+  }
+}
+
 async function connectTab(
   port: MessagePort,
   message: BrowserSharedWorkerConnectRequest,
+  signal: AbortSignal,
   finishBootstrap: () => void,
 ): Promise<void> {
+  const claim = Symbol("runtime-admission");
+  let claimedContext: RuntimeContext | undefined;
+  let claimHeld = false;
+  const releaseClaim = () => {
+    if (!claimHeld) return;
+    claimHeld = false;
+    claimedContext?.admissionClaims.delete(claim);
+  };
+  const assertAdmission = () => {
+    signal.throwIfAborted();
+    if (
+      claimedContext &&
+      (claimedContext.closing || contexts.get(claimedContext.key) !== claimedContext)
+    ) {
+      throw new Error("Shared browser runtime context closed during initialization");
+    }
+  };
+  signal.addEventListener("abort", releaseClaim, { once: true });
   try {
+    assertAdmission();
     const key = runtimeKey(message.options);
     let context = contexts.get(key);
     if (context?.idleReleaseTimer) {
@@ -891,13 +961,10 @@ async function connectTab(
     }
     if (context?.closing) {
       await context.closing;
+      assertAdmission();
       context = contexts.get(key);
     }
-    // `runtimeKey` intentionally names the physical root alone. Do not let a
-    // caller with a stale or forged compatible fingerprint attach a different
-    // auth scope to that already-open root: this path bypasses a fresh
-    // IndexedDbPageStore.open, so the durable marker cannot perform its usual
-    // owner comparison for us.
+    // A reused root still admits the durable owner and complete configuration.
     if (context && context.options.storageOwner !== message.options.storageOwner) {
       throw new Error(
         `IndexedDB database ${message.options.dbName} is already owned by a different Jazz browser session; choose a different driver.dbName or reset this database before changing accounts`,
@@ -913,21 +980,49 @@ async function connectTab(
       context = createContext(key, message.fingerprint, message.options);
       contexts.set(key, context);
     }
+    claimedContext = context;
+    context.admissionClaims.add(claim);
+    claimHeld = true;
+    context.pendingAdmissionTasks += 1;
     await context.initialize;
-    await enqueueTransportTransition(context, () => configureServer(context, message.options));
+    assertAdmission();
+    await enqueueTransportTransition(context, () => {
+      assertAdmission();
+      return configureServer(context, message.options);
+    });
+    assertAdmission();
+    // No await between the final fence, peer publication and listener handoff.
     attachTab(context, message.tabId, port);
-    // The peer now owns a durable runtime context.  Drop the bootstrap
-    // reservation before publishing readiness so an immediately closing tab
-    // still sees normal idle cleanup ordering.
+    releaseClaim();
     finishBootstrap();
     post(port, { type: "runtime-ready" });
   } catch (error) {
-    // Failed connection setup has already cleaned any partial context; clear
-    // the bootstrap reservation before surfacing the terminal result so its
-    // physical owner can be released without a follow-on admission race.
     finishBootstrap();
-    post(port, { type: "runtime-error", error: serializeBrowserRelayError(error) });
-    port.close();
+    if (!signal.aborted) {
+      post(port, { type: "runtime-error", error: serializeBrowserRelayError(error) });
+      port.close();
+    }
+  } finally {
+    signal.removeEventListener("abort", releaseClaim);
+    releaseClaim();
+    if (claimedContext) {
+      claimedContext.pendingAdmissionTasks -= 1;
+      // A cancelled claim cannot retire a sibling admission or attached peer.
+      // Keep the exact context alive until all async admission phases settle.
+      if (
+        claimedContext.pendingAdmissionTasks === 0 &&
+        claimedContext.admissionClaims.size === 0 &&
+        claimedContext.peers.size === 0
+      ) {
+        const owner = physicalDatabaseOwners.get(message.options.dbName);
+        await releaseIdleContext(claimedContext);
+        if (owner && physicalDatabaseOwners.get(message.options.dbName) === owner) {
+          pendingRuntimeOwnerRetirements.set(message.options.dbName, owner);
+        }
+        retireUnclaimedRuntimeOwners();
+        maybeCloseWorker();
+      }
+    }
   }
 }
 
@@ -941,6 +1036,8 @@ function createContext(
     fingerprint,
     options,
     peers: new Map(),
+    admissionClaims: new Set(),
+    pendingAdmissionTasks: 0,
     runtime: null,
     pageStore: null,
     disposePageStoreInvalidation: null,
@@ -1276,6 +1373,16 @@ function attachTab(
 
 async function handleTabMessage(peer: TabPeer, message: BrowserFollowerPortRequest): Promise<void> {
   if (peer.context.peers.get(peer.tabId) !== peer) return;
+  // Answer outside runtime, storage and transport queues: a healthy worker
+  // can legitimately be waiting indefinitely for an upstream acknowledgement.
+  if (message.type === "runtime-probe") {
+    post(peer.port, {
+      type: "runtime-pong",
+      connectionId: message.connectionId,
+      nonce: message.nonce,
+    });
+    return;
+  }
   if (message.type === "frames") {
     if (peer.context.options.logLevel === "trace") {
       recordWorkerLifecycle(
@@ -1297,7 +1404,10 @@ async function handleTabMessage(peer: TabPeer, message: BrowserFollowerPortReque
     return;
   }
   if (message.type === "close") {
-    const releaseWhenIdle = peer.context.peers.size === 1 && message.releaseContext;
+    const releaseWhenIdle =
+      peer.context.peers.size === 1 &&
+      peer.context.pendingAdmissionTasks === 0 &&
+      message.releaseContext;
     // The requester owns graceful port closure. Closing this endpoint in the
     // same task as the acknowledgement can discard that queued message in
     // WebKit, leaving shutdown pending forever. Detach runtime ownership now;
@@ -1862,6 +1972,7 @@ async function finalizeContextStorageReset(context: RuntimeContext): Promise<voi
 }
 
 async function releaseIdleContext(context: RuntimeContext): Promise<void> {
+  if (context.peers.size !== 0 || context.pendingAdmissionTasks !== 0) return;
   if (!context.closing) {
     context.closing = (async () => {
       for (const peer of context.peers.values()) {
@@ -1892,7 +2003,7 @@ function scheduleIdleContextRelease(context: RuntimeContext): void {
   if (context.idleReleaseTimer) clearTimeout(context.idleReleaseTimer);
   context.idleReleaseTimer = setTimeout(() => {
     context.idleReleaseTimer = null;
-    if (context.peers.size !== 0) return;
+    if (context.peers.size !== 0 || context.pendingAdmissionTasks !== 0) return;
     void releaseIdleContext(context).then(() => {
       maybeCloseWorker();
     });

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -283,7 +283,7 @@ class TestPort {
     }
     // Bootstrap liveness is intentionally not a follower event or a runtime
     // connection outcome; tests only retain the latter two protocol classes.
-    if (message.type === "worker-alive") return;
+    if (message.type === "worker-alive" || message.type === "runtime-bootstrap-cancelled") return;
     if (
       message.type === "foreground-node-lease-worker-alive" ||
       message.type === "foreground-node-lease-worker-closing"
@@ -533,6 +533,54 @@ async function connect(
   return { outcome: await outcome, port };
 }
 
+function connectRuntimeChannel(initOptions: BrowserWorkerInitOptions, tabId: string) {
+  const channel = new MessageChannel();
+  const messages: Array<BrowserSharedWorkerConnectResponse | BrowserFollowerPortEvent> = [];
+  const waiters = new Set<() => void>();
+  channel.port1.addEventListener("message", (event) => {
+    messages.push(event.data);
+    for (const notify of waiters) notify();
+  });
+  channel.port1.start();
+  const onconnect = (globalThis as WorkerGlobal).onconnect;
+  if (!onconnect) throw new Error("broker worker did not install its connect handler");
+  onconnect({ ports: [channel.port2] } as MessageEvent & { ports: MessagePort[] });
+  channel.port1.postMessage({
+    type: "connect-runtime",
+    tabId,
+    fingerprint: "shared-fingerprint",
+    options: initOptions,
+  } satisfies BrowserSharedWorkerConnectRequest);
+  return {
+    port: channel.port1,
+    messages,
+    async waitFor(type: string, id?: number) {
+      const matches = () =>
+        messages.find(
+          (message) =>
+            message.type === type && (id === undefined || ("id" in message && message.id === id)),
+        );
+      const existing = matches();
+      if (existing) return existing;
+      const response = deferred<BrowserSharedWorkerConnectResponse | BrowserFollowerPortEvent>();
+      const notify = () => {
+        const message = matches();
+        if (message) response.resolve(message);
+      };
+      waiters.add(notify);
+      try {
+        return await bounded(response.promise);
+      } finally {
+        waiters.delete(notify);
+      }
+    },
+    dispose() {
+      channel.port1.close();
+      channel.port2.close();
+    },
+  };
+}
+
 async function initializeFollower(port: TestPort, id: number): Promise<void> {
   const result = port.waitForEvent((event) => event.type === "result" && event.id === id);
   port.emitMessage({ type: "init", id, sessionClaims: {} });
@@ -602,6 +650,75 @@ describe("broker worker context initialization", () => {
     // The worker owns process-global state, so each case must evaluate a fresh module instance.
     await import("./jazz-broker-worker.js");
   });
+
+  it.each(["wait-server", "flush-pending-writes"] as const)(
+    "answers real MessageChannel probes while %s is held",
+    async (operation) => {
+      const channel = new MessageChannel();
+      const receive = (predicate: (event: TestPortResponse) => boolean) =>
+        bounded(
+          new Promise<TestPortResponse>((resolve) => {
+            const listener = (event: MessageEvent<TestPortResponse>) => {
+              if (!predicate(event.data)) return;
+              channel.port1.removeEventListener("message", listener);
+              resolve(event.data);
+            };
+            channel.port1.addEventListener("message", listener);
+          }),
+        );
+      const send = (message: TestPortRequest) => channel.port1.postMessage(message);
+      channel.port1.start();
+      const held = deferred<void>();
+      const entered = deferred<void>();
+      try {
+        (globalThis as WorkerGlobal).onconnect!({
+          ports: [channel.port2],
+        } as MessageEvent & { ports: MessagePort[] });
+        const ready = receive((event) => event.type === "runtime-ready");
+        send({
+          type: "connect-runtime",
+          tabId: "real-channel",
+          fingerprint: "real-channel",
+          options: { ...options(`held-${operation}`), serverUrl: "ws://server.test" },
+        });
+        await ready;
+        const initialized = receive((event) => event.type === "result" && event.id === 1);
+        send({ type: "init", id: 1, sessionClaims: {} });
+        await initialized;
+        const runtime = mocks.runtimes[0]!;
+        const wait = vi.fn(() => {
+          entered.resolve();
+          return held.promise;
+        });
+        if (operation === "wait-server") runtime.waitForUpstreamServerConnection = wait;
+        else runtime.waitForPendingWrites = wait;
+        let completed = false;
+        const result = receive((event) => event.type === "result" && event.id === 2).then(
+          (event) => {
+            completed = true;
+            return event;
+          },
+        );
+        send({ type: operation, id: 2 });
+        await bounded(entered.promise);
+        for (let nonce = 1; nonce <= 3; nonce++) {
+          const pong = receive((event) => event.type === "runtime-pong" && event.nonce === nonce);
+          send({ type: "runtime-probe", connectionId: "held-rpc", nonce });
+          expect(await pong).toEqual({ type: "runtime-pong", connectionId: "held-rpc", nonce });
+          expect(completed).toBe(false);
+        }
+        held.resolve();
+        expect(await result).toEqual({ type: "result", id: 2 });
+        const closed = receive((event) => event.type === "result" && event.id === 3);
+        send({ type: "close", id: 3 });
+        await closed;
+      } finally {
+        held.resolve();
+        channel.port1.close();
+        channel.port2.close();
+      }
+    },
+  );
 
   it("retires admission completed after close without publishing frames or an init result", async () => {
     const initOptions = { ...options("close-pending-admission"), serverUrl: "ws://server.test" };
@@ -2103,6 +2220,302 @@ describe("broker worker context initialization", () => {
     });
     expect(mocks.openBrowser).toHaveBeenCalledOnce();
     expect(mocks.fromDb).toHaveBeenCalledOnce();
+  });
+
+  it("retires a lone cancelled runtime after late initialization and reopens the same physical root", async () => {
+    const gate = deferred<typeof mocks.wasmModule>();
+    mocks.loadWasmModule.mockReturnValueOnce(gate.promise);
+    const initOptions = options("cancelled-lone-runtime");
+    const first = connectRuntimeChannel(initOptions, "cancelled");
+    try {
+      await first.waitFor("worker-alive");
+      await vi.waitFor(() => expect(mocks.loadWasmModule).toHaveBeenCalledOnce());
+      first.port.postMessage({ type: "cancel-runtime-bootstrap" });
+      await first.waitFor("runtime-bootstrap-cancelled");
+      first.port.postMessage({ type: "cancel-runtime-bootstrap" });
+      gate.resolve(mocks.wasmModule);
+      await vi.waitFor(() => expect(mocks.pageStores[0]?.close).toHaveBeenCalledOnce());
+      const reopened = connectRuntimeChannel(initOptions, "reopened");
+      try {
+        await reopened.waitFor("runtime-ready");
+        reopened.port.postMessage({ type: "init", id: 1, sessionClaims: {} });
+        expect(await reopened.waitFor("result", 1)).not.toHaveProperty("error");
+        reopened.port.postMessage({ type: "close", id: 2, releaseContext: true });
+        expect(await reopened.waitFor("result", 2)).not.toHaveProperty("error");
+        expect(first.messages.map((message) => message.type)).toEqual([
+          "worker-alive",
+          "runtime-bootstrap-cancelled",
+        ]);
+        expect(mocks.runtimes[0]?.discard).toHaveBeenCalledOnce();
+      } finally {
+        reopened.dispose();
+      }
+    } finally {
+      gate.resolve(mocks.wasmModule);
+      first.dispose();
+    }
+  });
+
+  it("preserves a sibling claim sharing initialization when another runtime admission cancels", async () => {
+    const gate = deferred<typeof mocks.wasmModule>();
+    mocks.loadWasmModule.mockReturnValueOnce(gate.promise);
+    const initOptions = options("cancelled-sibling-runtime");
+    const first = connectRuntimeChannel(initOptions, "cancelled");
+    const sibling = connectRuntimeChannel(initOptions, "sibling");
+    try {
+      await Promise.all([first.waitFor("worker-alive"), sibling.waitFor("worker-alive")]);
+      first.port.postMessage({ type: "cancel-runtime-bootstrap" });
+      await first.waitFor("runtime-bootstrap-cancelled");
+      gate.resolve(mocks.wasmModule);
+      await sibling.waitFor("runtime-ready");
+      sibling.port.postMessage({ type: "init", id: 1, sessionClaims: {} });
+      expect(await sibling.waitFor("result", 1)).not.toHaveProperty("error");
+      // Exercise an admitted follower operation rather than only its ready envelope.
+      sibling.port.postMessage({ type: "disconnect", id: 2 });
+      expect(await sibling.waitFor("result", 2)).not.toHaveProperty("error");
+      expect(mocks.runtimes[0]?.discard).not.toHaveBeenCalled();
+      expect(mocks.openBrowser).toHaveBeenCalledOnce();
+      expect(first.messages.map((message) => message.type)).toEqual([
+        "worker-alive",
+        "runtime-bootstrap-cancelled",
+      ]);
+      sibling.port.postMessage({ type: "close", id: 3, releaseContext: true });
+      await sibling.waitFor("result", 3);
+    } finally {
+      gate.resolve(mocks.wasmModule);
+      first.dispose();
+      sibling.dispose();
+    }
+  });
+
+  it("fences cancellation during server configuration without releasing the established peer", async () => {
+    const initOptions = {
+      ...options("cancelled-configure-runtime"),
+      serverUrl: "wss://example.test",
+    };
+    const owner = await connect(initOptions, "owner");
+    await initializeFollower(owner.port, 1);
+    const runtime = mocks.runtimes[0]!;
+    const entered = deferred<void>();
+    const configured = deferred<void>();
+    runtime.updateAuth.mockImplementationOnce(() => {
+      entered.resolve();
+      return configured.promise;
+    });
+    const attempt = connectRuntimeChannel(initOptions, "cancelled");
+    try {
+      await bounded(entered.promise);
+      attempt.port.postMessage({ type: "cancel-runtime-bootstrap" });
+      await attempt.waitFor("runtime-bootstrap-cancelled");
+      configured.resolve();
+      // This queued transition acknowledges only after the cancelled
+      // configureServer phase has settled and its publication fence has run.
+      expect(await followerResult(owner.port, { type: "disconnect", id: 2 })).not.toHaveProperty(
+        "error",
+      );
+      await nextTask();
+      expect(attempt.messages.map((message) => message.type)).toEqual([
+        "worker-alive",
+        "runtime-bootstrap-cancelled",
+      ]);
+      expect(runtime.discard).not.toHaveBeenCalled();
+      await followerResult(owner.port, { type: "close", id: 3, releaseContext: true });
+    } finally {
+      configured.resolve();
+      attempt.dispose();
+    }
+  });
+
+  it("cancels a reopening admission while the former physical owner is still releasing", async () => {
+    const initOptions = options("cancelled-reopen-runtime");
+    const owner = await connect(initOptions, "owner");
+    const releaseStarted = deferred<void>();
+    const released = deferred<void>();
+    mocks.pageStores[0]!.releaseBrowserWorkerEpoch.mockImplementationOnce(() => {
+      releaseStarted.resolve();
+      return released.promise;
+    });
+    await followerResult(owner.port, { type: "close", id: 1, releaseContext: true });
+    await bounded(releaseStarted.promise);
+    const attempt = connectRuntimeChannel(initOptions, "cancelled-reopen");
+    try {
+      await attempt.waitFor("worker-alive");
+      attempt.port.postMessage({ type: "cancel-runtime-bootstrap" });
+      await attempt.waitFor("runtime-bootstrap-cancelled");
+      released.resolve();
+      await vi.waitFor(() => expect(mocks.pageStores[1]?.close).toHaveBeenCalledOnce());
+      const successor = connectRuntimeChannel(initOptions, "successor");
+      try {
+        await successor.waitFor("runtime-ready");
+        successor.port.postMessage({ type: "init", id: 1, sessionClaims: {} });
+        expect(await successor.waitFor("result", 1)).not.toHaveProperty("error");
+        expect(attempt.messages.map((message) => message.type)).toEqual([
+          "worker-alive",
+          "runtime-bootstrap-cancelled",
+        ]);
+        successor.port.postMessage({ type: "close", id: 2, releaseContext: true });
+        await successor.waitFor("result", 2);
+      } finally {
+        successor.dispose();
+      }
+    } finally {
+      released.resolve();
+      attempt.dispose();
+    }
+  });
+
+  it("retires a cancelled physical root while an unrelated runtime remains usable", async () => {
+    const unrelated = await connect(options("unrelated-live-root"), "unrelated");
+    await initializeFollower(unrelated.port, 1);
+    const db = mocks.createBrowserDb();
+    const opened = deferred<typeof db>();
+    mocks.openBrowser.mockReturnValueOnce(opened.promise);
+    const targetOptions = options("cancelled-independent-root");
+    const cancelled = connectRuntimeChannel(targetOptions, "cancelled");
+    try {
+      await cancelled.waitFor("worker-alive");
+      await vi.waitFor(() => expect(mocks.openBrowser).toHaveBeenCalledTimes(2));
+      cancelled.port.postMessage({ type: "cancel-runtime-bootstrap" });
+      await cancelled.waitFor("runtime-bootstrap-cancelled");
+      opened.resolve(db);
+      await vi.waitFor(() => expect(mocks.pageStores[1]?.close).toHaveBeenCalledOnce());
+      expect(mocks.pageStores[0]?.close).not.toHaveBeenCalled();
+      expect(mocks.runtimes[0]?.discard).not.toHaveBeenCalled();
+      expect(
+        await followerResult(unrelated.port, { type: "disconnect", id: 2 }),
+      ).not.toHaveProperty("error");
+      const reopened = connectRuntimeChannel(targetOptions, "reopened");
+      try {
+        await reopened.waitFor("runtime-ready");
+        reopened.port.postMessage({ type: "init", id: 1, sessionClaims: {} });
+        expect(await reopened.waitFor("result", 1)).not.toHaveProperty("error");
+        reopened.port.postMessage({ type: "close", id: 2, releaseContext: true });
+        await reopened.waitFor("result", 2);
+      } finally {
+        reopened.dispose();
+      }
+      await followerResult(unrelated.port, { type: "close", id: 3, releaseContext: true });
+    } finally {
+      opened.resolve(db);
+      cancelled.dispose();
+    }
+  });
+
+  it("expires an unclaimed production bootstrap so a cancelled root can retire beside a healthy root", async () => {
+    const unrelated = await connect(options("unclaimed-bootstrap-healthy-root"), "unrelated");
+    await initializeFollower(unrelated.port, 1);
+    const db = mocks.createBrowserDb();
+    const opened = deferred<typeof db>();
+    mocks.openBrowser.mockReturnValueOnce(opened.promise);
+    const targetOptions = options("unclaimed-bootstrap-cancelled-root");
+    const cancelled = connectRuntimeChannel(targetOptions, "cancelled");
+    let unclaimed: TestPort | undefined;
+    try {
+      await cancelled.waitFor("worker-alive");
+      await vi.waitFor(() => expect(mocks.openBrowser).toHaveBeenCalledTimes(2));
+      const pageStore = mocks.pageStores[1]!;
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      // This helper only delivers ordinary production onconnect. No probe,
+      // scope, or operation message ever arrives on this abandoned port.
+      unclaimed = connectLeaseProbe().port;
+      cancelled.port.postMessage({ type: "cancel-runtime-bootstrap" });
+      await cancelled.waitFor("runtime-bootstrap-cancelled");
+      opened.resolve(db);
+      await nextTask();
+      expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce();
+      expect(pageStore.close).not.toHaveBeenCalled();
+      expect(pageStore.releaseBrowserWorkerEpoch).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(unclaimed.close).not.toHaveBeenCalled();
+      expect(pageStore.close).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      // Assert the resource outcome directly: the old scope-only timer leaves
+      // this owner retained, rather than making the test wait for a timeout.
+      expect(pageStore.close).toHaveBeenCalledOnce();
+      expect(pageStore.releaseBrowserWorkerEpoch).toHaveBeenCalledOnce();
+      expect(unclaimed.close).toHaveBeenCalledOnce();
+      expect(mocks.pageStores[0]?.close).not.toHaveBeenCalled();
+      expect(mocks.runtimes[0]?.discard).not.toHaveBeenCalled();
+      vi.useRealTimers();
+      expect(
+        await followerResult(unrelated.port, { type: "disconnect", id: 2 }),
+      ).not.toHaveProperty("error");
+
+      const reopened = connectRuntimeChannel(targetOptions, "reopened");
+      try {
+        await reopened.waitFor("runtime-ready");
+        reopened.port.postMessage({ type: "init", id: 1, sessionClaims: {} });
+        expect(await reopened.waitFor("result", 1)).not.toHaveProperty("error");
+        expect(mocks.openPageStore).toHaveBeenCalledTimes(3);
+        expect(mocks.openPageStore).toHaveBeenLastCalledWith(targetOptions.dbName, {
+          owner: targetOptions.storageOwner,
+        });
+        expect(mocks.pageStores[2]?.close).not.toHaveBeenCalled();
+        expect(mocks.pageStores[0]?.close).not.toHaveBeenCalled();
+        expect(
+          await followerResult(unrelated.port, { type: "disconnect", id: 3 }),
+        ).not.toHaveProperty("error");
+      } finally {
+        reopened.port.postMessage({ type: "close", id: 2, releaseContext: true });
+        try {
+          await reopened.waitFor("result", 2);
+        } finally {
+          reopened.dispose();
+        }
+      }
+    } finally {
+      opened.resolve(db);
+      // Only clean up the baseline's still-unclaimed reservation after the
+      // expiry assertion, using its existing cancellation protocol.
+      unclaimed?.emitMessage({ type: "cancel-foreground-node-lease" });
+      vi.useRealTimers();
+      cancelled.dispose();
+      await followerResult(unrelated.port, { type: "close", id: 4, releaseContext: true });
+    }
+  });
+
+  it("preserves a cancelled root for a foreground lease bootstrap before lease bookkeeping exists", async () => {
+    const unrelated = await connect(options("unrelated-lease-control-root"), "unrelated");
+    await initializeFollower(unrelated.port, 1);
+    const db = mocks.createBrowserDb();
+    const opened = deferred<typeof db>();
+    mocks.openBrowser.mockReturnValueOnce(opened.promise);
+    const targetOptions = options("cancelled-pending-lease-root");
+    const cancelled = connectRuntimeChannel(targetOptions, "cancelled");
+    // onconnect reserves liveness before the lease's first request can create
+    // a ForegroundLeaseOwner or increment pendingLeaseAllocations.
+    const pendingLease = connectLeaseProbe();
+    try {
+      await cancelled.waitFor("worker-alive");
+      await vi.waitFor(() => expect(mocks.openBrowser).toHaveBeenCalledTimes(2));
+      const pageStore = mocks.pageStores[1]!;
+      cancelled.port.postMessage({ type: "cancel-runtime-bootstrap" });
+      await cancelled.waitFor("runtime-bootstrap-cancelled");
+      opened.resolve(db);
+      await vi.waitFor(() => expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce());
+      expect(pageStore.close).not.toHaveBeenCalled();
+      expect(pageStore.releaseBrowserWorkerEpoch).not.toHaveBeenCalled();
+      pendingLease.port.emitMessage({
+        type: "acquire-foreground-node-lease",
+        dbName: targetOptions.dbName,
+        storageOwner: targetOptions.storageOwner,
+      });
+      const lease = await bounded(pendingLease.port.waitForLeaseOutcome());
+      expect(lease.type).toBe("foreground-node-lease-ready");
+      expect(pageStore.close).not.toHaveBeenCalled();
+      expect(
+        await followerResult(unrelated.port, { type: "disconnect", id: 2 }),
+      ).not.toHaveProperty("error");
+      pendingLease.port.emitMessage({ type: "retire-foreground-node-lease" });
+      await vi.waitFor(() => expect(pageStore.retireForegroundNodeLease).toHaveBeenCalledOnce());
+      await followerResult(unrelated.port, { type: "close", id: 3, releaseContext: true });
+      await vi.waitFor(() => expect(pageStore.close).toHaveBeenCalledOnce());
+    } finally {
+      opened.resolve(db);
+      cancelled.dispose();
+      pendingLease.port.close();
+    }
   });
 
   it("rejects a tab whose policy claims differ from the worker upstream session", async () => {

--- a/packages/jazz-tools/tests/browser/jazz-broker-worker-test.ts
+++ b/packages/jazz-tools/tests/browser/jazz-broker-worker-test.ts
@@ -39,3 +39,52 @@ installJazzBrokerWorker({
     },
   },
 });
+
+// A URL-scoped capability isolates destructive liveness faults to one test
+// realm. No production request, runtime option or broker hook enables these.
+// ABI verification evaluates the bundle outside a worker, without a location.
+const faultChannelName = globalThis.location
+  ? new URL(globalThis.location.href).searchParams.get("followerFault")
+  : null;
+if (faultChannelName) {
+  const control = new BroadcastChannel(faultChannelName);
+  let holdClose = false;
+  let holdPendingWrites = false;
+  // This module is a SharedWorker entry, not a Window.
+  const worker = globalThis as unknown as {
+    close(): void;
+    onconnect: (event: MessageEvent & { ports: MessagePort[] }) => void;
+  };
+  control.onmessage = (event: MessageEvent<{ type: string }>) => {
+    if (event.data.type === "hold-close") {
+      holdClose = true;
+      control.postMessage({ type: "holding-close" });
+    } else if (event.data.type === "hold-pending-writes") {
+      holdPendingWrites = true;
+      control.postMessage({ type: "holding-pending-writes" });
+    } else if (event.data.type === "die") {
+      // Deliberately bypass every production cleanup/error notification.
+      worker.close();
+    }
+  };
+  const connect = worker.onconnect;
+  worker.onconnect = (event) => {
+    const port = event.ports[0]!;
+    const postMessage = port.postMessage.bind(port);
+    port.postMessage = ((message: { type?: string }, transfer: Transferable[] = []) => {
+      postMessage(message, transfer);
+      if (message.type === "runtime-pong") control.postMessage({ type: "pong-sent" });
+    }) as typeof port.postMessage;
+    port.addEventListener("message", (message: MessageEvent<{ type: string }>) => {
+      if (holdClose && message.data.type === "close") {
+        message.stopImmediatePropagation();
+        control.postMessage({ type: "close-held" });
+      }
+      if (holdPendingWrites && message.data.type === "flush-pending-writes") {
+        message.stopImmediatePropagation();
+        control.postMessage({ type: "pending-writes-held" });
+      }
+    });
+    connect(event);
+  };
+}

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 /**
  * Browser integration tests for the SharedWorker + IndexedDB runtime.
  *
@@ -10,6 +12,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { createBrowserTestDb as createDb } from "./support.js";
 import { createDb as createPublicDb } from "../../src/runtime/default-create-db.js";
+import { commands } from "vitest/browser";
 import {
   Db,
   getDbSubscriptionSource,
@@ -31,6 +34,9 @@ import {
   createBrowserSharedWorkerBaseName,
   SharedBrowserForegroundNodeLease,
 } from "../../src/runtime/native-runtime/browser-shared-worker-connection.js";
+import { NativeRuntimeAdapter } from "../../src/runtime/native-runtime/native-runtime-adapter.js";
+import { createOpenTransactionId } from "../../src/runtime/client.js";
+import { loadWasmModule } from "../../src/runtime/wasm-loader.js";
 import { createBrowserStorageOwner } from "../../src/runtime/browser-worker-config.js";
 import {
   TestCleanup,
@@ -63,6 +69,11 @@ import {
 import { CompiledPermissions, schema as s } from "../../src/";
 import { deploy } from "../../src/dev/catalogue.js";
 import {
+  BrowserWorkerUnresponsiveError,
+  serializeBrowserRelayError,
+  type BrowserForegroundNodeLeaseAcquireRequest,
+  type BrowserForegroundNodeLeasePortRequest,
+  type BrowserForegroundNodeLeaseProbeRequest,
   deserializeBrowserRelayError,
   type BrowserInspectorContext,
   type BrowserInspectorControlEvent,
@@ -71,6 +82,18 @@ import {
 } from "../../src/runtime/native-runtime/browser-worker-protocol.js";
 
 declare const __JAZZ_BROWSER_SOAK__: string;
+
+async function workerFaultBundleUrl(): Promise<string> {
+  if (
+    !("workerFaultBundleUrl" in commands) ||
+    typeof commands.workerFaultBundleUrl !== "function"
+  ) {
+    throw new Error("Browser test project is missing the worker fault bundle command.");
+  }
+  const url: unknown = await commands.workerFaultBundleUrl();
+  if (typeof url !== "string") throw new Error("Worker fault bundle command did not return a URL.");
+  return url;
+}
 
 let nextInspectorRequestId = 1;
 
@@ -389,6 +412,231 @@ function startRawForegroundLease(
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe("foreground lease terminal policy with real IndexedDB and WASM", () => {
+  async function storeBackedLease() {
+    const dbName = uniqueDbName("terminal-lease-store");
+    const store = await IndexedDbPageStore.open(dbName);
+    const channel = new MessageChannel();
+    let runtime: NativeRuntimeAdapter | undefined;
+    try {
+      const allocation = await store.acquireForegroundNodeLease();
+      const wasm = await loadWasmModule();
+      runtime = new NativeRuntimeAdapter(
+        wasm.WasmDb,
+        app.wasmSchema,
+        allocation.node,
+        new TextEncoder().encode('["urn:jazz:test","terminal-lease"]'),
+        1,
+        true,
+        { backendMode: true },
+      );
+      runtime.seedForegroundTxTimeHighWater(allocation.confirmedTxTime);
+      let committed!: () => void;
+      let failed!: (error: unknown) => void;
+      const terminalCommitted = new Promise<void>((resolve, reject) => {
+        committed = resolve;
+        failed = reject;
+      });
+      void terminalCommitted.catch(() => undefined);
+      const terminalOperations: Promise<void>[] = [];
+      channel.port2.onmessage = (
+        event: MessageEvent<
+          | BrowserForegroundNodeLeaseProbeRequest
+          | BrowserForegroundNodeLeaseAcquireRequest
+          | BrowserForegroundNodeLeasePortRequest
+        >,
+      ) => {
+        const message = event.data;
+        if (message.type === "probe-foreground-node-lease-worker") {
+          channel.port2.postMessage({
+            type: "foreground-node-lease-worker-alive",
+            attemptId: message.attemptId,
+          });
+        } else if (message.type === "acquire-foreground-node-lease") {
+          channel.port2.postMessage({
+            type: "foreground-node-lease-ready",
+            ...allocation,
+            confirmedTxTime: allocation.confirmedTxTime.toString(),
+          });
+        } else {
+          // Only transport delivery is controlled. A successful result cannot
+          // be released until the real IndexedDB transaction has committed.
+          const operation =
+            message.type === "return-foreground-node-lease"
+              ? store.returnForegroundNodeLease(allocation.leaseId, BigInt(message.confirmedTxTime))
+              : store.retireForegroundNodeLease(allocation.leaseId);
+          terminalOperations.push(operation);
+          void operation.then(committed, (error) => {
+            failed(error);
+            channel.port2.postMessage({
+              type: "foreground-node-lease-result",
+              error: serializeBrowserRelayError(error),
+            });
+          });
+        }
+      };
+      const lease = await SharedBrowserForegroundNodeLease.acquireFromPort(channel.port1, {
+        dbName,
+        storageOwner: "terminal-lease-control",
+      });
+      const post = vi.spyOn(channel.port1, "postMessage");
+      const close = vi.spyOn(channel.port1, "close");
+      return {
+        dbName,
+        store,
+        lease,
+        runtime,
+        post,
+        close,
+        terminalCommitted,
+        acknowledge() {
+          channel.port2.postMessage({ type: "foreground-node-lease-result" });
+        },
+        async dispose() {
+          channel.port1.close();
+          channel.port2.close();
+          await Promise.allSettled(terminalOperations);
+          await runtime!.close();
+          store.close();
+          await IndexedDbPageStore.destroy(dbName);
+        },
+      };
+    } catch (error) {
+      channel.port1.close();
+      channel.port2.close();
+      await runtime?.close();
+      store.close();
+      await IndexedDbPageStore.destroy(dbName);
+      throw error;
+    }
+  }
+
+  it("retains a committed quiesced return and its final durable HWM after local abandonment", async () => {
+    const fixture = await storeBackedLease();
+    const { runtime, lease } = fixture;
+    let releaseSource!: () => void;
+    const sourceGate = new Promise<void>((resolve) => {
+      releaseSource = resolve;
+    });
+    let sourceStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      sourceStarted = resolve;
+    });
+    let write: Promise<unknown> | undefined;
+    try {
+      const initialHighWater = runtime.foregroundTxTimeHighWater();
+      const oldBatch = createOpenTransactionId();
+      runtime.beginTransaction("mergeable", oldBatch);
+      write = runtime.streamingMutation(
+        "insert",
+        "projects",
+        {},
+        "name",
+        (async function* () {
+          sourceStarted();
+          await sourceGate;
+          yield "write admitted before handoff";
+        })(),
+      );
+      await withTimeout(
+        Promise.race([started, write]),
+        5_000,
+        "real native streaming write did not start",
+      );
+      let captured = false;
+      const handoff = runtime.quiesceForegroundTxTimeHighWater().then((value) => {
+        captured = true;
+        return value;
+      });
+      await Promise.resolve();
+      expect(captured).toBe(false);
+      expect(fixture.post).not.toHaveBeenCalled();
+      releaseSource();
+      await write;
+      const highWater = await handoff;
+      expect(highWater).toBeGreaterThan(initialHighWater);
+      expect(() => runtime.commitTransaction(oldBatch)).toThrow("native runtime is closed");
+      expect(() => runtime.beginTransaction("mergeable", createOpenTransactionId())).toThrow(
+        "native runtime is closed",
+      );
+      expect(() =>
+        runtime.insert("projects", { name: { type: "Text", value: "too late" } }),
+      ).toThrow("native runtime is closed");
+
+      const failure = new BrowserWorkerUnresponsiveError("worker reply was lost after commit");
+      const returned = lease.returnWithHighWater(highWater);
+      const rejected = expect(returned).rejects.toBe(failure);
+      await withTimeout(fixture.terminalCommitted, 5_000, "real return transaction did not commit");
+      expect(await fixture.store.foregroundNodeLeaseNodeState(lease.node)).toBe("reusable");
+      // Reuse may happen before the old page detects failure. An old-page
+      // abandonment cannot revoke this successor or lower its final floor.
+      const reopened = await IndexedDbPageStore.open(fixture.dbName);
+      try {
+        const successor = await reopened.acquireForegroundNodeLease();
+        expect(successor.node).toEqual(lease.node);
+        expect(successor.confirmedTxTime).toBe(highWater);
+        lease.abandonAfterWorkerFailure(failure);
+        await rejected;
+        expect(fixture.post).toHaveBeenCalledExactlyOnceWith({
+          type: "return-foreground-node-lease",
+          confirmedTxTime: highWater.toString(),
+        });
+        expect(await reopened.foregroundNodeLeaseNodeState(successor.node)).toBe("active");
+        expect(fixture.close).not.toHaveBeenCalled();
+        fixture.acknowledge();
+        await vi.waitFor(() => expect(fixture.close).toHaveBeenCalledOnce());
+        await expect(lease.returnWithHighWater(highWater + 1n)).rejects.toBe(failure);
+        await expect(lease.retire()).rejects.toBe(failure);
+        expect(runtime.foregroundTxTimeHighWater()).toBe(highWater);
+        await reopened.returnForegroundNodeLease(successor.leaseId, highWater);
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      releaseSource();
+      await write?.catch(() => undefined);
+      await fixture.dispose();
+    }
+  }, 15_000);
+
+  it("durably retires a quiesced foreground abandoned before any terminal request", async () => {
+    const fixture = await storeBackedLease();
+    try {
+      await fixture.runtime.quiesceForegroundTxTimeHighWater();
+      const failure = new BrowserWorkerUnresponsiveError("worker stopped before lease finish");
+      fixture.lease.abandonAfterWorkerFailure(failure);
+      await expect(fixture.lease.retire()).rejects.toBe(failure);
+      await withTimeout(
+        fixture.terminalCommitted,
+        5_000,
+        "real retirement transaction did not commit",
+      );
+      expect(fixture.post).toHaveBeenCalledExactlyOnceWith({
+        type: "retire-foreground-node-lease",
+      });
+      expect(await fixture.store.foregroundNodeLeaseNodeState(fixture.lease.node)).toBe("retired");
+      const reopened = await IndexedDbPageStore.open(fixture.dbName);
+      try {
+        const successor = await reopened.acquireForegroundNodeLease();
+        expect(successor.node).not.toEqual(fixture.lease.node);
+        expect(successor.confirmedTxTime).toBe(0n);
+        expect(() =>
+          fixture.runtime.insert("projects", { name: { type: "Text", value: "too late" } }),
+        ).toThrow("native runtime is closed");
+        expect(fixture.close).not.toHaveBeenCalled();
+        fixture.acknowledge();
+        await vi.waitFor(() => expect(fixture.close).toHaveBeenCalledOnce());
+        await expect(fixture.lease.returnWithHighWater(0n)).rejects.toBe(failure);
+        await reopened.retireForegroundNodeLease(successor.leaseId);
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      await fixture.dispose();
+    }
+  }, 15_000);
+});
 
 describe("SharedWorker bridge with IndexedDB", () => {
   it("retains a queued first-owner allocation after the preceding lease returns", async () => {
@@ -889,6 +1137,153 @@ describe("SharedWorker bridge with IndexedDB", () => {
     expect(db).toBeDefined();
     expect(db).toBeInstanceOf(Db);
   });
+
+  it("keeps public shutdown alive with pongs then rejects after silent worker death", async () => {
+    const capability = uniqueDbName("follower-fault");
+    const workerUrl = new URL(await workerFaultBundleUrl(), globalThis.location.href);
+    workerUrl.searchParams.set("followerFault", capability);
+    const control = new BroadcastChannel(capability);
+    const receive = (type: string) =>
+      new Promise<void>((resolve) => {
+        const listener = (event: MessageEvent<{ type: string }>) => {
+          if (event.data.type !== type) return;
+          control.removeEventListener("message", listener);
+          resolve();
+        };
+        control.addEventListener("message", listener);
+      });
+    let db: Db | undefined;
+    try {
+      db = track(
+        await createDb({
+          appId: "follower-silent-death",
+          driver: { type: "persistent", dbName: uniqueDbName("follower-silent-death") },
+          schema: app,
+          runtimeSources: {
+            brokerWorkerUrl: workerUrl.href,
+            wasmVersion: "follower-liveness-test",
+          },
+        }),
+      );
+      await db.all(allTodos, { tier: "local" });
+      const armed = receive("holding-close");
+      control.postMessage({ type: "hold-close" });
+      await withTimeout(armed, 5_000, "test worker did not arm the pending control hold");
+      const held = receive("close-held");
+      let outcome: "pending" | "resolved" | "rejected" = "pending";
+      const shutdown = db.shutdown().then(
+        () => {
+          outcome = "resolved";
+          return undefined;
+        },
+        (error: unknown) => {
+          outcome = "rejected";
+          return error;
+        },
+      );
+      // Ordinary shutdown returns its foreground lease before sending close.
+      // Killing here leaves no unrelated lease-return RPC in test cleanup.
+      await withTimeout(held, 5_000, "public shutdown did not reach the real worker close");
+      // Three real broker replies span more than the entire silent-death
+      // bound. Neither the public operation nor its failure is fabricated.
+      for (let index = 0; index < 3; index++) {
+        await withTimeout(
+          receive("pong-sent"),
+          45_000,
+          "real worker did not answer its liveness probe",
+        );
+        expect(outcome).toBe("pending");
+      }
+      control.postMessage({ type: "die" });
+      const error = await withTimeout(
+        shutdown,
+        75_000,
+        "silent worker death left public shutdown pending",
+      );
+      expect(outcome).toBe("rejected");
+      if (!(error instanceof Error)) throw new Error("Expected public shutdown to reject");
+      expect(error.message).toMatch(/outcomes are unknown.*not retried/);
+    } finally {
+      // Preserve setup/assertion failures without leaving this deliberately
+      // killed fixture in the shared afterEach's unbounded shutdown loop.
+      if (db) {
+        untrack(db);
+        void db.shutdown().catch(() => undefined);
+      }
+      control.postMessage({ type: "die" });
+      control.close();
+    }
+  }, 210_000);
+
+  it("settles public shutdown after a pending follower operation rejects on silent worker death", async () => {
+    const capability = uniqueDbName("follower-death-cleanup");
+    const workerUrl = new URL(await workerFaultBundleUrl(), globalThis.location.href);
+    workerUrl.searchParams.set("followerFault", capability);
+    const control = new BroadcastChannel(capability);
+    const receive = (type: string) =>
+      new Promise<void>((resolve) => {
+        const listener = (event: MessageEvent<{ type: string }>) => {
+          if (event.data.type !== type) return;
+          control.removeEventListener("message", listener);
+          resolve();
+        };
+        control.addEventListener("message", listener);
+      });
+    let db: Db | undefined;
+    try {
+      db = track(
+        await createDb({
+          appId: "follower-death-cleanup",
+          driver: { type: "persistent", dbName: uniqueDbName("follower-death-cleanup") },
+          schema: app,
+          runtimeSources: {
+            brokerWorkerUrl: workerUrl.href,
+            wasmVersion: "follower-liveness-test",
+          },
+        }),
+      );
+      await db.all(allTodos, { tier: "local" });
+      const armed = receive("holding-pending-writes");
+      control.postMessage({ type: "hold-pending-writes" });
+      await withTimeout(armed, 5_000, "test worker did not arm the pending control hold");
+      const held = receive("pending-writes-held");
+      const pending = db.shutdown({ waitForSync: true }).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      await withTimeout(held, 5_000, "public graceful shutdown did not reach the worker barrier");
+      control.postMessage({ type: "die" });
+      const error = await withTimeout(
+        pending,
+        75_000,
+        "silent worker death left the follower operation pending",
+      );
+      if (!(error instanceof Error) || !(error.cause instanceof Error)) {
+        throw new Error("Expected graceful shutdown to retain the follower failure cause");
+      }
+      expect(error.cause.message).toMatch(/outcomes are unknown.*not retried/);
+
+      // A terminal local cleanup failure is honest; an unanswered companion
+      // lease-return RPC must not keep the public Db alive indefinitely.
+      // Both observers precede the guard so rejection is not confused with a
+      // harness timeout and does not become an unhandled rejection.
+      const cleanup = db.shutdown().catch(() => undefined);
+      await withTimeout(
+        cleanup,
+        5_000,
+        "Db.shutdown remained pending after the follower connection had already failed",
+      );
+    } finally {
+      // Setup failures and the bounded cleanup assertion above remain the
+      // failure signal; never repeat a hanging shutdown in shared afterEach.
+      if (db) {
+        untrack(db);
+        void db.shutdown().catch(() => undefined);
+      }
+      control.postMessage({ type: "die" });
+      control.close();
+    }
+  }, 100_000);
 
   it("exposes a bounded redacted worker lifecycle ledger to the owning inspector", async () => {
     const syncServer = await publishSyncServerSchemaAndPermissions("worker-lifecycle-ledger");

--- a/packages/jazz-tools/tests/browser/worker-fault-bundle-node.ts
+++ b/packages/jazz-tools/tests/browser/worker-fault-bundle-node.ts
@@ -1,0 +1,111 @@
+import { execFile } from "node:child_process";
+import { createReadStream } from "node:fs";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import type { Plugin } from "vite";
+
+const runNode = promisify(execFile);
+const worktreeRoot = fileURLToPath(new URL("../../../..", import.meta.url));
+const bundlerUrl = new URL("../../scripts/bundle-broker-worker.mjs", import.meta.url).href;
+const workerEntry = fileURLToPath(new URL("./jazz-broker-worker-test.ts", import.meta.url));
+
+type FixtureAsset = { path: string; contentType: string };
+const assetRegistryKey = Symbol.for("jazz-tools.browser-worker-fault-assets.v1");
+// Vitest reloads this config for the browser server but runs commands from the
+// original config. A process-owned registry bridges those module instances;
+// neither a module-local singleton nor a shared build promise has that lifetime.
+const registryHost = process as typeof process & {
+  [assetRegistryKey]?: Map<string, Map<string, FixtureAsset>>;
+};
+const assetRegistry = (registryHost[assetRegistryKey] ??= new Map());
+
+/** Keep test-only worker capabilities out of both sealed dist and Vite's module transforms. */
+export function createWorkerFaultBundleFixture(wasmPackage: string | undefined): {
+  plugin: Plugin;
+  url(): Promise<string>;
+} {
+  // The admitted package path identifies an immutable sealed WASM/glue pair.
+  const identity = JSON.stringify([worktreeRoot, wasmPackage && resolve(wasmPackage)]);
+  const assets = assetRegistry.get(identity) ?? new Map<string, FixtureAsset>();
+  assetRegistry.set(identity, assets);
+  // Re-evaluating the config must build fresh source, not reuse an older bundle.
+  let bundle: Promise<string> | undefined;
+
+  async function buildBundle(): Promise<string> {
+    if (!wasmPackage) {
+      throw new Error("Worker fault fixture requires an admitted correctness WASM package");
+    }
+    const target = resolve(worktreeRoot, "target");
+    await mkdir(target, { recursive: true });
+    const outputDir = await mkdtemp(resolve(target, "browser-worker-fault-"));
+    try {
+      // Use a child so the bundler pins the admitted glue/binary pair before its
+      // module loads, without changing the concurrent browser runner's environment.
+      await runNode(
+        process.execPath,
+        [
+          "--input-type=module",
+          "--eval",
+          "const { bundleBrokerWorker } = await import(process.argv[1]); " +
+            "await bundleBrokerWorker(process.argv[2], process.argv[3]);",
+          bundlerUrl,
+          outputDir,
+          workerEntry,
+        ],
+        {
+          cwd: worktreeRoot,
+          env: {
+            ...process.env,
+            JAZZ_CORRECTNESS_ARTIFACT_RUN: "1",
+            JAZZ_CORRECTNESS_WASM_PACKAGE: wasmPackage,
+          },
+        },
+      );
+      // Publish routes only after the existing bundler has checked the ABI and
+      // published both complete files. Query parameters remain ordinary SDK assets.
+      const prefix = `/@jazz-worker-fault/${basename(outputDir)}`;
+      assets.set(`${prefix}/jazz-broker-worker.js`, {
+        path: resolve(outputDir, "jazz-broker-worker.js"),
+        contentType: "text/javascript",
+      });
+      assets.set(`${prefix}/jazz_wasm_bg.wasm`, {
+        path: resolve(outputDir, "jazz_wasm_bg.wasm"),
+        contentType: "application/wasm",
+      });
+      return `${prefix}/jazz-broker-worker.js`;
+    } catch (error) {
+      await rm(outputDir, { recursive: true, force: true });
+      throw error;
+    }
+  }
+
+  return {
+    url: () => (bundle ??= buildBundle()),
+    plugin: {
+      name: "jazz-worker-fault-bundle",
+      configureServer(server) {
+        server.middlewares.use((request, response, next) => {
+          const asset = assets.get((request.url ?? "").split("?", 1)[0]!);
+          if (!asset || (request.method !== "GET" && request.method !== "HEAD")) {
+            next();
+            return;
+          }
+          // Serve only these owned files, unchanged: Vitest page instrumentation
+          // is not a SharedWorker module loader, even for a prebundled entry.
+          response.setHeader("Content-Type", asset.contentType);
+          response.setHeader("Cache-Control", "no-store");
+          response.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+          response.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+          response.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+          if (request.method === "HEAD") {
+            response.end();
+            return;
+          }
+          createReadStream(asset.path).on("error", next).pipe(response);
+        });
+      },
+    },
+  };
+}

--- a/packages/jazz-tools/vitest.config.browser.ts
+++ b/packages/jazz-tools/vitest.config.browser.ts
@@ -1,4 +1,5 @@
 import { testWasmDelivery } from "../../dev/gates/test-wasm-delivery.mjs";
+import { createWorkerFaultBundleFixture } from "./tests/browser/worker-fault-bundle-node.js";
 import { recoverPendingIndexedDbWrites } from "./tests/browser/indexeddb-pending-recovery-node.js";
 import {
   liveEdgeBackendOpen,
@@ -60,6 +61,9 @@ const jazzWasmTestEntry = sealedWasmPackage
   : correctnessSnapshot
     ? resolve(correctnessSnapshot.wasmPackage, "jazz_wasm.js")
     : resolve(__dirname, "../../crates/jazz-wasm");
+const workerFaultBundle = createWorkerFaultBundleFixture(
+  sealedWasmPackage ?? correctnessSnapshot?.wasmPackage,
+);
 
 export default defineConfig({
   define: {
@@ -70,6 +74,7 @@ export default defineConfig({
     __JAZZ_REALISTIC_BROWSER_LIMIT_OVERRIDES_JSON__: JSON.stringify(realisticBrowserLimitOverrides),
   },
   plugins: [
+    workerFaultBundle.plugin,
     ...(sealedWasmPackage || correctnessSnapshot
       ? [
           testWasmDelivery(
@@ -124,6 +129,7 @@ export default defineConfig({
         },
       ],
       commands: {
+        workerFaultBundleUrl: async () => workerFaultBundle.url(),
         recoverPendingIndexedDbWrites: async ({ context, page }, config) =>
           recoverPendingIndexedDbWrites(context, page, config),
         writeBrowserStorageCorpus: async (_context, records: Record<string, string>) => {


### PR DESCRIPTION
## Summary
- Bound browser worker readiness, lease handoff, and terminal cleanup.
- Release browser lease scopes during storage reset and shutdown.

## Before
A browser worker or follower could be used before readiness was established, and reset or terminal paths could leave lifecycle ownership outstanding.

## After
Worker connections establish readiness before use, unresponsive followers fail through the lifecycle error path, and reset/shutdown release leases and pending ownership deterministically.

## Test plan
- [ ] Run the focused browser worker, follower, and initialisation suites.
- [ ] Run repository CI.