### PR TITLE
perf: avoid repeated canonical record reconstruction

### DIFF
--- a/.changeset/canonical-record-validation.md
+++ b/.changeset/canonical-record-validation.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reduce CPU work and allocations when validating nested records during local query delivery, without changing storage encoding or accepted values.

--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -40,3 +40,7 @@ harness = false
 [[bench]]
 name = "micro"
 harness = false
+
+[[bench]]
+name = "record_validation"
+harness = false

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -508,10 +508,16 @@ bytes of each element descriptor; no second outer-record layout is introduced.
 Record values are admitted only when their embedded descriptor equals the
 declared `ValueType::Record` descriptor and their raw bytes are canonical for
 that descriptor: decode every child value, recreate the record, and require
-byte equality. Validation alone is insufficient because `OwnedRecord::new`
-currently accepts arbitrary raw bytes (`src/records/mod.rs:1577-1582`). The
-recreate-and-compare rule is required for byte-based weighted consolidation and
-deterministic final tie-breaking.
+byte equality. This defines the acceptance rule; tuple-free descriptors may
+use an equivalent recursive canonical-byte validator without allocating the
+intermediate values or recreated bytes. That validator checks the entire packed
+layout, offsets, null padding, enum tags, scalar envelopes, and nested records.
+Generic structural validation alone is insufficient because `OwnedRecord::new`
+accepts arbitrary raw bytes. Descriptors recursively containing tuples retain
+the decode/recreate/compare implementation, including its historical tuple
+constructibility and nullable-member byte-order behavior. Exact canonical
+admission is required for byte-based weighted consolidation and deterministic
+final tie-breaking; this optimization changes no persisted encoding.
 
 `Record`, `Array<Record>`, and any recursively containing value type MUST be
 rejected as a durable primary-key part. The primary-key codec has no

--- a/crates/groove/benches/record_validation.rs
+++ b/crates/groove/benches/record_validation.rs
@@ -1,0 +1,75 @@
+//! Isolated nested record admission receipt. Run with
+//! `cargo bench -p groove --bench record_validation --profile perf`.
+use groove::records::{OwnedRecord, RecordDescriptor, Value, ValueType};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Instant;
+
+struct CountingAllocator;
+static COUNT: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNT.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        if COUNT.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(size, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, size) }
+    }
+}
+fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    let iterations: usize = std::env::var("GROOVE_RECORD_ITERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(10_000);
+    for depth in [1, 3, 6] {
+        let setup_start = Instant::now();
+        let mut descriptor =
+            RecordDescriptor::new([("id", ValueType::U64), ("text", ValueType::String)]);
+        let mut raw = descriptor
+            .create(&[Value::U64(7), Value::String("synthetic payload".repeat(8))])
+            .unwrap();
+        for _ in 1..depth {
+            let value = Value::Record(OwnedRecord::new(raw, descriptor));
+            descriptor =
+                RecordDescriptor::new([("child", ValueType::Record(Box::new(descriptor)))]);
+            raw = descriptor.create(&[value]).unwrap();
+        }
+        let values = [Value::Record(OwnedRecord::new(raw, descriptor))];
+        let parent = RecordDescriptor::new([("child", ValueType::Record(Box::new(descriptor)))]);
+        let setup_ns = setup_start.elapsed().as_nanos();
+        for _ in 0..100 {
+            black_box(parent.create(black_box(&values)).unwrap());
+        }
+        let start = Instant::now();
+        for _ in 0..iterations {
+            black_box(parent.create(black_box(&values)).unwrap());
+        }
+        let encode_ns = start.elapsed().as_nanos();
+        ALLOCATIONS.store(0, Ordering::Relaxed);
+        BYTES.store(0, Ordering::Relaxed);
+        COUNT.store(true, Ordering::Relaxed);
+        black_box(parent.create(black_box(&values)).unwrap());
+        COUNT.store(false, Ordering::Relaxed);
+        println!(
+            "{{\"depth\":{depth},\"iterations\":{iterations},\"setup_ns\":{setup_ns},\"encode_ns\":{encode_ns},\"allocations_per_encode\":{},\"bytes_per_encode\":{}}}",
+            ALLOCATIONS.load(Ordering::Relaxed),
+            BYTES.load(Ordering::Relaxed)
+        );
+    }
+}

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -2398,6 +2398,26 @@ fn embedded_record_admission_matches_legacy_roundtrip_corpus() {
         ),
     ];
     let mut cases = cases;
