### PR TITLE
Restore local Edge query serving while retaining authorized repair

### DIFF
--- a/crates/jazz-testkit/tests/readable_scope_exit.rs
+++ b/crates/jazz-testkit/tests/readable_scope_exit.rs
@@ -299,6 +299,19 @@ fn revocation_schema(dependency: bool) -> Schema {
 }
 
 async fn run_revoked_exit(dependency: bool, relayed: bool) {
+    run_revoked_exit_case(dependency, relayed, true).await;
+}
+
+async fn run_revoked_exit_case(dependency: bool, relayed: bool, changes_filter: bool) {
+    run_revoked_exit_shared_case(dependency, relayed, changes_filter, false).await;
+}
+
+async fn run_revoked_exit_shared_case(
+    dependency: bool,
+    relayed: bool,
+    changes_filter: bool,
+    shared_cache: bool,
+) {
     let schema = revocation_schema(dependency);
     let authority = JazzServer::start_with_schema(schema.clone()).await;
     let relay = if relayed {
@@ -340,6 +353,38 @@ async fn run_revoked_exit(dependency: bool, relayed: bool) {
     }
     let (task, _, tx) = bob.insert("tasks", input).unwrap();
     jazz_testkit::wait_for_edge_txs(&bob, &[tx.unwrap()]).await;
+    // A different reader can populate this same Edge's cache with a newer
+    // task. Alice's narrowed scope must not leak that shared-cache successor.
+    let shared_reader = if shared_cache {
+        Some(
+            TestingClient::builder()
+                .with_server(&server)
+                .with_schema(schema.clone())
+                .with_user_id("shared-backend")
+                .as_admin()
+                .connect()
+                .await,
+        )
+    } else {
+        None
+    };
+    let _shared_subscription = if let Some(reader) = &shared_reader {
+        let mut subscription = reader
+            .subscribe_with_read_tier(Query::from("tasks"), ReadTier::Remote)
+            .await
+            .unwrap();
+        wait_for_subscription_update(
+            &mut subscription,
+            &mut Vec::new(),
+            TIMEOUT,
+            "shared Edge cache receives task",
+            |log| has_added_id(log, task),
+        )
+        .await;
+        Some(subscription)
+    } else {
+        None
+    };
     let alice = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema)
@@ -369,7 +414,7 @@ async fn run_revoked_exit(dependency: bool, relayed: bool) {
     let tx = bob.begin_transaction().unwrap().transaction_id();
     let staged = bob.with_write_context(WriteContext::default().with_transaction_id(tx));
     let mut changes = vec![
-        ("done".into(), Value::Boolean(true)),
+        ("done".into(), Value::Boolean(changes_filter)),
         ("title".into(), Value::Text("new forbidden title".into())),
     ];
     if let Some(grant) = grant {
@@ -401,7 +446,39 @@ async fn run_revoked_exit(dependency: bool, relayed: bool) {
             "revocation must withhold the new content, not merely hide membership"
         );
     }
+    // Restoring access must clear the exact reader's denial, without requiring
+    // a new client or discarding the Edge's shared cache.
+    let start = log.len();
+    let tx = bob.begin_transaction().unwrap().transaction_id();
+    let staged = bob.with_write_context(WriteContext::default().with_transaction_id(tx));
+    staged
+        .update(
+            task,
+            vec![
+                ("done".into(), Value::Boolean(false)),
+                ("owner".into(), Value::Text("alice".into())),
+                ("title".into(), Value::Text("readmitted".into())),
+            ],
+        )
+        .unwrap();
+    if let Some(grant) = grant {
+        staged
+            .update(grant, vec![("owner".into(), Value::Text("alice".into()))])
+            .unwrap();
+    }
+    jazz_testkit::wait_for_edge_txs(&bob, &[bob.commit_transaction(tx).unwrap()]).await;
+    wait_for_subscription_update(
+        &mut remote,
+        &mut log,
+        TIMEOUT,
+        "same Edge readmits task",
+        |log| has_added_id(&log[start..], task),
+    )
+    .await;
     alice.shutdown().await.unwrap();
+    if let Some(reader) = shared_reader {
+        reader.shutdown().await.unwrap();
+    }
     bob.shutdown().await.unwrap();
     if let Some(relay) = relay {
         relay.shutdown().await;
@@ -988,5 +1065,32 @@ async fn scalar_input_policy_rule_change_revokes_and_readmits() {
             relay.shutdown().await;
             authority.shutdown().await;
         })
+        .await;
+}
+
+/// Access alone removes the row; a scalar-filter change cannot hide a stale
+/// Edge authorization decision while trusted repair refreshes the task.
+#[tokio::test]
+async fn edge_direct_access_loss_without_filter_change_withholds_successor() {
+    tokio::task::LocalSet::new()
+        .run_until(run_revoked_exit_case(false, true, false))
+        .await;
+}
+
+/// A changed task must not pass an old cached grant while the Edge repairs
+/// inputs on its trusted Core connection.
+#[tokio::test]
+async fn edge_dependency_access_loss_without_filter_change_withholds_successor() {
+    tokio::task::LocalSet::new()
+        .run_until(run_revoked_exit_case(true, true, false))
+        .await;
+}
+
+/// Another reader fills the Edge cache with a successor which Alice cannot
+/// read. A task-only shared scope deliberately does not hydrate its grant.
+#[tokio::test]
+async fn edge_shared_cache_dependency_revocation_withholds_successor() {
+    tokio::task::LocalSet::new()
+        .run_until(run_revoked_exit_shared_case(true, true, false, true))
         .await;
 }

--- a/crates/jazz/SPEC/7_authorization.md
+++ b/crates/jazz/SPEC/7_authorization.md
@@ -348,6 +348,14 @@ policy binding's authoritative membership separate and may not treat possession
 of a cached row as permission to reveal it to another scope (ch. 9,
 `INV-EDGE-21..24`).
 
+A server Edge remains a serving authority: its ordinary query graph composes
+read policies locally. Verified upstream current-unavailable decisions add an
+exclusion for the exact admitted reader and claims. This excludes app/serving
+inputs only; raw policy-proof subplans and fresh permission probes must not
+consume it, or an old denial could prevent its own later readmission. SYSTEM
+and another reader's scope do not inherit the exclusion. Explicit extra-row and
+missing-body repair continue to obtain current Core authorization.
+
 effective branch-view reads evaluate ordinary table policy over the effective branch-view
 view. Partition columns are normal policy-visible values, including references
 to application-owned rows that represent a draft or lifecycle when the schema

--- a/crates/jazz/SPEC/8_sync_protocol.md
+++ b/crates/jazz/SPEC/8_sync_protocol.md
@@ -1004,8 +1004,9 @@ client identity and immutable claims.
 
 On an untrusted client-to-Edge path, shared cache possession is never evidence
 of permission to disclose. A partial Edge may hold a fresh task fetched for
-SYSTEM and an obsolete grant permitting Alice. Neither ordinary query delivery
-nor FetchRowVersions may use that cached grant to authorize fresh bytes for Alice.
+SYSTEM and an obsolete grant permitting Alice. An explicit repair must not use that cached grant to authorize fresh bytes for
+Alice. Ordinary Edge evaluation uses its maintained local policy inputs and also
+honors verified Core access-loss decisions for the admitted reader.
 Exact-version repair is subject to the same current read authorization contract
 as ordinary repair at Core. Knowing a row/transaction coordinate is not a grant.
 
@@ -1026,13 +1027,30 @@ per-request query policy bindings on trusted Edge-to-Core links. Bare
 not grant this capability. Existing admission APIs default to no capability;
 write authorization and publication trust are unchanged.
 
-At a partial Edge, every admitted non-SYSTEM query scope (including delegated
-users over trusted links), and every untrusted session, consumes its exact
-Core-authorized source versions. Those sources compile in ClientLocal mode:
-missing policy-proof rows must not cause cached-policy re-evaluation or authorize
-fresh shared-cache bytes. The Edge's own SYSTEM scope retains local evaluation
-and ordinary query-driven reconciliation. Host topology selects this boundary,
-not a wire role or a cache history-completeness claim.
+A server Edge evaluates ordinary admitted queries and their read policies over
+its local data. It forwards the subscription to keep inputs synchronized, but
+opening the local evaluator does not require the exact Core-selected result for
+that new query. A scope-isolated browser/native client relay has a different
+role: it still consumes the selected authority's exact inputs and does not
+re-evaluate permissions from an incomplete client cache.
+
+Extra-row and missing-body repairs remain Core-authorized under the admitted
+reader in this implementation. A verified current-unavailable decision excludes
+that physical row from the Edge's ordinary serving graph for that exact reader
+and claims, as well as from client-local reads in that context. It does not
+remove shared storage, constrain SYSTEM, or become an input to permission-proof
+evaluation. A later verified readable decision clears the exclusion. Unknown,
+connection replacement and stale replies retain the existing retry/cancellation
+rules. These are delegated reader decisions on a trusted transport, not a claim
+that the Edge's own SYSTEM identity lost access.
+
+For example, Alice can read task T through grant G. Core revokes G while updating
+T, but T still matches Alice's task filter. Repair must not fetch just T as
+SYSTEM and then apply an old cached G: that could disclose T's new content.
+The admitted Alice repair returns current-unavailable without that content;
+the Edge's serving graph excludes T for Alice. Other readers and SYSTEM retain
+their independent access. Fully local repair requires maintained coverage of
+all authorization inputs and is outside this bounded restoration.
 
 Strict receivers retain the selected usage's deletion-layer CoveredInput facts
 and exact version bodies beside the content graph, since a tombstone contributes

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -2533,6 +2533,9 @@ where
         downstream_fates: PendingDownstreamFates,
         startup_error: Option<Error>,
     ) -> Rc<LocalMutex<PeerConnection<S>>> {
+        if edge_authority {
+            self.node.borrow_mut().enable_edge_query_serving();
+        }
         let local_receiver = self.receives_commits_as_local() && !edge_authority;
         let (peer, ingest_context, session_claims, session_claim_revision) = match cursor {
             Some(cursor) => {

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -946,17 +946,11 @@ pub(super) struct SubscriberConnectionState {
     pub(super) serve_dirty: bool,
 }
 
-/// Host topology and the admitted logical scope select query authority.
-/// Trusted transport does not turn a delegated user's scope into SYSTEM.
-pub(super) fn selects_authority_query_source(
-    client_scope_relay: bool,
-    partial_edge_query_host: bool,
-    trust: CommitUnitTrust,
-    subject: AuthorSubject,
-) -> bool {
-    client_scope_relay
-        || (partial_edge_query_host
-            && (trust == CommitUnitTrust::Session || subject != AuthorSubject::SYSTEM))
+/// Missing-body repair must not authorize a new payload from stale policy
+/// inputs. Ordinary Edge queries evaluate locally; explicit repair still asks
+/// Core under the admitted reader, including readers on trusted transports.
+pub(super) fn row_repair_requires_core(trust: CommitUnitTrust, subject: AuthorSubject) -> bool {
+    trust == CommitUnitTrust::Session || subject != AuthorSubject::SYSTEM
 }
 
 /// A valid request awaiting activation of its schema, not a rejected query.
@@ -1646,6 +1640,7 @@ where
     pub(crate) fn set_partial_edge_query_host(&mut self) {
         if let ConnectionLink::Subscriber(state) = &mut self.link {
             state.partial_edge_query_host = true;
+            self.node.borrow_mut().enable_edge_query_serving();
         }
     }
 
@@ -1723,7 +1718,6 @@ where
             peer,
             coverage_groups,
             ingest_context,
-            partial_edge_query_host,
             scope_purposes,
             scope_aggregates,
             serve_dirty,
@@ -1758,12 +1752,7 @@ where
         ) in groups
         {
             let group_subscription = coverage_group_subscription_key(&coverage);
-            let scope_relay = selects_authority_query_source(
-                self.node.borrow().client_relay_scope().is_some(),
-                *partial_edge_query_host,
-                ingest_context.trust,
-                policy_binding.0,
-            );
+            let scope_relay = self.node.borrow().client_relay_scope().is_some();
             peer.set_subscription_policy_binding(group_subscription, policy_binding);
             if awaiting_upstream_settlement {
                 let authority_result_source = self
@@ -4503,9 +4492,7 @@ where
                             }
                             let group_subscription = coverage_group_subscription_key(&coverage);
                             let local_subscriber = *local_receiver;
-                            let scope_relay = selects_authority_query_source(
-                                self.node.borrow().client_relay_scope().is_some(), *partial_edge_query_host,
-                                ingest_context.trust, subscription_policy_binding.0);
+                            let scope_relay = self.node.borrow().client_relay_scope().is_some();
                             let upstream_opts = if local_subscriber || scope_relay {
                                 let mut opts = upstream_register_shape_options(
                                     opts.tier,
@@ -5014,7 +5001,7 @@ where
                                     drop_peer_request(&self.node);
                                     continue;
                                 };
-                                let requires_core = selects_authority_query_source(false, true, ingest_context.trust, binding.0);
+                                let requires_core = row_repair_requires_core(ingest_context.trust, binding.0);
                                 super::row_version_repairs::enqueue_authority_repair(
                                     pending_authority_repairs, requests, binding, *session_claim_revision, requires_core,
                                 )?;

--- a/crates/jazz/src/db/reads.rs
+++ b/crates/jazz/src/db/reads.rs
@@ -447,7 +447,7 @@ where
                 ));
             }
             let snapshot = match authorization_mode {
-                QueryAuthorizationMode::TrustedServing => {
+                QueryAuthorizationMode::TrustedServing | QueryAuthorizationMode::EdgeServing => {
                     node.query_relation_snapshot_for_serving_in_read_view(
                         &prepared.shape,
                         &prepared.binding,
@@ -486,7 +486,10 @@ where
                 )
                 .await
             }
-            (false, QueryAuthorizationMode::TrustedServing) => {
+            (
+                false,
+                QueryAuthorizationMode::TrustedServing | QueryAuthorizationMode::EdgeServing,
+            ) => {
                 node.query_rows_with_prepared_plan_for_identity(
                     &prepared.shape,
                     &prepared.binding,

--- a/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
+++ b/crates/jazz/src/db/tests/peer_connection/admission_and_fates.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::db::peer_connection::{
     ConnectionLink, PendingRowVersionFetch, PendingSubscriberControlResponse,
     coverage_group_subscription_key, dispatch_admitted_subscriber_message,
-    selects_authority_query_source,
+    row_repair_requires_core,
 };
 use crate::node::SKEW_TOLERANCE_MS;
 
@@ -5730,17 +5730,16 @@ fn delegated_request_binding_requires_backend_client_link() {
 // Internal: this matrix pins host admission independently of wire declarations;
 // the reconnect test exercises its observable confidentiality consequence.
 #[test]
-fn partial_edge_query_source_uses_effective_scope_not_transport_trust() {
+fn partial_edge_row_repair_uses_effective_scope_not_transport_trust() {
     let alice = AuthorSubject::for_test_bytes([0x71; 16]);
     for trust in [
         CommitUnitTrust::Session,
         CommitUnitTrust::TrustedBackend,
         CommitUnitTrust::TrustedAuthority,
     ] {
-        assert!(selects_authority_query_source(false, true, trust, alice));
-        assert!(!selects_authority_query_source(false, false, trust, alice));
+        assert!(row_repair_requires_core(trust, alice));
         assert_eq!(
-            selects_authority_query_source(false, true, trust, AuthorSubject::SYSTEM),
+            row_repair_requires_core(trust, AuthorSubject::SYSTEM),
             trust == CommitUnitTrust::Session
         );
     }
@@ -5811,6 +5810,17 @@ fn remote_query_delivery(
         cells("unverified shared bytes", false, alice),
     )
     .unwrap();
+    let forbidden = row(0x78);
+    edge.insert_with_id(
+        "todos",
+        forbidden,
+        cells(
+            "another reader",
+            false,
+            AuthorSubject::for_test_bytes([0x79; 16]),
+        ),
+    )
+    .unwrap();
     let shape = Query::from("todos").validate(&schema).unwrap();
     let binding = shape.bind(BTreeMap::new()).unwrap();
     let opts = RegisterShapeOptions {
@@ -5854,7 +5864,7 @@ fn remote_query_delivery(
         .unwrap();
     let delegated_session = delegated.then(|| crate::protocol::DelegatedSessionBinding {
         identity: alice,
-        claims: BTreeMap::new(),
+        claims: test_provider_claims(alice),
     });
     let request = SyncMessage::Subscribe(Subscribe {
         shape_id: shape.shape_id(),
@@ -5876,6 +5886,15 @@ fn remote_query_delivery(
             if let SyncMessage::ViewUpdate(view) = message {
                 for carrier in view.version_carriers {
                     for bundle in carrier.bundle_refs().unwrap() {
+                        if !matches!(client_scope, QueryTestClient::System) {
+                            assert!(
+                                !bundle
+                                    .versions
+                                    .iter()
+                                    .any(|version| version.row_uuid() == forbidden),
+                                "local Edge evaluation must narrow payloads under the admitted reader"
+                            );
+                        }
                         emitted |= bundle
                             .versions
                             .iter()
@@ -5913,39 +5932,27 @@ fn remote_queries_cannot_disable_upstream_propagation() {
     }
 }
 
+// Internal transport fixture isolates local serving from upstream hydration:
+// no Core is connected. The Edge must evaluate cached data under the admitted
+// reader instead of waiting for a selected Core result for this exact query.
 #[test]
-fn partial_edge_lower_tier_still_requires_selected_authority_source() {
-    assert!(
-        !remote_query_delivery(
-            true,
-            DurabilityTier::Local,
-            QueryTestHost::PartialEdge,
-            QueryTestClient::Session
-        )
-        .0
-    );
-}
-
-#[test]
-fn partial_edge_default_waits_for_core_and_system_keeps_cache() {
-    assert_eq!(
-        remote_query_delivery(
-            true,
-            DurabilityTier::Global,
-            QueryTestHost::PartialEdge,
-            QueryTestClient::Session
-        ),
-        (false, false)
-    );
-    assert_eq!(
-        remote_query_delivery(
-            true,
-            DurabilityTier::Global,
-            QueryTestHost::PartialEdge,
-            QueryTestClient::System
-        ),
-        (true, false)
-    );
+fn partial_edge_evaluates_cached_queries_without_selected_core_source() {
+    for client in [
+        QueryTestClient::Session,
+        QueryTestClient::Delegated,
+        QueryTestClient::System,
+    ] {
+        assert_eq!(
+            remote_query_delivery(
+                true,
+                DurabilityTier::Global,
+                QueryTestHost::PartialEdge,
+                client,
+            ),
+            (true, false),
+            "{client:?}"
+        );
+    }
 }
 
 // Rust equivalent of a memory-only browser foreground: LocalOnly can read its

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -1154,7 +1154,7 @@ where
                 )
                 .await
                 .map_err(Error::from)?,
-            QueryAuthorizationMode::TrustedServing => node
+            QueryAuthorizationMode::TrustedServing | QueryAuthorizationMode::EdgeServing => node
                 .tx_relation_snapshot_for_identity_with_options(
                     tx_id,
                     &prepared.shape,
@@ -1190,7 +1190,7 @@ where
                 )
                 .await
                 .map_err(Error::from)?,
-            QueryAuthorizationMode::TrustedServing => node
+            QueryAuthorizationMode::TrustedServing | QueryAuthorizationMode::EdgeServing => node
                 .tx_query_for_identity_with_options(
                     tx_id,
                     &prepared.shape,

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -115,6 +115,9 @@ struct VersionDecodePlan {
 
 #[derive(Clone, Debug)]
 pub(crate) struct MaintainedSubscriptionView {
+    /// Keep reader exclusion inputs alive until the final serving view closes.
+    pub(crate) edge_availability_owner:
+        Option<std::sync::Arc<super::query_eval::EdgeAvailabilityOwner>>,
     /// The immutable resolved read-view identity of this maintained program.
     /// Terminal row members must retain it so distinct branch views never
     /// collapse when their source row and transaction coincide.
@@ -175,6 +178,7 @@ pub(crate) struct MaintainedSubscriptionView {
 impl Default for MaintainedSubscriptionView {
     fn default() -> Self {
         Self {
+            edge_availability_owner: None,
             read_view: Default::default(),
             witness_table_names: BTreeMap::new(),
             result_weights: BTreeMap::new(),

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -844,6 +844,10 @@ struct QueryServing {
         query_eval::LocalAvailabilityRecord,
     >,
     local_availability_authorities: BTreeMap<PolicyBindingKey, (NodeUuid, u64)>,
+    /// A serving scope remains live while any maintained Edge view uses it.
+    edge_availability_owners:
+        BTreeMap<PolicyBindingKey, std::sync::Weak<query_eval::EdgeAvailabilityOwner>>,
+    edge_availability_retirements: std::sync::Arc<std::sync::Mutex<VecDeque<PolicyBindingKey>>>,
     /// Runtime-only, exact-context app-read exclusions. These do not change
     /// stored payloads or serving-side permission proofs.
     local_unavailable_inputs: BTreeMap<

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -530,6 +530,8 @@ pub struct NodeState<S> {
     /// Disabled unless a core serving shell owns the complete policy inputs.
     /// This is runtime capability, never wire or durable authorization evidence.
     authoritative_scalar_exit_refresh: bool,
+    /// Host-selected Edge query serving; never inferred from peer declarations.
+    edge_query_serving: bool,
     /// Durability recorded for commits authored by this process.
     ///
     /// Ordinary storage-backed nodes author at `Local`. A browser main-thread

--- a/crates/jazz/src/node/query_engine/input.rs
+++ b/crates/jazz/src/node/query_engine/input.rs
@@ -28,6 +28,8 @@ pub(crate) struct QueryProgramRequest {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum QueryAuthorizationMode {
     TrustedServing,
+    /// Evaluate policy locally, additionally honoring verified upstream denials.
+    EdgeServing,
     ClientLocal,
 }
 

--- a/crates/jazz/src/node/query_engine/lowering/terminals.rs
+++ b/crates/jazz/src/node/query_engine/lowering/terminals.rs
@@ -1857,7 +1857,7 @@ fn lowered_aggregate_terminals(
     // Retaining an authority ResultPayload here would reintroduce a second
     // truth path for aggregates.
     let authority_publishes_covered_inputs = request.authorization_mode
-        == QueryAuthorizationMode::TrustedServing
+        != QueryAuthorizationMode::ClientLocal
         && request
             .output
             .facts

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -897,8 +897,7 @@ where
         // local execution must lower concrete bindings into its locally
         // available (already upstream-scoped at Edge/Global) data, rather
         // than trying to evaluate a server-maintained binding graph.
-        let use_prepared_binding_source = authorization_mode
-            == QueryAuthorizationMode::TrustedServing
+        let use_prepared_binding_source = authorization_mode != QueryAuthorizationMode::ClientLocal
             && !force_inline_binding_source
             && self.can_use_prepared_current_query_plan(shape)
             && settled_binding_view.is_none()
@@ -1375,7 +1374,7 @@ where
             // A serving node evaluates its complete authority program. A
             // `SettledBindingView` is a receiver-local CoveredInput source,
             // not a server-side cache or an alternate trusted read path.
-            QueryAuthorizationMode::TrustedServing => None,
+            QueryAuthorizationMode::TrustedServing | QueryAuthorizationMode::EdgeServing => None,
         };
         // Ordinary Edge/Global reads are allowed to consume only a source
         // binding view registered by upstream coverage. A client-local plan
@@ -2486,7 +2485,7 @@ where
                 self.prepare_client_subscription_binding(shape, binding, tier, identity)
                     .await
             }
-            QueryAuthorizationMode::TrustedServing => {
+            QueryAuthorizationMode::TrustedServing | QueryAuthorizationMode::EdgeServing => {
                 self.prepare_trusted_subscription_binding(shape, binding, tier, identity)
                     .await
             }
@@ -2895,7 +2894,7 @@ where
                     self.query_rows_for_client(shape, binding, tier, identity)
                         .await?
                 }
-                QueryAuthorizationMode::TrustedServing => {
+                QueryAuthorizationMode::TrustedServing | QueryAuthorizationMode::EdgeServing => {
                     self.query_rows_with_prepared_plan_for_identity(
                         shape, binding, tier, None, identity,
                     )
@@ -2913,7 +2912,7 @@ where
                 self.query_relation_snapshot_for_client(shape, binding, tier, identity, read_view)
                     .await
             }
-            QueryAuthorizationMode::TrustedServing => {
+            QueryAuthorizationMode::TrustedServing | QueryAuthorizationMode::EdgeServing => {
                 self.query_relation_snapshot_for_serving_in_read_view(
                     shape, binding, tier, identity, read_view,
                 )
@@ -3192,7 +3191,7 @@ where
                 permission_subject: bound_identity,
                 ..
             } => {
-                if matches!(authorization_mode, QueryAuthorizationMode::TrustedServing)
+                if authorization_mode != QueryAuthorizationMode::ClientLocal
                     && identity != bound_identity
                 {
                     return Err(Error::OpenTransactionIdentityMismatch);
@@ -3205,7 +3204,7 @@ where
                 permission_subject: Some(bound_identity),
                 ..
             } => {
-                if matches!(authorization_mode, QueryAuthorizationMode::TrustedServing)
+                if authorization_mode != QueryAuthorizationMode::ClientLocal
                     && identity != bound_identity
                 {
                     return Err(Error::OpenTransactionIdentityMismatch);
@@ -3403,9 +3402,15 @@ where
         )
     }
 
+    pub(crate) fn enable_edge_query_serving(&mut self) {
+        self.edge_query_serving = true;
+    }
+
     pub(crate) fn peer_query_authorization_mode(&self) -> QueryAuthorizationMode {
         if self.client_relay_scope().is_some() {
             QueryAuthorizationMode::ClientLocal
+        } else if self.edge_query_serving {
+            QueryAuthorizationMode::EdgeServing
         } else {
             QueryAuthorizationMode::TrustedServing
         }

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -10,6 +10,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::time::Instant;
+pub(crate) use unavailable_inputs::EdgeAvailabilityOwner;
 
 use groove::ivm::SubscriptionEvent as GrooveSubscriptionEvent;
 use groove::ivm::{
@@ -3721,6 +3722,18 @@ where
             prepared_claim_binding_mode,
             false,
         )?;
+        // Acquire before compiling the input graph, including across cold
+        // storage awaits. On failure the temporary owner drops; on success
+        // the maintained view retains it for its complete serving lifetime.
+        let edge_availability_owner = if authorization_mode == QueryAuthorizationMode::EdgeServing
+            || (self.edge_query_serving
+                && authorization_mode == QueryAuthorizationMode::ClientLocal)
+        {
+            unavailable_inputs::local_unavailable_policy_binding(&request)
+                .map(|scope| self.pin_edge_availability_scope(scope))
+        } else {
+            None
+        };
         if let Some(authority_result_key) = settled_authority_result_key.as_ref() {
             for source in request.reads.primary.sources.values_mut() {
                 if let SourceExpr::SettledBindingView {
@@ -3870,6 +3883,7 @@ where
             eprintln!("JAZZ_COVERED_INPUT_TRACE stage=receiver_subscription_opened");
         }
         let mut maintained = MaintainedSubscriptionView::default();
+        maintained.edge_availability_owner = edge_availability_owner;
         maintained.set_read_view(read_view_key);
         // Resolve names from permanent physical catalogue identities, never
         // from equal row UUIDs or a search for the first matching table label.

--- a/crates/jazz/src/node/query_eval/lowering.rs
+++ b/crates/jazz/src/node/query_eval/lowering.rs
@@ -568,6 +568,18 @@ where
         covered_input_descriptors: BTreeMap<SourceId, RecordDescriptor>,
         count_access_path_metrics: bool,
     ) -> Result<QueryProgram, Error> {
+        // Preflight-only compilation also owns its temporary Edge inputs.
+        // Actual maintained views hold a second owner across their lifetime.
+        let _edge_availability_owner = if request.authorization_mode
+            == QueryAuthorizationMode::EdgeServing
+            || (self.edge_query_serving
+                && request.authorization_mode == QueryAuthorizationMode::ClientLocal)
+        {
+            unavailable_inputs::local_unavailable_policy_binding(&request)
+                .map(|scope| self.pin_edge_availability_scope(scope))
+        } else {
+            None
+        };
         self.restore_expired_policy_compilation_state();
         if std::env::var_os("JAZZ_COVERED_INPUT_TRACE").is_some()
             && !covered_input_sources.is_empty()

--- a/crates/jazz/src/node/query_eval/tests/unavailable_inputs.rs
+++ b/crates/jazz/src/node/query_eval/tests/unavailable_inputs.rs
@@ -1150,3 +1150,134 @@ fn local_availability_readmission_after_restart_uses_incarnation_not_epoch_order
     );
     assert_eq!(parent_ids(&mut node, &schema, alice).len(), 2);
 }
+
+/// Internal lifecycle control retains live graphs while closing hundreds of
+/// siblings. Results and subsequent live updates detect premature retirement.
+#[test]
+fn edge_serving_scope_churn_reclaims_closed_inputs_without_retiring_live_siblings() {
+    let (_dir, mut node, schema) = fixture();
+    node.enable_edge_query_serving();
+    let alice = author(1);
+    let scope = node.local_read_policy_binding(alice).unwrap();
+    node.set_local_row_unavailable(&scope, "parents", row(1), true)
+        .unwrap();
+    let shape = Query::from("parents").validate(&schema).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let (mut live, initial) = node
+        .open_maintained_view_subscription_in_authorization_mode(
+            &shape,
+            &binding,
+            alice,
+            DurabilityTier::Global,
+            &ReadViewSpec::default(),
+            None,
+            QueryAuthorizationMode::EdgeServing,
+        )
+        .unwrap();
+    assert_eq!(initial.root_count, 1);
+    let bob = author(2);
+    let (mut local_live, initial) = node
+        .open_maintained_view_subscription_in_authorization_mode(
+            &shape,
+            &binding,
+            bob,
+            DurabilityTier::Local,
+            &ReadViewSpec::default(),
+            None,
+            QueryAuthorizationMode::ClientLocal,
+        )
+        .unwrap();
+    assert_eq!(initial.root_count, 2);
+    for index in 0..(crate::authorization_scope::MAX_AUTHORIZATION_SCOPES + 4) {
+        let mut bytes = [0x9a; 16];
+        bytes[..8].copy_from_slice(&(index as u64).to_le_bytes());
+        let reader = AuthorSubject::for_test_bytes(bytes);
+        let (temporary, initial) = node
+            .open_maintained_view_subscription_in_authorization_mode(
+                &shape,
+                &binding,
+                reader,
+                DurabilityTier::Global,
+                &ReadViewSpec::default(),
+                None,
+                QueryAuthorizationMode::EdgeServing,
+            )
+            .unwrap();
+        assert_eq!(initial.root_count, 2, "reader {index}");
+        node.database.unsubscribe(temporary.subscription.id());
+        drop(temporary);
+    }
+    assert!(
+        node.query.local_unavailable_inputs.len() < 8,
+        "closed empty scopes must not accumulate"
+    );
+    node.set_local_row_unavailable(&scope, "parents", row(1), false)
+        .unwrap();
+    assert!(
+        node.drain_local_maintained_view_subscription(&mut live, None)
+            .unwrap()
+            .is_some()
+    );
+    let bob_scope = node.local_read_policy_binding(bob).unwrap();
+    node.set_local_row_unavailable(&bob_scope, "parents", row(1), true)
+        .unwrap();
+    assert!(
+        node.drain_local_maintained_view_subscription(&mut local_live, None)
+            .unwrap()
+            .is_some()
+    );
+    node.database.unsubscribe(live.subscription.id());
+    node.database.unsubscribe(local_live.subscription.id());
+}
+
+/// Capability checks can be abandoned before Subscribe opens its evaluator.
+#[test]
+fn edge_serving_preflight_churn_reclaims_unowned_inputs() {
+    let (_dir, mut node, schema) = fixture();
+    let shape = Query::from("parents").validate(&schema).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    for index in 0..(crate::authorization_scope::MAX_AUTHORIZATION_SCOPES + 4) {
+        let mut bytes = [0x9b; 16];
+        bytes[..8].copy_from_slice(&(index as u64).to_le_bytes());
+        node.ensure_peer_maintained_subscription_view_supported(
+            &shape,
+            &binding,
+            DurabilityTier::Global,
+            AuthorSubject::for_test_bytes(bytes),
+            &ReadViewSpec::default(),
+            QueryAuthorizationMode::EdgeServing,
+        )
+        .unwrap();
+    }
+    assert!(node.query.local_unavailable_inputs.len() < 4);
+}
+
+/// The advice cache's fixed request quota must not cap live Edge readers.
+#[test]
+fn edge_serving_more_than_advice_quota_live_readers_remain_independent() {
+    let (_dir, mut node, schema) = fixture();
+    let shape = Query::from("parents").validate(&schema).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let mut readers = Vec::new();
+    for index in 0..(crate::authorization_scope::MAX_AUTHORIZATION_SCOPES + 4) {
+        let mut bytes = [0x9c; 16];
+        bytes[..8].copy_from_slice(&(index as u64).to_le_bytes());
+        let reader = AuthorSubject::for_test_bytes(bytes);
+        let (live, initial) = node
+            .open_maintained_view_subscription_in_authorization_mode(
+                &shape,
+                &binding,
+                reader,
+                DurabilityTier::Global,
+                &ReadViewSpec::default(),
+                None,
+                QueryAuthorizationMode::EdgeServing,
+            )
+            .unwrap();
+        assert_eq!(initial.root_count, 2, "reader {index}");
+        readers.push(live);
+    }
+    for live in readers {
+        node.database.unsubscribe(live.subscription.id());
+    }
+}

--- a/crates/jazz/src/node/query_eval/unavailable_inputs.rs
+++ b/crates/jazz/src/node/query_eval/unavailable_inputs.rs
@@ -18,6 +18,25 @@ pub(crate) struct LocalUnavailableInput {
     rows: BTreeSet<RowUuid>,
 }
 
+/// Final-owner drop queues reclamation without borrowing the node or running
+/// storage work. Arc preserves PeerState's cross-thread ownership contract.
+#[derive(Debug)]
+pub(crate) struct EdgeAvailabilityOwner {
+    scope: PolicyBindingKey,
+    retirements: std::sync::Weak<std::sync::Mutex<VecDeque<PolicyBindingKey>>>,
+}
+
+impl Drop for EdgeAvailabilityOwner {
+    fn drop(&mut self) {
+        if let Some(queue) = self.retirements.upgrade() {
+            queue
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .push_back(self.scope.clone());
+        }
+    }
+}
+
 fn descriptor() -> RecordDescriptor {
     RecordDescriptor::new([("row_uuid", ValueType::Uuid)])
 }
@@ -185,6 +204,12 @@ impl<S: OrderedKvStorage> NodeState<S> {
         &self,
         scope: &PolicyBindingKey,
     ) -> Result<(), Error> {
+        // Serving graph ownership is bounded by normal query/connection
+        // admission and reclaimed on close, not by the request-only advice
+        // cache's 256-context budget. Do not cap an Edge at 256 readers.
+        if self.query.edge_availability_owners.contains_key(scope) {
+            return Ok(());
+        }
         let live_scopes = self
             .query
             .local_unavailable_inputs
@@ -194,6 +219,7 @@ impl<S: OrderedKvStorage> NodeState<S> {
             })
             .map(|((scope, _), _)| scope)
             .chain(self.query.local_availability_authorities.keys())
+            .filter(|key| !self.query.edge_availability_owners.contains_key(*key))
             .collect::<BTreeSet<_>>();
         if !live_scopes.contains(scope)
             && live_scopes.len() >= crate::authorization_scope::MAX_AUTHORIZATION_SCOPES
@@ -203,11 +229,68 @@ impl<S: OrderedKvStorage> NodeState<S> {
         Ok(())
     }
 
+    pub(super) fn pin_edge_availability_scope(
+        &mut self,
+        scope: PolicyBindingKey,
+    ) -> std::sync::Arc<EdgeAvailabilityOwner> {
+        if let Some(owner) = self
+            .query
+            .edge_availability_owners
+            .get(&scope)
+            .and_then(std::sync::Weak::upgrade)
+        {
+            return owner;
+        }
+        let owner = std::sync::Arc::new(EdgeAvailabilityOwner {
+            scope: scope.clone(),
+            retirements: std::sync::Arc::downgrade(&self.query.edge_availability_retirements),
+        });
+        self.query
+            .edge_availability_owners
+            .insert(scope, std::sync::Arc::downgrade(&owner));
+        owner
+    }
+
+    async fn retire_closed_edge_availability_scopes(&mut self) -> Result<(), Error> {
+        loop {
+            let scope = self
+                .query
+                .edge_availability_retirements
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .front()
+                .cloned();
+            let Some(scope) = scope else {
+                return Ok(());
+            };
+            // Keep the queued entry across awaits: cancellation or storage
+            // failure must leave the cleanup retryable by the next owner.
+            if self
+                .query
+                .edge_availability_owners
+                .get(&scope)
+                .is_some_and(|owner| owner.strong_count() == 0)
+            {
+                self.retire_local_availability_scope_inputs(&scope).await?;
+                self.query.edge_availability_owners.remove(&scope);
+                self.query
+                    .local_unavailable_inputs
+                    .retain(|(key, _), input| key != &scope || !input.rows.is_empty());
+            }
+            self.query
+                .edge_availability_retirements
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .pop_front();
+        }
+    }
+
     async fn local_unavailable_input(
         &mut self,
         scope: &PolicyBindingKey,
         table: crate::ids::GlobalPhysicalTableId,
     ) -> Result<InputSourceId, Error> {
+        self.retire_closed_edge_availability_scopes().await?;
         let key = (scope.clone(), table);
         if let Some(input) = self.query.local_unavailable_inputs.get(&key)
             && input.runtime_token == self.groove_runtime_token

--- a/crates/jazz/src/node/query_eval/unavailable_inputs.rs
+++ b/crates/jazz/src/node/query_eval/unavailable_inputs.rs
@@ -25,7 +25,7 @@ fn descriptor() -> RecordDescriptor {
 pub(super) fn local_unavailable_policy_binding(
     request: &QueryProgramRequest,
 ) -> Option<PolicyBindingKey> {
-    if request.authorization_mode != QueryAuthorizationMode::ClientLocal {
+    if request.authorization_mode == QueryAuthorizationMode::TrustedServing {
         return None;
     }
     policy_binding(&request.policy)

--- a/crates/jazz/src/node/state/lifecycle.rs
+++ b/crates/jazz/src/node/state/lifecycle.rs
@@ -662,6 +662,7 @@ where
             history_complete,
             authored_commit_durability: DurabilityTier::Local,
             authoritative_scalar_exit_refresh: false,
+            edge_query_serving: false,
             relay_authority_session_owner: None,
             pending_persistence: BTreeSet::new(),
             node_aliases: BTreeMap::new(),

--- a/crates/jazz/src/node/state/lifecycle.rs
+++ b/crates/jazz/src/node/state/lifecycle.rs
@@ -623,6 +623,8 @@ where
             query: QueryServing {
                 local_availability_records: BTreeMap::new(),
                 local_availability_authorities: BTreeMap::new(),
+                edge_availability_owners: BTreeMap::new(),
+                edge_availability_retirements: Default::default(),
                 local_unavailable_inputs: BTreeMap::new(),
                 query_shape_cache: BTreeMap::new(),
                 read_policy_authorization_request_cache: BTreeMap::new(),


### PR DESCRIPTION
🤖 Restore the server Edge's responsibility for evaluating queries and read policies over its local data, on top of #2696. Browser/native client relays retain their separate role of consuming exact authority-selected inputs.

Anselm approved merging this stack on 2026-09-09 after local, hosted, packaged, and Cloud acceptance. The focused scope-exit suite passes 16 cases, including new grant-only revocation, shared-cache isolation and same-connection readmission checks. A raw-transport test also proves that an ordinary or delegated reader can receive an authorized cached row from an Edge with no Core connected, while another reader's row is withheld. The 146 peer-protocol tests and nine inherited-policy/revocation tests also pass. Mutation checks prove the cached-serving test detects a return to Core-selected serving and the exclusion test detects ignored Edge denials. The full Rust library suite passes: 1,957 passed, two ignored, zero failures. The final topology rerun also passes all 25 selected tests. Broad acceptance is now complete; results and the remaining intermittent-test investigation are recorded below. The release stack is approved for merge.

## A new query can use the Edge's cache

Alice asks an Edge for unfinished tasks. The Edge has the relevant task data and evaluates the query and Alice's read policy locally. It still forwards the subscription to keep inputs synchronized, but it does not require Core's exact result for this new query before opening its local evaluator.

In #2696, non-SYSTEM scopes on partial server Edges instead take the same selected-source path as a browser worker. This PR removes that restriction for server Edges. Ordinary serving follows the policy inputs received from Core, with the existing network/processing lag, rather than requiring a Core roundtrip for every answer. A verified Core repair denial supersedes stale local policy evidence for that reader. It does not change the browser worker: a client relay cannot infer permissions from its incomplete client cache.

## A task stops matching

Alice has task T with `done = false`. Bob changes it to `done = true`, perhaps while Alice is disconnected. The existing query-driven reconciliation from #2696 notices the extra cached T and obtains its current readable version. The Edge computes the new answer locally and T leaves the unfinished list. Readable repair remains authorized under Alice; it does not blindly fetch fresh shared-cache content as SYSTEM.

## Access disappears without a filter change

Alice can read T through grant G. Bob revokes G and changes T's title, but T remains unfinished. A stale local G must not make an explicit repair disclose T's new title.

The repair still asks Core under Alice's admitted identity and claims. Core returns current-unavailable without the new task content. The Edge now honors that verified decision in its ordinary serving graph, excluding T for Alice. Previously only client-local graphs consumed that decision, so simply restoring Edge evaluation left the old authorized task visible indefinitely.

The shared row is retained. SYSTEM and other readers do not inherit Alice's exclusion. When Core later confirms that T is readable again, the exclusion clears and the same Edge/subscription can readmit T.

A trusted transport can carry this delegated Alice decision; it does not mean the Edge's own SYSTEM account lost access. SYSTEM reconciliation remains query-driven refresh without a user availability marker.

## Responsibilities and boundaries

- Ordinary Edge queries: local evaluation of query predicates and read policies, plus verified upstream reader-specific exclusions.
- Explicit extra-row and missing-body repairs: current Core authorization remains required for non-SYSTEM readers.
- Fresh permission probes and raw policy-proof subplans: ignore the cached exclusion, so a previous denial cannot prevent its own later correction.
- Client relays: retain exact selected-authority inputs and existing scope isolation.
- Remote requests cannot disable upstream propagation. Connection/claims replacement, cancellation, unknown replies and receipt ordering retain #2696's rules.

This does not claim that an Edge can independently authorize arbitrary repair from cached grants. Doing that requires coverage of all relevant authorization inputs. The spike restores ordinary serving while retaining the smaller, conservative repair boundary.

## Reader lifetime and scale

Opening and closing queries must not exhaust a fixed lifetime quota of reader identities. Serving graphs now retain a shared owner for their reader-specific exclusion inputs. Closing the final graph queues those inputs for retirement on the next input allocation; another live query for the same reader keeps them alive. Abandoned capability checks are reclaimed too. Existing unavailable-row markers remain available to seed a later reopening.

Tests keep more than 256 different readers live at once, churn another 260 readers while checking existing subscriptions still update, and repeatedly abandon preflight checks. Removing retirement makes both churn tests fail. This removes the accidental 256-reader ceiling without increasing the request-only advice-cache budget. It is lifecycle coverage, not a throughput benchmark.

## Wire and storage

No wire or storage format changes. The existing postcard control messages, native row encoding and reader-scoped RecordStore availability records are unchanged. The new serving mode is internal compiler/runtime state.

## Validation at `ab40af746a`

The new tests target the distinctions that a simple filter-exit test cannot prove: the task can remain in the filter while access changes; another reader can populate the shared cache; revocation can later be reversed; and a new query must actually evaluate without an exact Core source. Verification:

- Full Rust library suite: 1,957 passed, two existing ignored tests, zero failures (includes all 146 peer-protocol tests and 20 availability-input tests).
- Real native Core/Edge/client topology suites: 16 readable-scope-exit cases, eight inherited-policy cases, one scope-revocation case; all passed.
- Reversible mutation checks: restoring selected-Core serving fails the cached-query test; ignoring Edge denials fails the reader exclusion test; omitting retirement fails both query/preflight churn tests. All mutations restored before final positive runs.
- Clippy, formatting, sensitive-data guard, invariant registry and spec issue-link gates passed. Final committed worktree is clean.

Release acceptance is complete. The full local CI-equivalent gate now passes: 3,869 workspace Rust tests (73 skipped), differential/scenario checks, all target classes, TypeScript/browser consumers, RN bridge tests and native/browser storage compatibility. The producer's three generated fingerprint-literal updates were preserved separately and restored after the gate; implementation source was unchanged.

Hosted and packaged acceptance completed on the unchanged commit:

- [CI](https://github.com/garden-co/jazz/actions/runs/34383800392): all partitions passed. The first React todo canary timeout remains tracked in #2716; the unchanged hosted retry, full local consumer gate, ten focused repetitions and eight full-suite repetitions restricted to four CPUs passed. This is not a causal fix for the original timeout.
- [Android and iOS device acceptance](https://github.com/garden-co/jazz/actions/runs/34384001380): passed. iOS needed an unchanged retry after React Native's dependency archive failed to unpack before app launch.
- [Exact preview publication](https://github.com/garden-co/jazz/actions/runs/34384001869): passed, including freshly installed Android/iOS package-consumer builds. Publication needed an unchanged retry after a multipart-upload whitelist rejection/HTTP 413; the repository was already on the provider's whitelist.
- Four standalone apps installed the exact published `ab40af746af828eb9ffa384c6832f4c4d8af9402` packages. Backend inventory passed prior-preview data reopen, fresh validate/deploy/transaction/delete/restore and server restart.
- External JWT enrollment, login, linking, account isolation, offline access loss and readmission passed through a separate packaged CLI Edge connected to Core.
- Chromium and Linux WebKit passed persisted offline predicate-exit repair, disconnected writes, reconnect upload and reload through that Edge. Backend mutations went directly to Core.
- Installed Android passed prior persisted data after upgrade, immediate readback, offline done-only query exit through Edge, offline deletion surviving force-stop/reopen while Edge was unavailable, then upload after Edge restart.

Fresh Cloud backend, Chromium/Linux WebKit, external-JWT, and Android acceptance passed on the exact ab40 preview; see the acceptance comment below. No physical iPhone Safari test was performed for this spike. Existing related-input/negative-evidence reconciliation limits documented in #2696 remain. All owned adopter services were stopped after acceptance, preserving their test data and receipts. The source worktree is clean. Anselm has approved merging #2678 → #2696 → #2715. Core-restart admission recovery remains separately tracked in #2718 and will be fixed on the new main.

