### PR TITLE
Align streamed JSON admission with buffered validation

### DIFF
--- a/.changeset/streamed-json-admission.md
+++ b/.changeset/streamed-json-admission.md
@@ -1,0 +1,9 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+"jazz-napi": patch
+"jazz-rn": patch
+"create-jazz": patch
+---
+
+Keep streamed JSON admission aligned with buffered validation, including bounded syntax and size checks.

--- a/crates/groove/SPEC/9_large_values.md
+++ b/crates/groove/SPEC/9_large_values.md
@@ -761,6 +761,28 @@ JSON source remains literal UTF-8 JSON bytes in the same tree and edit format as
 bytes and text. Complete replacement is deterministically lowered to byte edits;
 persisted operations do not form a second JSON-tree mutation protocol.
 
+Buffered preparation, reader-streamed preparation, push preparation and completed
+remote uploads enforce the same JSON grammar, numeric representability, Unicode
+escape and recursion rules as the configured default `serde_json::Value` parser.
+Outside strings only SP, HT, LF and CR are whitespace; FF and VT are rejected.
+The validator's normative memory ceiling remains 128 open array/object frames.
+The resolved parser starts with a recursion budget of 128 and rejects the
+container that exhausts it, so all admission paths support at most 127
+simultaneous containers and reject the 128th without retaining its frame.
+The memory ceiling is not an independent promise to admit deeper values than
+the parser supports. Numbers that overflow
+its finite floating-point range and unpaired UTF-16 surrogate escapes (in keys
+or values) fail with `InvalidJson`; finite underflow and zero with a large
+exponent remain valid. Streaming admission retains only bounded numeric and
+escape metadata across windows, never an entire number or string token.
+Mantissas exceeding the parser's signed 32-bit decimal-place counter domain
+are rejected before that parser could panic or wrap on a subsequent read.
+
+Validation never normalizes source bytes or changes descriptor, node, storage
+or wire encodings. A failed completed upload removes pending upload metadata and
+issues no staging receipt. Immutable chunks already staged are queued for the
+existing explicit orphan reclamation lifecycle, not synchronously deleted.
+
 Queries may use a streaming parser to satisfy pointer and predicate demands.
 The parser retains bounded syntactic state and requests further logical windows
 as needed. It may finish early only when it has proved the exact semantic answer

--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -3798,6 +3798,121 @@ async fn malformed_json_tail_upload_is_rejected_and_reclaimed_before_staging() {
     assert_eq!(chunks.len(), 0);
 }
 
