### PR TITLE
Scope implicit server storage by application

### DIFF
--- a/.changeset/app-scoped-server-storage.md
+++ b/.changeset/app-scoped-server-storage.md
@@ -1,0 +1,5 @@
+---
+"@jazz/rust": patch
+---
+
+Apply deterministic CLI configuration precedence before selecting the implicit application-scoped server storage path.

--- a/crates/jazz-cli/src/bin/jazz-server.rs
+++ b/crates/jazz-cli/src/bin/jazz-server.rs
@@ -529,7 +529,8 @@ struct CliOptions {
 
 impl CliOptions {
     fn parse(args: Vec<String>, program: &str) -> Result<Self, String> {
-        let mut options = Self::from_env()?;
+        let mut options = Self::defaults(StorageConfig::InMemory, "/sync".to_owned());
+        Self::apply_env(&mut options)?;
         Self::parse_into(&mut options, args, program)?;
         options.reject_unsupported_upstream_url()?;
         Ok(options)
@@ -543,9 +544,11 @@ impl CliOptions {
         if app_id.trim().is_empty() {
             return Err("empty_app_id".to_owned());
         }
-        let mut options = Self::from_env()?;
-        options.storage = StorageConfig::data_dir("./data");
-        options.websocket_path = format!("/apps/{app_id}/ws");
+        let mut options = Self::defaults(
+            StorageConfig::data_dir("./data"),
+            format!("/apps/{app_id}/ws"),
+        );
+        Self::apply_env(&mut options)?;
         Self::parse_into(&mut options, args, program)?;
         options.auth_admission.expected_audience = Some(app_id.to_owned());
         options.reject_unsupported_upstream_url()?;
@@ -677,15 +680,19 @@ impl CliOptions {
         Ok(())
     }
 
-    fn from_env() -> Result<Self, String> {
-        let mut options = Self {
+    fn defaults(storage: StorageConfig, websocket_path: String) -> Self {
+        Self {
             listen: SocketAddr::from(([127, 0, 0, 1], 0)),
-            websocket_path: "/sync".to_owned(),
-            storage: StorageConfig::InMemory,
+            websocket_path,
+            storage,
             auth_admission: AuthAdmissionConfig::default(),
             admitted_account: None,
-            upstream_url: env::var("JAZZ_UPSTREAM_URL").ok(),
-        };
+            upstream_url: None,
+        }
+    }
+
+    fn apply_env(options: &mut Self) -> Result<(), String> {
+        options.upstream_url = env::var("JAZZ_UPSTREAM_URL").ok();
         if let Ok(value) = env::var("JAZZ_SERVER_LISTEN") {
             options.listen = parse_socket_addr(&value)?;
         }
@@ -733,7 +740,7 @@ impl CliOptions {
         if let Ok(value) = env::var("JAZZ_SERVER_ANONYMOUS_SUBJECT") {
             options.auth_admission.anonymous_subject = value;
         }
-        Ok(options)
+        Ok(())
     }
 
     fn reject_unsupported_upstream_url(&self) -> Result<(), String> {

--- a/crates/jazz-cli/src/bin/jazz-server.rs
+++ b/crates/jazz-cli/src/bin/jazz-server.rs
@@ -12,6 +12,7 @@ use jazz::serving::{
     StorageConfig, StorageKind,
     auth_admission::{AuthAdmissionConfig, JwtVerifierConfig},
 };
+use jazz::tools::AppId;
 use jazz_server::loopback::websocket::{LoopbackWebSocketServer, LoopbackWebSocketServerConfig};
 
 fn empty_runtime_schema() -> JazzSchema {
@@ -146,6 +147,10 @@ fn run_server_app(app_id: &str, args: Vec<String>, program: &str) -> ExitCode {
             return ExitCode::from(2);
         }
     };
+    if let Err(error) = options.reject_legacy_implicit_storage() {
+        eprintln!("error={error}");
+        return ExitCode::FAILURE;
+    }
     let schema = empty_runtime_schema();
     let identity = DbIdentity {
         node: NodeUuid::from_bytes([0x5e; 16]),
@@ -297,16 +302,20 @@ fn print_usage_stderr(program: &str) {
     );
 }
 
+const SERVER_STORAGE_HELP: &str = "storage_default=./data/apps/<canonical-app-uuid> (UUID APP_ID spellings are canonicalised; other names use a deterministic UUID). Explicit storage paths are unchanged. If ./data/CURRENT exists, the implicit default refuses to start: deliberately use --data-dir ./data or JAZZ_SERVER_DATA_DIR=./data to reopen that store, or migrate it manually. No legacy data is moved or adopted automatically.";
+
 fn print_server_usage(program: &str) {
     println!(
         "usage={program} server <APP_ID> [--listen <addr>|--bind <addr>] [--port <port>] [--data-dir <dir>|--dataDir <dir>|--in-memory|--memory] [--websocket-path <path>|--ws-path <path>] [--auth-static-bearer <token>|--static-bearer <token>] [--loopback-admitted-account <uuid>] [--auth-jwt-ed-public-key-pem <pem>] [--jwt-issuer <issuer>] [--allow-local-first-auth <bool>] [--anonymous-subject <subject>] [--upstream-url <url>]"
     );
+    println!("{SERVER_STORAGE_HELP}");
 }
 
 fn print_server_usage_stderr(program: &str) {
     eprintln!(
         "usage={program} server <APP_ID> [--listen <addr>|--bind <addr>] [--port <port>] [--data-dir <dir>|--dataDir <dir>|--in-memory|--memory] [--websocket-path <path>|--ws-path <path>] [--auth-static-bearer <token>|--static-bearer <token>] [--loopback-admitted-account <uuid>] [--auth-jwt-ed-public-key-pem <pem>] [--jwt-issuer <issuer>] [--allow-local-first-auth <bool>] [--anonymous-subject <subject>] [--upstream-url <url>]"
     );
+    eprintln!("{SERVER_STORAGE_HELP}");
 }
 
 fn print_serve_usage(program: &str, command: &str) {
@@ -522,6 +531,7 @@ struct CliOptions {
     listen: SocketAddr,
     websocket_path: String,
     storage: StorageConfig,
+    implicit_app_storage: bool,
     auth_admission: AuthAdmissionConfig,
     admitted_account: Option<AccountId>,
     upstream_url: Option<String>,
@@ -544,10 +554,13 @@ impl CliOptions {
         if app_id.trim().is_empty() {
             return Err("empty_app_id".to_owned());
         }
+        let canonical_app_id =
+            AppId::from_string(app_id).unwrap_or_else(|_| AppId::from_name(app_id));
         let mut options = Self::defaults(
-            StorageConfig::data_dir("./data"),
+            StorageConfig::data_dir(format!("./data/apps/{canonical_app_id}")),
             format!("/apps/{app_id}/ws"),
         );
+        options.implicit_app_storage = true;
         Self::apply_env(&mut options)?;
         Self::parse_into(&mut options, args, program)?;
         options.auth_admission.expected_audience = Some(app_id.to_owned());
@@ -569,10 +582,10 @@ impl CliOptions {
                     options.listen.set_port(port);
                 }
                 "--data-dir" | "--dataDir" => {
-                    options.storage = StorageConfig::data_dir(next_value(&mut args, &arg)?);
+                    options.select_storage(StorageConfig::data_dir(next_value(&mut args, &arg)?));
                 }
                 "--in-memory" | "--memory" => {
-                    options.storage = StorageConfig::InMemory;
+                    options.select_storage(StorageConfig::InMemory);
                 }
                 "--websocket-path" | "--ws-path" => {
                     options.websocket_path = next_value(&mut args, &arg)?;
@@ -627,7 +640,7 @@ impl CliOptions {
                     options.listen.set_port(port);
                 }
                 _ if arg.starts_with("--data-dir=") || arg.starts_with("--dataDir=") => {
-                    options.storage = StorageConfig::data_dir(value_after_equals(&arg)?);
+                    options.select_storage(StorageConfig::data_dir(value_after_equals(&arg)?));
                 }
                 _ if arg.starts_with("--websocket-path=") || arg.starts_with("--ws-path=") => {
                     options.websocket_path = value_after_equals(&arg)?.to_owned();
@@ -685,9 +698,32 @@ impl CliOptions {
             listen: SocketAddr::from(([127, 0, 0, 1], 0)),
             websocket_path,
             storage,
+            implicit_app_storage: false,
             auth_admission: AuthAdmissionConfig::default(),
             admitted_account: None,
             upstream_url: None,
+        }
+    }
+
+    fn select_storage(&mut self, storage: StorageConfig) {
+        self.storage = storage;
+        self.implicit_app_storage = false;
+    }
+
+    fn reject_legacy_implicit_storage(&self) -> Result<(), String> {
+        if !self.implicit_app_storage {
+            return Ok(());
+        }
+        // Inspect the entry itself: even a dangling CURRENT link is legacy evidence.
+        // Do not create or open the app root until this read-only check succeeds.
+        match std::fs::symlink_metadata("./data/CURRENT") {
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Ok(_) => Err(format!(
+                "legacy_default_storage: ./data/CURRENT exists; {SERVER_STORAGE_HELP}"
+            )),
+            Err(error) => Err(format!(
+                "legacy_default_storage_probe_failed: cannot inspect ./data/CURRENT: {error}; resolve this filesystem error before using the implicit default. {SERVER_STORAGE_HELP}"
+            )),
         }
     }
 
@@ -703,9 +739,9 @@ impl CliOptions {
             options.listen.set_port(port);
         }
         if env_truthy("JAZZ_SERVER_IN_MEMORY") {
-            options.storage = StorageConfig::InMemory;
+            options.select_storage(StorageConfig::InMemory);
         } else if let Ok(value) = env::var("JAZZ_SERVER_DATA_DIR") {
-            options.storage = StorageConfig::data_dir(value);
+            options.select_storage(StorageConfig::data_dir(value));
         }
         if let Ok(value) = env::var("JAZZ_SERVER_WEBSOCKET_PATH") {
             options.websocket_path = value;
@@ -809,17 +845,6 @@ fn parse_bool(value: &str, name: &str) -> Result<bool, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn server_app_parse_defaults_to_data_dir_and_app_ws_path() {
-        let options = CliOptions::parse_for_server_app(Vec::new(), "jazz-server", "demo").unwrap();
-
-        assert_eq!(options.listen, SocketAddr::from(([127, 0, 0, 1], 0)));
-        assert_eq!(options.websocket_path, "/apps/demo/ws");
-        assert!(
-            matches!(options.storage, StorageConfig::RocksDb { ref path } if path == std::path::Path::new("./data"))
-        );
-    }
 
     #[test]
     fn server_app_parse_accepts_alpha_flags_and_in_memory_opt_out() {

--- a/crates/jazz-cli/tests/cli_dry_run.rs
+++ b/crates/jazz-cli/tests/cli_dry_run.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use std::collections::VecDeque;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
-use std::path::Path;
-use std::process::{Child, ChildStdin, Command, Stdio};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Output, Stdio};
 use std::rc::Rc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -64,7 +64,7 @@ fn jazz_server_command() -> Command {
     command
 }
 
-fn server_command_report(command: &mut Command) -> String {
+fn server_command_output(command: &mut Command) -> Output {
     let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -88,7 +88,11 @@ fn server_command_report(command: &mut Command) -> String {
             }
         }
     }
-    let output = child.wait_with_output().expect("collect server report");
+    child.wait_with_output().expect("collect server report")
+}
+
+fn server_command_report(command: &mut Command) -> String {
+    let output = server_command_output(command);
     assert!(
         output.status.success(),
         "server failed: {}",
@@ -717,6 +721,262 @@ fn server_command_defaults_to_data_dir_and_accepts_aliases() {
             .iter()
             .any(|line| line.starts_with("ws_url=ws://127.0.0.1:") && line.ends_with("/custom-ws"))
     );
+}
+
+#[test]
+fn server_command_isolates_implicit_data_directories_between_apps() {
+    let temp_dir = tempfile::tempdir().expect("create server temp dir");
+    let data_dirs = ["app-a", "app-b"].map(|app_id| {
+        let stdout = server_command_report(
+            jazz_server_command()
+                .args([
+                    "server",
+                    app_id,
+                    "--listen",
+                    "127.0.0.1:0",
+                    "--auth-static-bearer",
+                    "secret",
+                ])
+                .current_dir(temp_dir.path()),
+        );
+        let reported_path = stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("data_dir="))
+            .unwrap_or_else(|| panic!("{app_id} must report durable storage:\n{stdout}"));
+        let data_dir = temp_dir.path().join(reported_path);
+        assert!(
+            data_dir.join("CURRENT").is_file(),
+            "{app_id} must initialise the reported store root: {}\n{stdout}",
+            data_dir.display()
+        );
+        data_dir
+            .canonicalize()
+            .expect("canonicalise initialised store root")
+    });
+
+    assert_ne!(
+        data_dirs[0], data_dirs[1],
+        "different apps must not reuse the same implicit store in a shared working directory"
+    );
+}
+
+fn app_storage_command(cwd: &Path, app_id: &str) -> Command {
+    let mut command = jazz_server_command();
+    command
+        .args([
+            "server",
+            app_id,
+            "--listen",
+            "127.0.0.1:0",
+            "--auth-static-bearer",
+            "secret",
+        ])
+        .current_dir(cwd);
+    command
+}
+
+fn reported_data_directory(stdout: &str) -> &str {
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("data_dir="))
+        .unwrap_or_else(|| panic!("server must report durable storage:\n{stdout}"))
+}
+
+fn storage_snapshot(root: &Path) -> BTreeMap<PathBuf, Option<Vec<u8>>> {
+    fn visit(root: &Path, path: &Path, entries: &mut BTreeMap<PathBuf, Option<Vec<u8>>>) {
+        for entry in std::fs::read_dir(path).expect("read storage directory") {
+            let path = entry.expect("read storage entry").path();
+            let key = path.strip_prefix(root).unwrap().to_owned();
+            if path.is_dir() {
+                entries.insert(key, None);
+                visit(root, &path, entries);
+            } else {
+                entries.insert(key, Some(std::fs::read(path).expect("read storage bytes")));
+            }
+        }
+    }
+    let mut entries = BTreeMap::new();
+    visit(root, root, &mut entries);
+    entries
+}
+
+#[test]
+fn server_command_reopens_canonical_app_storage_without_changing_raw_app_identity() {
+    let temp_dir = tempfile::tempdir().expect("create server temp dir");
+    let named = server_command_report(&mut app_storage_command(temp_dir.path(), "stable-app"));
+    let named_again =
+        server_command_report(&mut app_storage_command(temp_dir.path(), "stable-app"));
+    assert_eq!(
+        reported_data_directory(&named),
+        reported_data_directory(&named_again)
+    );
+    let named_path = Path::new(reported_data_directory(&named));
+    assert_eq!(named_path.parent(), Some(Path::new("./data/apps")));
+    assert!(temp_dir.path().join(named_path).join("CURRENT").is_file());
+
+    // Reopening by the reported canonical identity must address the named app's store.
+    let canonical_name = named_path.file_name().unwrap().to_str().unwrap();
+    let by_id = server_command_report(&mut app_storage_command(temp_dir.path(), canonical_name));
+    assert_eq!(
+        reported_data_directory(&named),
+        reported_data_directory(&by_id)
+    );
+
+    let uuid = "7c5fd0da-4bd1-4ba9-9203-41e1f0da142c";
+    for spelling in [uuid, "7C5FD0DA4BD14BA9920341E1F0DA142C"] {
+        let stdout = server_command_report(&mut app_storage_command(temp_dir.path(), spelling));
+        assert_eq!(
+            reported_data_directory(&stdout),
+            format!("./data/apps/{uuid}")
+        );
+        assert!(
+            stdout
+                .lines()
+                .any(|line| line == format!("app_id={spelling}"))
+        );
+        assert!(
+            stdout
+                .lines()
+                .any(|line| line == format!("websocket_path=/apps/{spelling}/ws"))
+        );
+    }
+    assert!(
+        temp_dir
+            .path()
+            .join(format!("data/apps/{uuid}/CURRENT"))
+            .is_file()
+    );
+    assert_eq!(
+        std::fs::read_dir(temp_dir.path().join("data/apps"))
+            .unwrap()
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn server_command_keeps_path_separator_app_names_inside_canonical_storage_root() {
+    let temp_dir = tempfile::tempdir().expect("create server temp dir");
+    let stdout = server_command_report(&mut app_storage_command(temp_dir.path(), "../nested/app"));
+    let relative = Path::new(reported_data_directory(&stdout));
+    assert_eq!(relative.parent(), Some(Path::new("./data/apps")));
+    let child = relative.file_name().unwrap().to_str().unwrap();
+    let id = uuid::Uuid::parse_str(child).expect("storage child is a UUID, not a raw app name");
+    assert_eq!(child, id.to_string());
+    assert!(temp_dir.path().join(relative).join("CURRENT").is_file());
+    assert!(!temp_dir.path().join("data/nested").exists());
+}
+
+#[test]
+fn server_command_refuses_legacy_default_without_mutation_but_allows_explicit_reopen() {
+    let temp_dir = tempfile::tempdir().expect("create server temp dir");
+    server_command_report(
+        app_storage_command(temp_dir.path(), "legacy-app").args(["--data-dir", "./data"]),
+    );
+    let before = storage_snapshot(temp_dir.path());
+    let output = server_command_output(
+        app_storage_command(temp_dir.path(), "new-app").env("JAZZ_SERVER_IN_MEMORY", "false"),
+    );
+    assert!(!output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("ws_url="));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("legacy_default_storage"), "{stderr}");
+    assert!(stderr.contains("--data-dir ./data"), "{stderr}");
+    assert!(stderr.contains("JAZZ_SERVER_DATA_DIR=./data"), "{stderr}");
+    assert_eq!(storage_snapshot(temp_dir.path()), before);
+    assert!(!temp_dir.path().join("data/apps").exists());
+
+    let cli = server_command_report(
+        app_storage_command(temp_dir.path(), "new-app")
+            .env("JAZZ_SERVER_IN_MEMORY", "true")
+            .args(["--memory", "--data-dir", "./data"]),
+    );
+    assert_eq!(reported_data_directory(&cli), "./data");
+    let env = server_command_report(
+        app_storage_command(temp_dir.path(), "new-app").env("JAZZ_SERVER_DATA_DIR", "./data"),
+    );
+    assert_eq!(reported_data_directory(&env), "./data");
+    assert!(!temp_dir.path().join("data/apps").exists());
+}
+
+#[test]
+fn server_command_explicit_storage_bypasses_legacy_guard_without_touching_legacy_data() {
+    let temp_dir = tempfile::tempdir().expect("create server temp dir");
+    let data = temp_dir.path().join("data");
+    // Any existing CURRENT entry is legacy evidence, even a directory.
+    std::fs::create_dir_all(data.join("CURRENT")).unwrap();
+    std::fs::write(data.join("CURRENT/keep"), b"do not adopt").unwrap();
+    let before = storage_snapshot(&data);
+    let refused = server_command_output(&mut app_storage_command(temp_dir.path(), "new-app"));
+    assert!(!refused.status.success());
+    assert!(String::from_utf8_lossy(&refused.stderr).contains("legacy_default_storage"));
+    assert_eq!(storage_snapshot(&data), before);
+
+    let env = server_command_report(
+        app_storage_command(temp_dir.path(), "new-app").env("JAZZ_SERVER_DATA_DIR", "./env-data"),
+    );
+    assert_eq!(reported_data_directory(&env), "./env-data");
+    assert!(temp_dir.path().join("env-data/CURRENT").is_file());
+    let cli = server_command_report(
+        app_storage_command(temp_dir.path(), "new-app")
+            .env("JAZZ_SERVER_DATA_DIR", "./unused-env")
+            .args(["--in-memory", "--dataDir=./cli-data"]),
+    );
+    assert_eq!(reported_data_directory(&cli), "./cli-data");
+    assert!(temp_dir.path().join("cli-data/CURRENT").is_file());
+    let env_memory = server_command_report(
+        app_storage_command(temp_dir.path(), "new-app")
+            .env("JAZZ_SERVER_IN_MEMORY", "true")
+            .env("JAZZ_SERVER_DATA_DIR", "./unused-env"),
+    );
+    let cli_memory = server_command_report(
+        app_storage_command(temp_dir.path(), "new-app")
+            .env("JAZZ_SERVER_DATA_DIR", "./unused-env")
+            .args(["--dataDir", "./unused-cli", "--memory"]),
+    );
+    for stdout in [env_memory, cli_memory] {
+        assert!(stdout.lines().any(|line| line == "storage=in-memory"));
+        assert!(!stdout.lines().any(|line| line.starts_with("data_dir=")));
+    }
+    assert!(!temp_dir.path().join("unused-env").exists());
+    assert!(!temp_dir.path().join("unused-cli").exists());
+    assert_eq!(storage_snapshot(&data), before);
+    assert!(!data.join("apps").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn server_command_refuses_dangling_legacy_marker_without_mutation() {
+    let temp_dir = tempfile::tempdir().expect("create server temp dir");
+    let data = temp_dir.path().join("data");
+    std::fs::create_dir(&data).unwrap();
+    std::os::unix::fs::symlink("missing-manifest", data.join("CURRENT")).unwrap();
+    let output = server_command_output(&mut app_storage_command(temp_dir.path(), "new-app"));
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("legacy_default_storage"));
+    assert_eq!(
+        std::fs::read_link(data.join("CURRENT")).unwrap(),
+        Path::new("missing-manifest")
+    );
+    assert_eq!(std::fs::read_dir(&data).unwrap().count(), 1);
+    assert!(!data.join("apps").exists());
+}
+
+#[test]
+fn server_command_fails_closed_when_legacy_probe_parent_is_not_a_directory() {
+    let temp_dir = tempfile::tempdir().expect("create server temp dir");
+    std::fs::write(temp_dir.path().join("data"), b"not a directory").unwrap();
+    let before = storage_snapshot(temp_dir.path());
+    let output = server_command_output(&mut app_storage_command(temp_dir.path(), "new-app"));
+    assert!(!output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("ws_url="));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("legacy_default_storage_probe_failed"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("./data/CURRENT"), "{stderr}");
+    assert_eq!(storage_snapshot(temp_dir.path()), before);
 }
 
 #[test]

--- a/crates/jazz-cli/tests/cli_dry_run.rs
+++ b/crates/jazz-cli/tests/cli_dry_run.rs
@@ -64,6 +64,39 @@ fn jazz_server_command() -> Command {
     command
 }
 
+fn server_command_report(command: &mut Command) -> String {
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn jazz-server server");
+
+    // EOF requests clean shutdown after startup; reap before checking the report.
+    drop(child.stdin.take());
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if Instant::now() < deadline => {
+                thread::sleep(Duration::from_millis(20));
+            }
+            result => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("server did not exit cleanly before the deadline: {result:?}");
+            }
+        }
+    }
+    let output = child.wait_with_output().expect("collect server report");
+    assert!(
+        output.status.success(),
+        "server failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("server stdout is utf-8")
+}
+
 fn jazz_tools_command() -> Command {
     let mut command = Command::new(cargo_binary("jazz-tools"));
     command
@@ -687,6 +720,154 @@ fn server_command_defaults_to_data_dir_and_accepts_aliases() {
 }
 
 #[test]
+fn server_command_honours_environment_storage_and_websocket_route() {
+    let temp_dir = tempfile::tempdir().expect("create server temp dir");
+    let stdout = server_command_report(
+        jazz_server_command()
+            .args([
+                "server",
+                "environment-app",
+                "--listen",
+                "127.0.0.1:0",
+                "--auth-static-bearer",
+                "secret",
+            ])
+            .env("JAZZ_SERVER_IN_MEMORY", "true")
+            .env("JAZZ_SERVER_DATA_DIR", "./unused-environment-data")
+            .env("JAZZ_SERVER_WEBSOCKET_PATH", "/environment-route")
+            .current_dir(temp_dir.path()),
+    );
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(
+        lines.contains(&"storage=in-memory"),
+        "environment must select memory storage:\n{stdout}"
+    );
+    assert!(
+        !lines.iter().any(|line| line.starts_with("data_dir=")),
+        "memory storage must not report a data directory:\n{stdout}"
+    );
+    assert!(
+        lines.contains(&"websocket_path=/environment-route"),
+        "environment must select the websocket route:\n{stdout}"
+    );
+    assert!(
+        lines.iter().any(|line| {
+            line.starts_with("ws_url=ws://127.0.0.1:") && line.ends_with("/environment-route")
+        }),
+        "server URL must use the selected websocket route:\n{stdout}"
+    );
+}
+
+#[test]
+fn server_command_honours_environment_data_directory_when_memory_is_false() {
+    let temp_dir = tempfile::tempdir().expect("create server temp dir");
+    let stdout = server_command_report(
+        jazz_server_command()
+            .args([
+                "server",
+                "durable-environment-app",
+                "--listen",
+                "127.0.0.1:0",
+                "--auth-static-bearer",
+                "secret",
+            ])
+            .env("JAZZ_SERVER_IN_MEMORY", "false")
+            .env("JAZZ_SERVER_DATA_DIR", "./environment-data")
+            .env("JAZZ_SERVER_WEBSOCKET_PATH", "/durable-environment")
+            .current_dir(temp_dir.path()),
+    );
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines.contains(&"storage=rocksdb"), "{stdout}");
+    assert!(lines.contains(&"data_dir=./environment-data"), "{stdout}");
+    assert!(
+        lines.contains(&"websocket_path=/durable-environment"),
+        "{stdout}"
+    );
+    assert!(
+        lines.iter().any(|line| {
+            line.starts_with("ws_url=ws://127.0.0.1:") && line.ends_with("/durable-environment")
+        }),
+        "{stdout}"
+    );
+    assert!(temp_dir.path().join("environment-data").is_dir());
+    assert!(!temp_dir.path().join("data").exists());
+}
+
+#[test]
+fn server_command_explicit_data_directory_overrides_environment_and_earlier_memory_flag() {
+    let temp_dir = tempfile::tempdir().expect("create server temp dir");
+    let stdout = server_command_report(
+        jazz_server_command()
+            .args([
+                "server",
+                "explicit-durable-app",
+                "--bind=127.0.0.1:0",
+                "--memory",
+                "--dataDir=./cli-data",
+                "--ws-path=/cli-durable",
+                "--auth-static-bearer",
+                "secret",
+            ])
+            .env("JAZZ_SERVER_IN_MEMORY", "true")
+            .env("JAZZ_SERVER_DATA_DIR", "./unused-environment-data")
+            .env("JAZZ_SERVER_WEBSOCKET_PATH", "/unused-environment-route")
+            .current_dir(temp_dir.path()),
+    );
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines.contains(&"storage=rocksdb"), "{stdout}");
+    assert!(lines.contains(&"data_dir=./cli-data"), "{stdout}");
+    assert!(lines.contains(&"websocket_path=/cli-durable"), "{stdout}");
+    assert!(
+        lines.iter().any(|line| {
+            line.starts_with("ws_url=ws://127.0.0.1:") && line.ends_with("/cli-durable")
+        }),
+        "{stdout}"
+    );
+    assert!(temp_dir.path().join("cli-data").is_dir());
+    assert!(!temp_dir.path().join("unused-environment-data").exists());
+    assert!(!temp_dir.path().join("data").exists());
+}
+
+#[test]
+fn server_command_explicit_memory_overrides_environment_and_earlier_data_directory_flag() {
+    let temp_dir = tempfile::tempdir().expect("create server temp dir");
+    let stdout = server_command_report(
+        jazz_server_command()
+            .args([
+                "server",
+                "explicit-memory-app",
+                "--listen",
+                "127.0.0.1:0",
+                "--data-dir",
+                "./unused-cli-data",
+                "--in-memory",
+                "--websocket-path",
+                "/cli-memory",
+                "--auth-static-bearer",
+                "secret",
+            ])
+            .env("JAZZ_SERVER_DATA_DIR", "./unused-environment-data")
+            .env("JAZZ_SERVER_WEBSOCKET_PATH", "/unused-environment-route")
+            .current_dir(temp_dir.path()),
+    );
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines.contains(&"storage=in-memory"), "{stdout}");
+    assert!(
+        !lines.iter().any(|line| line.starts_with("data_dir=")),
+        "{stdout}"
+    );
+    assert!(lines.contains(&"websocket_path=/cli-memory"), "{stdout}");
+    assert!(
+        lines.iter().any(|line| {
+            line.starts_with("ws_url=ws://127.0.0.1:") && line.ends_with("/cli-memory")
+        }),
+        "{stdout}"
+    );
+    assert!(!temp_dir.path().join("unused-cli-data").exists());
+    assert!(!temp_dir.path().join("unused-environment-data").exists());
+    assert!(!temp_dir.path().join("data").exists());
+}
+
 fn websocket_reconnect_preserves_local_structured_terminal_patches() {
     let schema = structured_schema();
     let server = RunningServer::start_schema(&schema);


### PR DESCRIPTION
## Summary
- Scope implicit server storage by application.
- Give explicit CLI flags precedence over environment defaults.

## Before
Implicit server storage and environment defaults could be shared or selected inconsistently across applications.

## After
Implicit storage paths are application-scoped, while explicit CLI options override environment configuration deterministically.

## Test plan
- [ ] Run the focused CLI storage suite.
- [ ] Run repository CI.