### PR TITLE
fix(groove): wait for hydration temporal predecessors

### DIFF
--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -1541,6 +1541,11 @@ impl<'a> EvaluationSession<'a> {
             if self.requests.has_pending() {
                 return Poll::Pending;
             }
+            if !self.work_queue.temporal_waiting.is_empty() {
+                // Earlier evaluations own the continuation until their shared
+                // nodes are installed and the temporal barriers are released.
+                return Poll::Pending;
+            }
             return Poll::Ready(Err(IvmRuntimeError::EvaluationBlocked));
         }
     }

--- a/crates/groove/tests/async_hydration_session.rs
+++ b/crates/groove/tests/async_hydration_session.rs
@@ -253,6 +253,39 @@ fn cancelling_cold_hydration_releases_a_later_shared_subscription() {
 }
 
 #[test]
+fn shared_hydrations_wait_for_the_predecessor_without_failing() {
+    let (storage, _) = TestStorage::controlled(&["albums"]);
+    let mut database = block_on(Database::new(schema(), storage)).unwrap();
+    let descriptor =
+        RecordDescriptor::new([("id", ColumnType::U64), ("title", ColumnType::String)]);
+    let source = |id| {
+        GraphBuilder::values(
+            descriptor.clone(),
+            [vec![Value::U64(id), Value::String("Album".into())]],
+        )
+        .unwrap()
+    };
+    // A large opening deliberately spans several owner turns. The second
+    // subscription shares a node whose private predecessor is not installed.
+    let waker = noop_waker();
+    let first = database
+        .subscribe_with_waker(
+            (0..256).map(|id| (format!("album_{id}"), source(id))),
+            Some(&waker),
+        )
+        .unwrap();
+    let second = database
+        .subscribe([("shared", source(0)), ("independent", source(256))])
+        .unwrap();
+    block_on(database.drive_progress()).unwrap();
+    let first_rows = block_on(database.next_multisink_subscription(&first)).unwrap();
+    assert_eq!(first_rows.sinks.len(), 256);
+    let second_rows = block_on(database.next_multisink_subscription(&second)).unwrap();
+    assert_eq!(second_rows.sinks["shared"].deltas.len(), 1);
+    assert_eq!(second_rows.sinks["independent"].deltas.len(), 1);
+}
+
+#[test]
 fn write_during_cold_subscription_hydration_is_delivered_exactly_once() {
     let (storage, control) = TestStorage::controlled(&["albums"]);
     let mut database = block_on(Database::new(schema(), storage)).unwrap();


### PR DESCRIPTION
A subscription opened while an earlier, overlapping hydration is still yielding can end with `SubscriptionFailed(Evaluation(EvaluationBlocked))`. All of its storage reads may be ready while shared nodes remain blocked until the predecessor installs its private snapshot. `EvaluationSession::poll` currently treats that temporal wait as an impossible storage stall and fails the subscription.

Return `Pending` while temporal blockers remain. The predecessor retains the continuation and releases the shared nodes after installation; the existing error still covers unfinished work with neither storage requests nor temporal dependencies.

The regression uses public Groove subscription APIs: a 256-sink opening spans owner turns, then a second opening shares one source and adds an independent source. It fails with `EvaluationBlocked` without the change and receives both outputs with it. The full `async_hydration_session` target passes (29 tests), including cancellation, scoped failure, and incremental-write handoff coverage. The Groove library suite also passes (726 tests; two existing tests ignored). Both suites were rerun on this PR head. `cargo clippy --package groove -- -D warnings` and rustfmt pass.

A downstream browser diagnostic also stopped reporting internal subscription errors and delivered an employee-state update through to the next screen with the patched WASM. That diagnostic used an unoptimized build and an extended wait; normal packaged-runtime browser and native verification remain downstream work.

Validation:
```
cargo test -p groove --features test --lib --test async_hydration_session
```