+    // Exercise recursive tuple detection through every containing type. Raw
+    // wrappers are intentional: public encoding rejects some legacy tuple
+    // representations before they can reach the embedding admission boundary.
+    for (inner, raw) in cases.clone() {
+        let record_type = ValueType::Record(Box::new(inner));
+        cases.push((descriptor([record_type.clone()]), raw.clone()));
+        cases.push((
+            descriptor([ValueType::Array(Box::new(record_type.clone()))]),
+            [1u32.to_le_bytes().as_slice(), raw.as_slice()].concat(),
+        ));
+        cases.push((
+            descriptor([ValueType::Nullable(Box::new(record_type))]),
+            [b"\x01".as_slice(), raw.as_slice()].concat(),
+        ));
+        let schema = EnumSchema::new("wrapper", [EnumCase::new("value", inner)]).unwrap();
+        cases.push((
+            descriptor([ValueType::Enum(Box::new(schema))]),
+            [b"\x00".as_slice(), raw.as_slice()].concat(),
+        ));
+    }
     for value_type in [
         ValueType::String,
         ValueType::Bytes,

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -2374,6 +2374,14 @@ fn embedded_record_admission_matches_legacy_roundtrip_corpus() {
             epoch_1_scalar_record_descriptor(),
             EPOCH_1_SCALAR_RECORD_FIXTURE.to_vec(),
         ),
+        (
+            descriptor([ValueType::F64]),
+            f64::NAN.to_le_bytes().to_vec(),
+        ),
+        (
+            descriptor([ValueType::Nullable(Box::new(ValueType::F64))]),
+            [b"\x01".as_slice(), f64::NAN.to_le_bytes().as_slice()].concat(),
+        ),
         (descriptor([ValueType::raw_bytes()]), vec![]),
         (descriptor([ValueType::raw_string()]), b"text".to_vec()),
         (

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -2324,3 +2324,166 @@ fn unwrap_nested_nullable_preserves_outer_none_as_inner_null() {
         assert_eq!(target.get_idx(&output[span], 0).unwrap(), expected);
     }
 }
+
+// Internal byte-admission coverage is necessary here: database APIs cannot
+// construct malformed OwnedRecord payloads or expose canonicality errors.
+#[test]
+fn embedded_record_admission_matches_legacy_roundtrip_corpus() {
+    fn check(descriptor: RecordDescriptor, raw: &[u8]) {
+        let expected = descriptor.bind(raw).to_values().and_then(|values| {
+            if descriptor.create(&values)? == raw {
+                Ok(())
+            } else {
+                Err(Error::NonCanonicalRecord)
+            }
+        });
+        let record = OwnedRecord::new(raw.to_vec(), descriptor);
+        let actual = values::ensure_value_type(
+            &Value::Record(record.clone()),
+            &ValueType::Record(Box::new(descriptor)),
+        );
+        assert_eq!(
+            actual, expected,
+            "record {descriptor:?}: {raw:?}, old={expected:?}, new={actual:?}"
+        );
+        let schema = EnumSchema::new("fixture", [EnumCase::new("payload", descriptor)]).unwrap();
+        let actual = values::ensure_value_type(
+            &Value::Enum(EnumValue::new(0, record)),
+            &ValueType::Enum(Box::new(schema)),
+        );
+        assert_eq!(
+            actual, expected,
+            "enum {descriptor:?}: {raw:?}, old={expected:?}, new={actual:?}"
+        );
+    }
+    let child = descriptor([
+        ValueType::Bool,
+        ValueType::Nullable(Box::new(ValueType::U16)),
+    ]);
+    let event = EnumSchema::new(
+        "event",
+        [
+            EnumCase::new("empty", RecordDescriptor::default()),
+            EnumCase::new("value", child),
+        ],
+    )
+    .unwrap();
+    let cases = vec![
+        (RecordDescriptor::default(), vec![]),
+        (
+            epoch_1_scalar_record_descriptor(),
+            EPOCH_1_SCALAR_RECORD_FIXTURE.to_vec(),
+        ),
+        (descriptor([ValueType::raw_bytes()]), vec![]),
+        (descriptor([ValueType::raw_string()]), b"text".to_vec()),
+        (
+            descriptor([ValueType::Tuple(vec![ValueType::F64])]),
+            1.0f64.to_le_bytes().to_vec(),
+        ),
+        (
+            descriptor([ValueType::Tuple(vec![ValueType::Nullable(Box::new(
+                ValueType::U32,
+            ))])]),
+            vec![1, 1, 2, 3, 4],
+        ),
+        (
+            descriptor([ValueType::Nullable(Box::new(ValueType::Tuple(vec![
+                ValueType::F64,
+            ])))]),
+            vec![0; 9],
+        ),
+        (
+            descriptor([ValueType::Array(Box::new(ValueType::Tuple(vec![])))]),
+            vec![],
+        ),
+    ];
+    let mut cases = cases;
+    for value_type in [
+        ValueType::String,
+        ValueType::Bytes,
+        ValueType::stored_scalar(crate::large_values::LargeValueKind::Json),
+    ] {
+        let value = if value_type == ValueType::Bytes {
+            Value::Bytes(vec![0, 128, 255])
+        } else {
+            Value::String("null".into())
+        };
+        let d = descriptor([value_type]);
+        cases.push((d, d.create(&[value]).unwrap()));
+        // Primitive, chunked, unknown/future format and nonminimal envelopes.
+        for raw in [
+            vec![2],
+            vec![2, 255],
+            vec![3],
+            vec![3, 255],
+            vec![4, 0],
+            vec![0x82, 0, 1],
+        ] {
+            cases.push((d, raw));
+        }
+    }
+    for (kind, logical) in [
+        (
+            crate::large_values::LargeValueKind::Bytes,
+            b"bytes".as_slice(),
+        ),
+        (
+            crate::large_values::LargeValueKind::String,
+            b"text".as_slice(),
+        ),
+        (
+            crate::large_values::LargeValueKind::Json,
+            b"null".as_slice(),
+        ),
+    ] {
+        let prepared = crate::large_values::prepare(kind, logical).unwrap();
+        let d = descriptor([ValueType::stored_scalar(kind)]);
+        cases.push((d, d.create(&[Value::Large(prepared.value_ref)]).unwrap()));
+    }
+    let composite = descriptor([
+        ValueType::Record(Box::new(child)),
+        ValueType::Enum(Box::new(event)),
+        ValueType::Array(Box::new(ValueType::Nullable(Box::new(ValueType::String)))),
+        ValueType::Array(Box::new(ValueType::Record(Box::new(child)))),
+        ValueType::EnumTag(ScalarEnumSchema::new("status", ["one", "two"]).unwrap()),
+    ]);
+    let child_value = OwnedRecord::new(
+        child
+            .create(&[Value::Bool(true), Value::Nullable(None)])
+            .unwrap(),
+        child,
+    );
+    cases.push((
+        composite,
+        composite
+            .create(&[
+                Value::Record(child_value.clone()),
+                Value::Enum(EnumValue::new(1, child_value.clone())),
+                Value::Array(vec![
+                    Value::Nullable(None),
+                    Value::Nullable(Some(Box::new(Value::String("abc".into())))),
+                ]),
+                Value::Array(vec![Value::Record(child_value)]),
+                Value::EnumTag(1),
+            ])
+            .unwrap(),
+    ));
+    for (descriptor, raw) in cases {
+        check(descriptor, &raw);
+        for length in 0..raw.len() {
+            check(descriptor, &raw[..length]);
+        }
+        for extra in [0, 1, 255] {
+            let mut changed = raw.clone();
+            changed.push(extra);
+            check(descriptor, &changed);
+        }
+        for index in 0..raw.len() {
+            for byte in [0, 1, 2, 3, 127, 128, 254, 255] {
+                let mut changed = raw.clone();
+                changed[index] = byte;
+                check(descriptor, &changed);
+            }
+        }
+    }
+}

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -2203,11 +2203,7 @@ pub(super) fn ensure_value_type(value: &Value, value_type: &ValueType) -> Result
                     expected: value_type.clone(),
                 });
             }