+// Only the remote upload seam can receive authenticated JSON that bypassed
+// preparation. Construct the physical leaf independently for both controls and
+// failures, rather than using the streaming validator to make its own fixture.
+#[futures_test::test]
+async fn completed_json_upload_matches_serde_and_queues_rejected_chunks_for_reclamation() {
+    use crate::large_values::{
+        LargeValueUploadProgress, json_admission_corpus, unvalidated_json_leaf_fixture,
+    };
+    for (name, json) in json_admission_corpus() {
+        let schema = DatabaseSchema::new([TableSchema::new(
+            "objects",
+            [
+                ColumnSchema::new("id", ColumnType::U64),
+                ColumnSchema::new("payload", ColumnType::Bytes),
+            ],
+        )
+        .with_primary_key(PrimaryKey::new("id", IntegerKeyType::U64))]);
+        let storage =
+            MemoryStorage::new(&schema.column_families()).expect("valid memory storage families");
+        let chunks = Rc::new(crate::chunks::MemoryChunkStorage::new());
+        let mut database = Database::new(schema, storage).await.unwrap();
+        database.set_chunk_storage(chunks.clone());
+        let prepared = unvalidated_json_leaf_fixture(json.as_bytes());
+        let root = prepared.value_ref.root.clone();
+        assert!(
+            matches!(
+                database
+                    .begin_large_value_upload(prepared.value_ref.clone())
+                    .await
+                    .unwrap(),
+                LargeValueUploadProgress::Missing(_)
+            ),
+            "{name}"
+        );
+        let result = database
+            .continue_large_value_upload(prepared.value_ref, prepared.staged_chunks)
+            .await;
+        if serde_json::from_str::<serde_json::Value>(&json).is_ok() {
+            assert!(
+                matches!(result, Ok(LargeValueUploadProgress::Staged(_))),
+                "{name}: {result:?}"
+            );
+            assert_eq!(
+                database.staged_large_values().await.unwrap().len(),
+                1,
+                "{name}"
+            );
+            assert_eq!(
+                database
+                    .reclaim_orphaned_large_value_chunks(usize::MAX)
+                    .await
+                    .unwrap(),
+                0,
+                "{name}"
+            );
+            assert_eq!(
+                chunks.len(),
+                1,
+                "{name}: accepted receipt protects its leaf"
+            );
+        } else {
+            assert!(
+                matches!(
+                    result,
+                    Err(Error::IvmRuntime(
+                        crate::ivm::runtime::IvmRuntimeError::LargeValue(
+                            crate::large_values::Error::InvalidJson
+                        )
+                    ))
+                ),
+                "{name}: {result:?}"
+            );
+            assert!(
+                database.staged_large_values().await.unwrap().is_empty(),
+                "{name}"
+            );
+            // Rejection ends publication protection, not physical residency.
+            assert_eq!(chunks.len(), 1, "{name}: deletion waits for reclamation");
+            assert!(
+                database
+                    .storage
+                    .get(
+                        LARGE_VALUE_METADATA_CF.to_owned(),
+                        large_value_reclaim_key(&root).unwrap(),
+                    )
+                    .await
+                    .unwrap()
+                    .is_some(),
+                "{name}: rejected leaf is queued"
+            );
+            assert_eq!(
+                database
+                    .reclaim_orphaned_large_value_chunks(usize::MAX)
+                    .await
+                    .unwrap(),
+                1,
+                "{name}"
+            );
+            assert_eq!(
+                chunks.len(),
+                0,
+                "{name}: explicit reclamation removes the leaf"
+            );
+        }
+        assert!(
+            database
+                .pending_large_value_uploads()
+                .await
+                .unwrap()
+                .is_empty(),
+            "{name}"
+        );
+    }
+}
+
 // This facade-level test uses a deliberately malformed physical child because
 // only the peer upload path receives untrusted pre-chunked bytes. The root
 // remains authenticated while one requested child is a hash-valid invalid

--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -133,6 +133,8 @@ pub const MAX_PHYSICAL_TRAVERSAL_NODES: usize = MAX_LOGICAL_TRAVERSAL_STEPS;
 /// JSON syntax validation retains one frame per open array/object. Keep this
 /// separate from the immutable-tree bound: a small logical value can otherwise
 /// use arbitrarily deep JSON nesting to grow validator memory.
+/// This is a safe memory ceiling, not a promise to admit every depth below it:
+/// the default serde_json::Value parser admits only 127 simultaneous containers.
 pub const MAX_JSON_NESTING_DEPTH: usize = 128;
 pub const MAX_EDIT_COUNT: usize = 64;
 pub const MAX_EDIT_TAIL_BYTES: usize = 256 * 1024;
