### PR TITLE
fix(idb): reclaim obsolete pages under exclusive ownership

### DIFF
--- a/.changeset/browser-page-reclamation.md
+++ b/.changeset/browser-page-reclamation.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reclaim obsolete IndexedDB pages during writes under exclusive ownership, and safely retire browser runtime storage handles during schema changes and reconnects. Existing unused pages are not automatically collected.

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -468,9 +468,18 @@ Tree writes are copy-on-write: the changed leaf and every changed ancestor get
 fresh page ids, then one IndexedDB transaction writes the new immutable closure
 and replaces `current` after checking the observed generation. A crash before
 publication leaves at most unreachable new pages; a published root never names
-a torn or missing child. Reclamation is a separate reachability operation and
-may delete only pages proven unreachable from the published root, never pages
-merely replaced by an in-flight write. Reopening observes either the old root
+a torn or missing child. Reclamation may delete only pages proven unreachable
+from the published root. Path-local retirement atomically deletes replaced leaves,
+ancestors, and the overflow chains owned by replaced/deleted values together with
+publication, only when the PageStore proves exclusive tree ownership. Generic and
+memory stores default to retaining durable pages so independent cold handles can
+finish reading their older complete closure and reach generation-conflict recovery.
+The browser capability consumes one live database Web Lock/worker epoch proof for
+one tree; tree clones share its root. It expires before release/close/invalidation,
+and deletion commits recheck it at publication. Unpublished superseded fresh pages
+are omitted from the commit regardless of ownership. A separate reachability
+collector is still required for historical garbage; this policy changes neither
+the durable page encoding nor the storage epoch. Reopening observes either the old root
 and complete closure or the new root and complete closure.
 Before persistence, one logical write—including every operation in a
 `write_many` call—is also locally atomic. If page construction or validation

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -479,7 +479,11 @@ handles may not coexist with an exclusive browser worker owner.
 The browser capability consumes one live database Web Lock/worker epoch proof for
 one live tree at a time; tree clones share its root, and the last clone dropping
 releases tree admission for a fresh open. It expires before release/close/invalidation,
-and deletion commits recheck it at publication. Unpublished superseded fresh pages
+and deletion commits recheck it at publication. An idle browser runtime is reused
+while foreground lease work retains its physical owner; once that work ends, the
+worker retires the page-store/epoch before a successor opens another tree. This
+boundary must not depend on garbage collection of closed WASM wrappers.
+Unpublished superseded fresh pages
 are omitted from the commit regardless of ownership. A separate reachability
 collector is still required for historical garbage; this policy changes neither
 the durable page encoding nor the storage epoch. Reopening observes either the old root

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -479,10 +479,16 @@ handles may not coexist with an exclusive browser worker owner.
 The browser capability consumes one live database Web Lock/worker epoch proof for
 one live tree at a time; tree clones share its root, and the last clone dropping
 releases tree admission for a fresh open. It expires before release/close/invalidation,
-and deletion commits recheck it at publication. An idle browser runtime is reused
-while foreground lease work retains its physical owner; once that work ends, the
-worker retires the page-store/epoch before a successor opens another tree. This
-boundary must not depend on garbage collection of closed WASM wrappers.
+and deletion commits recheck it at publication. A worker runtime owns a revocable
+tree token independent of foreground identity leases. After the last admitted
+peer's flush barrier, retirement revokes that token synchronously and drains its
+already-started page transactions before permitting a new runtime/schema to claim
+a successor token. Every cached read/write and pending hydration/open completion
+checks liveness; every token-bearing commit rechecks its exact token before page
+publication, including commits with no deletions. A late old guard release cannot
+release its successor. Foreground lease operations retain the same page store and
+Web Lock across this handoff. No boundary depends on garbage collection of closed
+WASM wrappers.
 Unpublished superseded fresh pages
 are omitted from the commit regardless of ownership. A separate reachability
 collector is still required for historical garbage; this policy changes neither

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -474,8 +474,11 @@ ancestors, and the overflow chains owned by replaced/deleted values together wit
 publication, only when the PageStore proves exclusive tree ownership. Generic and
 memory stores default to retaining durable pages so independent cold handles can
 finish reading their older complete closure and reach generation-conflict recovery.
+All writers sharing those handles must remain non-reclaiming: low-level direct
+handles may not coexist with an exclusive browser worker owner.
 The browser capability consumes one live database Web Lock/worker epoch proof for
-one tree; tree clones share its root. It expires before release/close/invalidation,
+one live tree at a time; tree clones share its root, and the last clone dropping
+releases tree admission for a fresh open. It expires before release/close/invalidation,
 and deletion commits recheck it at publication. Unpublished superseded fresh pages
 are omitted from the commit regardless of ownership. A separate reachability
 collector is still required for historical garbage; this policy changes neither

