### PR TITLE
Roll back failed multisink shape preparation

### DIFF
--- a/.changeset/atomic-multisink-rollback.md
+++ b/.changeset/atomic-multisink-rollback.md
@@ -1,0 +1,9 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+"jazz-napi": patch
+"jazz-rn": patch
+"create-jazz": patch
+---
+
+Roll back failed multisink shape preparation without publishing partial prepared state.

--- a/crates/groove/SPEC/5_prepared_shapes.md
+++ b/crates/groove/SPEC/5_prepared_shapes.md
@@ -103,6 +103,15 @@ internally; callers with separate clean and routed graphs can instead use
 `output_key_fields` entry absent from the graph output descriptor
 (`ShapeKeyFieldNotFound`).
 
+Graph-level `Database::prepare` installs all routed terminals atomically. If any
+terminal fails to compile, preparation MUST return that compile error without
+publishing a prepared shape or any of its graph retainers. A binding source
+newly inserted by that attempt MUST be removed, and unretained ephemeral graph
+additions MUST be collected. A pre-existing compatible binding source, its
+active bindings, and graphs retained by existing shapes or subscriptions MUST
+remain unchanged. Retrying after a failed first preparation may therefore reuse
+the same source name with a different binding descriptor.
+
 ### 5.3 The binding lifecycle
 
 A binding source represents active parameter tuples, not subscriber identities.

--- a/crates/groove/src/db/tests/subscriptions/prepared.rs
+++ b/crates/groove/src/db/tests/subscriptions/prepared.rs
@@ -100,6 +100,180 @@ async fn prepared_binding_source_reuse_validates_descriptor() {
 }
 
 #[futures_test::test]