-            let values = record.to_values()?;
-            if descriptor.create(&values)? != record.raw() {
-                return Err(Error::NonCanonicalRecord);
-            }
-            Ok(())
+            validate_embedded_record(record.borrowed())
         }
         (Value::Enum(enum_value), ValueType::Enum(schema)) => ensure_enum_value(enum_value, schema),
         _ => Err(Error::TypeMismatch {
@@ -2223,8 +2219,47 @@ fn ensure_enum_value(value: &EnumValue, schema: &EnumSchema) -> Result<(), Error
             expected: ValueType::Enum(Box::new(schema.clone())),
         });
     }
-    let values = value.record.to_values()?;
-    if case.payload.create(&values)? != value.record.raw() {
+    validate_embedded_record(value.record.borrowed())
+}
+
+// Tuple decoding and encoding have historically different constructibility
+// rules (including nullable member byte order). Preserve the exact round-trip
+// admission rule for those descriptors rather than broadening accepted bytes.
+fn contains_tuple(value_type: &ValueType) -> bool {
+    match value_type {
+        ValueType::Tuple(_) => true,
+        ValueType::Array(inner) | ValueType::Nullable(inner) => contains_tuple(inner),
+        ValueType::Record(descriptor) => descriptor
+            .fields()
+            .iter()
+            .any(|field| contains_tuple(&field.value_type)),
+        ValueType::Enum(schema) => schema.cases.iter().any(|case| {
+            case.payload
+                .fields()
+                .iter()
+                .any(|field| contains_tuple(&field.value_type))
+        }),
+        _ => false,
+    }
+}
+
+fn validate_embedded_record(record: super::BorrowedRecord<'_>) -> Result<(), Error> {
+    let descriptor = record.descriptor();
+    if !descriptor
+        .fields()
+        .iter()
+        .any(|field| contains_tuple(&field.value_type))
+        && record.validate_canonical().is_ok()
+    {
+        // Record spans cover the complete packed layout; scalar, offset,
+        // nullable and enum validators enforce canonical encodings.
+        return Ok(());
+    }
+    // The diagnostic error ordering of structural validation differs from
+    // decoding (for example malformed UTF-8 scalar payloads). Preserve legacy
+    // errors on invalid input as well as legacy tuple admission semantics.
+    let values = record.to_values()?;
+    if descriptor.create(&values)? != record.raw() {
         return Err(Error::NonCanonicalRecord);
     }
     Ok(())


### PR DESCRIPTION
🤖 Browser profiling found repeated reconstruction of nested records consuming substantial CPU while delivering locally stored query rows. Validating a record previously decoded its children, rebuilt them, then compared the resulting bytes. With nested records, those steps repeatedly validated the same descendants.

This change checks canonical bytes directly for tuple-free embedded records and enum payloads. For example, validating a row with nested authorship now walks its existing encoding instead of allocating and reconstructing every nested value repeatedly. Descriptors containing tuples retain the previous implementation because their historical decoding and encoding rules differ. Invalid inputs also fall back to the old path, preserving diagnostic errors as well as rejection behavior.

The storage acceptance rule and persisted bytes remain unchanged. Canonical encoding still matters for byte-based consolidation and deterministic ordering; this is an equivalent fast path, not weaker validation. Decode paths are unchanged.

Validation so far: full Groove tests passed; independent correctness review found no blockers, including exhaustive short-input comparisons and nested tuple/NaN cases. Deliberately bypassing validation or removing tuple fallback makes the differential tests fail. A focused native benchmark reduces allocation counts from 63/591/16035 to 21 at nesting depths 1/3/6. These are mechanism measurements, not a claim about browser wall time: combined optimized browser acceptance is pending.

Fixes #2756. Part of the investigation of #2746 and #2747; exact-row write lookup and IndexedDB page reclamation are separate PRs.
