### PR TITLE
fix(sync): propagate deletions under account ownership policies

### DIFF
--- a/.changeset/account-owned-deletion-sync.md
+++ b/.changeset/account-owned-deletion-sync.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix live synchronization of deleted rows protected by account-based ownership permissions, so other clients remove the deleted row without requiring a reload.

--- a/crates/jazz/src/db/tests/peer_connection/transport_sync.rs
+++ b/crates/jazz/src/db/tests/peer_connection/transport_sync.rs
@@ -1153,6 +1153,229 @@ fn default_current_subscription_reconciles_deletion_witness_without_reset() {
 }
 
 #[test]
+fn default_local_subscription_reconciles_deletion_witness_without_reset() {
+    let schema = schema();
+    let owner = AuthorSubject::for_test_bytes([0x50; 16]);
+    let client_author = AuthorSubject::for_test_bytes([0x51; 16]);
+    let server = open_core(0x52, AuthorSubject::SYSTEM, &schema);
+    let client = open_db(0x53, client_author, &schema);
+    let current_row = RowUuid::from_bytes([0x54; 16]);
+    server
+        .insert_with_id("todos", current_row, cells("current", false, owner))
+        .unwrap();
+    let survivor = RowUuid::from_bytes([0x55; 16]);
+    server
+        .insert_with_id("todos", survivor, cells("survivor", false, owner))
+        .unwrap();
+    let query = Query::from("todos");
+    let current_view = ReadViewSpec::default();
+    assert_eq!(
+        row_ids(&serving_rows_in_read_view(
+            &server,
+            &schema,
+            &query,
+            client_author,
+            &current_view,
+        )),
+        vec![current_row, survivor]
+    );
+
+    let (client_transport, server_transport) = duplex();
+    let _upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let _subscriber = server.accept_subscriber(server_transport, client_author);
+    let mut subscription = prepared_subscribe(&client, &query, ReadOpts::default()).unwrap();
+    assert!(opened_rows(block_on(subscription.next_raw()).unwrap()).is_empty());
+
+    let mut snapshot = RelationSnapshot::default();
+    for _ in 0..10 {
+        client.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        while let Some(event) = subscription.try_next_event() {
+            apply_subscription_event(&mut snapshot, event);
+        }
+        if row_ids(&snapshot.rows) == vec![current_row, survivor] {
+            break;
+        }
+    }
+    assert_eq!(row_ids(&snapshot.rows), vec![current_row, survivor]);
+
+    write_deletion_register(&server, "todos", current_row, BranchSelector::default());
+    let mut saw_removal = false;
+    for _ in 0..10 {
+        server.tick().unwrap();
+        client.tick().unwrap();
+        while let Some(event) = subscription.try_next_event() {
+            match &event {
+                SubscriptionEvent::Delta {
+                    reset,
+                    added,
+                    removed,
+                    ..
+                } => {
+                    assert!(!reset, "deletion-witness reconcile must remain a delta");
+                    assert!(
+                        added.is_empty(),
+                        "default/current deletion reconcile must not add rows"
+                    );
+                    saw_removal |= removed
+                        .iter()
+                        .any(|removed| removed.row_uuid == current_row);
+                }
+                SubscriptionEvent::Rejected { reason } => {
+                    panic!("default/current subscription was rejected: {reason:?}")
+                }
+                SubscriptionEvent::Closed => panic!("default/current subscription closed"),
+            }
+            apply_subscription_event(&mut snapshot, event);
+            assert!(
+                row_ids(&snapshot.rows).contains(&survivor),
+                "every post-delete snapshot must retain the survivor"
+            );
+        }
+        if saw_removal {
+            break;
+        }
+    }
+    assert!(
+        saw_removal,
+        "default/current reconcile must remove the deleted row"
+    );
+    assert_eq!(row_ids(&snapshot.rows), vec![survivor]);
+    let fresh = serving_rows_in_read_view(&server, &schema, &query, client_author, &current_view);
+    assert_eq!(row_ids(&snapshot.rows), row_ids(&fresh));
+}
+
+#[test]
+fn owner_local_subscription_reconciles_peer_delete_without_reset() {
+    let policy = public_session_eq("owner", &["claims", "sub"]);
+    let schema = build_public_db_test_schema(
+        PublicSchemaBuilder::new().table(
+            PublicTableSchemaBuilder::new("todos")
+                .column("title", PublicColumnType::Text)
+                .column("done", PublicColumnType::Boolean)
+                .column("owner", PublicColumnType::Uuid)
+                .policies(public_legacy_write_policy(policy.clone()).with_select(policy)),
+        ),
+    );
+    let owner = AuthorSubject::for_test_bytes([0x50; 16]);
+    let client_author = owner;
+    let server = open_core(0x52, AuthorSubject::SYSTEM, &schema);
+    server.server.enable_authoritative_scalar_exit_refresh();
+    server
+        .node()
+        .borrow_mut()
+        .set_test_provider_claims(owner, test_provider_claims(owner));
+    let writer = open_db(0x56, owner, &schema);
+    let (writer_up, writer_down) = duplex();
+    let _writer_up = block_on(writer.connect_upstream(writer_up));
+    let _writer_down = server.accept_subscriber(writer_down, owner);
+    let client = open_db(0x53, client_author, &schema);
+    let current_row = RowUuid::from_bytes([0x54; 16]);
+    server
+        .insert_with_id("todos", current_row, cells("current", false, owner))
+        .unwrap();
+    let survivor = RowUuid::from_bytes([0x55; 16]);
+    server
+        .insert_with_id("todos", survivor, cells("survivor", false, owner))
+        .unwrap();
+    let query = Query::from("todos");
+    let current_view = ReadViewSpec::default();
+    assert_eq!(
+        row_ids(&serving_rows_in_read_view(
+            &server,
+            &schema,
+            &query,
+            client_author,
+            &current_view,
+        )),
+        vec![current_row, survivor]
+    );
+
+    let (client_transport, server_transport) = duplex();
+    let _upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let _subscriber = server.accept_subscriber(server_transport, client_author);
+    let mut subscription = prepared_subscribe(&client, &query, ReadOpts::default()).unwrap();
+    assert!(opened_rows(block_on(subscription.next_raw()).unwrap()).is_empty());
+
+    let mut snapshot = RelationSnapshot::default();
+    for _ in 0..10 {
+        client.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        while let Some(event) = subscription.try_next_event() {
+            apply_subscription_event(&mut snapshot, event);
+        }
+        if row_ids(&snapshot.rows) == vec![current_row, survivor] {
+            break;
+        }
+    }
+    assert_eq!(row_ids(&snapshot.rows), vec![current_row, survivor]);
+
+    let mut writer_stream = prepared_subscribe(&writer, &query, ReadOpts::default()).unwrap();
+    let mut writer_snapshot = RelationSnapshot::default();
+    for _ in 0..32 {
+        writer.tick().unwrap();
+        server.tick().unwrap();
+        writer.tick().unwrap();
+        while let Some(event) = writer_stream.try_next_event() {
+            apply_subscription_event(&mut writer_snapshot, event);
+        }
+        if row_ids(&writer_snapshot.rows) == vec![current_row, survivor] {
+            break;
+        }
+    }
+    assert_eq!(row_ids(&writer_snapshot.rows), vec![current_row, survivor]);
+    writer
+        .delete("todos", current_row, Default::default())
+        .unwrap();
+    let mut saw_removal = false;
+    for _ in 0..32 {
+        writer.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        while let Some(event) = subscription.try_next_event() {
+            match &event {
+                SubscriptionEvent::Delta {
+                    reset,
+                    added,
+                    removed,
+                    ..
+                } => {
+                    assert!(!reset, "deletion-witness reconcile must remain a delta");
+                    assert!(
+                        added.is_empty(),
+                        "default/current deletion reconcile must not add rows"
+                    );
+                    saw_removal |= removed
+                        .iter()
+                        .any(|removed| removed.row_uuid == current_row);
+                }
+                SubscriptionEvent::Rejected { reason } => {
+                    panic!("default/current subscription was rejected: {reason:?}")
+                }
+                SubscriptionEvent::Closed => panic!("default/current subscription closed"),
+            }
+            apply_subscription_event(&mut snapshot, event);
+            assert!(
+                row_ids(&snapshot.rows).contains(&survivor),
+                "every post-delete snapshot must retain the survivor"
+            );
+        }
+        if saw_removal {
+            break;
+        }
+    }
+    assert!(
+        saw_removal,
+        "default/current reconcile must remove the deleted row"
+    );
+    assert_eq!(row_ids(&snapshot.rows), vec![survivor]);
+    let fresh = serving_rows_in_read_view(&server, &schema, &query, client_author, &current_view);
+    assert_eq!(row_ids(&snapshot.rows), row_ids(&fresh));
+}
+
+#[test]
 fn delayed_row_repair_does_not_replace_a_newer_supporting_snapshot() {
     // INV-SYNC-46: exercise the complete-snapshot receiver contract.
     let schema = schema();

--- a/crates/jazz/src/db/tests/peer_connection/transport_sync.rs
+++ b/crates/jazz/src/db/tests/peer_connection/transport_sync.rs
@@ -1376,6 +1376,178 @@ fn owner_local_subscription_reconciles_peer_delete_without_reset() {
 }
 
 #[test]
+fn account_owned_local_subscription_reconciles_peer_delete_without_reset() {
+    assert_account_owned_subscription_reconciles_peer_delete(ReadOpts::default());
+}
+
+#[test]
+fn account_owned_branch_subscription_reconciles_peer_delete_without_reset() {
+    assert_account_owned_subscription_reconciles_peer_delete(
+        ReadOpts::default().branch_view(BranchSelector::default(), None),
+    );
+}
+
+fn assert_account_owned_subscription_reconciles_peer_delete(opts: ReadOpts) {
+    let policy = public_session_eq("$createdBy.account", &["user", "account"]);
+    let schema = build_public_db_test_schema(
+        PublicSchemaBuilder::new().table(
+            PublicTableSchemaBuilder::new("todos")
+                .column("title", PublicColumnType::Text)
+                .column("done", PublicColumnType::Boolean)
+                .column("owner", PublicColumnType::Uuid)
+                .policies(public_legacy_write_policy(policy.clone()).with_select(policy)),
+        ),
+    );
+    let owner = AuthorSubject::for_test_bytes([0x50; 16]);
+    let client_author = owner;
+    let server = open_core(0x52, owner, &schema);
+    server.server.enable_authoritative_scalar_exit_refresh();
+    server
+        .node()
+        .borrow_mut()
+        .set_test_provider_claims(owner, test_provider_claims(owner));
+    let writer = open_db(0x56, owner, &schema);
+    let (writer_up, writer_down) = duplex();
+    let _writer_up = block_on(writer.connect_upstream(writer_up));
+    let _writer_down = server.accept_subscriber(writer_down, owner);
+    let client = open_db(0x53, client_author, &schema);
+    let current_row = RowUuid::from_bytes([0x54; 16]);
+    server
+        .insert_with_id("todos", current_row, cells("current", false, owner))
+        .unwrap();
+    let survivor = RowUuid::from_bytes([0x55; 16]);
+    server
+        .insert_with_id("todos", survivor, cells("survivor", false, owner))
+        .unwrap();
+    let query = Query::from("todos");
+    let current_view = opts.read_view.clone();
+    assert_eq!(
+        row_ids(&serving_rows_in_read_view(
+            &server,
+            &schema,
+            &query,
+            client_author,
+            &current_view,
+        )),
+        vec![current_row, survivor]
+    );
+
+    let (client_transport, server_transport) = duplex();
+    let _upstream = crate::db::block_on(client.connect_upstream(client_transport));
+    let _subscriber = server.accept_subscriber(server_transport, client_author);
+    let mut subscription = prepared_subscribe(&client, &query, opts.clone()).unwrap();
+    assert!(opened_rows(block_on(subscription.next_raw()).unwrap()).is_empty());
+
+    let mut snapshot = RelationSnapshot::default();
+    for _ in 0..10 {
+        client.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        while let Some(event) = subscription.try_next_event() {
+            apply_subscription_event(&mut snapshot, event);
+        }
+        if row_ids(&snapshot.rows) == vec![current_row, survivor] {
+            break;
+        }
+    }
+    assert_eq!(row_ids(&snapshot.rows), vec![current_row, survivor]);
+
+    let mut writer_stream = prepared_subscribe(&writer, &query, opts).unwrap();
+    let mut writer_snapshot = RelationSnapshot::default();
+    for _ in 0..32 {
+        writer.tick().unwrap();
+        server.tick().unwrap();
+        writer.tick().unwrap();
+        while let Some(event) = writer_stream.try_next_event() {
+            apply_subscription_event(&mut writer_snapshot, event);
+        }
+        if row_ids(&writer_snapshot.rows) == vec![current_row, survivor] {
+            break;
+        }
+    }
+    assert_eq!(row_ids(&writer_snapshot.rows), vec![current_row, survivor]);
+    writer
+        .update(
+            "todos",
+            current_row,
+            BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+            Default::default(),
+        )
+        .unwrap();
+    for _ in 0..32 {
+        writer.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        while let Some(event) = subscription.try_next_event() {
+            apply_subscription_event(&mut snapshot, event);
+        }
+    }
+    assert_eq!(
+        snapshot
+            .rows
+            .iter()
+            .find(|row| row.row_uuid() == current_row)
+            .unwrap()
+            .application_field("done"),
+        Some(Value::Nullable(Some(Box::new(Value::Bool(true)))))
+    );
+    let survivor_before = snapshot
+        .rows
+        .iter()
+        .find(|row| row.row_uuid() == survivor)
+        .unwrap()
+        .clone();
+    writer
+        .delete("todos", current_row, Default::default())
+        .unwrap();
+    let mut saw_removal = false;
+    for _ in 0..32 {
+        writer.tick().unwrap();
+        server.tick().unwrap();
+        client.tick().unwrap();
+        while let Some(event) = subscription.try_next_event() {
+            match &event {
+                SubscriptionEvent::Delta {
+                    reset,
+                    added,
+                    removed,
+                    ..
+                } => {
+                    assert!(!reset, "deletion-witness reconcile must remain a delta");
+                    assert!(
+                        added.is_empty(),
+                        "default/current deletion reconcile must not add rows"
+                    );
+                    saw_removal |= removed
+                        .iter()
+                        .any(|removed| removed.row_uuid == current_row);
+                }
+                SubscriptionEvent::Rejected { reason } => {
+                    panic!("default/current subscription was rejected: {reason:?}")
+                }
+                SubscriptionEvent::Closed => panic!("default/current subscription closed"),
+            }
+            apply_subscription_event(&mut snapshot, event);
+            assert_eq!(
+                snapshot.rows.iter().find(|row| row.row_uuid() == survivor),
+                Some(&survivor_before),
+                "every post-delete snapshot must retain the exact survivor"
+            );
+        }
+        if saw_removal {
+            break;
+        }
+    }
+    assert!(
+        saw_removal,
+        "default/current reconcile must remove the deleted row"
+    );
+    assert_eq!(row_ids(&snapshot.rows), vec![survivor]);
+    let fresh = serving_rows_in_read_view(&server, &schema, &query, client_author, &current_view);
+    assert_eq!(row_ids(&snapshot.rows), row_ids(&fresh));
+}
+
+#[test]
 fn delayed_row_repair_does_not_replace_a_newer_supporting_snapshot() {
     // INV-SYNC-46: exercise the complete-snapshot receiver contract.
     let schema = schema();

--- a/crates/jazz/src/node/query_eval/read_sources.rs
+++ b/crates/jazz/src/node/query_eval/read_sources.rs
@@ -502,15 +502,22 @@ where
                             .graph
                     }
                 };