+async fn failed_multisink_prepare_rolls_back_new_binding_source() {
+    let storage = MemoryStorage::new(&["albums"]).expect("valid memory storage families");
+    let mut database = Database::new(albums_schema(), storage).await.unwrap();
+    let u64_descriptor = RecordDescriptor::new([("route", ColumnType::U64.clone())]);
+    let invalid_terminal = GraphBuilder::collect_by(
+        GraphBuilder::table("albums"),
+        ["id"],
+        [CollectByField::named("id")],
+        [CollectByField::named("title")],
+        "children",
+        [TopByOrder::asc("title")],
+        ["title"],
+        0,
+        TopByLimit::Finite(1),
+    )
+    .filter(PredicateExpr::gt("id", Value::U64(0)));
+
+    let error = database
+        .prepare(
+            [
+                RoutedMultisinkTerminal::new(
+                    "rows",
+                    GraphBuilder::binding_source("retry_source", u64_descriptor),
+                    ["route"],
+                    ["route"],
+                ),
+                RoutedMultisinkTerminal::new(
+                    "invalid",
+                    invalid_terminal,
+                    [] as [&str; 0],
+                    [] as [&str; 0],
+                ),
+            ],
+            "retry_source",
+            u64_descriptor,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::IvmRuntime(IvmRuntimeError::CollectByMustBeTerminal)
+    ));
+
+    let string_descriptor = RecordDescriptor::new([("route", ColumnType::String.clone())]);
+    let shape = database
+        .prepare(
+            [RoutedMultisinkTerminal::new(
+                "rows",
+                GraphBuilder::binding_source("retry_source", string_descriptor),
+                ["route"],
+                ["route"],
+            )],
+            "retry_source",
+            string_descriptor,
+        )
+        .await
+        .expect("failed preparation must not reserve the binding source descriptor");
+    let subscription = database
+        .bind_shape(shape.id(), &[Value::String("retry".to_owned())])
+        .await
+        .unwrap();
+    database.drive_progress().await.unwrap();
+
+    let deltas = subscription.try_recv().unwrap();
+    assert_eq!(
+        deltas.get("rows").unwrap().to_values().unwrap(),
+        [(vec![Value::String("retry".to_owned())], 1)]
+    );
+}
+
+#[futures_test::test]
+async fn failed_multisink_prepare_preserves_active_shared_binding_source() {
+    let storage = MemoryStorage::new(&["albums"]).expect("valid memory storage families");
+    let mut database = Database::new(albums_schema(), storage).await.unwrap();
+    let baseline_graph_nodes = database.runtime_stats().graph_nodes;
+    let binding_descriptor = RecordDescriptor::new([("wanted", ColumnType::String.clone())]);
+    let graph = GraphBuilder::join(
+        GraphBuilder::binding_source("shared_source", binding_descriptor),
+        GraphBuilder::table("albums"),
+        ["wanted"],
+        ["title"],
+    )
+    .project_fields([
+        ProjectField::renamed("right.id", "id"),
+        ProjectField::renamed("right.title", "title"),
+        ProjectField::renamed("left.wanted", "wanted"),
+    ]);
+    let shape = database
+        .prepare_one_sink(
+            graph.clone(),
+            "shared_source",
+            binding_descriptor,
+            ["wanted"],
+        )
+        .await
+        .unwrap();
+    let active = database
+        .bind_shape_one_sink(shape.id(), &[Value::String("Blue Train".to_owned())])
+        .await
+        .unwrap();
+    assert!(active.recv().unwrap().is_empty());
+
+    let invalid_terminal = GraphBuilder::collect_by(
+        GraphBuilder::table("albums"),
+        ["id"],
+        [CollectByField::named("id")],
+        [CollectByField::named("title")],
+        "children",
+        [TopByOrder::asc("title")],
+        ["title"],
+        0,
+        TopByLimit::Finite(1),
+    )
+    .filter(PredicateExpr::gt("id", Value::U64(0)));
+    let error = database
+        .prepare(
+            [
+                RoutedMultisinkTerminal::new("rows", graph, ["wanted"], ["id", "title", "wanted"]),
+                RoutedMultisinkTerminal::new(
+                    "invalid",
+                    invalid_terminal,
+                    [] as [&str; 0],
+                    [] as [&str; 0],
+                ),
+            ],
+            "shared_source",
+            binding_descriptor,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::IvmRuntime(IvmRuntimeError::CollectByMustBeTerminal)
+    ));
+
+    let sibling = database
+        .bind_shape_one_sink(shape.id(), &[Value::String("Giant Steps".to_owned())])
+        .await
+        .expect("failed sibling preparation must preserve the registered binding source");
+    assert!(sibling.recv().unwrap().is_empty());
+
+    let mut batch = database.open_batch();
+    batch.insert(
+        "albums",
+        vec![Value::U64(7), Value::String("Blue Train".to_owned())],
+    );
+    batch.insert(
+        "albums",
+        vec![Value::U64(11), Value::String("Giant Steps".to_owned())],
+    );
+    database.commit_batch(batch).await.unwrap();
+
+    assert_eq!(
+        expect_recv_vals(&active),
+        [(
+            vec![7_u64.into(), "Blue Train".into(), "Blue Train".into()],
+            1
+        )]
+    );
+    assert_eq!(
+        expect_recv_vals(&sibling),
+        [(
+            vec![11_u64.into(), "Giant Steps".into(), "Giant Steps".into()],
+            1
+        )]
+    );
+
+    database.unsubscribe(active.id());
+    database.unsubscribe(sibling.id());
+    database.retire_prepared_shape(shape.id()).unwrap();
+    assert_eq!(database.runtime_stats().graph_nodes, baseline_graph_nodes);
+}
+
+#[futures_test::test]
 async fn graph_prepared_subscription_can_hide_internal_routing_fields() {
     let storage = MemoryStorage::new(&["albums"]).expect("valid memory storage families");
     let mut database = Database::new(albums_schema(), storage).await.unwrap();

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -3284,34 +3284,51 @@ impl IvmRuntime {
         let shape = binding_source_shape.into();
         let shape_id = self.next_shape_id();
         let source_key = BindingSourceKey::prepared(shape.clone());
-        match self.binding_sources.entry(source_key) {
+        let inserted_source = match self.binding_sources.entry(source_key) {
             std::collections::hash_map::Entry::Occupied(existing)
                 if existing.get().descriptor != binding_descriptor =>
             {
                 return Err(IvmRuntimeError::BindingSourceDescriptorMismatch(shape));
             }
-            std::collections::hash_map::Entry::Occupied(_) => {}
+            std::collections::hash_map::Entry::Occupied(_) => false,
             std::collections::hash_map::Entry::Vacant(vacant) => {
                 vacant.insert(BindingSourceState {
                     descriptor: binding_descriptor,
                     refcounts: HashMap::default(),
                     initialized: true,
                 });
+                true
             }
-        }
+        };
+        let mut install = super::graph_lifecycle::EphemeralGraphInstall::new(self);
+        let runtime = install.runtime();
         let mut terminal_states = BTreeMap::new();
         for terminal in terminals {
-            let output = self.add_dedup_graph(&terminal.graph)?;
-            self.add_retainer(
-                output.node,
-                Retainer::PreparedShape(shape_id.retainer_key()),
-            );
+            let output = match runtime.add_dedup_graph(&terminal.graph) {
+                Ok(output) => output,
+                Err(error) => {
+                    if inserted_source {
+                        runtime
+                            .binding_sources
+                            .remove(&BindingSourceKey::prepared(shape));
+                    }
+                    return Err(error);
+                }
+            };
             terminal_states.insert(
                 terminal.sink.clone(),
                 RoutedMultisinkTerminalState { terminal, output },
             );
         }
-        self.prepared_shapes.insert(
+        // Publish retainers only after every terminal compiles, so the guard
+        // can collect failed additions without disturbing existing shapes.
+        for terminal in terminal_states.values() {
+            runtime.add_retainer(
+                terminal.output.node,
+                Retainer::PreparedShape(shape_id.retainer_key()),
+            );
+        }
+        runtime.prepared_shapes.insert(
             shape_id,
             RoutedMultisinkShapeState {
                 shape,
@@ -3320,6 +3337,7 @@ impl IvmRuntime {
                 auto_family_key: None,
             },
         );
+        install.commit();
         Ok(PreparedShape { id: shape_id })
     }
 


### PR DESCRIPTION
## Summary
- Roll back binding-source and graph state when prepared multisink shape admission fails.
- Preserve active shared binding sources across failed preparation.

## Before
A failed multisink preparation could leave new or shared binding-source state behind.

## After
Failed preparation is atomic for new state and leaves existing active shared state usable for retry.

## Test plan
- [ ] Run the focused Groove prepared-shape suite.
- [ ] Run repository CI.