### PR TITLE
fix(browser): require explicit worker handoff during slow startup

### DIFF
--- a/.changeset/browser-worker-startup-budget.md
+++ b/.changeset/browser-worker-startup-budget.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Avoid opening a competing browser worker generation when runtime startup is slow; preserve a bounded initialization deadline and explicit worker handoff.

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.test.ts
@@ -695,6 +695,30 @@ describe("browser SharedWorker realm identity", () => {
     expect(port.closed).toBe(true);
   });
 
+  it("does not restart the startup budget when the first alive reply arrives late", async () => {
+    vi.useFakeTimers();
+    const { connection, port, sent } = runtimeBootstrapFixture(299_000);
+    let outcome = "pending";
+    void connection.ready().then(
+      () => {
+        outcome = "ready";
+      },
+      () => {
+        outcome = "failed";
+      },
+    );
+    await vi.advanceTimersByTimeAsync(299_000);
+    expect(outcome).toBe("pending");
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(outcome).toBe("failed");
+    await expect(connection.ready()).rejects.toBeInstanceOf(BrowserWorkerUnresponsiveError);
+    expect(sent.filter((message) => message.type === "connect-runtime")).toHaveLength(1);
+    expect(sent.filter((message) => message.type === "cancel-runtime-bootstrap")).toHaveLength(1);
+    port.emit({ type: "runtime-bootstrap-cancelled" });
+    await connection.shutdown();
+    expect(port.closed).toBe(true);
+  });
+
   it("does not let duplicate alive messages extend runtime startup", async () => {
     vi.useFakeTimers();
     const { connection, port, sent } = runtimeBootstrapFixture();

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.test.ts
@@ -153,11 +153,14 @@ class ScriptedRuntimePort {
   }
 }
 
-function runtimeBootstrapFixture() {
+function runtimeBootstrapFixture(aliveDelayMs = 0) {
   const sent: Array<{ type?: string; id?: number }> = [];
   const port = new ScriptedRuntimePort((message) => {
     sent.push(message);
-    if (message.type === "connect-runtime") port.emit({ type: "worker-alive" });
+    if (message.type === "connect-runtime") {
+      if (aliveDelayMs === 0) port.emit({ type: "worker-alive" });
+      else setTimeout(() => port.emit({ type: "worker-alive" }), aliveDelayMs);
+    }
     if (message.type === "init") port.emit({ type: "result", id: message.id });
   });
   vi.stubGlobal(
@@ -659,6 +662,36 @@ describe("browser SharedWorker realm identity", () => {
     // The follower has finished admission and owns normal close acknowledgement.
     port.emit({ type: "result", id: sent.find((message) => message.type === "close")?.id });
     await shutdown;
+    expect(port.closed).toBe(true);
+  });
+
+  it("keeps runtime admission in the same realm when its alive reply is delayed", async () => {
+    vi.useFakeTimers();
+    const { connection, port, sent } = runtimeBootstrapFixture(1_100);
+    await vi.advanceTimersByTimeAsync(1_100);
+    expect(sent.filter((message) => message.type === "connect-runtime")).toHaveLength(1);
+    expect(sent.filter((message) => message.type === "cancel-runtime-bootstrap")).toHaveLength(0);
+    port.emit({ type: "runtime-ready" });
+    await expect(connection.ready()).resolves.toBeUndefined();
+    const shutdown = connection.shutdown();
+    await vi.advanceTimersByTimeAsync(0);
+    port.emit({ type: "result", id: sent.find((message) => message.type === "close")?.id });
+    await shutdown;
+    expect(port.closed).toBe(true);
+  });
+
+  it("rejects a silent runtime without opening a competing worker generation", async () => {
+    vi.useFakeTimers();
+    const { connection, port, sent } = runtimeBootstrapFixture(6 * 60_000);
+    const rejected = expect(connection.ready()).rejects.toBeInstanceOf(
+      BrowserWorkerUnresponsiveError,
+    );
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    await rejected;
+    expect(sent.filter((message) => message.type === "connect-runtime")).toHaveLength(1);
+    expect(sent.filter((message) => message.type === "cancel-runtime-bootstrap")).toHaveLength(1);
+    port.emit({ type: "runtime-bootstrap-cancelled" });
+    await connection.shutdown();
     expect(port.closed).toBe(true);
   });
 

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -530,7 +530,10 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
       let closingLatePeer = false;
       let alive = false;
       let lastTick = Date.now();
-      let deadline = lastTick + 1_000;
+      // A delayed alive reply is not evidence that this realm released its
+      // physical database lock. Only worker-closing authorizes a generation
+      // change; apply the bounded startup grace even before the first reply.
+      let deadline = lastTick + RUNTIME_STARTUP_TIMEOUT_MS;
       let suspended = typeof document !== "undefined" && document.hidden;
       let bootstrapTimer: ReturnType<typeof setTimeout> | undefined;
       const settle = (outcome: { connected: boolean; error?: Error }) => {
@@ -564,7 +567,7 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
       this.cancelBootstrap = cancelForShutdown;
       const refreshGrace = () => {
         lastTick = Date.now();
-        deadline = lastTick + (alive ? RUNTIME_STARTUP_TIMEOUT_MS : 1_000);
+        deadline = lastTick + RUNTIME_STARTUP_TIMEOUT_MS;
       };
       const onVisibilityChange = () => {
         const hidden = typeof document !== "undefined" && document.hidden;
@@ -579,16 +582,12 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
         if (suspended || now - lastTick > RUNTIME_STARTUP_CLOCK_INTERVAL_MS * 2) refreshGrace();
         lastTick = now;
         if (now >= deadline) {
-          cancel(
-            alive
-              ? {
-                  connected: false,
-                  error: new BrowserWorkerUnresponsiveError(
-                    "Shared browser runtime did not finish initialization within five minutes",
-                  ),
-                }
-              : { connected: false },
-          );
+          cancel({
+            connected: false,
+            error: new BrowserWorkerUnresponsiveError(
+              "Shared browser runtime did not finish initialization within five minutes",
+            ),
+          });
           return;
         }
         bootstrapTimer = setTimeout(

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -528,7 +528,6 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
       let settled = false;
       let cancelled = false;
       let closingLatePeer = false;
-      let alive = false;
       let lastTick = Date.now();
       // A delayed alive reply is not evidence that this realm released its
       // physical database lock. Only worker-closing authorizes a generation
@@ -626,13 +625,9 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
           port.close();
           return;
         }
-        if (event.data?.type === "worker-alive") {
-          if (!alive) {
-            alive = true;
-            refreshGrace();
-          }
-          return;
-        }
+        // Liveness is not completed initialization. A first or repeated
+        // alive reply must not restart the single startup budget.
+        if (event.data?.type === "worker-alive") return;
         if (event.data?.type === "runtime-error") {
           cleanup();
           port.close();


### PR DESCRIPTION
🤖 Prevent slow browser runtime startup from creating a competing SharedWorker generation while the original realm can still own the IndexedDB database lock.

For example, a runtime that replies after 1.1 seconds previously exceeded the initial one-second alive timeout. The caller treated silence as permission to advance generation and sent a second connection, even though its foreground lease could still belong to the first worker. That can produce a database-busy failure instead of completing startup.

The runtime now uses its existing five-minute initialization budget from the start. Silence at the deadline is a terminal BrowserWorkerUnresponsiveError, not permission to change generation. Only the explicit worker-closing response permits handoff. First or repeated alive responses do not restart the deadline; existing page suspension/resume handling remains unchanged.

The tests cover a delayed successful reply with exactly one connection, a completely silent worker with one cancellation and terminal error, and a reply at 299 seconds that still times out at the original 300-second deadline. Independent review and the coordinator each ran the complete mocked lifecycle file: 27/27 passed. Restoring the original generation retry or alive-triggered deadline extension makes the new tests fail.

This is a reproduced lifecycle bug found while investigating #2749's broad CI database-busy failure. The CI log alone does not prove it caused that particular occurrence. No storage/wire format changes; native artifact builds are not needed for the deterministic lifecycle tests. Fresh broad CI remains pending.
