### PR TITLE
Require trusted transport for JWKS discovery

### DIFF
--- a/.changeset/trusted-jwks-transport.md
+++ b/.changeset/trusted-jwks-transport.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Require trusted transport for backend JWKS discovery and reject insecure redirects.

--- a/docs/content/docs/getting-started/server-setup.mdx
+++ b/docs/content/docs/getting-started/server-setup.mdx
@@ -94,6 +94,15 @@ Request scopes do not change the shared session's selected account, so concurren
 
 `forRequest` reads standard HTTP headers from Express, Hono, Fastify, or a Web Fetch API `Request`. Configure `jwksUrl` or `jwtPublicKey` on `createJazzSession(...)` for external IdP tokens, but not both. Without either, it accepts only Jazz local-first tokens; `allowLocalFirstAuth: false` disables those too. Application cookies must first be resolved to an admitted account by your auth integration.
 
+The TypeScript backend's `jwksUrl` must use HTTPS, except for development HTTP
+with a WHATWG-canonical hostname of `localhost`, `[::1]`, or an IPv4 address in
+`127.0.0.0/8`. For example, `http://localhost:3000/api/auth/jwks` is allowed;
+`http://localhost.:3000/api/auth/jwks` (the trailing-dot spelling) and
+`http://keys.example/api/auth/jwks` are rejected before fetching keys.
+Every redirect is rejected, including redirects to HTTPS. Use the provider's
+final JWKS URL directly. This policy applies to TypeScript request authentication,
+not the separate Rust server's `--jwks-url` verifier.
+
 ### Attribution without impersonation
 
 Use `await client.withAttribution(account)` or `await client.withAttributionForRequest(req)` to retain backend access while recording verified user provenance. Raw session objects and issuer/subject strings are not public authority inputs. See [Sessions &gt; Attribution without impersonation](/docs/auth/sessions#attribution-without-impersonation).

--- a/docs/content/docs/install/typescript-server.mdx
+++ b/docs/content/docs/install/typescript-server.mdx
@@ -83,6 +83,14 @@ Create `src/index.ts`. This quickstart puts everything in one file; a real app w
 - `jwksUrl` verifies external JWTs inside `await client.forRequest(req)`. Without it, the backend only accepts Jazz local-first tokens unless you set `allowLocalFirstAuth: false`. It does not currently accept anonymous bearer tokens.
 - `dataPath` controls where local server state persists.
 
+For this TypeScript backend, use a direct HTTPS `jwksUrl`. HTTP is allowed for
+development only when the URL's WHATWG-canonical hostname is `localhost`,
+`[::1]`, or an IPv4 address in `127.0.0.0/8` (for example,
+`http://127.0.0.1:3000/api/auth/jwks`). HTTP with the trailing-dot spelling
+`localhost.`, other schemes, and remote HTTP are rejected before fetching keys.
+The backend rejects every redirect, even to another HTTPS URL, so configure your
+provider's final JWKS URL rather than a redirecting URL.
+
 Each route handler awaits `client.forRequest(c.req)` to get a database handle with [permissions](/docs/auth/permissions) scoped to the request.
 For server-owned work, use the ready snapshot's `client.db`. Backend admission requires the core
 even with a memory driver; keep the secret server-side and provide it through `initial` or `session.becomeBackend(...)`. [Server Setup](/docs/getting-started/server-setup)

--- a/packages/jazz-tools/src/backend/create-jazz-context.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.ts
@@ -58,7 +58,14 @@ export type BackendContextConfig = Omit<AppContext, "schema" | "driver" | "clien
   driver: BackendDriver;
   /** Optional node durability tier identity. */
   tier?: "local" | "edge" | "global";
-  /** JWKS endpoint used to verify external bearer JWTs in `forRequest()`. */
+  /**
+   * Direct JWKS endpoint used to verify external bearer JWTs in `forRequest()`.
+   * Requires HTTPS, except development HTTP whose WHATWG-canonical hostname is
+   * localhost, [::1], or an IPv4 address in 127/8.
+   * HTTP with the trailing-dot spelling localhost., other schemes, and remote
+   * HTTP are rejected before fetching. Redirects are
+   * rejected, including redirects to HTTPS; configure the final URL directly.
+   */
   jwksUrl?: string;
   /** Single JWK object or PEM/JWK string used to verify external bearer JWTs in `forRequest()`. */
   jwtPublicKey?: BackendJwtPublicKey;

--- a/packages/jazz-tools/src/backend/request-auth.test.ts
+++ b/packages/jazz-tools/src/backend/request-auth.test.ts
@@ -582,7 +582,8 @@ describe("backend request auth", () => {
   });
 
   it.each([
-    ["LOCALHOST", "localhost"],
+    // Bind both loopback families: localhost resolution differs across hosts.
+    ["LOCALHOST", "::"],
     ["[0:0:0:0:0:0:0:1]", "::1"],
     ["127.1", "127.0.0.1"],
     ["2130706433", "127.0.0.1"],

--- a/packages/jazz-tools/src/backend/request-auth.test.ts
+++ b/packages/jazz-tools/src/backend/request-auth.test.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { createHmac, randomUUID } from "node:crypto";
 import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -75,10 +75,10 @@ class JwksServer {
     this.secret = secret;
   }
 
-  static async start(secret = JWT_SECRET): Promise<JwksServer> {
+  static async start(secret = JWT_SECRET, path = "/jwks"): Promise<JwksServer> {
     let instance: JwksServer;
     const server = createHttpServer((request, response) => {
-      if (request.url !== "/jwks") {
+      if (request.url !== path) {
         response.statusCode = 404;
         response.end("not found");
         return;
@@ -114,7 +114,7 @@ class JwksServer {
       });
     });
 
-    instance = new JwksServer(server, `http://127.0.0.1:${port}/jwks`, secret);
+    instance = new JwksServer(server, `http://127.0.0.1:${port}${path}`, secret);
     return instance;
   }
 
@@ -351,6 +351,7 @@ describe("backend request auth", () => {
   });
 
   it("accepts local-first JWTs without jwksUrl and uses the shared session mapping", async () => {
+    const fetcher = vi.spyOn(globalThis, "fetch");
     const appId = "local-first-backend-app";
     const userId = "11111111-1111-1111-1111-111111111111";
     const token = makeUnsignedJwt({
@@ -379,6 +380,7 @@ describe("backend request auth", () => {
       claims: { auth_mode: "local-first" },
       authMode: "local-first",
     });
+    expect(fetcher).not.toHaveBeenCalled();
   });
 
   it("rejects local-first JWTs when allowLocalFirstAuth is disabled", async () => {
@@ -431,6 +433,205 @@ describe("backend request auth", () => {
       claims: { role: "editor" },
       authMode: "external",
     });
+  });
+
+  it("rejects remote plaintext JWKS before fetching valid signing keys", async () => {
+    const secret = randomUUID();
+    const path = `/jwks/${randomUUID()}`;
+    const token = signHs256Jwt({ iss: "https://issuer.example", sub: "transport-user" }, secret);
+    const request = { headers: { authorization: `Bearer ${token}` } };
+    const fetcher = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          keys: [{ kty: "oct", kid: JWT_KID, k: base64Url(secret) }],
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    try {
+      await expect(
+        resolveRequestSession(request, {
+          appId: "app-with-secure-jwks",
+          jwksUrl: `https://keys.example${path}`,
+        }),
+      ).resolves.toMatchObject({
+        issuer: "https://issuer.example",
+        user_id: "transport-user",
+        authMode: "external",
+      });
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      fetcher.mockClear();
+
+      const [attempt] = await Promise.allSettled([
+        resolveRequestSession(request, {
+          appId: "app-with-plaintext-jwks",
+          jwksUrl: `http://keys.example${path}`,
+        }),
+      ]);
+
+      expect({
+        status: attempt!.status,
+        fetches: fetcher.mock.calls.length,
+      }).toEqual({ status: "rejected", fetches: 0 });
+    } finally {
+      fetcher.mockRestore();
+    }
+  });
+
+  it("rejects redirected JWKS without contacting the valid-key destination", async () => {
+    const secret = randomUUID();
+    const destination = await JwksServer.start(secret, `/jwks/${randomUUID()}`);
+    const redirectPath = `/redirect/${randomUUID()}`;
+    let redirectRequests = 0;
+    const redirectServer = createHttpServer((request, response) => {
+      if (request.url !== redirectPath) {
+        response.writeHead(404).end();
+        return;
+      }
+      redirectRequests += 1;
+      response.writeHead(302, { Location: destination.url }).end();
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        redirectServer.once("error", reject);
+        redirectServer.listen(0, "127.0.0.1", () => resolve());
+      });
+      const address = redirectServer.address();
+      if (!address || typeof address === "string") {
+        throw new Error("failed to allocate redirect test port");
+      }
+      const token = signHs256Jwt(
+        { iss: "https://issuer.example", sub: "redirect-key-user" },
+        secret,
+      );
+      const request = { headers: { authorization: `Bearer ${token}` } };
+
+      await expect(
+        resolveRequestSession(request, {
+          appId: "app-with-direct-jwks",
+          jwksUrl: destination.url,
+        }),
+      ).resolves.toMatchObject({
+        issuer: "https://issuer.example",
+        user_id: "redirect-key-user",
+        authMode: "external",
+      });
+      expect(destination.requests).toBe(1);
+      // Count only destination traffic caused by the redirected authentication attempt.
+      destination.requests = 0;
+
+      const [attempt] = await Promise.allSettled([
+        resolveRequestSession(request, {
+          appId: "app-with-redirected-jwks",
+          jwksUrl: `http://127.0.0.1:${address.port}${redirectPath}`,
+        }),
+      ]);
+
+      expect(redirectRequests).toBe(1);
+      expect({
+        status: attempt!.status,
+        destinationRequests: destination.requests,
+      }).toEqual({ status: "rejected", destinationRequests: 0 });
+    } finally {
+      await Promise.all([
+        destination.stop(),
+        new Promise<void>((resolve) => redirectServer.close(() => resolve())),
+      ]);
+    }
+  });
+
+  it.each([
+    "http://localhost.",
+    "http://localhost.example",
+    "http://dev.localhost",
+    "http://127.attacker.example",
+    "http://126.255.255.255",
+    "http://128.0.0.1",
+    "http://0.0.0.0",
+    "http://192.168.1.1",
+    "http://[::ffff:127.0.0.1]",
+    "http://[::2]",
+    "ftp://localhost",
+    "file://localhost",
+    "data:application/json,",
+  ])("rejects JWKS at %s before fetching signing keys", async (origin) => {
+    const secret = randomUUID();
+    const token = signHs256Jwt({ iss: "https://issuer.example", sub: "url-policy-user" }, secret);
+    const fetcher = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          keys: [{ kty: "oct", kid: JWT_KID, k: base64Url(secret) }],
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    const [attempt] = await Promise.allSettled([
+      resolveRequestSession(
+        { headers: { authorization: `Bearer ${token}` } },
+        { appId: "app-with-url-policy", jwksUrl: `${origin}/jwks/${randomUUID()}` },
+      ),
+    ]);
+
+    expect({
+      status: attempt!.status,
+      fetches: fetcher.mock.calls.length,
+    }).toEqual({ status: "rejected", fetches: 0 });
+  });
+
+  it.each([
+    ["LOCALHOST", "localhost"],
+    ["[0:0:0:0:0:0:0:1]", "::1"],
+    ["127.1", "127.0.0.1"],
+    ["2130706433", "127.0.0.1"],
+    ["127.255.255.254", "127.255.255.254"],
+  ])("verifies signing keys over HTTP at canonical loopback %s", async (hostname, listenHost) => {
+    const secret = randomUUID();
+    const path = `/jwks/${randomUUID()}`;
+    let requests = 0;
+    const server = createHttpServer((request, response) => {
+      if (request.url !== path) {
+        response.writeHead(404).end();
+        return;
+      }
+      requests += 1;
+      response.writeHead(200, { "Content-Type": "application/json" }).end(
+        JSON.stringify({
+          keys: [{ kty: "oct", kid: JWT_KID, k: base64Url(secret) }],
+        }),
+      );
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, listenHost, () => resolve());
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("failed to allocate loopback test port");
+      }
+      const token = signHs256Jwt({ iss: "https://issuer.example", sub: "loopback-user" }, secret);
+
+      await expect(
+        resolveRequestSession(
+          { headers: { authorization: `Bearer ${token}` } },
+          {
+            appId: "app-with-loopback-jwks",
+            jwksUrl: `http://${hostname}:${address.port}${path}`,
+          },
+        ),
+      ).resolves.toMatchObject({
+        issuer: "https://issuer.example",
+        user_id: "loopback-user",
+        authMode: "external",
+      });
+      expect(requests).toBe(1);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("shares one cold JWKS fetch and rejects invalid JWTs without an immediate refresh", async () => {
@@ -681,6 +882,7 @@ describe("backend request auth", () => {
   });
 
   it("verifies external JWTs via a static JWK and uses JWT sub as the session user", async () => {
+    const fetcher = vi.spyOn(globalThis, "fetch");
     const token = signHs256Jwt({
       sub: "user-subject",
       iss: "https://issuer.example",
@@ -710,6 +912,7 @@ describe("backend request auth", () => {
       claims: { role: "editor" },
       authMode: "external",
     });
+    expect(fetcher).not.toHaveBeenCalled();
   });
 
   it("rejects a signed external JWT from a different configured issuer", async () => {

--- a/packages/jazz-tools/src/backend/request-auth.ts
+++ b/packages/jazz-tools/src/backend/request-auth.ts
@@ -111,6 +111,21 @@ function parseJwksUrl(jwksUrl: string): URL {
     throw new Error(`Invalid jwksUrl: ${jwksUrl}`);
   }
 
+  // WHATWG URL parsing canonicalises numeric IP spellings and IPv6 compression.
+  // Check the parsed hostname, never a textual prefix or a DNS resolution.
+  const hostname = parsedUrl.hostname;
+  if (
+    parsedUrl.protocol !== "https:" &&
+    !(
+      parsedUrl.protocol === "http:" &&
+      (hostname === "localhost" ||
+        hostname === "[::1]" ||
+        /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname))
+    )
+  ) {
+    throw new Error("Invalid jwksUrl: HTTPS is required except for loopback HTTP development");
+  }
+
   return parsedUrl;
 }
 
@@ -122,7 +137,7 @@ async function fetchRemoteJwks(jwksUrl: string): Promise<LocalJwksDocument> {
 
   let response: Response;
   try {
-    response = await fetchFn(parseJwksUrl(jwksUrl));
+    response = await fetchFn(parseJwksUrl(jwksUrl), { redirect: "error" });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Unable to fetch JWKS: ${message}`);


### PR DESCRIPTION
## Summary
- Require an authenticated trusted transport for backend JWKS discovery.
- Reject insecure JWKS redirects instead of silently following them.

## Before
Backend JWKS discovery could cross an untrusted transport boundary or accept an insecure redirect.

## After
JWKS discovery is admitted only through the trusted backend transport contract and redirect policy fails closed.

## Test plan
- [ ] Run the focused request-auth and server JWKS suites.
- [ ] Run repository CI.