### PR TITLE
fix(wasm): use exact local row reads for transaction staging

### DIFF
--- a/.changeset/browser-exact-write-merge.md
+++ b/.changeset/browser-exact-write-merge.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Avoid full-table reads when staging browser transaction updates, and prevent failed write-merge reads from leaving patches staged for a later commit.

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ data-multi/
 
 # Lane-local Android SDK, NDK, JDK and emulator cache.
 /.cache/android-device-acceptance/
+# Generated browser benchmark phase receipts.
+packages/jazz-tools/.vitest-browser-bench/

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1957,6 +1957,17 @@ impl WasmDb {
             .map_err(to_js_error)
     }
 
+    /// Exact local state for the write-merge bridge, matching NAPI. Write
+    /// authorization remains at the mutation boundary; this is not a query.
+    #[wasm_bindgen(js_name = localCurrentRow)]
+    pub fn local_current_row(&self, table: String, row_id: Vec<u8>) -> Result<Vec<u8>, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let inner = self.open_inner()?;
+        let row = with_wasm_db!(&inner, |db| block_on(db.local_current_row(&table, row_id)))
+            .map_err(to_js_error)?;
+        encode_rows(&row.into_iter().collect::<Vec<_>>()).map_err(to_js_error)
+    }
+
     #[wasm_bindgen(js_name = prepareQuery)]
     pub fn prepare_query(
         &self,

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1965,7 +1965,7 @@ impl WasmDb {
         let inner = self.open_inner()?;
         let row = with_wasm_db!(&inner, |db| block_on(db.local_current_row(&table, row_id)))
             .map_err(to_js_error)?;
-        encode_rows(&row.into_iter().collect::<Vec<_>>()).map_err(to_js_error)
+        encode_synchronous_rows(&row.into_iter().collect::<Vec<_>>())
     }
 
     #[wasm_bindgen(js_name = prepareQuery)]

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1440,6 +1440,10 @@ export class NativeRuntimeAdapter implements Runtime {
     const patch = encodeCellsForPatch(this.table(table), values);
     if (tx) {
       this.assertTransactionWriteIdentity(tx, attribution ? undefined : writeIdentity);
+      // Resolve the synchronous preimage before staging. A rejected merge
+      // (for example an indirect large value) must not leave a native patch
+      // that a caller can accidentally commit after catching the error.
+      const row = this.mergeRowState(table, rowId, values, tx, writeIdentity);
       this.db.updateInTransaction(tx.id, table, rowId, patch, {
         head: branchView?.head,
         base: branchView?.base,
@@ -1448,7 +1452,7 @@ export class NativeRuntimeAdapter implements Runtime {
       tx.writes.push({
         table,
         rowId,
-        row: this.mergeRowState(table, rowId, values, tx, writeIdentity),
+        row,
       });
       return { kind: "staged", openTransactionId: txIdFromContext(writeContext)! };
     }
@@ -1540,6 +1544,9 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     if (tx) {
       this.assertTransactionWriteIdentity(tx, attribution ? undefined : writeIdentity);
+      const row = existing
+        ? this.mergeRowState(table, rowId, values, tx, writeIdentity)
+        : this.rowStateFromValues(table, rowId, values);
       this.db.upsertInTransaction(tx.id, table, rowId, cells, {
         head: branchView?.head,
         base: branchView?.base,
@@ -1548,9 +1555,7 @@ export class NativeRuntimeAdapter implements Runtime {
       tx.writes.push({
         table,
         rowId,
-        row: existing
-          ? this.mergeRowState(table, rowId, values, tx, writeIdentity)
-          : this.rowStateFromValues(table, rowId, values),
+        row,
       });
       return { kind: "staged", openTransactionId: txIdFromContext(writeContext)! };
     }

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -8,6 +8,66 @@ const app = schema.defineApp({
 });
 
 describe("exact local transaction write merging", () => {
+  it("does not commit a rejected large-row patch after its error is caught", async () => {
+    const db = await createBrowserTestDb({
+      appId: "transaction-staging-large-rejection",
+      driver: { type: "memory" },
+    });
+    try {
+      const title = "large text ".repeat(20_000);
+      const large = db.insert(app.todos, { title, done: false });
+      await large.wait({ tier: "local" });
+      const small = db.insert(app.todos, { title: "small", done: false });
+      await small.wait({ tier: "local" });
+      const tx = db.beginTransaction();
+      expect(() => tx.update(app.todos, large.value.id, { done: true })).toThrow(
+        "synchronous WASM all/transaction reads cannot materialize a large value",
+      );
+      tx.update(app.todos, small.value.id, { done: true });
+      await tx.commit().wait({ tier: "local" });
+      expect(await db.all(app.todos)).toEqual(
+        expect.arrayContaining([
+          { id: large.value.id, title, done: false },
+          { id: small.value.id, title: "small", done: true },
+        ]),
+      );
+    } finally {
+      await db.shutdown();
+    }
+  }, 30_000);
+
+  it("retains the previous staged state when native staging rejects a later patch", async () => {
+    const db = await createBrowserTestDb({
+      appId: "transaction-staging-native-rejection",
+      driver: { type: "memory" },
+    });
+    try {
+      const inserted = db.insert(app.todos, { title: "original", done: false });
+      await inserted.wait({ tier: "local" });
+      const tx = db.beginTransaction();
+      tx.update(app.todos, inserted.value.id, { title: "first patch" });
+      const { WasmDb } = await loadWasmModule();
+      const nativeUpdate = vi.spyOn(WasmDb.prototype, "updateInTransaction");
+      nativeUpdate.mockImplementationOnce(() => {
+        throw new Error("synthetic staging failure");
+      });
+      try {
+        expect(() => tx.update(app.todos, inserted.value.id, { title: "rejected patch" })).toThrow(
+          "synthetic staging failure",
+        );
+      } finally {
+        nativeUpdate.mockRestore();
+      }
+      tx.update(app.todos, inserted.value.id, { done: true });
+      await tx.commit().wait({ tier: "local" });
+      expect(await db.all(app.todos)).toEqual([
+        { id: inserted.value.id, title: "first patch", done: true },
+      ]);
+    } finally {
+      await db.shutdown();
+    }
+  });
+
   for (const count of [150, 300, 1500]) {
     it(`stages 90% of ${count} rows without table reads`, async () => {
       const db = await createBrowserTestDb({

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -9,7 +9,7 @@ const app = schema.defineApp({
 });
 
 describe("exact local transaction write merging", () => {
-  it("preserves large content and does not commit a patch whose merge read failed", async () => {
+  it("preserves large content after commit rejection and a caught merge-read failure", async () => {
     const db = await createBrowserTestDb({
       appId: "transaction-staging-large-rejection",
       driver: { type: "memory" },
@@ -25,9 +25,11 @@ describe("exact local transaction write merging", () => {
       await large.wait({ tier: "local" });
       const small = db.insert(app.todos, { title: "small", done: false });
       await small.wait({ tier: "local" });
-      const successful = db.beginTransaction();
-      successful.update(app.todos, large.value.id, { done: true });
-      await successful.commit().wait({ tier: "local" });
+      const unsupported = db.beginTransaction();
+      unsupported.update(app.todos, large.value.id, { done: true });
+      await expect(unsupported.commit().wait({ tier: "local" })).rejects.toThrow(
+        "callers must author logical scalar values, not physical large descriptors",
+      );
       const tx = db.beginTransaction();
       const { WasmDb } = await loadWasmModule();
       const exact = vi.spyOn(WasmDb.prototype, "localCurrentRow");
@@ -35,7 +37,7 @@ describe("exact local transaction write merging", () => {
         throw new Error("synthetic exact read failure");
       });
       try {
-        expect(() => tx.update(app.todos, large.value.id, { done: false })).toThrow(
+        expect(() => tx.update(app.todos, large.value.id, { done: true })).toThrow(
           "synthetic exact read failure",
         );
       } finally {
@@ -45,7 +47,7 @@ describe("exact local transaction write merging", () => {
       await tx.commit().wait({ tier: "local" });
       expect(await db.all(app.todos)).toEqual(
         expect.arrayContaining([
-          { id: large.value.id, title, done: true },
+          { id: large.value.id, title, done: false },
           { id: small.value.id, title: "small", done: true },
         ]),
       );

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -9,7 +9,7 @@ const app = schema.defineApp({
 });
 
 describe("exact local transaction write merging", () => {
-  it("does not commit a rejected large-row patch after its error is caught", async () => {
+  it("preserves large content and does not commit a patch whose merge read failed", async () => {
     const db = await createBrowserTestDb({
       appId: "transaction-staging-large-rejection",
       driver: { type: "memory" },
@@ -25,15 +25,27 @@ describe("exact local transaction write merging", () => {
       await large.wait({ tier: "local" });
       const small = db.insert(app.todos, { title: "small", done: false });
       await small.wait({ tier: "local" });
+      const successful = db.beginTransaction();
+      successful.update(app.todos, large.value.id, { done: true });
+      await successful.commit().wait({ tier: "local" });
       const tx = db.beginTransaction();
-      expect(() => tx.update(app.todos, large.value.id, { done: true })).toThrow(
-        "synchronous WASM all/transaction reads cannot materialize a large value",
-      );
+      const { WasmDb } = await loadWasmModule();
+      const exact = vi.spyOn(WasmDb.prototype, "localCurrentRow");
+      exact.mockImplementationOnce(() => {
+        throw new Error("synthetic exact read failure");
+      });
+      try {
+        expect(() => tx.update(app.todos, large.value.id, { done: false })).toThrow(
+          "synthetic exact read failure",
+        );
+      } finally {
+        exact.mockRestore();
+      }
       tx.update(app.todos, small.value.id, { done: true });
       await tx.commit().wait({ tier: "local" });
       expect(await db.all(app.todos)).toEqual(
         expect.arrayContaining([
-          { id: large.value.id, title, done: false },
+          { id: large.value.id, title, done: true },
           { id: small.value.id, title: "small", done: true },
         ]),
       );

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { commands } from "vitest/browser";
 import { schema } from "../../src/index.js";
 import { loadWasmModule } from "../../src/runtime/wasm-loader.js";
 import { createBrowserTestDb } from "./account-fixtures.js";
@@ -124,17 +125,14 @@ describe("exact local transaction write merging", () => {
           title: "Second patch",
           done: true,
         });
-        console.info(
-          "transaction-staging-receipt",
-          JSON.stringify({
-            count,
-            updated: updates.length,
-            seedMs,
-            readMs,
-            stageMs,
-            commitMs,
-          }),
-        );
+        await commands.writeRealisticBrowserReport(`transaction-staging-${count}`, {
+          count,
+          updated: updates.length,
+          seedMs,
+          readMs,
+          stageMs,
+          commitMs,
+        });
       } finally {
         await db.shutdown();
       }

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -15,7 +15,12 @@ describe("exact local transaction write merging", () => {
     });
     try {
       const title = "large text ".repeat(20_000);
-      const large = db.insert(app.todos, { title, done: false });
+      const large = await db.insertStreaming(app.todos, {
+        title: (async function* () {
+          yield title;
+        })(),
+        done: false,
+      });
       await large.wait({ tier: "local" });
       const small = db.insert(app.todos, { title: "small", done: false });
       await small.wait({ tier: "local" });
@@ -36,7 +41,7 @@ describe("exact local transaction write merging", () => {
     }
   }, 30_000);
 
-  it("retains the previous staged state when native staging rejects a later patch", async () => {
+  it("does not cache a patch rejected by native staging", async () => {
     const db = await createBrowserTestDb({
       appId: "transaction-staging-native-rejection",
       driver: { type: "memory" },
@@ -45,8 +50,8 @@ describe("exact local transaction write merging", () => {
       const inserted = db.insert(app.todos, { title: "original", done: false });
       await inserted.wait({ tier: "local" });
       const tx = db.beginTransaction();
-      tx.update(app.todos, inserted.value.id, { title: "first patch" });
       const { WasmDb } = await loadWasmModule();
+      const exact = vi.spyOn(WasmDb.prototype, "localCurrentRow");
       const nativeUpdate = vi.spyOn(WasmDb.prototype, "updateInTransaction");
       nativeUpdate.mockImplementationOnce(() => {
         throw new Error("synthetic staging failure");
@@ -58,10 +63,15 @@ describe("exact local transaction write merging", () => {
       } finally {
         nativeUpdate.mockRestore();
       }
-      tx.update(app.todos, inserted.value.id, { done: true });
+      try {
+        tx.update(app.todos, inserted.value.id, { done: true });
+        expect(exact).toHaveBeenCalledTimes(2);
+      } finally {
+        exact.mockRestore();
+      }
       await tx.commit().wait({ tier: "local" });
       expect(await db.all(app.todos)).toEqual([
-        { id: inserted.value.id, title: "first patch", done: true },
+        { id: inserted.value.id, title: "original", done: true },
       ]);
     } finally {
       await db.shutdown();

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { schema } from "../../src/index.js";
+import { loadWasmModule } from "../../src/runtime/wasm-loader.js";
+import { createBrowserTestDb } from "./account-fixtures.js";
+
+const app = schema.defineApp({
+  todos: schema.table({ title: schema.string(), done: schema.boolean() }),
+});
+
+describe("exact local transaction write merging", () => {
+  for (const count of [150, 300, 1500]) {
+    it(`stages 90% of ${count} rows without table reads`, async () => {
+      const db = await createBrowserTestDb({
+        appId: `transaction-staging-${count}`,
+        driver: { type: "memory" },
+      });
+      try {
+        await db.all(app.todos);
+        const seedStart = performance.now();
+        const seed = await db.transaction((tx) => {
+          for (let index = 0; index < count; index++) {
+            tx.insert(app.todos, { title: `Item ${index}`, done: false });
+          }
+        });
+        await seed.wait({ tier: "local" });
+        const seedMs = performance.now() - seedStart;
+        const readStart = performance.now();
+        const rows = await db.all(app.todos);
+        const readMs = performance.now() - readStart;
+        const updates = rows.slice(0, Math.floor(count * 0.9));
+        const { WasmDb } = await loadWasmModule();
+        const all = vi.spyOn(WasmDb.prototype, "all");
+        const exact = vi.spyOn(WasmDb.prototype, "localCurrentRow");
+        const tx = db.beginTransaction();
+        const stageStart = performance.now();
+        try {
+          for (const row of updates) tx.update(app.todos, row.id, { done: true });
+          // A second patch must merge with this transaction's first patch.
+          tx.update(app.todos, updates[0].id, { title: "Second patch" });
+          expect(all).not.toHaveBeenCalled();
+          expect(exact).toHaveBeenCalledTimes(updates.length);
+        } finally {
+          all.mockRestore();
+          exact.mockRestore();
+        }
+        const stageMs = performance.now() - stageStart;
+        const commitStart = performance.now();
+        await tx.commit().wait({ tier: "local" });
+        const commitMs = performance.now() - commitStart;
+        const committed = await db.all(app.todos);
+        expect(committed.filter((row) => row.done)).toHaveLength(updates.length);
+        expect(committed.find((row) => row.id === updates[0].id)).toEqual({
+          ...updates[0],
+          title: "Second patch",
+          done: true,
+        });
+        console.info(
+          "transaction-staging-receipt",
+          JSON.stringify({
+            count,
+            updated: updates.length,
+            seedMs,
+            readMs,
+            stageMs,
+            commitMs,
+          }),
+        );
+      } finally {
+        await db.shutdown();
+      }
+    }, 120_000);
+  }
+});


### PR DESCRIPTION
🤖 Fixes #2746. Browser transaction updates no longer query and decode the entire table to merge each individual patch.

### Example and cause

An app loads 1,500 todos, starts a transaction, and marks 1,350 of them done. Previously, each first patch to a row called `readRowForWriteMerge`. NAPI supplied `localCurrentRow`, but WASM did not, so the adapter fell back to an unfiltered table query followed by a JavaScript search for that ID. That means roughly 1,350 complete table materializations for this example. Joe's optimized baseline measured 2.23 seconds for 135 updates and 8.36 seconds for 270 updates.

The patch exposes the existing core exact-row operation through WASM. The adapter's existing preferred path now reads just the requested local row; a second patch to that same row uses the transaction's already staged state. It does not introduce a new query or change mutation authorization. This internal local write-merge read has the same authority boundary as NAPI.

### Failed patches cannot leak into a later commit

Review found that `updateInTransaction` previously ran before the merge read. If that read threw and the application caught the error, the native patch could remain staged even though the JavaScript call failed.

Update and upsert now compute the merged state before native staging, and append JavaScript transaction bookkeeping only after staging succeeds. A caught read failure therefore cannot be committed accidentally; a native staging failure also cannot poison the cached row used by the next patch. Tests commit an unrelated successful update after the error and verify that the rejected patch remains absent.

### Coverage and limits

- The browser workload covers 150/300/1,500 rows, forbids any full-table `all` call during staging, and requires one exact read per first updated row. It checks the final values and a second patch to the same row.
- Five new browser cases passed, including failure atomicity. The coordinator independently reran them: **5/5 passed**. Existing mergeable transaction coverage passed **11 tests** (19 outside the selected scope); independent adapter lifecycle verification passed **22/22**.
- Three deliberate regressions were detected: restoring full-table fallback, staging before a failed merge read, and caching a patch before native staging succeeds.
- Independent correctness/security review found no remaining implementation blockers.

The tests assert call behavior and correctness, not a wall-clock speed threshold. Optimized before/after measurements are still in progress. Transaction bookkeeping still scans prior staged writes, so eliminating full-table reads is not a claim that total staging is asymptotically linear. IndexedDB page reclamation (#2751), cold-load CPU profiling (#2750), and ordinary updates with active subscriptions are separate work.

A pre-existing limitation remains: a transaction updating a small field on a row with a streamed large Text value can reject at commit because a physical large-value descriptor reaches the logical authoring boundary. The identical fixture fails with the original fallback and with this patch, leaving the original data unchanged. This is tracked on #1844; the tests preserve that behavior rather than claim new large-value support.

Storage and wire formats are unchanged. Fresh CI and optimized measurements remain pending on this draft.