--- a/crates/groove/src/storage/idb.rs
+++ b/crates/groove/src/storage/idb.rs
@@ -24,7 +24,6 @@ const MAX_CONFLICT_BACKOFF_YIELDS: usize = 16;
 #[derive(Clone)]
 pub struct IdbStorage<S> {
     tree: Rc<RefCell<IdbTree<S>>>,
-    store: S,
     column_families: Rc<RefCell<BTreeSet<String>>>,
     mutation_gate: Rc<Mutex<()>>,
     needs_reset: Rc<Cell<bool>>,
@@ -41,7 +40,6 @@ where
             tree: Rc::new(RefCell::new(
                 IdbTree::open(store.clone(), Options::default()).await?,
             )),
-            store,
             column_families: Rc::new(RefCell::new(
                 column_families.iter().map(|cf| (*cf).to_owned()).collect(),
             )),
@@ -125,8 +123,7 @@ where
         // commit between our read and flush. Discard this stale cache rather
         // than replaying its dirty pages, then recompute the whole logical
         // batch from the newly durable tree.
-        let tree = IdbTree::open(self.store.clone(), Options::default()).await?;
-        *self.tree.borrow_mut() = tree;
+        self.tree().reload().await?;
         self.tree_epoch.set(self.tree_epoch.get().wrapping_add(1));
         self.needs_reset.set(false);
         Ok(())

--- a/crates/idb-tree/src/lib.rs
+++ b/crates/idb-tree/src/lib.rs
@@ -65,6 +65,8 @@ pub enum Error {
     Store(String),
     #[error("IDBTree generation conflict: {0}")]
     GenerationConflict(String),
+    #[error("IDBTree ownership has expired")]
+    OwnershipExpired,
     #[error("an IDBTree commit is already in flight")]
     CommitInFlight,
 }
@@ -151,6 +153,9 @@ impl<S: PageStore + Clone> IdbTree<S> {
     pub async fn open(store: S, options: Options) -> Result<Self, Error> {
         let ownership = store.claim_tree_ownership().map_err(Error::Store)?;
         let tree = TreeCore::open(store, options).await?;
+        if !ownership.is_live() {
+            return Err(Error::OwnershipExpired);
+        }
         Ok(Self {
             inner: Rc::new(RefCell::new(tree)),
             _ownership: Rc::new(ownership),
@@ -158,9 +163,18 @@ impl<S: PageStore + Clone> IdbTree<S> {
         })
     }
 
+    fn ensure_live(&self) -> Result<(), Error> {
+        if self._ownership.is_live() {
+            Ok(())
+        } else {
+            Err(Error::OwnershipExpired)
+        }
+    }
+
     /// Discard staged writes and reload the durable root while retaining this
     /// handle's ownership. Callers must serialize this with writes/flushes.
     pub async fn reload(&self) -> Result<(), Error> {
+        self.ensure_live()?;
         let (store, options) = {
             let tree = self.inner.borrow();
             if tree.commit_in_flight {
@@ -169,6 +183,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
             (tree.store.clone(), tree.options)
         };
         let fresh = TreeCore::open(store, options).await?;
+        self.ensure_live()?;
         *self.inner.borrow_mut() = fresh;
         self.reload_epoch
             .set(self.reload_epoch.get().wrapping_add(1));
@@ -185,6 +200,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
 
     pub async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         loop {
+            self.ensure_live()?;
             let attempt = self.inner.borrow().try_get(key)?;
             match attempt {
                 Attempt::Ready(value) => return Ok(value),
@@ -195,6 +211,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
 
     pub async fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error> {
         loop {
+            self.ensure_live()?;
             let attempt = self
                 .inner
                 .borrow_mut()
@@ -208,6 +225,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
 
     pub async fn delete(&self, key: &[u8]) -> Result<bool, Error> {
         loop {
+            self.ensure_live()?;
             let attempt = self
                 .inner
                 .borrow_mut()
@@ -220,11 +238,13 @@ impl<S: PageStore + Clone> IdbTree<S> {
     }
 
     pub async fn write_many(&self, operations: Vec<WriteOperation>) -> Result<(), Error> {
+        self.ensure_live()?;
         for operation in &operations {
             let key = match operation {
                 WriteOperation::Set { key, .. } | WriteOperation::Delete { key } => key,
             };
             loop {
+                self.ensure_live()?;
                 let attempt = self.inner.borrow().write_path_resident(key)?;
                 match attempt {
                     Attempt::Ready(()) => break,
@@ -251,6 +271,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
         limit: usize,
     ) -> Result<Vec<KeyValue>, Error> {
         loop {
+            self.ensure_live()?;
             let attempt = self.inner.borrow().try_range(start, end, limit)?;
             match attempt {
                 Attempt::Ready(rows) => return Ok(rows),
@@ -266,6 +287,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
         limit: usize,
     ) -> Result<Vec<KeyValue>, Error> {
         loop {
+            self.ensure_live()?;
             let attempt = self.inner.borrow().try_range_reverse(start, end, limit)?;
             match attempt {
                 Attempt::Ready(rows) => return Ok(rows),
@@ -275,6 +297,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
     }
 
     pub async fn flush(&self) -> Result<(), Error> {
+        self.ensure_live()?;
         let (store, prepared) = {
             let mut tree = self.inner.borrow_mut();
             (tree.store.clone(), tree.prepare_commit()?)
@@ -297,6 +320,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
         let root_before = self.inner.borrow().metadata.root_page_id;
         let reload_before = self.reload_epoch.get();
         let result = store.read_page(page_id).await;
+        self.ensure_live()?;
         // The operation retries from the current root, so never import an old
         // completion (including an error) across publication or failure reset.
         // Reset can reuse fresh page IDs, making a cache insert unsafe even if

--- a/crates/idb-tree/src/lib.rs
+++ b/crates/idb-tree/src/lib.rs
@@ -10,7 +10,7 @@ mod store;
 #[cfg(target_arch = "wasm32")]
 mod web;
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
@@ -106,6 +106,7 @@ struct TreeCore<S> {
     pages: HashMap<PageId, Page>,
     dirty: BTreeMap<PageId, Page>,
     deleted: BTreeSet<PageId>,
+    retirement_undo: Vec<PageId>,
     commit_in_flight: bool,
 }
 
@@ -114,7 +115,6 @@ struct TreeCore<S> {
 /// cache for every operation.
 struct WriteCheckpoint {
     metadata: Metadata,
-    deleted: BTreeSet<PageId>,
 }
 
 #[derive(Debug)]
@@ -144,6 +144,7 @@ impl<T> Attempt<T> {
 pub struct IdbTree<S> {
     inner: Rc<RefCell<TreeCore<S>>>,
     _ownership: Rc<TreeOwnership>,
+    reload_epoch: Rc<Cell<u64>>,
 }
 
 impl<S: PageStore + Clone> IdbTree<S> {
@@ -153,6 +154,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
         Ok(Self {
             inner: Rc::new(RefCell::new(tree)),
             _ownership: Rc::new(ownership),
+            reload_epoch: Rc::new(Cell::new(0)),
         })
     }
 
@@ -168,6 +170,8 @@ impl<S: PageStore + Clone> IdbTree<S> {
         };
         let fresh = TreeCore::open(store, options).await?;
         *self.inner.borrow_mut() = fresh;
+        self.reload_epoch
+            .set(self.reload_epoch.get().wrapping_add(1));
         Ok(())
     }
 
@@ -291,13 +295,20 @@ impl<S: PageStore + Clone> IdbTree<S> {
             tree.store.clone()
         };
         let root_before = self.inner.borrow().metadata.root_page_id;
-        let bytes = store.read_page(page_id).await.map_err(Error::Store)?;
-        let Some(bytes) = bytes else {
-            if self.inner.borrow().metadata.root_page_id != root_before {
-                return Ok(());
-            }
-            return Err(Error::MissingPage(page_id));
-        };
+        let reload_before = self.reload_epoch.get();
+        let result = store.read_page(page_id).await;
+        // The operation retries from the current root, so never import an old
+        // completion (including an error) across publication or failure reset.
+        // Reset can reuse fresh page IDs, making a cache insert unsafe even if
+        // the old read returned successfully.
+        if self.reload_epoch.get() != reload_before
+            || self.inner.borrow().metadata.root_page_id != root_before
+        {
+            return Ok(());
+        }
+        let bytes = result
+            .map_err(Error::Store)?
+            .ok_or(Error::MissingPage(page_id))?;
         let page_size = self.inner.borrow().options.page_size;
         if bytes.len() > page_size {
             return Err(Error::PageTooLarge { page_id, page_size });
@@ -333,7 +344,6 @@ impl<S: PageStore> TreeCore<S> {
     fn write_checkpoint(&self) -> WriteCheckpoint {
         WriteCheckpoint {
             metadata: self.metadata.clone(),
-            deleted: self.deleted.clone(),
         }
     }
 
@@ -343,7 +353,10 @@ impl<S: PageStore> TreeCore<S> {
     ) -> Result<T, Error> {
         let checkpoint = self.write_checkpoint();
         match write(self) {
-            Ok(value) => Ok(value),
+            Ok(value) => {
+                self.retirement_undo.clear();
+                Ok(value)
+            }
             Err(error) => {
                 self.rollback_write(checkpoint);
                 Err(error)
@@ -357,7 +370,10 @@ impl<S: PageStore> TreeCore<S> {
     ) -> Result<Attempt<T>, Error> {
         let checkpoint = self.write_checkpoint();
         match write(self) {
-            Ok(Attempt::Ready(value)) => Ok(Attempt::Ready(value)),
+            Ok(Attempt::Ready(value)) => {
+                self.retirement_undo.clear();
+                Ok(Attempt::Ready(value))
+            }
             Ok(Attempt::Missing(page_id)) => {
                 self.rollback_write(checkpoint);
                 Ok(Attempt::Missing(page_id))
@@ -377,7 +393,9 @@ impl<S: PageStore> TreeCore<S> {
             self.pages.remove(&page_id);
             self.dirty.remove(&page_id);
         }
-        self.deleted = checkpoint.deleted;
+        for page_id in self.retirement_undo.drain(..) {
+            self.deleted.remove(&page_id);
+        }
         self.metadata = checkpoint.metadata;
     }
 
@@ -391,6 +409,7 @@ impl<S: PageStore> TreeCore<S> {
             pages: HashMap::new(),
             dirty: BTreeMap::new(),
             deleted: BTreeSet::new(),
+            retirement_undo: Vec::new(),
             commit_in_flight: false,
         };
         if tree.metadata.page_size != options.page_size {
@@ -861,7 +880,7 @@ impl<S: PageStore> TreeCore<S> {
                 })?,
             }
         };
-        self.deleted.insert(page_id);
+        self.retire_page(page_id);
         self.publish_replacement(replacement, path)
     }
 
@@ -887,7 +906,7 @@ impl<S: PageStore> TreeCore<S> {
                     "descent parent is not internal".to_owned(),
                 ));
             };
-            self.deleted.insert(parent_id);
+            self.retire_page(parent_id);
             replacement = match replacement {
                 PageReplacement::One(page_id) => {
                     children[child_index] = page_id;
@@ -945,6 +964,15 @@ impl<S: PageStore> TreeCore<S> {
         Ok(())
     }
 
+    // Track only new retirements in the current attempt. A failed operation
+    // removes these IDs; successful writes retain the set and discard the log.
+    // Cloning the whole growing set at every checkpoint made staged writes O(n²).
+    fn retire_page(&mut self, page_id: PageId) {
+        if self.deleted.insert(page_id) {
+            self.retirement_undo.push(page_id);
+        }
+    }
+
     // The complete leaf ownership graph has already been validated and hydrated.
     // Only the replaced value owns this chain; surviving values retain theirs.
     fn retire_value(&mut self, value: &ValueCell) {
@@ -959,7 +987,7 @@ impl<S: PageStore> TreeCore<S> {
                 unreachable!()
             };
             current = *next;
-            self.deleted.insert(id);
+            self.retire_page(id);
         }
     }
 

--- a/crates/idb-tree/src/lib.rs
+++ b/crates/idb-tree/src/lib.rs
@@ -11,10 +11,10 @@ mod store;
 mod web;
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
-pub use store::{BoxFuture, Commit, MemoryPageStore, Metadata, PageStore};
+pub use store::{BoxFuture, Commit, MemoryPageStore, Metadata, PageStore, TreeOwnership};
 #[cfg(target_arch = "wasm32")]
 pub use web::IndexedDbPageStore;
 
@@ -105,7 +105,7 @@ struct TreeCore<S> {
     metadata: Metadata,
     pages: HashMap<PageId, Page>,
     dirty: BTreeMap<PageId, Page>,
-    deleted: Vec<PageId>,
+    deleted: BTreeSet<PageId>,
     commit_in_flight: bool,
 }
 
@@ -114,12 +114,13 @@ struct TreeCore<S> {
 /// cache for every operation.
 struct WriteCheckpoint {
     metadata: Metadata,
-    deleted: Vec<PageId>,
+    deleted: BTreeSet<PageId>,
 }
 
 #[derive(Debug)]
 pub struct PreparedCommit {
     commit: Commit,
+    retired: BTreeSet<PageId>,
 }
 
 enum Attempt<T> {
@@ -142,13 +143,32 @@ impl<T> Attempt<T> {
 #[derive(Clone)]
 pub struct IdbTree<S> {
     inner: Rc<RefCell<TreeCore<S>>>,
+    _ownership: Rc<TreeOwnership>,
 }
 
 impl<S: PageStore + Clone> IdbTree<S> {
     pub async fn open(store: S, options: Options) -> Result<Self, Error> {
+        let ownership = store.claim_tree_ownership().map_err(Error::Store)?;
+        let tree = TreeCore::open(store, options).await?;
         Ok(Self {
-            inner: Rc::new(RefCell::new(TreeCore::open(store, options).await?)),
+            inner: Rc::new(RefCell::new(tree)),
+            _ownership: Rc::new(ownership),
         })
+    }
+
+    /// Discard staged writes and reload the durable root while retaining this
+    /// handle's ownership. Callers must serialize this with writes/flushes.
+    pub async fn reload(&self) -> Result<(), Error> {
+        let (store, options) = {
+            let tree = self.inner.borrow();
+            if tree.commit_in_flight {
+                return Err(Error::CommitInFlight);
+            }
+            (tree.store.clone(), tree.options)
+        };
+        let fresh = TreeCore::open(store, options).await?;
+        *self.inner.borrow_mut() = fresh;
+        Ok(())
     }
 
     pub fn metadata(&self) -> Metadata {
@@ -270,11 +290,14 @@ impl<S: PageStore + Clone> IdbTree<S> {
             }
             tree.store.clone()
         };
-        let bytes = store
-            .read_page(page_id)
-            .await
-            .map_err(Error::Store)?
-            .ok_or(Error::MissingPage(page_id))?;
+        let root_before = self.inner.borrow().metadata.root_page_id;
+        let bytes = store.read_page(page_id).await.map_err(Error::Store)?;
+        let Some(bytes) = bytes else {
+            if self.inner.borrow().metadata.root_page_id != root_before {
+                return Ok(());
+            }
+            return Err(Error::MissingPage(page_id));
+        };
         let page_size = self.inner.borrow().options.page_size;
         if bytes.len() > page_size {
             return Err(Error::PageTooLarge { page_id, page_size });
@@ -367,7 +390,7 @@ impl<S: PageStore> TreeCore<S> {
             metadata: metadata.unwrap_or_else(|| Metadata::empty(options.page_size)),
             pages: HashMap::new(),
             dirty: BTreeMap::new(),
-            deleted: Vec::new(),
+            deleted: BTreeSet::new(),
             commit_in_flight: false,
         };
         if tree.metadata.page_size != options.page_size {
@@ -417,6 +440,7 @@ impl<S: PageStore> TreeCore<S> {
         let new_value = self.build_value(value.to_vec())?;
         match entries.binary_search_by(|(candidate, _)| candidate.as_slice().cmp(key)) {
             Ok(index) => {
+                self.retire_value(&entries[index].1);
                 entries[index].1 = new_value;
             }
             Err(index) => entries.insert(index, (key.to_vec(), new_value)),
@@ -438,6 +462,7 @@ impl<S: PageStore> TreeCore<S> {
             return Ok(Attempt::Missing(page_id));
         }
         let mut entries = entries;
+        self.retire_value(&entries[index].1);
         entries.remove(index);
         self.finish_leaf_write(page_id, entries, path)?;
         Ok(Attempt::Ready(true))
@@ -518,6 +543,9 @@ impl<S: PageStore> TreeCore<S> {
         }
         let mut pages = Vec::with_capacity(self.dirty.len());
         for (&page_id, page) in &self.dirty {
+            if self.deleted.contains(&page_id) {
+                continue;
+            }
             let bytes = encode_page(page).map_err(Error::InvalidPage)?;
             if bytes.len() > self.options.page_size {
                 return Err(Error::PageTooLarge {
@@ -532,10 +560,21 @@ impl<S: PageStore> TreeCore<S> {
             expected_generation: self.metadata.generation,
             metadata: self.metadata.clone(),
             pages,
-            deleted_page_ids: std::mem::take(&mut self.deleted),
+            deleted_page_ids: if self.store.can_reclaim_obsolete_pages() {
+                self.deleted
+                    .iter()
+                    .filter(|id| !self.dirty.contains_key(id))
+                    .copied()
+                    .collect()
+            } else {
+                Vec::new()
+            },
         };
         self.dirty.clear();
-        Ok(Some(PreparedCommit { commit }))
+        Ok(Some(PreparedCommit {
+            commit,
+            retired: std::mem::take(&mut self.deleted),
+        }))
     }
 
     /// Reconcile an atomic commit result with writes made after
@@ -563,6 +602,9 @@ impl<S: PageStore> TreeCore<S> {
                 }
                 // Root and allocation metadata may already describe writes in
                 // the next dirty generation. Only advance its durable base.
+                for page_id in prepared.retired {
+                    self.pages.remove(&page_id);
+                }
                 self.metadata.generation = committed.generation;
                 Ok(())
             }
@@ -575,11 +617,7 @@ impl<S: PageStore> TreeCore<S> {
                         self.dirty.insert(page_id, page.clone());
                     }
                 }
-                for page_id in prepared.commit.deleted_page_ids {
-                    if !self.pages.contains_key(&page_id) && !self.deleted.contains(&page_id) {
-                        self.deleted.push(page_id);
-                    }
-                }
+                self.deleted.extend(prepared.retired);
                 if error.contains("generation changed") {
                     Err(Error::GenerationConflict(error))
                 } else {
@@ -823,13 +861,13 @@ impl<S: PageStore> TreeCore<S> {
                 })?,
             }
         };
+        self.deleted.insert(page_id);
         self.publish_replacement(replacement, path)
     }
 
     /// Rebuild every changed ancestor under fresh page ids. A committed root
-    /// therefore names a complete immutable closure. Reclamation is deferred
-    /// to a reachability-based maintenance pass, rather than deleting pages
-    /// while an older root could still name them.
+    /// therefore names a complete immutable closure. Retire the replaced path
+    /// atomically with publication, only when the store proves exclusive ownership.
     fn publish_replacement(
         &mut self,
         mut replacement: PageReplacement,
@@ -849,6 +887,7 @@ impl<S: PageStore> TreeCore<S> {
                     "descent parent is not internal".to_owned(),
                 ));
             };
+            self.deleted.insert(parent_id);
             replacement = match replacement {
                 PageReplacement::One(page_id) => {
                     children[child_index] = page_id;
@@ -902,9 +941,26 @@ impl<S: PageStore> TreeCore<S> {
             })?,
         };
         self.metadata.root_page_id = Some(root);
-        // The old closure remains durable until a future mark/sweep collector
-        // proves it unreachable from the published root.
+
         Ok(())
+    }
+
+    // The complete leaf ownership graph has already been validated and hydrated.
+    // Only the replaced value owns this chain; surviving values retain theirs.
+    fn retire_value(&mut self, value: &ValueCell) {
+        let ValueCell::Overflow { head, .. } = value else {
+            return;
+        };
+        let mut current = Some(*head);
+        while let Some(id) = current {
+            let Page::Overflow { next, .. } =
+                self.pages.get(&id).expect("validated overflow is resident")
+            else {
+                unreachable!()
+            };
+            current = *next;
+            self.deleted.insert(id);
+        }
     }
 
     fn page_fits(&self, page: &Page) -> Result<bool, Error> {

--- a/crates/idb-tree/src/store.rs
+++ b/crates/idb-tree/src/store.rs
@@ -34,7 +34,38 @@ pub struct Commit {
     pub deleted_page_ids: Vec<PageId>,
 }
 
+/// Keeps a store's single-tree admission alive until the last tree clone drops.
+#[derive(Default)]
+pub struct TreeOwnership(Option<Box<dyn FnOnce()>>);
+
+impl TreeOwnership {
+    pub fn new(release: impl FnOnce() + 'static) -> Self {
+        Self(Some(Box::new(release)))
+    }
+}
+
+impl Drop for TreeOwnership {
+    fn drop(&mut self) {
+        if let Some(release) = self.0.take() {
+            release();
+        }
+    }
+}
+
 pub trait PageStore {
+    /// Opt in only while this tree exclusively owns the store: no independent
+    /// handle may retain an older root. The store must also reject reclamation
+    /// commits after ownership expires, including already prepared commits.
+    /// Clones of one IdbTree share a root and are permitted. Independent trees
+    /// (including ones built from cloned stores) require this to remain false.
+    fn claim_tree_ownership(&self) -> Result<TreeOwnership, String> {
+        Ok(TreeOwnership::default())
+    }
+
+    fn can_reclaim_obsolete_pages(&self) -> bool {
+        false
+    }
+
     fn load_metadata(&self) -> BoxFuture<'_, Result<Option<Metadata>, String>>;
     fn read_page(&self, page_id: PageId) -> BoxFuture<'_, Result<Option<Vec<u8>>, String>>;
     fn commit<'a>(&'a self, commit: &'a Commit) -> BoxFuture<'a, Result<Metadata, String>>;

--- a/crates/idb-tree/src/store.rs
+++ b/crates/idb-tree/src/store.rs
@@ -34,19 +34,40 @@ pub struct Commit {
     pub deleted_page_ids: Vec<PageId>,
 }
 
-/// Keeps a store's single-tree admission alive until the last tree clone drops.
+/// Keeps a store's single-tree admission alive until it is revoked or the
+/// last tree clone drops. Revocation fences even resident reads and writes.
 #[derive(Default)]
-pub struct TreeOwnership(Option<Box<dyn FnOnce()>>);
+pub struct TreeOwnership {
+    is_live: Option<Box<dyn Fn() -> bool>>,
+    release: Option<Box<dyn FnOnce()>>,
+}
 
 impl TreeOwnership {
     pub fn new(release: impl FnOnce() + 'static) -> Self {
-        Self(Some(Box::new(release)))
+        Self {
+            is_live: None,
+            release: Some(Box::new(release)),
+        }
+    }
+
+    pub fn revocable(
+        is_live: impl Fn() -> bool + 'static,
+        release: impl FnOnce() + 'static,
+    ) -> Self {
+        Self {
+            is_live: Some(Box::new(is_live)),
+            release: Some(Box::new(release)),
+        }
+    }
+
+    pub fn is_live(&self) -> bool {
+        self.is_live.as_ref().is_none_or(|check| check())
     }
 }
 
 impl Drop for TreeOwnership {
     fn drop(&mut self) {
-        if let Some(release) = self.0.take() {
+        if let Some(release) = self.release.take() {
             release();
         }
     }

--- a/crates/idb-tree/src/store.rs
+++ b/crates/idb-tree/src/store.rs
@@ -57,7 +57,9 @@ pub trait PageStore {
     /// handle may retain an older root. The store must also reject reclamation
     /// commits after ownership expires, including already prepared commits.
     /// Clones of one IdbTree share a root and are permitted. Independent trees
-    /// (including ones built from cloned stores) require this to remain false.
+    /// (including ones built from cloned stores) require this to remain false
+    /// for every writer sharing their store. Default-off does not make a reader
+    /// safe alongside another writer that violates this exclusivity contract.
     fn claim_tree_ownership(&self) -> Result<TreeOwnership, String> {
         Ok(TreeOwnership::default())
     }

--- a/crates/idb-tree/src/web.rs
+++ b/crates/idb-tree/src/web.rs
@@ -1,4 +1,6 @@
 use js_sys::{Array, Promise, Reflect, Uint8Array};
+use std::cell::Cell;
+use std::rc::Rc;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -12,10 +14,16 @@ extern "C" {
     type IndexedDbPageStoreHandle;
 
     #[wasm_bindgen(method, catch, js_name = claimTreeOwnership)]
-    fn claim_tree_ownership_js(this: &IndexedDbPageStoreHandle) -> Result<(), JsValue>;
+    fn claim_tree_ownership_js(this: &IndexedDbPageStoreHandle) -> Result<f64, JsValue>;
 
     #[wasm_bindgen(method, js_name = releaseTreeOwnership)]
-    fn release_tree_ownership_js(this: &IndexedDbPageStoreHandle);
+    fn release_tree_ownership_js(this: &IndexedDbPageStoreHandle, token: f64);
+
+    #[wasm_bindgen(method, catch, js_name = isTreeOwnershipActive)]
+    fn tree_ownership_active_js(
+        this: &IndexedDbPageStoreHandle,
+        token: f64,
+    ) -> Result<bool, JsValue>;
 
     #[wasm_bindgen(method, getter, js_name = canReclaimObsoletePages)]
     fn can_reclaim_obsolete_pages_js(this: &IndexedDbPageStoreHandle) -> bool;
@@ -36,6 +44,7 @@ extern "C" {
         page_ids: &Array,
         page_bytes: &Array,
         deleted_page_ids: &Array,
+        tree_token: JsValue,
     ) -> Promise;
 }
 
@@ -44,12 +53,14 @@ extern "C" {
 #[derive(Clone)]
 pub struct IndexedDbPageStore {
     handle: IndexedDbPageStoreHandle,
+    tree_token: Rc<Cell<Option<f64>>>,
 }
 
 impl IndexedDbPageStore {
     pub fn from_js(handle: JsValue) -> Self {
         Self {
             handle: handle.unchecked_into(),
+            tree_token: Rc::new(Cell::new(None)),
         }
     }
 
@@ -57,12 +68,16 @@ impl IndexedDbPageStore {
     // They remain non-reclaiming unless they explicitly implement the complete
     // single-tree ownership contract as well.
     fn supports_tree_ownership(&self) -> bool {
-        ["claimTreeOwnership", "releaseTreeOwnership"]
-            .into_iter()
-            .all(|name| {
-                Reflect::get(&self.handle, &JsValue::from_str(name))
-                    .is_ok_and(|value| value.is_function())
-            })
+        [
+            "claimTreeOwnership",
+            "releaseTreeOwnership",
+            "isTreeOwnershipActive",
+        ]
+        .into_iter()
+        .all(|name| {
+            Reflect::get(&self.handle, &JsValue::from_str(name))
+                .is_ok_and(|value| value.is_function())
+        })
     }
 }
 
@@ -71,15 +86,27 @@ impl PageStore for IndexedDbPageStore {
         if !self.supports_tree_ownership() {
             return Ok(TreeOwnership::default());
         }
-        self.handle.claim_tree_ownership_js().map_err(js_error)?;
-        let handle = self.handle.clone();
-        Ok(TreeOwnership::new(move || {
-            handle.release_tree_ownership_js()
-        }))
+        let token = self.handle.claim_tree_ownership_js().map_err(js_error)?;
+        self.tree_token.set(Some(token));
+        let live_handle = self.handle.clone();
+        let release_handle = self.handle.clone();
+        let current_token = self.tree_token.clone();
+        Ok(TreeOwnership::revocable(
+            move || live_handle.tree_ownership_active_js(token).unwrap_or(false),
+            move || {
+                release_handle.release_tree_ownership_js(token);
+                if current_token.get() == Some(token) {
+                    current_token.set(None);
+                }
+            },
+        ))
     }
 
     fn can_reclaim_obsolete_pages(&self) -> bool {
-        self.supports_tree_ownership() && self.handle.can_reclaim_obsolete_pages_js()
+        self.tree_token.get().is_some_and(|token| {
+            self.handle.tree_ownership_active_js(token).unwrap_or(false)
+                && self.handle.can_reclaim_obsolete_pages_js()
+        })
     }
 
     fn load_metadata(&self) -> BoxFuture<'_, Result<Option<Metadata>, String>> {
@@ -132,6 +159,9 @@ impl PageStore for IndexedDbPageStore {
                     &page_ids,
                     &page_bytes,
                     &deleted_page_ids,
+                    self.tree_token
+                        .get()
+                        .map_or(JsValue::UNDEFINED, JsValue::from_f64),
                 ),
             )
             .await

--- a/crates/idb-tree/src/web.rs
+++ b/crates/idb-tree/src/web.rs
@@ -1,6 +1,5 @@
 use js_sys::{Array, Promise, Reflect, Uint8Array};
 use std::cell::Cell;
-use std::rc::Rc;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -53,14 +52,16 @@ extern "C" {
 #[derive(Clone)]
 pub struct IndexedDbPageStore {
     handle: IndexedDbPageStoreHandle,
-    tree_token: Rc<Cell<Option<f64>>>,
+    // Clones used by one TreeCore retain its token; a separate open only
+    // replaces the token in its own adapter, never in another live tree.
+    tree_token: Cell<Option<f64>>,
 }
 
 impl IndexedDbPageStore {
     pub fn from_js(handle: JsValue) -> Self {
         Self {
             handle: handle.unchecked_into(),
-            tree_token: Rc::new(Cell::new(None)),
+            tree_token: Cell::new(None),
         }
     }
 
@@ -90,15 +91,9 @@ impl PageStore for IndexedDbPageStore {
         self.tree_token.set(Some(token));
         let live_handle = self.handle.clone();
         let release_handle = self.handle.clone();
-        let current_token = self.tree_token.clone();
         Ok(TreeOwnership::revocable(
             move || live_handle.tree_ownership_active_js(token).unwrap_or(false),
-            move || {
-                release_handle.release_tree_ownership_js(token);
-                if current_token.get() == Some(token) {
-                    current_token.set(None);
-                }
-            },
+            move || release_handle.release_tree_ownership_js(token),
         ))
     }
 

--- a/crates/idb-tree/src/web.rs
+++ b/crates/idb-tree/src/web.rs
@@ -52,10 +52,25 @@ impl IndexedDbPageStore {
             handle: handle.unchecked_into(),
         }
     }
+
+    // Existing/custom JS stores implement only metadata/readPage/commitPages.
+    // They remain non-reclaiming unless they explicitly implement the complete
+    // single-tree ownership contract as well.
+    fn supports_tree_ownership(&self) -> bool {
+        ["claimTreeOwnership", "releaseTreeOwnership"]
+            .into_iter()
+            .all(|name| {
+                Reflect::get(&self.handle, &JsValue::from_str(name))
+                    .is_ok_and(|value| value.is_function())
+            })
+    }
 }
 
 impl PageStore for IndexedDbPageStore {
     fn claim_tree_ownership(&self) -> Result<TreeOwnership, String> {
+        if !self.supports_tree_ownership() {
+            return Ok(TreeOwnership::default());
+        }
         self.handle.claim_tree_ownership_js().map_err(js_error)?;
         let handle = self.handle.clone();
         Ok(TreeOwnership::new(move || {
@@ -64,7 +79,7 @@ impl PageStore for IndexedDbPageStore {
     }
 
     fn can_reclaim_obsolete_pages(&self) -> bool {
-        self.handle.can_reclaim_obsolete_pages_js()
+        self.supports_tree_ownership() && self.handle.can_reclaim_obsolete_pages_js()
     }
 
     fn load_metadata(&self) -> BoxFuture<'_, Result<Option<Metadata>, String>> {

--- a/crates/idb-tree/src/web.rs
+++ b/crates/idb-tree/src/web.rs
@@ -3,13 +3,22 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
-use crate::{BoxFuture, Commit, Metadata, PageStore};
+use crate::{BoxFuture, Commit, Metadata, PageStore, TreeOwnership};
 
 #[wasm_bindgen]
 extern "C" {
     #[derive(Clone)]
     #[wasm_bindgen(typescript_type = "IndexedDbPageStore")]
     type IndexedDbPageStoreHandle;
+
+    #[wasm_bindgen(method, catch, js_name = claimTreeOwnership)]
+    fn claim_tree_ownership_js(this: &IndexedDbPageStoreHandle) -> Result<(), JsValue>;
+
+    #[wasm_bindgen(method, js_name = releaseTreeOwnership)]
+    fn release_tree_ownership_js(this: &IndexedDbPageStoreHandle);
+
+    #[wasm_bindgen(method, getter, js_name = canReclaimObsoletePages)]
+    fn can_reclaim_obsolete_pages_js(this: &IndexedDbPageStoreHandle) -> bool;
 
     #[wasm_bindgen(method, js_name = metadata)]
     fn metadata_js(this: &IndexedDbPageStoreHandle) -> Promise;
@@ -46,6 +55,18 @@ impl IndexedDbPageStore {
 }
 
 impl PageStore for IndexedDbPageStore {
+    fn claim_tree_ownership(&self) -> Result<TreeOwnership, String> {
+        self.handle.claim_tree_ownership_js().map_err(js_error)?;
+        let handle = self.handle.clone();
+        Ok(TreeOwnership::new(move || {
+            handle.release_tree_ownership_js()
+        }))
+    }
+
+    fn can_reclaim_obsolete_pages(&self) -> bool {
+        self.handle.can_reclaim_obsolete_pages_js()
+    }
+
     fn load_metadata(&self) -> BoxFuture<'_, Result<Option<Metadata>, String>> {
         Box::pin(async move {
             let value = JsFuture::from(self.handle.metadata_js())

--- a/crates/idb-tree/tests/reclamation.rs
+++ b/crates/idb-tree/tests/reclamation.rs
@@ -20,6 +20,7 @@ struct Store {
     live: Rc<RefCell<BTreeSet<u64>>>,
     deleted: Rc<RefCell<BTreeSet<u64>>>,
     pause: Rc<Cell<bool>>,
+    fail_paused_read: Rc<Cell<bool>>,
     commit_resume: Rc<RefCell<Option<futures::channel::oneshot::Receiver<()>>>>,
     read_resume: Rc<RefCell<Option<futures::channel::oneshot::Receiver<()>>>>,
 }
@@ -57,6 +58,9 @@ impl PageStore for Store {
             };
             if let Some(resume) = resume {
                 resume.await.map_err(|e| e.to_string())?;
+                if self.fail_paused_read.replace(false) {
+                    return Err("old read failed".into());
+                }
             }
             self.memory.read_page(id).await
         })
@@ -247,5 +251,110 @@ fn reload_retains_exclusive_admission_and_discards_failed_staging() {
         tree.put(b"key".to_vec(), vec![3; 4000]).await.unwrap();
         tree.flush().await.unwrap();
         assert!(store.live.borrow().len() <= 6);
+    });
+}
+
+#[test]
+fn pending_read_error_from_before_reload_retries_even_when_root_id_is_unchanged() {
+    block_on(async {
+        let store = Store::exclusive();
+        let initial = IdbTree::open(store.clone(), options()).await.unwrap();
+        initial.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        initial.flush().await.unwrap();
+        drop(initial);
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        let (resume, receiver) = futures::channel::oneshot::channel();
+        *store.read_resume.borrow_mut() = Some(receiver);
+        store.pause.set(true);
+        store.fail_paused_read.set(true);
+        let mut read = Box::pin(tree.get(b"key"));
+        assert!(read.as_mut().now_or_never().is_none());
+        let root = tree.metadata().root_page_id;
+        tree.reload().await.unwrap();
+        assert_eq!(tree.metadata().root_page_id, root);
+        resume.send(()).unwrap();
+        assert_eq!(read.await.unwrap(), Some(vec![1; 4000]));
+    });
+}
+
+#[test]
+fn failed_batch_restores_retirement_and_multilevel_replacements_stay_bounded() {
+    block_on(async {
+        let store = Store::exclusive();
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        for n in 0u32..1000 {
+            tree.put(n.to_be_bytes().to_vec(), vec![1; 80])
+                .await
+                .unwrap();
+        }
+        tree.flush().await.unwrap();
+        let initial_pages = store.live.borrow().len();
+        assert!(initial_pages > 100, "fixture must span multiple leaves");
+        for generation in 2..6 {
+            let operations = (0u32..1000)
+                .map(|n| WriteOperation::Set {
+                    key: n.to_be_bytes().to_vec(),
+                    value: vec![generation; 80],
+                })
+                .collect();
+            tree.write_many(operations).await.unwrap();
+            tree.flush().await.unwrap();
+            assert!(
+                store.live.borrow().len() <= initial_pages,
+                "replaced ancestors leaked"
+            );
+        }
+        let failed = tree
+            .write_many(vec![
+                WriteOperation::Set {
+                    key: 0u32.to_be_bytes().to_vec(),
+                    value: vec![7; 5000],
+                },
+                WriteOperation::Set {
+                    key: vec![255; 2000],
+                    value: vec![8; 5000],
+                },
+            ])
+            .await;
+        assert!(failed.is_err());
+        tree.put(999u32.to_be_bytes().to_vec(), vec![9; 80])
+            .await
+            .unwrap();
+        tree.flush().await.unwrap();
+        drop(tree);
+        let reopened = IdbTree::open(store.clone(), options()).await.unwrap();
+        assert_eq!(
+            reopened.get(&0u32.to_be_bytes()).await.unwrap(),
+            Some(vec![5; 80])
+        );
+        assert_eq!(
+            reopened.get(&999u32.to_be_bytes()).await.unwrap(),
+            Some(vec![9; 80])
+        );
+        assert!(store.live.borrow().len() <= initial_pages);
+    });
+}
+
+#[test]
+fn successful_publication_keeps_newer_staged_generation_and_reclaims_it_on_next_flush() {
+    block_on(async {
+        let store = Store::exclusive();
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        tree.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        tree.flush().await.unwrap();
+        tree.put(b"key".to_vec(), vec![2; 4000]).await.unwrap();
+        let (resume, receiver) = futures::channel::oneshot::channel();
+        *store.commit_resume.borrow_mut() = Some(receiver);
+        let mut flush = Box::pin(tree.flush());
+        assert!(flush.as_mut().now_or_never().is_none());
+        tree.put(b"key".to_vec(), vec![3; 4000]).await.unwrap();
+        resume.send(()).unwrap();
+        flush.await.unwrap();
+        assert_eq!(tree.get(b"key").await.unwrap(), Some(vec![3; 4000]));
+        tree.flush().await.unwrap();
+        assert!(store.live.borrow().len() <= 6);
+        drop(tree);
+        let reopened = IdbTree::open(store, options()).await.unwrap();
+        assert_eq!(reopened.get(b"key").await.unwrap(), Some(vec![3; 4000]));
     });
 }

--- a/crates/idb-tree/tests/reclamation.rs
+++ b/crates/idb-tree/tests/reclamation.rs
@@ -14,6 +14,8 @@ struct Store {
     memory: MemoryPageStore,
     exclusive: Rc<Cell<bool>>,
     claimed: Rc<Cell<bool>>,
+    ownership_generation: Rc<Cell<u64>>,
+    metadata_resume: Rc<RefCell<Option<futures::channel::oneshot::Receiver<()>>>>,
     fail: Rc<Cell<bool>>,
     fail_metadata: Rc<Cell<bool>>,
     metadata_reads: Rc<Cell<usize>>,
@@ -33,12 +35,28 @@ impl Store {
 }
 impl PageStore for Store {
     fn claim_tree_ownership(&self) -> Result<TreeOwnership, String> {
-        if self.exclusive.get() && self.claimed.replace(true) {
+        if !self.exclusive.get() {
+            return Ok(TreeOwnership::default());
+        }
+        if self.claimed.replace(true) {
             return Err("owner already has a tree".into());
         }
-        let claimed = self.claimed.clone();
-        Ok(TreeOwnership::new(move || claimed.set(false)))
+        let token = self.ownership_generation.get() + 1;
+        self.ownership_generation.set(token);
+        let live = self.claimed.clone();
+        let generation = self.ownership_generation.clone();
+        let release_live = live.clone();
+        let release_generation = generation.clone();
+        Ok(TreeOwnership::revocable(
+            move || live.get() && generation.get() == token,
+            move || {
+                if release_generation.get() == token {
+                    release_live.set(false);
+                }
+            },
+        ))
     }
+
     fn can_reclaim_obsolete_pages(&self) -> bool {
         self.exclusive.get()
     }
@@ -47,7 +65,14 @@ impl PageStore for Store {
         if self.fail_metadata.replace(false) {
             return Box::pin(async { Err("metadata unavailable".into()) });
         }
-        self.memory.load_metadata()
+        Box::pin(async move {
+            let metadata = self.memory.load_metadata().await?;
+            let resume = self.metadata_resume.borrow_mut().take();
+            if let Some(resume) = resume {
+                resume.await.map_err(|e| e.to_string())?;
+            }
+            Ok(metadata)
+        })
     }
     fn read_page(&self, id: u64) -> BoxFuture<'_, Result<Option<Vec<u8>>, String>> {
         Box::pin(async move {
@@ -356,5 +381,102 @@ fn successful_publication_keeps_newer_staged_generation_and_reclaims_it_on_next_
         drop(tree);
         let reopened = IdbTree::open(store, options()).await.unwrap();
         assert_eq!(reopened.get(b"key").await.unwrap(), Some(vec![3; 4000]));
+    });
+}
+
+#[test]
+fn revoked_cached_and_pending_handles_cannot_access_or_release_successor() {
+    block_on(async {
+        let store = Store::exclusive();
+        let old = IdbTree::open(store.clone(), options()).await.unwrap();
+        old.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        old.flush().await.unwrap();
+        assert_eq!(old.get(b"key").await.unwrap(), Some(vec![1; 4000]));
+        let retained = old.clone();
+        store.claimed.set(false); // synchronous runtime retirement
+        let successor = IdbTree::open(store.clone(), options()).await.unwrap();
+        assert!(matches!(
+            old.get(b"key").await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.put(b"key".to_vec(), vec![2]).await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.delete(b"key").await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.write_many(vec![]).await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.range(b"", b"z").await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.range_limit(b"", b"z", 0).await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.range_reverse(b"", b"z", 0).await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.range_reverse(b"", b"z", 1).await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.flush().await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.reload().await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        drop(old);
+        drop(retained);
+        assert!(IdbTree::open(store.clone(), options()).await.is_err());
+        successor.put(b"key".to_vec(), vec![3; 4000]).await.unwrap();
+        successor.flush().await.unwrap();
+        successor.reload().await.unwrap();
+        let (resume, receiver) = futures::channel::oneshot::channel();
+        *store.read_resume.borrow_mut() = Some(receiver);
+        store.pause.set(true);
+        let mut read = Box::pin(successor.get(b"key"));
+        assert!(read.as_mut().now_or_never().is_none());
+        store.claimed.set(false);
+        let final_owner = IdbTree::open(store.clone(), options()).await.unwrap();
+        final_owner
+            .put(b"key".to_vec(), vec![4; 4000])
+            .await
+            .unwrap();
+        final_owner.flush().await.unwrap();
+        resume.send(()).unwrap();
+        assert!(matches!(read.await, Err(idb_tree::Error::OwnershipExpired)));
+        assert_eq!(final_owner.get(b"key").await.unwrap(), Some(vec![4; 4000]));
+    });
+}
+
+#[test]
+fn revocation_during_open_rejects_old_metadata_and_preserves_new_guard() {
+    block_on(async {
+        let store = Store::exclusive();
+        let (resume, receiver) = futures::channel::oneshot::channel();
+        *store.metadata_resume.borrow_mut() = Some(receiver);
+        let mut old_open = Box::pin(IdbTree::open(store.clone(), options()));
+        assert!(old_open.as_mut().now_or_never().is_none());
+        store.claimed.set(false);
+        let new = IdbTree::open(store.clone(), options()).await.unwrap();
+        new.put(b"key".to_vec(), vec![7]).await.unwrap();
+        new.flush().await.unwrap();
+        resume.send(()).unwrap();
+        assert!(matches!(
+            old_open.await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(IdbTree::open(store.clone(), options()).await.is_err());
+        assert_eq!(new.get(b"key").await.unwrap(), Some(vec![7]));
     });
 }

--- a/crates/idb-tree/tests/reclamation.rs
+++ b/crates/idb-tree/tests/reclamation.rs
@@ -1,0 +1,251 @@
+use futures::{FutureExt, executor::block_on};
+use idb_tree::{
+    BoxFuture, Commit, IdbTree, MemoryPageStore, Metadata, Options, PageStore, TreeOwnership,
+    WriteOperation,
+};
+use std::{
+    cell::{Cell, RefCell},
+    collections::BTreeSet,
+    rc::Rc,
+};
+
+#[derive(Clone, Default)]
+struct Store {
+    memory: MemoryPageStore,
+    exclusive: Rc<Cell<bool>>,
+    claimed: Rc<Cell<bool>>,
+    fail: Rc<Cell<bool>>,
+    fail_metadata: Rc<Cell<bool>>,
+    metadata_reads: Rc<Cell<usize>>,
+    live: Rc<RefCell<BTreeSet<u64>>>,
+    deleted: Rc<RefCell<BTreeSet<u64>>>,
+    pause: Rc<Cell<bool>>,
+    commit_resume: Rc<RefCell<Option<futures::channel::oneshot::Receiver<()>>>>,
+    read_resume: Rc<RefCell<Option<futures::channel::oneshot::Receiver<()>>>>,
+}
+impl Store {
+    fn exclusive() -> Self {
+        let store = Self::default();
+        store.exclusive.set(true);
+        store
+    }
+}
+impl PageStore for Store {
+    fn claim_tree_ownership(&self) -> Result<TreeOwnership, String> {
+        if self.exclusive.get() && self.claimed.replace(true) {
+            return Err("owner already has a tree".into());
+        }
+        let claimed = self.claimed.clone();
+        Ok(TreeOwnership::new(move || claimed.set(false)))
+    }
+    fn can_reclaim_obsolete_pages(&self) -> bool {
+        self.exclusive.get()
+    }
+    fn load_metadata(&self) -> BoxFuture<'_, Result<Option<Metadata>, String>> {
+        self.metadata_reads.set(self.metadata_reads.get() + 1);
+        if self.fail_metadata.replace(false) {
+            return Box::pin(async { Err("metadata unavailable".into()) });
+        }
+        self.memory.load_metadata()
+    }
+    fn read_page(&self, id: u64) -> BoxFuture<'_, Result<Option<Vec<u8>>, String>> {
+        Box::pin(async move {
+            let resume = if self.pause.replace(false) {
+                self.read_resume.borrow_mut().take()
+            } else {
+                None
+            };
+            if let Some(resume) = resume {
+                resume.await.map_err(|e| e.to_string())?;
+            }
+            self.memory.read_page(id).await
+        })
+    }
+    fn commit<'a>(&'a self, commit: &'a Commit) -> BoxFuture<'a, Result<Metadata, String>> {
+        Box::pin(async move {
+            let resume = self.commit_resume.borrow_mut().take();
+            if let Some(resume) = resume {
+                resume.await.map_err(|e| e.to_string())?;
+            }
+            if self.fail.replace(false) {
+                return Err("injected failure".into());
+            }
+            if !commit.deleted_page_ids.is_empty() && !self.exclusive.get() {
+                return Err("ownership expired".into());
+            }
+            let metadata = self.memory.commit(commit).await?;
+            let mut live = self.live.borrow_mut();
+            live.extend(commit.pages.iter().map(|(id, _)| *id));
+            for id in &commit.deleted_page_ids {
+                live.remove(id);
+                self.deleted.borrow_mut().insert(*id);
+            }
+            Ok(metadata)
+        })
+    }
+}
+fn options() -> Options {
+    Options { page_size: 1024 }
+}
+
+#[test]
+fn exclusive_replacement_bounds_live_pages_and_preserves_sibling_overflow_on_reopen() {
+    block_on(async {
+        let store = Store::exclusive();
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        let sibling = vec![9; 5000];
+        tree.put(b"sibling".to_vec(), sibling.clone())
+            .await
+            .unwrap();
+        for n in 0..80 {
+            tree.write_many(vec![
+                WriteOperation::Set {
+                    key: b"changing".to_vec(),
+                    value: vec![n; 4000],
+                },
+                WriteOperation::Set {
+                    key: b"temporary".to_vec(),
+                    value: vec![n; 3000],
+                },
+                WriteOperation::Delete {
+                    key: b"temporary".to_vec(),
+                },
+            ])
+            .await
+            .unwrap();
+            tree.flush().await.unwrap();
+            assert!(
+                store.live.borrow().len() <= 12,
+                "historical COW pages leaked"
+            );
+            assert_eq!(tree.get(b"sibling").await.unwrap(), Some(sibling.clone()));
+        }
+        tree.delete(b"changing").await.unwrap();
+        tree.flush().await.unwrap();
+        assert!(store.live.borrow().len() <= 7);
+        drop(tree);
+        let reopened = IdbTree::open(store.clone(), options()).await.unwrap();
+        assert_eq!(reopened.get(b"sibling").await.unwrap(), Some(sibling));
+        assert_eq!(reopened.get(b"changing").await.unwrap(), None);
+        assert!(!store.deleted.borrow().is_empty());
+    });
+}
+
+#[test]
+fn generic_independent_cold_handle_keeps_its_complete_old_closure() {
+    block_on(async {
+        let store = Store::default();
+        let writer = IdbTree::open(store.clone(), options()).await.unwrap();
+        writer.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        writer.flush().await.unwrap();
+        let cold = IdbTree::open(store.clone(), options()).await.unwrap();
+        writer.put(b"key".to_vec(), vec![2; 4000]).await.unwrap();
+        writer.flush().await.unwrap();
+        assert_eq!(cold.get(b"key").await.unwrap(), Some(vec![1; 4000]));
+        cold.put(b"other".to_vec(), vec![3]).await.unwrap();
+        assert!(matches!(
+            cold.flush().await,
+            Err(idb_tree::Error::GenerationConflict(_))
+        ));
+        assert!(store.deleted.borrow().is_empty());
+        let reopened = IdbTree::open(store, options()).await.unwrap();
+        assert_eq!(reopened.get(b"key").await.unwrap(), Some(vec![2; 4000]));
+    });
+}
+
+#[test]
+fn failed_publication_with_newer_writes_retries_complete_closure() {
+    block_on(async {
+        let store = Store::exclusive();
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        tree.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        tree.flush().await.unwrap();
+        tree.put(b"key".to_vec(), vec![2; 4000]).await.unwrap();
+        let (resume, receiver) = futures::channel::oneshot::channel();
+        *store.commit_resume.borrow_mut() = Some(receiver);
+        store.fail.set(true);
+        let mut flush = Box::pin(tree.flush());
+        assert!(flush.as_mut().now_or_never().is_none());
+        tree.put(b"key".to_vec(), vec![3; 4000]).await.unwrap();
+        resume.send(()).unwrap();
+        flush.await.unwrap_err();
+        tree.flush().await.unwrap();
+        drop(tree);
+        let reopened = IdbTree::open(store.clone(), options()).await.unwrap();
+        assert_eq!(reopened.get(b"key").await.unwrap(), Some(vec![3; 4000]));
+        assert!(store.live.borrow().len() <= 6);
+    });
+}
+
+#[test]
+fn same_handle_pending_cold_read_retries_after_old_page_is_reclaimed() {
+    block_on(async {
+        let store = Store::exclusive();
+        let initial = IdbTree::open(store.clone(), options()).await.unwrap();
+        initial.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        initial.flush().await.unwrap();
+        drop(initial);
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        let (resume, receiver) = futures::channel::oneshot::channel();
+        *store.read_resume.borrow_mut() = Some(receiver);
+        store.pause.set(true);
+        let mut read = Box::pin(tree.get(b"key"));
+        assert!(read.as_mut().now_or_never().is_none());
+        tree.put(b"key".to_vec(), vec![2; 4000]).await.unwrap();
+        tree.flush().await.unwrap();
+        resume.send(()).unwrap();
+        assert_eq!(read.await.unwrap(), Some(vec![2; 4000]));
+    });
+}
+
+#[test]
+fn exclusive_admission_precedes_metadata_io_and_failed_open_releases_it() {
+    block_on(async {
+        let store = Store::exclusive();
+        let initial = IdbTree::open(store.clone(), options()).await.unwrap();
+        initial.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        initial.flush().await.unwrap();
+        let reads = store.metadata_reads.get();
+        assert!(IdbTree::open(store.clone(), options()).await.is_err());
+        assert_eq!(
+            store.metadata_reads.get(),
+            reads,
+            "competing open must not observe a stale root before admission"
+        );
+        initial.put(b"key".to_vec(), vec![2; 4000]).await.unwrap();
+        initial.flush().await.unwrap();
+        let retained = initial.clone();
+        drop(initial);
+        assert!(IdbTree::open(store.clone(), options()).await.is_err());
+        drop(retained);
+        store.fail_metadata.set(true);
+        assert!(IdbTree::open(store.clone(), options()).await.is_err());
+        assert!(
+            IdbTree::open(store.clone(), Options { page_size: 2048 })
+                .await
+                .is_err()
+        );
+        let reopened = IdbTree::open(store.clone(), options()).await.unwrap();
+        assert_eq!(reopened.get(b"key").await.unwrap(), Some(vec![2; 4000]));
+    });
+}
+
+#[test]
+fn reload_retains_exclusive_admission_and_discards_failed_staging() {
+    block_on(async {
+        let store = Store::exclusive();
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        tree.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        tree.flush().await.unwrap();
+        tree.put(b"key".to_vec(), vec![2; 4000]).await.unwrap();
+        store.fail.set(true);
+        tree.flush().await.unwrap_err();
+        let clone = tree.clone();
+        tree.reload().await.unwrap();
+        assert!(IdbTree::open(store.clone(), options()).await.is_err());
+        assert_eq!(clone.get(b"key").await.unwrap(), Some(vec![1; 4000]));
+        tree.put(b"key".to_vec(), vec![3; 4000]).await.unwrap();
+        tree.flush().await.unwrap();
+        assert!(store.live.borrow().len() <= 6);
+    });
+}

--- a/packages/jazz-tools/src/runtime/browser-physical-database-epoch.ts
+++ b/packages/jazz-tools/src/runtime/browser-physical-database-epoch.ts
@@ -29,6 +29,28 @@ export type BrowserPhysicalDatabaseEpoch = {
   release(): Promise<void>;
 };
 
+const liveEpochs = new WeakMap<
+  BrowserPhysicalDatabaseEpoch,
+  {
+    databaseName: string;
+    active: () => boolean;
+    claimed: boolean;
+  }
+>();
+
+/** Consume the live lock proof once, for one page-store/tree owner. */
+export function claimBrowserReclamationOwnership(
+  epoch: BrowserPhysicalDatabaseEpoch,
+  databaseName: string,
+): () => boolean {
+  const state = liveEpochs.get(epoch);
+  if (!state || state.databaseName !== databaseName || !state.active() || state.claimed) {
+    throw new Error("IndexedDB reclamation requires an unclaimed live database Web Lock");
+  }
+  state.claimed = true;
+  return state.active;
+}
+
 type WebLock = object;
 type LockManagerLike = {
   request<T>(
@@ -78,7 +100,7 @@ export async function acquireBrowserPhysicalDatabaseEpoch(
           rejectEpoch(new BrowserPhysicalDatabaseBusyError(databaseName));
           return;
         }
-        resolveEpoch({
+        const owner: BrowserPhysicalDatabaseEpoch = {
           id,
           release: () => {
             if (!releaseRequested) {
@@ -87,13 +109,19 @@ export async function acquireBrowserPhysicalDatabaseEpoch(
             }
             return lockReleased;
           },
-        });
+        };
+        liveEpochs.set(owner, { databaseName, active: () => !releaseRequested, claimed: false });
+        resolveEpoch(owner);
         await released;
       },
     )
     .then(
-      () => resolveLockReleased(),
+      () => {
+        releaseRequested = true;
+        resolveLockReleased();
+      },
       (error: unknown) => {
+        releaseRequested = true;
         resolveLockReleased();
         rejectEpoch(error instanceof Error ? error : new Error(String(error)));
       },

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
@@ -26,8 +26,8 @@ async function ownReclamation(store: IndexedDbPageStore) {
     },
   });
   await store.claimBrowserWorkerEpoch(epoch.id, epoch);
-  store.claimTreeOwnership();
-  return epoch;
+  const treeToken = store.claimTreeOwnership();
+  return Object.assign(epoch, { treeToken });
 }
 
 const databaseNames: string[] = [];
@@ -209,7 +209,7 @@ describe("IndexedDbPageStore", () => {
     const epoch = await ownReclamation(store);
     expect(store.canReclaimObsoletePages).toBe(true);
     expect(() => store.claimTreeOwnership()).toThrow("already has a tree");
-    store.releaseTreeOwnership();
+    await store.retireTreeOwnership();
     expect(store.canReclaimObsoletePages).toBe(false);
     store.claimTreeOwnership();
     const pending = store.commit(retirement);
@@ -220,6 +220,69 @@ describe("IndexedDbPageStore", () => {
     expect(await store.readPage(2)).toEqual(new Uint8Array([2]));
     expect((await store.metadata())?.generation).toBe(1);
     store.close();
+  });
+
+  it("revokes exact tree generations and drains stale non-deletion commits before a successor", async () => {
+    const store = await IndexedDbPageStore.open(databaseName());
+    const epoch = await ownReclamation(store);
+    const oldToken = epoch.treeToken;
+    await store.commitPages(
+      0,
+      INDEXEDDB_BTREE_PAGE_SIZE,
+      1,
+      2,
+      [1],
+      [new Uint8Array([1])],
+      [],
+      oldToken,
+    );
+    const pending = store.commitPages(
+      1,
+      INDEXEDDB_BTREE_PAGE_SIZE,
+      2,
+      3,
+      [2],
+      [new Uint8Array([2])],
+      [],
+      oldToken,
+    );
+    const rejected = expect(pending).rejects.toThrow("tree ownership expired");
+    const retirement = store.retireTreeOwnership();
+    expect(store.isTreeOwnershipActive(oldToken)).toBe(false);
+    expect(() => store.claimTreeOwnership()).toThrow("pending transaction");
+    await retirement;
+    await rejected;
+    const successor = store.claimTreeOwnership();
+    store.releaseTreeOwnership(oldToken); // late destructor must not retire the successor
+    expect(store.isTreeOwnershipActive(successor)).toBe(true);
+    expect(store.canReclaimObsoletePages).toBe(true);
+    await expect(
+      store.commitPages(
+        1,
+        INDEXEDDB_BTREE_PAGE_SIZE,
+        3,
+        4,
+        [3],
+        [new Uint8Array([3])],
+        [],
+        oldToken,
+      ),
+    ).rejects.toThrow("tree ownership has expired");
+    await store.commitPages(
+      1,
+      INDEXEDDB_BTREE_PAGE_SIZE,
+      4,
+      5,
+      [4],
+      [new Uint8Array([4])],
+      [1],
+      successor,
+    );
+    expect((await store.metadata())?.rootPageId).toBe(4);
+    expect(await store.readPage(2)).toBeNull();
+    expect(await store.readPage(3)).toBeNull();
+    store.close();
+    await epoch.release();
   });
 
   it("rejects forged, mismatched and multiply consumed reclamation proofs", async () => {

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
@@ -1,3 +1,4 @@
+import { acquireBrowserPhysicalDatabaseEpoch } from "./browser-physical-database-epoch.js";
 import { IDBFactory, indexedDB as fakeIndexedDb } from "fake-indexeddb";
 import { readFile } from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -17,6 +18,17 @@ import {
   INDEXEDDB_REPLICA_NODE_KEY,
   IndexedDbPageStore,
 } from "./indexeddb-page-store.js";
+
+async function ownReclamation(store: IndexedDbPageStore) {
+  const epoch = await acquireBrowserPhysicalDatabaseEpoch(store.name, {
+    async request(_name, _options, callback) {
+      return await callback({});
+    },
+  });
+  await store.claimBrowserWorkerEpoch(epoch.id, epoch);
+  store.claimTreeOwnership();
+  return epoch;
+}
 
 const databaseNames: string[] = [];
 
@@ -151,6 +163,7 @@ describe("IndexedDbPageStore", () => {
   it("persists only supplied dirty pages and can delete retired pages", async () => {
     const name = databaseName();
     let store = await IndexedDbPageStore.open(name);
+    const epoch = await ownReclamation(store);
     await store.commit({
       expectedGeneration: 0,
       metadata: { pageSize: INDEXEDDB_BTREE_PAGE_SIZE, rootPageId: 1, nextPageId: 3 },
@@ -172,6 +185,64 @@ describe("IndexedDbPageStore", () => {
     expect(await store.readPage(2)).toBeNull();
     expect((await store.metadata())?.generation).toBe(2);
     store.close();
+    await epoch.release();
+  });
+
+  it("requires live single-tree ownership and fences a queued retirement on release", async () => {
+    const store = await IndexedDbPageStore.open(databaseName());
+    await store.commit({
+      expectedGeneration: 0,
+      metadata: { pageSize: INDEXEDDB_BTREE_PAGE_SIZE, rootPageId: 1, nextPageId: 3 },
+      pages: new Map([
+        [1, new Uint8Array([1])],
+        [2, new Uint8Array([2])],
+      ]),
+    });
+    const retirement = {
+      expectedGeneration: 1,
+      metadata: { pageSize: INDEXEDDB_BTREE_PAGE_SIZE, rootPageId: 1, nextPageId: 3 },
+      pages: new Map<number, Uint8Array>(),
+      deletedPageIds: [2],
+    };
+    expect(store.canReclaimObsoletePages).toBe(false);
+    await expect(store.commit(retirement)).rejects.toThrow("ownership is not active");
+    const epoch = await ownReclamation(store);
+    expect(store.canReclaimObsoletePages).toBe(true);
+    expect(() => store.claimTreeOwnership()).toThrow("already has a tree");
+    store.releaseTreeOwnership();
+    expect(store.canReclaimObsoletePages).toBe(false);
+    store.claimTreeOwnership();
+    const pending = store.commit(retirement);
+    const release = epoch.release();
+    expect(store.canReclaimObsoletePages).toBe(false);
+    await expect(pending).rejects.toThrow("ownership expired before publication");
+    await release;
+    expect(await store.readPage(2)).toEqual(new Uint8Array([2]));
+    expect((await store.metadata())?.generation).toBe(1);
+    store.close();
+  });
+
+  it("rejects forged, mismatched and multiply consumed reclamation proofs", async () => {
+    const name = databaseName();
+    const first = await IndexedDbPageStore.open(name);
+    const second = await IndexedDbPageStore.open(name);
+    const epoch = await ownReclamation(first);
+    await expect(second.claimBrowserWorkerEpoch(epoch.id, epoch)).rejects.toThrow("unclaimed live");
+    await expect(
+      second.claimBrowserWorkerEpoch(epoch.id, {
+        id: epoch.id,
+        release: async () => undefined,
+      }),
+    ).rejects.toThrow("unclaimed live");
+    const other = await IndexedDbPageStore.open(databaseName());
+    await expect(other.claimBrowserWorkerEpoch(epoch.id, epoch)).rejects.toThrow("unclaimed live");
+    const release = first.releaseBrowserWorkerEpoch(epoch.id);
+    expect(first.canReclaimObsoletePages).toBe(false);
+    await release;
+    first.close();
+    second.close();
+    other.close();
+    await epoch.release();
   });
 
   it("rejects a stale generation instead of overwriting a newer root", async () => {

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
@@ -245,6 +245,28 @@ describe("IndexedDbPageStore", () => {
     await epoch.release();
   });
 
+  it("does not reactivate a pending ownership claim after close or release", async () => {
+    for (const close of [false, true]) {
+      const store = await IndexedDbPageStore.open(databaseName());
+      const epoch = await acquireBrowserPhysicalDatabaseEpoch(store.name, {
+        async request(_name, _options, callback) {
+          return await callback({});
+        },
+      });
+      const claim = store.claimBrowserWorkerEpoch(epoch.id, epoch);
+      const rejected = expect(claim).rejects.toThrow();
+      if (close) {
+        store.close();
+      } else {
+        await store.releaseBrowserWorkerEpoch(epoch.id);
+      }
+      await rejected;
+      expect(store.canReclaimObsoletePages).toBe(false);
+      store.close();
+      await epoch.release();
+    }
+  });
+
   it("rejects a stale generation instead of overwriting a newer root", async () => {
     const name = databaseName();
     const store = await IndexedDbPageStore.open(name);

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
@@ -167,6 +167,7 @@ export class IndexedDbPageStore {
   private invalidated = false;
   private reclamationOwnership: (() => boolean) | null = null;
   private treeClaims = 0;
+  private ownershipRevision = 0;
 
   /** One independently opened tree per exclusive owner; IdbTree clones share it. */
   claimTreeOwnership(): void {
@@ -372,6 +373,7 @@ export class IndexedDbPageStore {
     if (ownership && (ownership.id !== epoch || this.treeClaims > 0)) {
       throw new Error("IndexedDB reclamation ownership must precede tree construction");
     }
+    const revision = this.ownershipRevision;
     const proof = ownership ? claimBrowserReclamationOwnership(ownership, this.name) : null;
     const tx = this.db.transaction(INDEXEDDB_STORAGE_MANIFEST_STORE, "readwrite");
     const done = transactionDone(tx);
@@ -380,11 +382,16 @@ export class IndexedDbPageStore {
       INDEXEDDB_BROWSER_WORKER_EPOCH_KEY,
     );
     await done;
+    this.assertValid();
+    if (revision !== this.ownershipRevision) {
+      throw new Error("IndexedDB worker ownership was released while claiming");
+    }
     this.reclamationOwnership = proof;
   }
 
   /** Delete only this realm's epoch; a stale realm must never clear its successor. */
   async releaseBrowserWorkerEpoch(epoch: string): Promise<void> {
+    this.ownershipRevision++;
     this.reclamationOwnership = null;
     if (!isBrowserWorkerEpoch(epoch)) throw new Error("Invalid browser worker epoch");
     this.assertValid();
@@ -622,6 +629,8 @@ export class IndexedDbPageStore {
   }
 
   close(): void {
+    this.invalidated = true;
+    this.ownershipRevision++;
     this.reclamationOwnership = null;
     this.removeInvalidationListeners();
     this.db.close();

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
@@ -166,24 +166,46 @@ export class IndexedDbStorageInvalidatedError extends Error {
 export class IndexedDbPageStore {
   private invalidated = false;
   private reclamationOwnership: (() => boolean) | null = null;
-  private treeClaims = 0;
+  private readonly treeClaims = new Set<number>();
+  private nextTreeToken = 0;
+  private readonly treeTransactions = new Set<Promise<unknown>>();
   private ownershipRevision = 0;
 
   /** One independently opened tree per exclusive owner; IdbTree clones share it. */
-  claimTreeOwnership(): void {
+  claimTreeOwnership(): number {
     this.assertValid();
-    if (this.reclamationOwnership && this.treeClaims > 0) {
-      throw new Error("IndexedDB reclamation owner already has a tree");
+    if (this.reclamationOwnership && (this.treeClaims.size > 0 || this.treeTransactions.size > 0)) {
+      throw new Error("IndexedDB reclamation owner already has a tree or pending transaction");
     }
-    this.treeClaims++;
+    if (this.nextTreeToken === Number.MAX_SAFE_INTEGER)
+      throw new Error("IndexedDB tree token space exhausted");
+    const token = ++this.nextTreeToken;
+    this.treeClaims.add(token);
+    return token;
   }
 
-  releaseTreeOwnership(): void {
-    this.treeClaims--;
+  releaseTreeOwnership(token: number): void {
+    this.treeClaims.delete(token);
+  }
+
+  isTreeOwnershipActive(token: number): boolean {
+    return (
+      !this.invalidated &&
+      this.treeClaims.has(token) &&
+      (this.reclamationOwnership === null || this.reclamationOwnership())
+    );
+  }
+
+  /** Revoke cached handles first, then drain every already-started tree commit. */
+  async retireTreeOwnership(): Promise<void> {
+    this.treeClaims.clear();
+    await Promise.allSettled(this.treeTransactions);
   }
 
   get canReclaimObsoletePages(): boolean {
-    return !this.invalidated && this.treeClaims === 1 && this.reclamationOwnership?.() === true;
+    return (
+      !this.invalidated && this.treeClaims.size === 1 && this.reclamationOwnership?.() === true
+    );
   }
 
   private replicaNodeBytes: Uint8Array | null = null;
@@ -370,7 +392,7 @@ export class IndexedDbPageStore {
   ): Promise<void> {
     if (!isBrowserWorkerEpoch(epoch)) throw new Error("Invalid browser worker epoch");
     this.assertValid();
-    if (ownership && (ownership.id !== epoch || this.treeClaims > 0)) {
+    if (ownership && (ownership.id !== epoch || this.treeClaims.size > 0)) {
       throw new Error("IndexedDB reclamation ownership must precede tree construction");
     }
     const revision = this.ownershipRevision;
@@ -391,6 +413,7 @@ export class IndexedDbPageStore {
 
   /** Delete only this realm's epoch; a stale realm must never clear its successor. */
   async releaseBrowserWorkerEpoch(epoch: string): Promise<void> {
+    this.treeClaims.clear();
     this.ownershipRevision++;
     this.reclamationOwnership = null;
     if (!isBrowserWorkerEpoch(epoch)) throw new Error("Invalid browser worker epoch");
@@ -535,9 +558,12 @@ export class IndexedDbPageStore {
     return bytes.slice();
   }
 
-  async commit(commit: IndexedDbPageCommit): Promise<IndexedDbBtreeMetadata> {
+  async commit(commit: IndexedDbPageCommit, treeToken?: number): Promise<IndexedDbBtreeMetadata> {
     this.assertValid();
     assertCommit(commit);
+    if (treeToken !== undefined && !this.isTreeOwnershipActive(treeToken)) {
+      throw new Error("IndexedDB tree ownership has expired");
+    }
     const requiresOwnership = (commit.deletedPageIds?.length ?? 0) > 0;
     if (requiresOwnership && !this.canReclaimObsoletePages) {
       throw new Error("IndexedDB page reclamation ownership is not active");
@@ -577,6 +603,9 @@ export class IndexedDbPageStore {
       ) {
         throw new Error(`IndexedDB B-tree root page ${metadata.rootPageId} is missing`);
       }
+      if (treeToken !== undefined && !this.isTreeOwnershipActive(treeToken)) {
+        throw new Error("IndexedDB tree ownership expired before publication");
+      }
       if (requiresOwnership && !this.canReclaimObsoletePages) {
         throw new Error("IndexedDB page reclamation ownership expired before publication");
       }
@@ -612,23 +641,36 @@ export class IndexedDbPageStore {
     pageIds: readonly number[],
     pageBytes: readonly Uint8Array[],
     deletedPageIds: readonly number[],
+    treeToken?: number,
   ): Promise<IndexedDbBtreeMetadata> {
     if (pageIds.length !== pageBytes.length) {
       return Promise.reject(new Error("IDBTree page ids and page bytes have different lengths"));
     }
-    return this.commit({
-      expectedGeneration,
-      metadata: {
-        pageSize,
-        rootPageId: rootPageId < 0 ? null : rootPageId,
-        nextPageId,
+    const operation = this.commit(
+      {
+        expectedGeneration,
+        metadata: {
+          pageSize,
+          rootPageId: rootPageId < 0 ? null : rootPageId,
+          nextPageId,
+        },
+        pages: new Map(pageIds.map((pageId, index) => [pageId, pageBytes[index]!])),
+        deletedPageIds,
       },
-      pages: new Map(pageIds.map((pageId, index) => [pageId, pageBytes[index]!])),
-      deletedPageIds,
-    });
+      treeToken,
+    );
+    if (treeToken !== undefined) {
+      this.treeTransactions.add(operation);
+      void operation.then(
+        () => this.treeTransactions.delete(operation),
+        () => this.treeTransactions.delete(operation),
+      );
+    }
+    return operation;
   }
 
   close(): void {
+    this.treeClaims.clear();
     this.invalidated = true;
     this.ownershipRevision++;
     this.reclamationOwnership = null;
@@ -674,6 +716,7 @@ export class IndexedDbPageStore {
   private invalidate(): void {
     if (this.invalidated) return;
     this.invalidated = true;
+    this.treeClaims.clear();
     this.reclamationOwnership = null;
     this.removeInvalidationListeners();
     const error = new IndexedDbStorageInvalidatedError(this.name);

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
@@ -1,3 +1,8 @@
+import {
+  claimBrowserReclamationOwnership,
+  type BrowserPhysicalDatabaseEpoch,
+} from "./browser-physical-database-epoch.js";
+
 /** Durable IndexedDB metadata/page-store format, independent of browser IDB's schema version. */
 export const INDEXEDDB_BTREE_FORMAT_VERSION = 1;
 export const INDEXEDDB_BTREE_FORMAT_MAGIC = "jazz-idb-tree";
@@ -160,6 +165,26 @@ export class IndexedDbStorageInvalidatedError extends Error {
  */
 export class IndexedDbPageStore {
   private invalidated = false;
+  private reclamationOwnership: (() => boolean) | null = null;
+  private treeClaims = 0;
+
+  /** One independently opened tree per exclusive owner; IdbTree clones share it. */
+  claimTreeOwnership(): void {
+    this.assertValid();
+    if (this.reclamationOwnership && this.treeClaims > 0) {
+      throw new Error("IndexedDB reclamation owner already has a tree");
+    }
+    this.treeClaims++;
+  }
+
+  releaseTreeOwnership(): void {
+    this.treeClaims--;
+  }
+
+  get canReclaimObsoletePages(): boolean {
+    return !this.invalidated && this.treeClaims === 1 && this.reclamationOwnership?.() === true;
+  }
+
   private replicaNodeBytes: Uint8Array | null = null;
   private readonly invalidationListeners = new Set<
     (error: IndexedDbStorageInvalidatedError) => void
@@ -338,9 +363,16 @@ export class IndexedDbPageStore {
    * origin-wide Web Lock. A successor may replace an epoch only after that
    * lock proves the preceding realm is no longer alive.
    */
-  async claimBrowserWorkerEpoch(epoch: string): Promise<void> {
+  async claimBrowserWorkerEpoch(
+    epoch: string,
+    ownership?: BrowserPhysicalDatabaseEpoch,
+  ): Promise<void> {
     if (!isBrowserWorkerEpoch(epoch)) throw new Error("Invalid browser worker epoch");
     this.assertValid();
+    if (ownership && (ownership.id !== epoch || this.treeClaims > 0)) {
+      throw new Error("IndexedDB reclamation ownership must precede tree construction");
+    }
+    const proof = ownership ? claimBrowserReclamationOwnership(ownership, this.name) : null;
     const tx = this.db.transaction(INDEXEDDB_STORAGE_MANIFEST_STORE, "readwrite");
     const done = transactionDone(tx);
     tx.objectStore(INDEXEDDB_STORAGE_MANIFEST_STORE).put(
@@ -348,10 +380,12 @@ export class IndexedDbPageStore {
       INDEXEDDB_BROWSER_WORKER_EPOCH_KEY,
     );
     await done;
+    this.reclamationOwnership = proof;
   }
 
   /** Delete only this realm's epoch; a stale realm must never clear its successor. */
   async releaseBrowserWorkerEpoch(epoch: string): Promise<void> {
+    this.reclamationOwnership = null;
     if (!isBrowserWorkerEpoch(epoch)) throw new Error("Invalid browser worker epoch");
     this.assertValid();
     const tx = this.db.transaction(INDEXEDDB_STORAGE_MANIFEST_STORE, "readwrite");
@@ -497,6 +531,10 @@ export class IndexedDbPageStore {
   async commit(commit: IndexedDbPageCommit): Promise<IndexedDbBtreeMetadata> {
     this.assertValid();
     assertCommit(commit);
+    const requiresOwnership = (commit.deletedPageIds?.length ?? 0) > 0;
+    if (requiresOwnership && !this.canReclaimObsoletePages) {
+      throw new Error("IndexedDB page reclamation ownership is not active");
+    }
     const tx = relaxedReadWriteTransaction(this.db, [
       INDEXEDDB_BTREE_PAGES_STORE,
       INDEXEDDB_BTREE_METADATA_STORE,
@@ -531,6 +569,9 @@ export class IndexedDbPageStore {
         (await requestResult(pages.get(metadata.rootPageId))) === undefined
       ) {
         throw new Error(`IndexedDB B-tree root page ${metadata.rootPageId} is missing`);
+      }
+      if (requiresOwnership && !this.canReclaimObsoletePages) {
+        throw new Error("IndexedDB page reclamation ownership expired before publication");
       }
       for (const [pageId, bytes] of commit.pages) {
         if (bytes.byteLength > metadata.pageSize) {
@@ -581,6 +622,7 @@ export class IndexedDbPageStore {
   }
 
   close(): void {
+    this.reclamationOwnership = null;
     this.removeInvalidationListeners();
     this.db.close();
   }
@@ -623,6 +665,7 @@ export class IndexedDbPageStore {
   private invalidate(): void {
     if (this.invalidated) return;
     this.invalidated = true;
+    this.reclamationOwnership = null;
     this.removeInvalidationListeners();
     const error = new IndexedDbStorageInvalidatedError(this.name);
     for (const listener of this.invalidationListeners) listener(error);

--- a/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
@@ -346,7 +346,7 @@ async function openPhysicalDatabaseOwner(
   let pageStore: IndexedDbPageStore | null = null;
   try {
     pageStore = await IndexedDbPageStore.open(dbName, { owner: storageOwner });
-    await pageStore.claimBrowserWorkerEpoch(epoch.id);
+    await pageStore.claimBrowserWorkerEpoch(epoch.id, epoch);
     const owner: PhysicalDatabaseOwner = {
       epoch,
       pageStore,

--- a/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
@@ -1972,7 +1972,12 @@ async function finalizeContextStorageReset(context: RuntimeContext): Promise<voi
 }
 
 async function releaseIdleContext(context: RuntimeContext): Promise<void> {
+  if (contexts.get(context.key) !== context) return;
   if (context.peers.size !== 0 || context.pendingAdmissionTasks !== 0) return;
+  // Foreground lease handoff can outlive the last runtime peer. Reuse this
+  // exact tree until the physical owner can retire; dropping only the wrapper
+  // would leave its storage alive through GC-retained WASM transport handles.
+  if (pendingBootstrapOperations !== 0 || hasForegroundLeaseWork(context.options.dbName)) return;
   if (!context.closing) {
     context.closing = (async () => {
       for (const peer of context.peers.values()) {
@@ -1993,6 +1998,16 @@ async function releaseIdleContext(context: RuntimeContext): Promise<void> {
       context.disposeTelemetry = null;
       context.disposeAuxiliaryTrace?.();
       context.disposeAuxiliaryTrace = null;
+      // No lease work remains; remove its alias before a successor bootstrap
+      // can mistake the closing page store for a reusable lease owner.
+      foregroundLeaseOwners.delete(context.options.dbName);
+      // Start retirement before removing the context. A successor can create
+      // its context immediately, but ensurePhysicalDatabaseOwner waits for this
+      // exact release before opening a fresh page store. Close acknowledgement
+      // must not wait on a slow epoch transaction after the flush barrier.
+      void releasePhysicalDatabaseOwner(context.options.dbName)
+        .catch(() => undefined)
+        .then(maybeCloseWorker);
       if (contexts.get(context.key) === context) contexts.delete(context.key);
     })();
   }
@@ -2011,6 +2026,23 @@ function scheduleIdleContextRelease(context: RuntimeContext): void {
 }
 
 function maybeCloseWorker(): void {
+  // Final lease return/retirement must break the retained-context ownership
+  // cycle, even if another database or inspector keeps this realm alive.
+  if (pendingBootstrapOperations === 0) {
+    for (const context of contexts.values()) {
+      if (
+        context.peers.size === 0 &&
+        context.pendingAdmissionTasks === 0 &&
+        !context.closing &&
+        !context.idleReleaseTimer &&
+        !hasForegroundLeaseWork(context.options.dbName)
+      ) {
+        void releaseIdleContext(context)
+          .catch(() => undefined)
+          .then(maybeCloseWorker);
+      }
+    }
+  }
   if (!workerHasLiveWork()) {
     if (pendingWorkerClose) return;
     const closeToken = Symbol("worker-idle-close");
@@ -2066,12 +2098,13 @@ function workerHasLiveWork(): boolean {
   );
 }
 
-function hasForegroundLeaseWork(): boolean {
-  return [...foregroundLeaseOwners.values()].some(
-    (owner) =>
-      owner.activeLeaseIds.size > 0 ||
-      owner.pendingLeaseAllocations > 0 ||
-      owner.pendingLeaseFinalizations > 0,
+function hasForegroundLeaseWork(dbName?: string): boolean {
+  return [...foregroundLeaseOwners.entries()].some(
+    ([name, owner]) =>
+      (dbName === undefined || name === dbName) &&
+      (owner.activeLeaseIds.size > 0 ||
+        owner.pendingLeaseAllocations > 0 ||
+        owner.pendingLeaseFinalizations > 0),
   );
 }
 

--- a/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
@@ -911,9 +911,10 @@ async function retireForegroundNodeLease(
 function retireUnclaimedRuntimeOwners(): void {
   if (pendingBootstrapOperations !== 0) return;
   for (const [dbName, owner] of pendingRuntimeOwnerRetirements) {
-    pendingRuntimeOwnerRetirements.delete(dbName);
-    if (physicalDatabaseOwners.get(dbName) !== owner) continue;
-    if (contexts.has(dbName)) continue;
+    if (physicalDatabaseOwners.get(dbName) !== owner || contexts.has(dbName)) {
+      pendingRuntimeOwnerRetirements.delete(dbName);
+      continue;
+    }
     const leaseOwner = foregroundLeaseOwners.get(dbName);
     if (
       leaseOwner &&
@@ -922,6 +923,7 @@ function retireUnclaimedRuntimeOwners(): void {
         leaseOwner.pendingLeaseFinalizations > 0)
     )
       continue;
+    pendingRuntimeOwnerRetirements.delete(dbName);
     foregroundLeaseOwners.delete(dbName);
     void releasePhysicalDatabaseOwner(dbName).catch(() => undefined);
   }
@@ -1974,10 +1976,6 @@ async function finalizeContextStorageReset(context: RuntimeContext): Promise<voi
 async function releaseIdleContext(context: RuntimeContext): Promise<void> {
   if (contexts.get(context.key) !== context) return;
   if (context.peers.size !== 0 || context.pendingAdmissionTasks !== 0) return;
-  // Foreground lease handoff can outlive the last runtime peer. Reuse this
-  // exact tree until the physical owner can retire; dropping only the wrapper
-  // would leave its storage alive through GC-retained WASM transport handles.
-  if (pendingBootstrapOperations !== 0 || hasForegroundLeaseWork(context.options.dbName)) return;
   if (!context.closing) {
     context.closing = (async () => {
       for (const peer of context.peers.values()) {
@@ -1989,6 +1987,10 @@ async function releaseIdleContext(context: RuntimeContext): Promise<void> {
       // The last peer's flush barrier already drained evaluator persistence.
       // Do not retain a graceful close future after every page has gone: a
       // suspended cold/query lifecycle cannot add durability at this point.
+      // Revoke every old cached tree before dropping GC-retained WASM wrappers.
+      // Foreground leases belong to the physical owner, not to this schema pin.
+      const physicalOwner = physicalDatabaseOwners.get(context.options.dbName);
+      const treeRetirement = context.pageStore?.retireTreeOwnership();
       context.runtime?.discard();
       context.runtime = null;
       context.disposePageStoreInvalidation?.();
@@ -1998,17 +2000,13 @@ async function releaseIdleContext(context: RuntimeContext): Promise<void> {
       context.disposeTelemetry = null;
       context.disposeAuxiliaryTrace?.();
       context.disposeAuxiliaryTrace = null;
-      // No lease work remains; remove its alias before a successor bootstrap
-      // can mistake the closing page store for a reusable lease owner.
-      foregroundLeaseOwners.delete(context.options.dbName);
-      // Start retirement before removing the context. A successor can create
-      // its context immediately, but ensurePhysicalDatabaseOwner waits for this
-      // exact release before opening a fresh page store. Close acknowledgement
-      // must not wait on a slow epoch transaction after the flush barrier.
-      void releasePhysicalDatabaseOwner(context.options.dbName)
-        .catch(() => undefined)
-        .then(maybeCloseWorker);
-      if (contexts.get(context.key) === context) contexts.delete(context.key);
+      await treeRetirement;
+      if (contexts.get(context.key) !== context) return;
+      contexts.delete(context.key);
+      if (physicalOwner && physicalDatabaseOwners.get(context.options.dbName) === physicalOwner) {
+        pendingRuntimeOwnerRetirements.set(context.options.dbName, physicalOwner);
+      }
+      retireUnclaimedRuntimeOwners();
     })();
   }
   await context.closing;
@@ -2026,23 +2024,7 @@ function scheduleIdleContextRelease(context: RuntimeContext): void {
 }
 
 function maybeCloseWorker(): void {
-  // Final lease return/retirement must break the retained-context ownership
-  // cycle, even if another database or inspector keeps this realm alive.
-  if (pendingBootstrapOperations === 0) {
-    for (const context of contexts.values()) {
-      if (
-        context.peers.size === 0 &&
-        context.pendingAdmissionTasks === 0 &&
-        !context.closing &&
-        !context.idleReleaseTimer &&
-        !hasForegroundLeaseWork(context.options.dbName)
-      ) {
-        void releaseIdleContext(context)
-          .catch(() => undefined)
-          .then(maybeCloseWorker);
-      }
-    }
-  }
+  retireUnclaimedRuntimeOwners();
   if (!workerHasLiveWork()) {
     if (pendingWorkerClose) return;
     const closeToken = Symbol("worker-idle-close");

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => {
   const pageStores: Array<{
     close: Mock;
     claimBrowserWorkerEpoch: Mock;
+    retireTreeOwnership: Mock;
     releaseBrowserWorkerEpoch: Mock;
     onInvalidated: Mock;
     acquireForegroundNodeLease: Mock;
@@ -92,6 +93,7 @@ const mocks = vi.hoisted(() => {
         const pageStore = {
           close: vi.fn(),
           claimBrowserWorkerEpoch: vi.fn(async () => undefined),
+          retireTreeOwnership: vi.fn(async () => undefined),
           releaseBrowserWorkerEpoch: vi.fn(async () => undefined),
           onInvalidated: vi.fn(() => () => undefined),
           acquireForegroundNodeLease: vi.fn(async () => ({
@@ -1402,11 +1404,16 @@ describe("broker worker context initialization", () => {
     expect(mocks.openPageStore).toHaveBeenCalledOnce();
   });
 
-  it("reuses the leased physical tree and retires it before a fresh successor beside a healthy root", async () => {
+  it("retires schema pins while keeping the leased physical owner and fences its final successor", async () => {
     const openedStores = new Set<unknown>();
     mocks.openBrowser.mockImplementation(async (pageStore: unknown) => {
       if (openedStores.has(pageStore)) throw new Error("physical owner already has a tree");
       openedStores.add(pageStore);
+      (pageStore as (typeof mocks.pageStores)[number]).retireTreeOwnership.mockImplementation(
+        async () => {
+          openedStores.delete(pageStore);
+        },
+      );
       return mocks.createBrowserDb();
     });
     const unrelated = await connect(options("reclamation-unrelated-root"), "unrelated");
@@ -1422,11 +1429,11 @@ describe("broker worker context initialization", () => {
     await initializeFollower(first.port, 1);
     const originalStore = mocks.pageStores[1]!;
     await followerResult(first.port, { type: "close", id: 2, releaseContext: true });
-    expect(mocks.runtimes[1]?.discard).not.toHaveBeenCalled();
+    expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce();
     expect(originalStore.close).not.toHaveBeenCalled();
-    const sameOwner = await connect(target, "same-owner");
+    const sameOwner = await connect(target, "same-owner", "next-schema-fingerprint");
     expect(sameOwner.outcome.type).toBe("runtime-ready");
-    expect(mocks.openBrowser).toHaveBeenCalledTimes(2);
+    expect(mocks.openBrowser).toHaveBeenCalledTimes(3);
     await followerResult(sameOwner.port, { type: "close", id: 1, releaseContext: true });
     lease.port.emitMessage({ type: "retire-foreground-node-lease" });
     await vi.waitFor(() => expect(originalStore.close).toHaveBeenCalledOnce());
@@ -1449,6 +1456,35 @@ describe("broker worker context initialization", () => {
     successorLease.port.emitMessage({ type: "retire-foreground-node-lease" });
     await vi.waitFor(() => expect(mocks.pageStores[2]?.close).toHaveBeenCalledOnce());
     await followerResult(unrelated.port, { type: "close", id: 2, releaseContext: true });
+  });
+
+  it("waits for revoked tree transactions before admitting a new schema on the leased store", async () => {
+    const target = options("tree-generation-barrier");
+    const lease = connectLease({
+      type: "acquire-foreground-node-lease",
+      dbName: target.dbName,
+      storageOwner: target.storageOwner,
+    });
+    await lease.outcome;
+    const first = await connect(target, "first", "old-schema");
+    const retirement = deferred<void>();
+    mocks.pageStores[0]!.retireTreeOwnership.mockImplementationOnce(() => retirement.promise);
+    const closed = first.port.waitForEvent((event) => event.type === "result" && event.id === 1);
+    first.port.emitMessage({ type: "close", id: 1, releaseContext: true });
+    await vi.waitFor(() => expect(mocks.pageStores[0]?.retireTreeOwnership).toHaveBeenCalledOnce());
+    const successor = connect(target, "second", "new-schema");
+    await nextTask();
+    expect(mocks.openBrowser).toHaveBeenCalledOnce();
+    expect(mocks.pageStores[0]?.close).not.toHaveBeenCalled();
+    retirement.resolve();
+    await closed;
+    const second = await successor;
+    expect(second.outcome.type).toBe("runtime-ready");
+    expect(mocks.openBrowser).toHaveBeenCalledTimes(2);
+    expect(mocks.pageStores).toHaveLength(1);
+    await followerResult(second.port, { type: "close", id: 1, releaseContext: true });
+    lease.port.emitMessage({ type: "retire-foreground-node-lease" });
+    await vi.waitFor(() => expect(mocks.pageStores[0]?.close).toHaveBeenCalledOnce());
   });
 
   it("retires an unleased tree on close even when another database keeps the worker alive", async () => {
@@ -1643,6 +1679,7 @@ describe("broker worker context initialization", () => {
       const pageStore = {
         close: vi.fn(),
         claimBrowserWorkerEpoch: vi.fn(async () => undefined),
+        retireTreeOwnership: vi.fn(async () => undefined),
         releaseBrowserWorkerEpoch: vi.fn(() => releasePhysicalOwner.promise),
         onInvalidated: vi.fn(() => () => undefined),
         acquireForegroundNodeLease: vi.fn(async () => ({
@@ -2492,7 +2529,7 @@ describe("broker worker context initialization", () => {
       await cancelled.waitFor("runtime-bootstrap-cancelled");
       opened.resolve(db);
       await nextTask();
-      expect(mocks.runtimes[1]?.discard).not.toHaveBeenCalled();
+      expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce();
       expect(pageStore.close).not.toHaveBeenCalled();
       expect(pageStore.releaseBrowserWorkerEpoch).not.toHaveBeenCalled();
 
@@ -2564,7 +2601,7 @@ describe("broker worker context initialization", () => {
       await cancelled.waitFor("runtime-bootstrap-cancelled");
       opened.resolve(db);
       await vi.waitFor(() => expect(mocks.runtimes).toHaveLength(2));
-      expect(mocks.runtimes[1]?.discard).not.toHaveBeenCalled();
+      expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce();
       expect(pageStore.close).not.toHaveBeenCalled();
       expect(pageStore.releaseBrowserWorkerEpoch).not.toHaveBeenCalled();
       pendingLease.port.emitMessage({

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -1402,6 +1402,76 @@ describe("broker worker context initialization", () => {
     expect(mocks.openPageStore).toHaveBeenCalledOnce();
   });
 
+  it("reuses the leased physical tree and retires it before a fresh successor beside a healthy root", async () => {
+    const openedStores = new Set<unknown>();
+    mocks.openBrowser.mockImplementation(async (pageStore: unknown) => {
+      if (openedStores.has(pageStore)) throw new Error("physical owner already has a tree");
+      openedStores.add(pageStore);
+      return mocks.createBrowserDb();
+    });
+    const unrelated = await connect(options("reclamation-unrelated-root"), "unrelated");
+    await initializeFollower(unrelated.port, 1);
+    const target = options("reclamation-leased-root");
+    const lease = connectLease({
+      type: "acquire-foreground-node-lease",
+      dbName: target.dbName,
+      storageOwner: target.storageOwner,
+    });
+    await lease.outcome;
+    const first = await connect(target, "first");
+    await initializeFollower(first.port, 1);
+    const originalStore = mocks.pageStores[1]!;
+    await followerResult(first.port, { type: "close", id: 2, releaseContext: true });
+    expect(mocks.runtimes[1]?.discard).not.toHaveBeenCalled();
+    expect(originalStore.close).not.toHaveBeenCalled();
+    const sameOwner = await connect(target, "same-owner");
+    expect(sameOwner.outcome.type).toBe("runtime-ready");
+    expect(mocks.openBrowser).toHaveBeenCalledTimes(2);
+    await followerResult(sameOwner.port, { type: "close", id: 1, releaseContext: true });
+    lease.port.emitMessage({ type: "retire-foreground-node-lease" });
+    await vi.waitFor(() => expect(originalStore.close).toHaveBeenCalledOnce());
+    expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce();
+    expect(mocks.pageStores[0]?.close).not.toHaveBeenCalled();
+    const successorLease = connectLease({
+      type: "acquire-foreground-node-lease",
+      dbName: target.dbName,
+      storageOwner: target.storageOwner,
+    });
+    await successorLease.outcome;
+    expect(mocks.pageStores).toHaveLength(3);
+    const successor = await connect(
+      { ...target, author: new Uint8Array([7]) },
+      "successor",
+      "new-fingerprint",
+    );
+    expect(successor.outcome.type).toBe("runtime-ready");
+    await followerResult(successor.port, { type: "close", id: 1, releaseContext: true });
+    successorLease.port.emitMessage({ type: "retire-foreground-node-lease" });
+    await vi.waitFor(() => expect(mocks.pageStores[2]?.close).toHaveBeenCalledOnce());
+    await followerResult(unrelated.port, { type: "close", id: 2, releaseContext: true });
+  });
+
+  it("retires an unleased tree on close even when another database keeps the worker alive", async () => {
+    const openedStores = new Set<unknown>();
+    mocks.openBrowser.mockImplementation(async (pageStore: unknown) => {
+      if (openedStores.has(pageStore)) throw new Error("physical owner already has a tree");
+      openedStores.add(pageStore);
+      return mocks.createBrowserDb();
+    });
+    const unrelated = await connect(options("reclamation-keepalive-root"), "unrelated");
+    const target = options("reclamation-reopened-root");
+    const first = await connect(target, "first");
+    await followerResult(first.port, { type: "close", id: 1, releaseContext: true });
+    const second = await connect(target, "second");
+    expect(second.outcome.type).toBe("runtime-ready");
+    expect(mocks.pageStores[1]?.releaseBrowserWorkerEpoch).toHaveBeenCalledOnce();
+    expect(mocks.pageStores[1]?.close).toHaveBeenCalledOnce();
+    expect(mocks.pageStores).toHaveLength(3);
+    expect(mocks.pageStores[0]?.close).not.toHaveBeenCalled();
+    await followerResult(second.port, { type: "close", id: 1, releaseContext: true });
+    await followerResult(unrelated.port, { type: "close", id: 1, releaseContext: true });
+  });
+
   it("can immediately reopen an account root for a linked identity after close acknowledgement", async () => {
     const initial = options("linked-account-handoff");
     const first = await connect(initial, "identity-a", "identity-a-fingerprint");
@@ -2422,7 +2492,7 @@ describe("broker worker context initialization", () => {
       await cancelled.waitFor("runtime-bootstrap-cancelled");
       opened.resolve(db);
       await nextTask();
-      expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce();
+      expect(mocks.runtimes[1]?.discard).not.toHaveBeenCalled();
       expect(pageStore.close).not.toHaveBeenCalled();
       expect(pageStore.releaseBrowserWorkerEpoch).not.toHaveBeenCalled();
 
@@ -2493,7 +2563,8 @@ describe("broker worker context initialization", () => {
       cancelled.port.postMessage({ type: "cancel-runtime-bootstrap" });
       await cancelled.waitFor("runtime-bootstrap-cancelled");
       opened.resolve(db);
-      await vi.waitFor(() => expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(mocks.runtimes).toHaveLength(2));
+      expect(mocks.runtimes[1]?.discard).not.toHaveBeenCalled();
       expect(pageStore.close).not.toHaveBeenCalled();
       expect(pageStore.releaseBrowserWorkerEpoch).not.toHaveBeenCalled();
       pendingLease.port.emitMessage({

--- a/packages/jazz-tools/tests/browser/indexeddb-physical-epoch.test.ts
+++ b/packages/jazz-tools/tests/browser/indexeddb-physical-epoch.test.ts
@@ -1,3 +1,4 @@
+import { acquireBrowserPhysicalDatabaseEpoch } from "../../src/runtime/browser-physical-database-epoch.js";
 /**
  * Real-browser physical epoch receipts for the raw IndexedDB page store.
  * This intentionally bypasses MemoryPageStore and the SharedWorker: it writes
@@ -28,6 +29,46 @@ afterEach(async () => {
 });
 
 describe("IndexedDB physical epoch", () => {
+  it("reclaims pages only during one live Web Lock epoch and reopens the published closure", async () => {
+    const name = databaseName();
+    const epoch = await acquireBrowserPhysicalDatabaseEpoch(name);
+    const store = await IndexedDbPageStore.open(name);
+    try {
+      await store.claimBrowserWorkerEpoch(epoch.id, epoch);
+      store.claimTreeOwnership();
+      expect(store.canReclaimObsoletePages).toBe(true);
+      await expect(acquireBrowserPhysicalDatabaseEpoch(name)).rejects.toThrow("active in another");
+      await store.commit({
+        expectedGeneration: 0,
+        metadata: { pageSize: INDEXEDDB_BTREE_PAGE_SIZE, rootPageId: 1, nextPageId: 2 },
+        pages: new Map([[1, new Uint8Array([1])]]),
+      });
+      await store.commit({
+        expectedGeneration: 1,
+        metadata: { pageSize: INDEXEDDB_BTREE_PAGE_SIZE, rootPageId: 2, nextPageId: 3 },
+        pages: new Map([[2, new Uint8Array([2])]]),
+        deletedPageIds: [1],
+      });
+      expect(await store.readPage(1)).toBeNull();
+      expect(await store.readPage(2)).toEqual(new Uint8Array([2]));
+      const release = store.releaseBrowserWorkerEpoch(epoch.id);
+      expect(store.canReclaimObsoletePages).toBe(false);
+      await release;
+    } finally {
+      store.close();
+      await epoch.release();
+    }
+    const reopened = await IndexedDbPageStore.open(name);
+    try {
+      expect(reopened.canReclaimObsoletePages).toBe(false);
+      expect((await reopened.metadata())?.rootPageId).toBe(2);
+      expect(await reopened.readPage(2)).toEqual(new Uint8Array([2]));
+      expect(await reopened.readPage(1)).toBeNull();
+    } finally {
+      reopened.close();
+    }
+  });
+
   it("atomically installs one replica node when concurrent first opens share a physical database", async () => {
     const name = databaseName();
     const [first, second] = await Promise.all([


### PR DESCRIPTION
🤖 Fixes #2747: stop accumulating obsolete IndexedDB B-tree pages during repeated writes, while retaining complete readable trees across publication and ownership changes.

A write copies the changed leaf and its ancestor path. Before this fix, replaced durable pages accumulated across generations. This patch tracks obsolete structural pages and the overflow chain belonging to a replaced/deleted value, omits already-obsolete fresh pages from publication, and retires eligible durable pages atomically with the new root.

Reclamation requires explicit exclusive ownership. Generic/custom stores and MemoryPageStore default to no durable deletion. The production browser worker supplies its live database Web Lock proof, and the adapter admits one independently opened tree; clones share that tree. Ownership is acquired before asynchronous metadata reads. Each tree has a revocable generation so an idle runtime can retire without waiting for JavaScript garbage collection; stale reads and writes fail closed, and old transactions drain before a successor is admitted. The adapter checks the capability at commit publication, and release/close/invalidation revoke it. This is the supported adapter ownership contract, not protection against unrelated raw IndexedDB access ignoring that contract.

For example, repeatedly updating one row should retain the live tree rather than every prior copy of its leaf/path. Updating one overflow value must not delete a surviving value's overflow chain. An independent generic handle can still read its old root because generic stores do not reclaim. Under exclusive browser ownership, an old runtime must retire before its successor uses the store. For example, a tab waiting for a new schema keeps its foreground lease but does not pin the old schema runtime. When the last admitted old-schema peer leaves, the old tree generation is revoked and drained while the physical database lock remains held. A late destructor cannot release the successor generation.

No physical storage format change or reset is introduced. Existing databases remain supported. This patch stops future accumulation but does not collect historical orphan pages. For this hotfix, explicit scoped-reset/resync guidance replaces shipping a collector (#2753): unsynced and local-only data would be lost, and account credentials must be preserved. There is no automatic reset.

Validation: native IDB tests (30), full Groove tests (826 passed; 4 existing ignored), focused TypeScript checks (82), and wasm32 compilation passed. Final independent review has no remaining blockers. Mutation checks cover stale reads, pending open, stale destructors, post-await publication, worker transaction draining, and actual WASM adapter clone isolation. The coordinator independently reran the 82 TypeScript checks and the formerly failing real-browser schema handoff.

Generated production browser acceptance passed: worker/IndexedDB compatibility/recovery 84 (2 existing skipped), RecordPlayer 9, docs/main todo examples 8/9, custom JS WASM store 11, physical epoch 7. The optimized combined synthetic 1,500-row workload stores 336 pages / 2.77 MB after seeding, compared with 24,200 / 209.84 MB before the fixes. Combined seeding fell from 22.46 seconds to 1.30 seconds; other concurrent performance changes also contribute, so that timing is not isolated attribution. Reopen and ordinary active-subscription updates still have substantial CPU/runtime costs and are being investigated separately.

Final CI is pending on the changeset-only head. No storage reset is required to use the new implementation.