@@ -497,7 +499,7 @@ impl LargeValueCursor {
 
 /// Incremental write-admission validation for an already-chunked logical
 /// value. The caller feeds consecutive final-logical windows, so this retains
-/// only an incomplete UTF-8 sequence and JSON syntax state, never the value.
+/// only an incomplete UTF-8 sequence and bounded JSON semantic state, never the value.
 pub(crate) struct LogicalValueValidator {
     kind: LargeValueKind,
     utf8_tail: Vec<u8>,
@@ -5058,6 +5060,177 @@ fn stage_unvalidated_fixture_node(
     }
 }
 
+/// Authenticated JSON bytes without preparation-time JSON validation. Remote
+/// admission tests must not depend on the validator they are trying to bypass.
+#[cfg(test)]
+pub(crate) fn unvalidated_json_leaf_fixture(bytes: &[u8]) -> PreparedLargeValue {
+    assert!(bytes.len() <= LEAF_MAX_BYTES);
+    let mut staged_chunks = Vec::new();
+    let leaf = stage_unvalidated_fixture_node(
+        ChunkNode::Leaf {
+            format: FORMAT_VERSION,
+            kind: LargeValueKind::Json,
+            bytes: bytes.to_vec(),
+        },
+        &mut random_locator,
+        &mut staged_chunks,
+    );
+    PreparedLargeValue {
+        value_ref: LargeValueRef {
+            kind: LargeValueKind::Json,
+            format_version: FORMAT_VERSION,
+            logical_hash: leaf.structural_hash,
+            root: leaf.node_ref,
+            byte_length: leaf.metrics.byte_length,
+            utf16_length: leaf.metrics.utf16_length,
+            edit_tail: Vec::new(),
+        },
+        staged_chunks,
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn json_admission_corpus() -> Vec<(&'static str, String)> {
+    let mut cases = vec![
+        ("overflow", "1e400".to_owned()),
+        ("negative overflow", "-1e400".to_owned()),
+        ("finite maximum", "1.7976931348623157e308".to_owned()),
+        (
+            "maximum adjacent decimal lower",
+            "1.7976931348623158e308".to_owned(),
+        ),
+        (
+            "maximum adjacent decimal upper",
+            "1.7976931348623159e308".to_owned(),
+        ),
+        (
+            "negative maximum rounding",
+            "-1.7976931348623158e308".to_owned(),
+        ),
+        (
+            "integer fallback finite",
+            "179769313486231570000e288".to_owned(),
+        ),
+        (
+            "integer fallback overflow",
+            "179769313486231590000e288".to_owned(),
+        ),
+        (
+            "fraction truncation finite",
+            "1.797693134862315700009999e308".to_owned(),
+        ),
+        (
+            "fraction truncation overflow",
+            "1.797693134862315900000001e308".to_owned(),
+        ),
+        ("u64 maximum", "18446744073709551615".to_owned()),
+        ("above u64 maximum", "18446744073709551616".to_owned()),
+        (
+            "negative integer fallback",
+            "-18446744073709551616".to_owned(),
+        ),
+        ("negative zero", "-0".to_owned()),
+        ("signed fractional zero", "-0.000e+308".to_owned()),
+        ("underflow", "1e-400".to_owned()),
+        ("signed underflow", "-1e-400".to_owned()),
+        ("subnormal", "4.9406564584124654e-324".to_owned()),
+        ("positive exponent limit", "1e2147483647".to_owned()),
+        ("positive exponent overflow", "1e2147483648".to_owned()),
+        ("negative exponent limit", "1e-2147483648".to_owned()),
+        ("zero exponent overflow", "0e2147483648".to_owned()),
+        (
+            "integer overflow then fitting fraction",
+            "184467440737095516160.0e288".to_owned(),
+        ),
+        (
+            "integer overflow then overflowing fraction",
+            "184467440737095516150.9e288".to_owned(),
+        ),
+    ];
+    let length = LEAF_MIN_BYTES + 17;
+    cases.extend([
+        (
+            "long integer compensated",
+            format!("1{}e-{length}", "0".repeat(length)),
+        ),
+        ("long integer overflow", format!("1{}", "0".repeat(length))),
+        (
+            "long compensated maximum",
+            format!(
+                "1797693134862315700{}e-{}",
+                "0".repeat(length),
+                length - 290
+            ),
+        ),
+        (
+            "long compensated overflow",
+            format!(
+                "1797693134862315900{}e-{}",
+                "0".repeat(length),
+                length - 290
+            ),
+        ),
+        (
+            "long leading fractional zeros",
+            format!("0.{}1e{}", "0".repeat(length), length + 1),
+        ),
+        (
+            "long leading fractional zeros overflow",
+            format!("0.{}17976931348623159e{}", "0".repeat(length), length + 309),
+        ),
+        (
+            "long fraction truncation",
+            format!("1.7976931348623157{}e308", "9".repeat(length)),
+        ),
+        (
+            "long exponent overflow",
+            format!("1e{}", "9".repeat(length)),
+        ),
+        ("long exponent zero", format!("-0e{}", "9".repeat(length))),
+        (
+            "long exponent underflow",
+            format!("1e-{}", "9".repeat(length)),
+        ),
+        (
+            "long exponent leading zeros",
+            format!("1e{}308", "0".repeat(length)),
+        ),
+    ]);
+    for (name, escaped) in [
+        ("lone high surrogate", r"\uD800"),
+        ("lone low surrogate", r"\uDC00"),
+        ("high high surrogate", r"\uD800\uDBFF"),
+        ("ordinary successor", r"\uD800x"),
+        ("non unicode successor", r"\uD800\n"),
+        ("non surrogate unicode successor", r"\uD800\u0041"),
+        ("truncated surrogate successor", r"\uD800\uDC0"),
+        ("paired surrogate", r"\uD83D\uDE42"),
+        ("paired surrogate extremes", r"\uDBFF\uDFFF"),
+        ("ordinary unicode escape", r"\uD7FF\uE000"),
+        ("raw non BMP", "🙂"),
+    ] {
+        cases.push((name, format!("\"{escaped}\"")));
+        cases.push((name, format!("{{\"{escaped}\":0}}")));
+        cases.push((name, format!("{{\"value\":\"{escaped}\"}}")));
+    }
+    // Place the escape pair and numeric overflow across completion-reader
+    // windows as well as across public push boundaries.
+    for (name, suffix) in [
+        ("window split pair", r#"\uD83D\uDE42"}"#),
+        ("window split unpaired surrogate", r#"\uD83D\u0041"}"#),
+    ] {
+        cases.push((
+            name,
+            format!("{{\"value\":\"{}{suffix}", "x".repeat(LEAF_MIN_BYTES - 12)),
+        ));
+    }
+    cases.push((
+        "window split exponent",
+        format!("[{}1e400]", " ".repeat(LEAF_MIN_BYTES - 3)),
+    ));
+    cases
+}
+
 /// Build an explicitly malformed bottom-up DAG whose every branch repeats one
 /// zero-metric child. This fixture deliberately bypasses canonical staging so
 /// authenticated historical/wire nodes can exercise fail-closed admission.
@@ -6466,6 +6639,187 @@ mod tests {
                 );
                 assert!(stats.peak_leaf_buffer_bytes <= LEAF_MAX_BYTES + LEAF_MIN_BYTES);
                 assert!(stats.peak_frontier_nodes <= BRANCH_MAX_CHILDREN * MAX_TREE_DEPTH);
+            }
+        }
+    }
+
+    #[test]
+    fn streamed_and_buffered_json_admission_reject_numeric_overflow() {
+        let bytes = b"1e400";
+        assert_eq!(
+            prepare(LargeValueKind::Json, bytes).unwrap_err(),
+            Error::InvalidJson
+        );
+
+        let mut streamed_chunks = Vec::new();
+        let streamed =
+            prepare_streaming(LargeValueKind::Json, std::io::Cursor::new(bytes), |chunk| {
+                streamed_chunks.push(chunk);
+                Ok(())
+            });
+
+        let mut pushed_chunks = Vec::new();
+        let mut preparation = PushStreamingPreparation::new(LargeValueKind::Json, |chunk| {
+            pushed_chunks.push(chunk);
+            Ok(())
+        });
+        let pushed = bytes
+            .iter()
+            .try_for_each(|byte| preparation.push(std::slice::from_ref(byte)))
+            .and_then(|()| preparation.finish());
+
+        assert_eq!(
+            (streamed.map(|_| ()), pushed.map(|_| ())),
+            (Err(Error::InvalidJson), Err(Error::InvalidJson)),
+            "neither streaming entry point may publish a descriptor for buffered-invalid JSON"
+        );
+    }
+
+    fn assert_json_admission_matches_serde(bytes: &[u8]) {
+        let expected = serde_json::from_slice::<serde_json::Value>(bytes)
+            .map(|_| ())
+            .map_err(|_| Error::InvalidJson);
+        assert_eq!(prepare(LargeValueKind::Json, bytes).map(|_| ()), expected);
+        let streamed =
+            prepare_streaming(
+                LargeValueKind::Json,
+                std::io::Cursor::new(bytes),
+                |_| Ok(()),
+            )
+            .map(|_| ());
+        let mut preparation = PushStreamingPreparation::new(LargeValueKind::Json, |_| Ok(()));
+        let pushed = bytes
+            .iter()
+            .try_for_each(|byte| preparation.push(std::slice::from_ref(byte)))
+            .and_then(|()| preparation.finish())
+            .map(|_| ());
+        assert_eq!(
+            (streamed, pushed),
+            (expected.clone(), expected),
+            "streamed and pushed admission must match serde_json for {bytes:?}"
+        );
+    }
+
+    #[test]
+    fn json_admission_matches_serde_for_ascii_whitespace() {
+        for whitespace in [b' ', b'\t', b'\n', b'\r', b'\x0b', b'\x0c'] {
+            for (prefix, suffix) in [("", "0"), ("0", ""), ("[0,", "1]"), ("{\"key\":", "0}")] {
+                let bytes = [prefix.as_bytes(), &[whitespace], suffix.as_bytes()].concat();
+                assert_json_admission_matches_serde(&bytes);
+            }
+        }
+    }
+
+    #[test]
+    fn json_admission_matches_serde_at_recursion_boundary() {
+        for depth in [126, 127, 128, 129] {
+            let arrays = format!("{}0{}", "[".repeat(depth), "]".repeat(depth));
+            assert_json_admission_matches_serde(arrays.as_bytes());
+            let objects = format!("{}0{}", "{\"key\":".repeat(depth), "}".repeat(depth));
+            assert_json_admission_matches_serde(objects.as_bytes());
+            let mixed = format!(
+                "{}0{}",
+                "[{\"key\":".repeat(depth / 2),
+                "}]".repeat(depth / 2)
+            );
+            let mixed = if depth % 2 == 1 {
+                format!("[{mixed}]")
+            } else {
+                mixed
+            };
+            assert_json_admission_matches_serde(mixed.as_bytes());
+        }
+    }
+
+    #[test]
+    fn json_admission_matches_serde_value_across_numeric_and_surrogate_splits() {
+        for (name, json) in json_admission_corpus() {
+            let bytes = json.as_bytes();
+            let expected = serde_json::from_slice::<serde_json::Value>(bytes)
+                .map(|_| ())
+                .map_err(|_| Error::InvalidJson);
+            let buffered = prepare(LargeValueKind::Json, bytes);
+            assert_eq!(
+                buffered.as_ref().map(|_| ()).map_err(Clone::clone),
+                expected,
+                "buffered {name}"
+            );
+            let check = |result: Result<(LargeValueRef, StreamingPrepareStats), Error>| {
+                assert_eq!(
+                    result.as_ref().map(|_| ()).map_err(Clone::clone),
+                    expected,
+                    "{name}"
+                );
+                if let Ok((value, _)) = result {
+                    let buffered = &buffered.as_ref().unwrap().value_ref;
+                    assert_eq!(
+                        value.logical_hash, buffered.logical_hash,
+                        "{name}: literal identity"
+                    );
+                    assert_eq!(
+                        value.byte_length, buffered.byte_length,
+                        "{name}: byte length"
+                    );
+                    assert_eq!(
+                        value.utf16_length, buffered.utf16_length,
+                        "{name}: UTF-16 length"
+                    );
+                }
+            };
+            check(prepare_streaming(
+                LargeValueKind::Json,
+                std::io::Cursor::new(bytes),
+                |_| Ok(()),
+            ));
+            check(prepare_streaming(
+                LargeValueKind::Json,
+                WindowReader {
+                    bytes,
+                    offset: 0,
+                    state: 7,
+                },
+                |_| Ok(()),
+            ));
+
+            let mut pushed = PushStreamingPreparation::new(LargeValueKind::Json, |_| Ok(()));
+            check(
+                bytes
+                    .iter()
+                    .try_for_each(|byte| pushed.push(std::slice::from_ref(byte)))
+                    .and_then(|()| pushed.finish()),
+            );
+
+            let splits = if bytes.len() < 128 {
+                (0..=bytes.len()).collect::<Vec<_>>()
+            } else {
+                vec![
+                    0,
+                    1,
+                    bytes.len() / 2,
+                    bytes.len() - 1,
+                    bytes.len(),
+                    LEAF_MIN_BYTES - 1,
+                    LEAF_MIN_BYTES,
+                    LEAF_MIN_BYTES + 1,
+                ]
+            };
+            for split in splits {
+                let mut pushed = PushStreamingPreparation::new(LargeValueKind::Json, |_| Ok(()));
+                check(
+                    pushed
+                        .push(&bytes[..split])
+                        .and_then(|()| pushed.push(&bytes[split..]))
+                        .and_then(|()| pushed.finish()),
+                );
+                // A chained reader forces the same two windows at its public
+                // Read seam, including every escape byte in the short corpus.
+                use std::io::Read;
+                check(prepare_streaming(
+                    LargeValueKind::Json,
+                    std::io::Cursor::new(&bytes[..split])
+                        .chain(std::io::Cursor::new(&bytes[split..])),
+                    |_| Ok(()),
+                ));
             }
         }
     }

--- a/crates/groove/src/large_values/json_syntax.rs
+++ b/crates/groove/src/large_values/json_syntax.rs
@@ -26,12 +26,14 @@ enum Token {
         key: bool,
         escaped: bool,
         unicode_digits: u8,
+        unicode_value: u16,
+        high_surrogate: bool,
     },
     Literal {
         expected: &'static [u8],
         offset: usize,
     },
-    Number(NumberState),
+    Number(Number),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -46,8 +48,13 @@ enum NumberState {
     ExponentDigits,
 }
 
-/// Syntax-only JSON validation that retains nesting state but never token
-/// contents, so one huge JSON string remains bounded by tree chunking.
+// The default serde_json::Value parser starts with a recursion budget of 128
+// and rejects the container that decrements it to zero. Keep its accepted
+// domain separate from our validator's normative memory ceiling.
+const SERDE_JSON_MAX_CONTAINERS: usize = 127;
+
+/// JSON validation retaining only bounded numeric, escape and nesting state,
+/// never token contents. UTF-8 validation belongs to the surrounding reader.
 pub(super) struct StreamingJsonValidator {
     stack: Vec<Frame>,
     token: Token,
@@ -86,25 +93,47 @@ impl StreamingJsonValidator {
                 key,
                 escaped,
                 unicode_digits,
+                unicode_value,
+                high_surrogate,
             } => {
                 if *unicode_digits > 0 {
-                    if !byte.is_ascii_hexdigit() {
-                        return Err(());
-                    }
+                    let digit = match byte {
+                        b'0'..=b'9' => byte - b'0',
+                        b'a'..=b'f' => byte - b'a' + 10,
+                        b'A'..=b'F' => byte - b'A' + 10,
+                        _ => return Err(()),
+                    };
+                    *unicode_value = (*unicode_value << 4) | u16::from(digit);
                     *unicode_digits -= 1;
+                    if *unicode_digits == 0 {
+                        if *high_surrogate {
+                            if !(0xdc00..=0xdfff).contains(unicode_value) {
+                                return Err(());
+                            }
+                            *high_surrogate = false;
+                        } else {
+                            if (0xdc00..=0xdfff).contains(unicode_value) {
+                                return Err(());
+                            }
+                            *high_surrogate = (0xd800..=0xdbff).contains(unicode_value);
+                        }
+                    }
                     return Ok(());
                 }
                 if *escaped {
                     *escaped = false;
                     if byte == b'u' {
                         *unicode_digits = 4;
-                    } else if !matches!(
-                        byte,
-                        b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't'
-                    ) {
+                        *unicode_value = 0;
+                    } else if *high_surrogate
+                        || !matches!(byte, b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't')
+                    {
                         return Err(());
                     }
                     return Ok(());
+                }
+                if *high_surrogate && byte != b'\\' {
+                    return Err(());
                 }
                 match byte {
                     b'\\' => *escaped = true,
@@ -140,8 +169,8 @@ impl StreamingJsonValidator {
                 }
                 Ok(())
             }
-            Token::Number(state) => {
-                if advance_number(state, byte)? {
+            Token::Number(number) => {
+                if number.advance(byte)? {
                     Ok(())
                 } else {
                     self.finish_number()?;
@@ -153,7 +182,7 @@ impl StreamingJsonValidator {
     }
 
     fn consume_idle(&mut self, byte: u8) -> Result<(), ()> {
-        if byte.is_ascii_whitespace() {
+        if matches!(byte, b' ' | b'\t' | b'\n' | b'\r') {
             return Ok(());
         }
         match self.stack.last().copied() {
@@ -186,6 +215,8 @@ impl StreamingJsonValidator {
                         key: true,
                         escaped: false,
                         unicode_digits: 0,
+                        unicode_value: 0,
+                        high_surrogate: false,
                     };
                     Ok(())
                 } else {
@@ -207,14 +238,16 @@ impl StreamingJsonValidator {
     fn start_value(&mut self, byte: u8) -> Result<(), ()> {
         match byte {
             b'{' => {
-                if self.stack.len() >= super::MAX_JSON_NESTING_DEPTH {
+                if self.stack.len() >= super::MAX_JSON_NESTING_DEPTH.min(SERDE_JSON_MAX_CONTAINERS)
+                {
                     return Err(());
                 }
                 self.stack.push(Frame::Object(ObjectState::FirstKeyOrEnd));
                 Ok(())
             }
             b'[' => {
-                if self.stack.len() >= super::MAX_JSON_NESTING_DEPTH {
+                if self.stack.len() >= super::MAX_JSON_NESTING_DEPTH.min(SERDE_JSON_MAX_CONTAINERS)
+                {
                     return Err(());
                 }
                 self.stack.push(Frame::Array(ArrayState::FirstValueOrEnd));
@@ -225,22 +258,16 @@ impl StreamingJsonValidator {
                     key: false,
                     escaped: false,
                     unicode_digits: 0,
+                    unicode_value: 0,
+                    high_surrogate: false,
                 };
                 Ok(())
             }
             b't' => self.start_literal(b"rue"),
             b'f' => self.start_literal(b"alse"),
             b'n' => self.start_literal(b"ull"),
-            b'-' => {
-                self.token = Token::Number(NumberState::Minus);
-                Ok(())
-            }
-            b'0' => {
-                self.token = Token::Number(NumberState::Zero);
-                Ok(())
-            }
-            b'1'..=b'9' => {
-                self.token = Token::Number(NumberState::Integer);
+            b'-' | b'0'..=b'9' => {
+                self.token = Token::Number(Number::new(byte));
                 Ok(())
             }
             _ => Err(()),
@@ -256,13 +283,9 @@ impl StreamingJsonValidator {
     }
 
     fn finish_number(&mut self) -> Result<(), ()> {
-        match self.token {
-            Token::Number(
-                NumberState::Zero
-                | NumberState::Integer
-                | NumberState::Fraction
-                | NumberState::ExponentDigits,
-            ) => {
+        match &self.token {
+            Token::Number(number) => {
+                number.finish()?;
                 self.token = Token::None;
                 self.value_complete()
             }
@@ -334,10 +357,160 @@ fn advance_number(state: &mut NumberState, byte: u8) -> Result<bool, ()> {
     Ok(true)
 }
 
+/// The default serde_json parser accumulates a u64, then discards overflowing
+/// integer digits (counting their decimal places) and overflowing fraction
+/// digits (without counting them). It does not use roundtrip parsing's sticky
+/// digits. Keep that reduction here, but let serde_json perform the final
+/// binary rounding so its power-of-ten table is not duplicated.
+struct Number {
+    state: NumberState,
+    significand: u64,
+    decimal_exponent: i32,
+    integer_overflow: bool,
+    fraction_overflow: bool,
+    exponent: i32,
+    exponent_negative: bool,
+    exponent_overflow: bool,
+}
+
+impl Number {
+    fn new(byte: u8) -> Self {
+        Self {
+            state: match byte {
+                b'-' => NumberState::Minus,
+                b'0' => NumberState::Zero,
+                _ => NumberState::Integer,
+            },
+            significand: if byte == b'-' {
+                0
+            } else {
+                u64::from(byte - b'0')
+            },
+            decimal_exponent: 0,
+            integer_overflow: false,
+            fraction_overflow: false,
+            exponent: 0,
+            exponent_negative: false,
+            exponent_overflow: false,
+        }
+    }
+
+    fn advance(&mut self, byte: u8) -> Result<bool, ()> {
+        if !advance_number(&mut self.state, byte)? {
+            return Ok(false);
+        }
+        match self.state {
+            NumberState::Zero | NumberState::Integer => {
+                if !self.integer_overflow {
+                    if let Some(next) = self.append_digit(byte) {
+                        self.significand = next;
+                    } else {
+                        self.integer_overflow = true;
+                    }
+                }
+                if self.integer_overflow {
+                    // Reject before serde_json's unchecked long-mantissa
+                    // counter would overflow (panic or wrap on later reads).
+                    self.decimal_exponent = self.decimal_exponent.checked_add(1).ok_or(())?;
+                }
+            }
+            NumberState::Fraction => {
+                if !self.fraction_overflow {
+                    if let Some(next) = self.append_digit(byte) {
+                        self.significand = next;
+                        self.decimal_exponent = self.decimal_exponent.checked_sub(1).ok_or(())?;
+                    } else {
+                        self.fraction_overflow = true;
+                    }
+                }
+            }
+            NumberState::ExponentSign => self.exponent_negative = byte == b'-',
+            NumberState::ExponentDigits => {
+                if !self.exponent_overflow {
+                    if let Some(next) = self
+                        .exponent
+                        .checked_mul(10)
+                        .and_then(|value| value.checked_add(i32::from(byte - b'0')))
+                    {
+                        self.exponent = next;
+                    } else {
+                        self.exponent_overflow = true;
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(true)
+    }
+
+    fn append_digit(&self, byte: u8) -> Option<u64> {
+        self.significand
+            .checked_mul(10)?
+            .checked_add(u64::from(byte - b'0'))
+    }
+
+    fn finish(&self) -> Result<(), ()> {
+        if !matches!(
+            self.state,
+            NumberState::Zero
+                | NumberState::Integer
+                | NumberState::Fraction
+                | NumberState::ExponentDigits
+        ) {
+            return Err(());
+        }
+        if self.exponent_overflow {
+            // serde_json handles exponent overflow before combining it with
+            // the mantissa's decimal places.
+            return if self.exponent_negative || self.significand == 0 {
+                Ok(())
+            } else {
+                Err(())
+            };
+        }
+        let exponent = if self.exponent_negative {
+            self.decimal_exponent.saturating_sub(self.exponent)
+        } else {
+            self.decimal_exponent.saturating_add(self.exponent)
+        };
+        if exponent <= 0 || self.significand == 0 {
+            // A u64 divided by a positive power of ten is always finite.
+            return Ok(());
+        }
+
+        // At most 20 significand digits, 'e', and 10 positive exponent digits.
+        // This is reduced parser metadata, not retained source-token scratch.
+        use std::io::Write;
+        let mut bytes = [0_u8; 31];
+        let mut output = std::io::Cursor::new(bytes.as_mut_slice());
+        write!(output, "{}e{}", self.significand, exponent).map_err(|_| ())?;
+        let length = output.position() as usize;
+        serde_json::from_slice::<f64>(&bytes[..length])
+            .map(|_| ())
+            .map_err(|_| ())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::StreamingJsonValidator;
-    use crate::large_values::MAX_JSON_NESTING_DEPTH;
+
+    // The public equivalent needs over 2 GiB of one numeric token. Seed only
+    // its counter here to defend the fail-closed arithmetic transition.
+    #[test]
+    fn numeric_mantissa_counter_limit_fails_closed() {
+        let mut integer = super::Number::new(b'1');
+        integer.integer_overflow = true;
+        integer.decimal_exponent = i32::MAX - 1;
+        assert_eq!(integer.advance(b'0'), Ok(true));
+        assert_eq!(integer.advance(b'0'), Err(()));
+
+        let mut fraction = super::Number::new(b'0');
+        fraction.advance(b'.').unwrap();
+        fraction.decimal_exponent = i32::MIN + 1;
+        assert_eq!(fraction.advance(b'0'), Ok(true));
+        assert_eq!(fraction.advance(b'0'), Err(()));
+    }
 
     fn validate_one_byte_at_a_time(json: &[u8]) -> Result<(), ()> {
         let mut validator = StreamingJsonValidator::new();
@@ -384,17 +557,17 @@ mod tests {
     }
 
     #[test]
-    fn accepts_json_at_the_explicit_nesting_bound() {
-        let mut json = vec![b'['; MAX_JSON_NESTING_DEPTH];
+    fn accepts_json_at_serde_nesting_bound() {
+        let mut json = vec![b'['; 127];
         json.push(b'0');
-        json.extend(std::iter::repeat_n(b']', MAX_JSON_NESTING_DEPTH));
+        json.extend(std::iter::repeat_n(b']', 127));
         assert!(validate_one_byte_at_a_time(&json).is_ok());
     }
 
     #[test]
-    fn rejects_json_over_the_explicit_nesting_bound_without_retaining_frames() {
+    fn rejects_json_over_serde_nesting_bound() {
         let mut validator = StreamingJsonValidator::new();
-        validator.push(&vec![b'['; MAX_JSON_NESTING_DEPTH]).unwrap();
+        validator.push(&vec![b'['; 127]).unwrap();
         assert!(validator.push(b"[").is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Make streamed JSON admission enforce the same syntax and numeric boundaries as buffered validation.
- Keep validation bounded across chunk boundaries.

## Before
Buffered and streamed JSON admission could disagree on malformed, overflowing, or boundary-split values.

## After
Both paths accept and reject the same JSON inputs while retaining bounded streaming state.

## Test plan
- [ ] Run the focused Groove large-value admission suite.
- [ ] Run repository CI.