+                let (graph, descriptor, metadata) = with_requested_author_paths(
+                    graph,
+                    include_deleted_current_row_descriptor(&table),
+                    BTreeMap::new(),
+                    &request.requirements,
+                )
+                .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?;
                 return Ok(ResolvedSource {
                     stored_column_ids: self.stored_column_ids_for_read_table(request, &table)?,
                     table_schema: table.clone(),
                     graph,
                     row_shape: SourceRowShape {
                         source: request.source.clone(),
-                        descriptor: include_deleted_current_row_descriptor(&table),
+                        descriptor,
                         row_uuid_field: "row_uuid".to_owned(),
-                        metadata: BTreeMap::new(),
+                        metadata,
                     },
                     routing_fields: BTreeSet::new(),
                     requires_result_payload: false,
@@ -1588,6 +1595,15 @@ where
             )
             .map_err(|error| source_resolution_error_from_policy_proof(request, error))?
         };
+        // Own pending deletions carry only winner coordinates and need no
+        // read-policy proof. Never manufacture author data for that overlay.
+        let (graph, descriptor, metadata) =
+            if request.visibility == RowVisibility::IncludeDeleted && !pending_overlay {
+                with_requested_author_paths(graph, descriptor, metadata, &request.requirements)
+                    .map_err(|_| source_resolution_error(request, SourceGap::Coverage))?
+            } else {
+                (graph, descriptor, metadata)
+            };
         let deletion_register = if snapshot_source {
             // The snapshot is immutable and already excludes rows whose
             // deletion winner is visible at its cut. It cannot later need a
@@ -3520,6 +3536,64 @@ pub(super) fn trace_capability_compile(
         "backtrace:\n{}",
         std::backtrace::Backtrace::force_capture()
     );
+}
+
+/// Expose requested nested-author fields on policy preimages that retain
+/// complete author records, including head-over-current branch preimages.
+fn with_requested_author_paths(
+    graph: GraphBuilder,
+    descriptor: RecordDescriptor,
+    mut metadata: BTreeMap<SourceMetadataRequirement, SourceMetadataFields>,
+    requirements: &SourceRequirements,
+) -> Result<
+    (
+        GraphBuilder,
+        RecordDescriptor,
+        BTreeMap<SourceMetadataRequirement, SourceMetadataFields>,
+    ),
+    Error,
+> {
+    let missing = requirements
+        .metadata
+        .iter()
+        .filter_map(|requirement| match requirement {
+            SourceMetadataRequirement::AuthorPath(name) if !metadata.contains_key(requirement) => {
+                Some(name.clone())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok((graph, descriptor, metadata));
+    }
+    let mut fields = descriptor.fields().to_vec();
+    let mut projection = descriptor_field_names(&descriptor)?
+        .into_iter()
+        .map(ProjectField::named)
+        .collect::<Vec<_>>();
+    for name in missing {
+        let (root, path) = AuthorSubject::metadata_path(&name).expect("validated author path");
+        projection.push(ProjectField::record_field(
+            root,
+            path.iter().copied(),
+            name.clone(),
+        ));
+        fields.push(records::DescriptorField::new(
+            name.clone(),
+            AuthorSubject::metadata_type(&name)
+                .expect("validated author path")
+                .clone(),
+        ));
+        metadata.insert(
+            SourceMetadataRequirement::AuthorPath(name.clone()),
+            SourceMetadataFields::Provenance { field: name },
+        );
+    }
+    Ok((
+        graph.project_fields(projection),
+        RecordDescriptor::new_with_fields(fields),
+        metadata,
+    ))
 }
 
 fn resolved_current_source_graph<S>(

--- a/packages/jazz-tools/tests/browser/db.disconnect.test.ts
+++ b/packages/jazz-tools/tests/browser/db.disconnect.test.ts
@@ -128,6 +128,83 @@ describe("Db disconnect/reconnect", () => {
     60_000,
   );
 
+  it("removes a remotely deleted owned row from the current default local worker snapshot", async () => {
+    const label = uniqueDbName("local-worker-live-delete");
+    const server = await getJazzServerInfo(label);
+    await deploy({
+      ...server,
+      schema: app,
+      permissions: s.definePermissions(app, ({ policy, session }) => {
+        policy.todos.allowRead.where({ "$createdBy.account": session.user.account });
+        policy.todos.allowInsert.always();
+        policy.todos.allowUpdate.where({ "$createdBy.account": session.user.account });
+        policy.todos.allowDelete.where({ "$createdBy.account": session.user.account });
+      }),
+    });
+    const secret = generateAuthSecret();
+    const db = await createWorkerDb(ctx, `${label}-reader`, secret, server);
+    const peer = await createWorkerDb(ctx, `${label}-writer`, secret, server);
+    let current: Todo[] = [];
+    let preserveSurvivor = false;
+    const subsequentSnapshots: Todo[][] = [];
+    ctx.trackSubscription(
+      db.subscribe(todos, (rows) => {
+        current = rows;
+        if (preserveSurvivor) subsequentSnapshots.push(rows);
+      }),
+    );
+    const row = await db.insert(todos, { title: label, done: false }).wait({ tier: "global" });
+    const survivor = await db
+      .insert(todos, { title: `${label}-survivor`, done: false })
+      .wait({ tier: "global" });
+    await waitForCondition(
+      async () => current.some((item) => item.id === row.id),
+      SYNC_OPERATION_TIMEOUT_MS,
+      "reader must first show the row",
+    );
+    let peerCurrent: Todo[] = [];
+    ctx.trackSubscription(
+      peer.subscribe(todos, (rows) => {
+        peerCurrent = rows;
+      }),
+    );
+    await waitForCondition(
+      async () =>
+        peerCurrent.some((item) => item.id === row.id) &&
+        peerCurrent.some((item) => item.id === survivor.id),
+      SYNC_OPERATION_TIMEOUT_MS,
+      "writer must hydrate both rows through default local query",
+    );
+    await peer.update(todos, row.id, { done: true }).wait({ tier: "global" });
+    await waitForCondition(
+      async () =>
+        current.some((item) => item.id === row.id && item.title === label && item.done) &&
+        current.some(
+          (item) => item.id === survivor.id && item.title === `${label}-survivor` && !item.done,
+        ),
+      SYNC_OPERATION_TIMEOUT_MS,
+      "reader must see the remote update before deletion",
+    );
+    preserveSurvivor = true;
+    await peer.delete(todos, row.id).wait({ tier: "global" });
+    await waitForCondition(
+      async () =>
+        !current.some((item) => item.id === row.id) &&
+        current.some(
+          (item) => item.id === survivor.id && item.title === `${label}-survivor` && !item.done,
+        ),
+      SYNC_OPERATION_TIMEOUT_MS,
+      "current local subscription must remove target and preserve survivor",
+    );
+    expect(subsequentSnapshots.length).toBeGreaterThan(0);
+    for (const rows of subsequentSnapshots) {
+      expect(rows.find((item) => item.id === survivor.id)).toMatchObject({
+        title: `${label}-survivor`,
+        done: false,
+      });
+    }
+  }, 60_000);
+
   describe("server-backed subscriptions", () => {
     it.each(["edge", "global"] as const)(
       "keeps a disconnected %s subscription pending, then hydrates its local write",


### PR DESCRIPTION
🤖 Fix #2734: deleting an account-owned row in one client now removes that specific row from another client's live local query without a reload.

### Example: two browsers sharing an account

The application grants access using the usual ownership policy:

```ts
policy.todos.allowRead.where({ "$createdBy.account": session.user.account });
policy.todos.allowDelete.where({ "$createdBy.account": session.user.account });
```

Browser A and browser B are signed into the same account. Both show two todos, `target` and `survivor`.

1. B changes `target.done` to `true`. A receives the update normally.
2. B deletes `target`, and the deletion reaches the server.
3. Before this fix, A's existing local query continued to show `target`. Reloading recovered the correct result, but the live client retained its stale row.
4. With this fix, A receives the authorized deletion information and removes `target`. `survivor` remains present and unchanged throughout.

This reproduced against both Cloud and a local CLI server. An equivalent native Rust test also reproduced it, so the cause is shared query evaluation rather than browser rendering or Cloud deployment.

### How deletion delivery works

A row disappearing from a server query is insufficient to tell a client to delete its cached copy: it could have stopped matching the query or become unreadable instead. The server therefore needs explicit, authorized evidence of deletion.

The existing implementation combines two inputs:

- The deletion register identifies the exact deletion transaction, including its row and transaction coordinates.
- A separate `IncludeDeleted` source exposes the retained row content and authorship for evaluating read permission even after deletion. This is the “preimage”: the retained row data against which the policy can be checked. `IncludeDeleted` does not bypass permissions.

`deletion_witness_graph_for_current_register` takes the policy-authorized deleted rows from the second input and matches them to the register on `(row_uuid, tx_time, tx_node_id)`. Only matching deletion records can be delivered. Matching the exact transaction prevents a later deletion from borrowing authorization from an earlier version of the same row.

### What was missing

The ownership policy needs the nested field `$createdBy.account`. The row already retains the full structured author, conceptually:

```text
$createdBy = { account: accountA, iss: issuer, sub: subject }
```

For evaluation, a source must also expose the requested nested field as a projected field, describe its type, and register where the evaluator can find it. Ordinary current-row sources did this. The `IncludeDeleted` sources retained the structured author but omitted that requested projection and its metadata.

Consequently, the ownership-policy path could not produce the authorized deletion evidence needed by the client. Normal reads and checkbox updates worked through ordinary sources; deletion exercised the incomplete source path. A policy based on an ordinary application column such as `owner` did not reproduce this omission, which is why the regression must use the actual `$createdBy.account` policy.

### What this patch changes

`with_requested_author_paths` makes `IncludeDeleted` sources satisfy the same nested-author requirements as ordinary sources. For each requested `AuthorPath` that is not already exposed, it:

1. Projects the nested value from the existing full author record—for example, `account` from `$createdBy`.
2. Adds the corresponding typed field to the row descriptor.
3. Registers that field in the source metadata used by query evaluation.

It preserves the original fields and does nothing when all requested author fields already exist. The helper is applied both to the ordinary `IncludeDeleted` return path and to the separate branch-view path that combines branch-head data with current data.

For the example above, the policy can now obtain `accountA` from the retained author, compare it with the authenticated account, and authorize the exact deletion record. The existing delivery machinery can then update A's cache and live query.

### Boundaries

- Permissions and exact-transaction matching remain unchanged. If the read policy does not authorize a row, this patch does not authorize its deletion evidence or expose hidden content.
- Authorship comes from the retained row record, not from the identity issuing the delete.
- The local overlay for one's own pending deletions is excluded: it carries only winner coordinates, not a full author record. The helper must not manufacture author fields for it.
- Storage and wire formats are unchanged. This repairs runtime source preparation; it does not introduce a new synchronization message or persisted field.

### Verification

The new regressions first establish that both specific row IDs are visible, then delete only `target`. Success requires the current result to exclude `target` while retaining the exact `survivor`. Every subsequent observed snapshot must preserve the survivor, so an empty result or a transient clear-all cannot satisfy the test.

- Persistent browser clients using default local subscriptions: the complete disconnect/reconnect test file passed **19/19**, including pending-deletion cases. The coordinator independently rebuilt the sealed WASM/NAPI artifacts after commit and reran the file: **19/19 passed**.
- Six focused native checks passed, covering account ownership, branch reads, ordinary-column ownership, deletion delivery, readable tombstones, and revoked-owner privacy.
- Reverting the fix while keeping the exact-account regression makes it fail at the target-removal assertion; restoring the fix makes it pass.
- Independent correctness/security review accepted the ordinary, branch, and pending-overlay handling.
