### PR TITLE
Reclaim obsolete IndexedDB B-tree pages

### DIFF
--- a/.changeset/idb-page-reclamation.md
+++ b/.changeset/idb-page-reclamation.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+---
+
+Reclaim obsolete IndexedDB B-tree pages after copy-on-write updates while preserving safe reads and non-browser storage behaviour.

--- a/crates/idb-tree/src/lib.rs
+++ b/crates/idb-tree/src/lib.rs
@@ -9,12 +9,11 @@ mod page;
 mod store;
 #[cfg(target_arch = "wasm32")]
 mod web;
-
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
-pub use store::{BoxFuture, Commit, MemoryPageStore, Metadata, PageStore};
+pub use store::{BoxFuture, Commit, MemoryPageStore, Metadata, PageReclamationToken, PageStore};
 #[cfg(target_arch = "wasm32")]
 pub use web::IndexedDbPageStore;
 
@@ -105,7 +104,11 @@ struct TreeCore<S> {
     metadata: Metadata,
     pages: HashMap<PageId, Page>,
     dirty: BTreeMap<PageId, Page>,
-    deleted: Vec<PageId>,
+    /// Page ids retired by COW replacement in the current unpublished state.
+    /// At commit preparation these are split into fresh ids, which were never
+    /// durable, and durable ids sent through Commit only while the backing
+    /// store currently proves exclusive ownership.
+    retired: BTreeSet<PageId>,
     commit_in_flight: bool,
 }
 
@@ -114,12 +117,15 @@ struct TreeCore<S> {
 /// cache for every operation.
 struct WriteCheckpoint {
     metadata: Metadata,
-    deleted: Vec<PageId>,
+    retired: BTreeSet<PageId>,
 }
 
 #[derive(Debug)]
 pub struct PreparedCommit {
     commit: Commit,
+    /// Retired pages allocated in the dirty generation. They were never
+    /// durable, so they are intentionally absent from commit writes/deletions.
+    fresh_retired_page_ids: Vec<PageId>,
 }
 
 enum Attempt<T> {
@@ -161,36 +167,42 @@ impl<S: PageStore + Clone> IdbTree<S> {
 
     pub async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         loop {
-            let attempt = self.inner.borrow().try_get(key)?;
+            let (attempt, generation) = {
+                let tree = self.inner.borrow();
+                (tree.try_get(key)?, tree.metadata.generation)
+            };
             match attempt {
                 Attempt::Ready(value) => return Ok(value),
-                Attempt::Missing(page_id) => self.hydrate(page_id).await?,
+                Attempt::Missing(page_id) => self.hydrate(page_id, generation).await?,
             }
         }
     }
 
     pub async fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error> {
         loop {
-            let attempt = self
-                .inner
-                .borrow_mut()
-                .with_write_attempt_checkpoint(|tree| tree.try_put(&key, &value))?;
+            let (attempt, generation) = {
+                let mut tree = self.inner.borrow_mut();
+                let attempt =
+                    tree.with_write_attempt_checkpoint(|tree| tree.try_put(&key, &value))?;
+                (attempt, tree.metadata.generation)
+            };
             match attempt {
                 Attempt::Ready(()) => return Ok(()),
-                Attempt::Missing(page_id) => self.hydrate(page_id).await?,
+                Attempt::Missing(page_id) => self.hydrate(page_id, generation).await?,
             }
         }
     }
 
     pub async fn delete(&self, key: &[u8]) -> Result<bool, Error> {
         loop {
-            let attempt = self
-                .inner
-                .borrow_mut()
-                .with_write_attempt_checkpoint(|tree| tree.try_delete(key))?;
+            let (attempt, generation) = {
+                let mut tree = self.inner.borrow_mut();
+                let attempt = tree.with_write_attempt_checkpoint(|tree| tree.try_delete(key))?;
+                (attempt, tree.metadata.generation)
+            };
             match attempt {
                 Attempt::Ready(deleted) => return Ok(deleted),
-                Attempt::Missing(page_id) => self.hydrate(page_id).await?,
+                Attempt::Missing(page_id) => self.hydrate(page_id, generation).await?,
             }
         }
     }
@@ -201,10 +213,13 @@ impl<S: PageStore + Clone> IdbTree<S> {
                 WriteOperation::Set { key, .. } | WriteOperation::Delete { key } => key,
             };
             loop {
-                let attempt = self.inner.borrow().write_path_resident(key)?;
+                let (attempt, generation) = {
+                    let tree = self.inner.borrow();
+                    (tree.write_path_resident(key)?, tree.metadata.generation)
+                };
                 match attempt {
                     Attempt::Ready(()) => break,
-                    Attempt::Missing(page_id) => self.hydrate(page_id).await?,
+                    Attempt::Missing(page_id) => self.hydrate(page_id, generation).await?,
                 }
             }
         }
@@ -227,10 +242,13 @@ impl<S: PageStore + Clone> IdbTree<S> {
         limit: usize,
     ) -> Result<Vec<KeyValue>, Error> {
         loop {
-            let attempt = self.inner.borrow().try_range(start, end, limit)?;
+            let (attempt, generation) = {
+                let tree = self.inner.borrow();
+                (tree.try_range(start, end, limit)?, tree.metadata.generation)
+            };
             match attempt {
                 Attempt::Ready(rows) => return Ok(rows),
-                Attempt::Missing(page_id) => self.hydrate(page_id).await?,
+                Attempt::Missing(page_id) => self.hydrate(page_id, generation).await?,
             }
         }
     }
@@ -242,10 +260,16 @@ impl<S: PageStore + Clone> IdbTree<S> {
         limit: usize,
     ) -> Result<Vec<KeyValue>, Error> {
         loop {
-            let attempt = self.inner.borrow().try_range_reverse(start, end, limit)?;
+            let (attempt, generation) = {
+                let tree = self.inner.borrow();
+                (
+                    tree.try_range_reverse(start, end, limit)?,
+                    tree.metadata.generation,
+                )
+            };
             match attempt {
                 Attempt::Ready(rows) => return Ok(rows),
-                Attempt::Missing(page_id) => self.hydrate(page_id).await?,
+                Attempt::Missing(page_id) => self.hydrate(page_id, generation).await?,
             }
         }
     }
@@ -255,14 +279,20 @@ impl<S: PageStore + Clone> IdbTree<S> {
             let mut tree = self.inner.borrow_mut();
             (tree.store.clone(), tree.prepare_commit()?)
         };
-        let Some(prepared) = prepared else {
+        let Some(mut prepared) = prepared else {
             return Ok(());
         };
+        // Capability lifetime can end after preparation but before the async
+        // store submission. Never send path-local deletions after ownership
+        // has been lost; TreeCore retains those durable retirement intents.
+        if store.reclamation_token().is_none() {
+            prepared.commit.deleted_page_ids.clear();
+        }
         let outcome = store.commit(prepared.commit()).await;
         self.inner.borrow_mut().complete_commit(prepared, outcome)
     }
 
-    async fn hydrate(&self, page_id: PageId) -> Result<(), Error> {
+    async fn hydrate(&self, page_id: PageId, expected_generation: u64) -> Result<(), Error> {
         let store = {
             let tree = self.inner.borrow();
             if tree.pages.contains_key(&page_id) {
@@ -270,12 +300,18 @@ impl<S: PageStore + Clone> IdbTree<S> {
             }
             tree.store.clone()
         };
-        let bytes = store
-            .read_page(page_id)
-            .await
-            .map_err(Error::Store)?
-            .ok_or(Error::MissingPage(page_id))?;
-        let page_size = self.inner.borrow().options.page_size;
+        let bytes = store.read_page(page_id).await.map_err(Error::Store)?;
+        let (generation, page_size) = {
+            let tree = self.inner.borrow();
+            (tree.metadata.generation, tree.options.page_size)
+        };
+        if generation != expected_generation {
+            // A newer publication invalidates this miss. The old read may
+            // return either the retired page or no page after deletion; in
+            // both cases discard it and retry from the current root.
+            return Ok(());
+        }
+        let bytes = bytes.ok_or(Error::MissingPage(page_id))?;
         if bytes.len() > page_size {
             return Err(Error::PageTooLarge { page_id, page_size });
         }
@@ -310,7 +346,7 @@ impl<S: PageStore> TreeCore<S> {
     fn write_checkpoint(&self) -> WriteCheckpoint {
         WriteCheckpoint {
             metadata: self.metadata.clone(),
-            deleted: self.deleted.clone(),
+            retired: self.retired.clone(),
         }
     }
 
@@ -354,7 +390,7 @@ impl<S: PageStore> TreeCore<S> {
             self.pages.remove(&page_id);
             self.dirty.remove(&page_id);
         }
-        self.deleted = checkpoint.deleted;
+        self.retired = checkpoint.retired;
         self.metadata = checkpoint.metadata;
     }
 
@@ -367,7 +403,7 @@ impl<S: PageStore> TreeCore<S> {
             metadata: metadata.unwrap_or_else(|| Metadata::empty(options.page_size)),
             pages: HashMap::new(),
             dirty: BTreeMap::new(),
-            deleted: Vec::new(),
+            retired: BTreeSet::new(),
             commit_in_flight: false,
         };
         if tree.metadata.page_size != options.page_size {
@@ -417,6 +453,8 @@ impl<S: PageStore> TreeCore<S> {
         let new_value = self.build_value(value.to_vec())?;
         match entries.binary_search_by(|(candidate, _)| candidate.as_slice().cmp(key)) {
             Ok(index) => {
+                let old_value = entries[index].1.clone();
+                self.retire_value(&old_value)?;
                 entries[index].1 = new_value;
             }
             Err(index) => entries.insert(index, (key.to_vec(), new_value)),
@@ -438,6 +476,8 @@ impl<S: PageStore> TreeCore<S> {
             return Ok(Attempt::Missing(page_id));
         }
         let mut entries = entries;
+        let old_value = entries[index].1.clone();
+        self.retire_value(&old_value)?;
         entries.remove(index);
         self.finish_leaf_write(page_id, entries, path)?;
         Ok(Attempt::Ready(true))
@@ -505,19 +545,38 @@ impl<S: PageStore> TreeCore<S> {
         }
         Ok(Attempt::Ready(rows))
     }
-
-    /// Swap the active dirty generation without awaiting persistence. New
-    /// writes can immediately begin populating a fresh generation while the
-    /// returned immutable page images are committed by the caller.
     pub fn prepare_commit(&mut self) -> Result<Option<PreparedCommit>, Error> {
         if self.commit_in_flight {
             return Err(Error::CommitInFlight);
         }
-        if self.dirty.is_empty() && self.deleted.is_empty() {
+        if self.dirty.is_empty() && self.retired.is_empty() {
             return Ok(None);
         }
-        let mut pages = Vec::with_capacity(self.dirty.len());
+
+        // A retired page in the active dirty map was allocated and replaced
+        // before it ever became durable. Do not write or delete it: only the
+        // surviving dirty closure and durable retirement intent cross the
+        // persistence seam.
+        let dirty_page_ids: BTreeSet<_> = self.dirty.keys().copied().collect();
+        let fresh_retired: BTreeSet<_> = self
+            .retired
+            .intersection(&dirty_page_ids)
+            .copied()
+            .collect();
+        let durable_retired: BTreeSet<_> =
+            self.retired.difference(&dirty_page_ids).copied().collect();
+        let reclamation_enabled = self.store.reclamation_token().is_some();
+        let retired_for_commit: Vec<_> = if reclamation_enabled {
+            durable_retired.iter().copied().collect()
+        } else {
+            Vec::new()
+        };
+        let fresh_retired_page_ids: Vec<_> = fresh_retired.iter().copied().collect();
+        let mut pages = Vec::with_capacity(self.dirty.len() - fresh_retired.len());
         for (&page_id, page) in &self.dirty {
+            if fresh_retired.contains(&page_id) {
+                continue;
+            }
             let bytes = encode_page(page).map_err(Error::InvalidPage)?;
             if bytes.len() > self.options.page_size {
                 return Err(Error::PageTooLarge {
@@ -527,20 +586,40 @@ impl<S: PageStore> TreeCore<S> {
             }
             pages.push((page_id, bytes));
         }
+        if pages
+            .iter()
+            .any(|(page_id, _)| durable_retired.contains(page_id))
+        {
+            return Err(Error::InvalidPage(
+                "IDBTree commit writes and deletes the same page".to_owned(),
+            ));
+        }
+
         self.commit_in_flight = true;
         let commit = Commit {
             expected_generation: self.metadata.generation,
             metadata: self.metadata.clone(),
             pages,
-            deleted_page_ids: std::mem::take(&mut self.deleted),
+            deleted_page_ids: retired_for_commit,
         };
+        // Fresh retired pages are unreachable and were never durable. Drop
+        // them at the generation swap rather than retaining phantom cache
+        // entries; a failed commit restores only durable commit pages.
+        for page_id in &fresh_retired_page_ids {
+            self.pages.remove(page_id);
+        }
+        self.retired = durable_retired;
         self.dirty.clear();
-        Ok(Some(PreparedCommit { commit }))
+        Ok(Some(PreparedCommit {
+            commit,
+            fresh_retired_page_ids,
+        }))
     }
 
     /// Reconcile an atomic commit result with writes made after
     /// [`prepare_commit`](Self::prepare_commit). On failure, pages unchanged
-    /// since the swap are marked dirty again; newer dirty versions win.
+    /// since the swap are marked dirty again and durable retirement intent is
+    /// restored; newer dirty versions win.
     pub fn complete_commit(
         &mut self,
         prepared: PreparedCommit,
@@ -552,40 +631,66 @@ impl<S: PageStore> TreeCore<S> {
             ));
         }
         self.commit_in_flight = false;
+        let PreparedCommit {
+            commit,
+            fresh_retired_page_ids,
+        } = prepared;
+        debug_assert!(fresh_retired_page_ids.iter().all(|page_id| {
+            !commit.pages.iter().any(|(written, _)| written == page_id)
+                && commit.deleted_page_ids.binary_search(page_id).is_err()
+        }));
+
         match outcome {
-            Ok(committed) => {
-                if committed.generation != prepared.commit.expected_generation + 1 {
-                    return Err(Error::Store(format!(
-                        "commit returned generation {}, expected {}",
-                        committed.generation,
-                        prepared.commit.expected_generation + 1
-                    )));
-                }
+            Ok(committed) if committed.generation == commit.expected_generation + 1 => {
                 // Root and allocation metadata may already describe writes in
                 // the next dirty generation. Only advance its durable base.
                 self.metadata.generation = committed.generation;
+                // A successful reclaiming commit consumes only the retirement
+                // ids it actually submitted. Intents omitted after capability
+                // loss remain queued for a later reclaiming commit.
+                for page_id in &commit.deleted_page_ids {
+                    self.retired.remove(page_id);
+                }
+                // A newer dirty generation may retain a page id only under a
+                // malformed alias. Never evict such a page while it is dirty.
+                for page_id in &commit.deleted_page_ids {
+                    if !self.dirty.contains_key(page_id) {
+                        self.pages.remove(page_id);
+                    }
+                }
                 Ok(())
             }
+            Ok(committed) => {
+                let error = format!(
+                    "commit returned generation {}, expected {}",
+                    committed.generation,
+                    commit.expected_generation + 1
+                );
+                self.restore_failed_commit(&commit);
+                Err(Error::Store(error))
+            }
             Err(error) => {
-                for (page_id, _) in prepared.commit.pages {
-                    if self.dirty.contains_key(&page_id) {
-                        continue;
-                    }
-                    if let Some(page) = self.pages.get(&page_id) {
-                        self.dirty.insert(page_id, page.clone());
-                    }
-                }
-                for page_id in prepared.commit.deleted_page_ids {
-                    if !self.pages.contains_key(&page_id) && !self.deleted.contains(&page_id) {
-                        self.deleted.push(page_id);
-                    }
-                }
+                self.restore_failed_commit(&commit);
                 if error.contains("generation changed") {
                     Err(Error::GenerationConflict(error))
                 } else {
                     Err(Error::Store(error))
                 }
             }
+        }
+    }
+
+    fn restore_failed_commit(&mut self, commit: &Commit) {
+        for (page_id, _) in &commit.pages {
+            if self.dirty.contains_key(page_id) {
+                continue;
+            }
+            if let Some(page) = self.pages.get(page_id) {
+                self.dirty.insert(*page_id, page.clone());
+            }
+        }
+        for page_id in &commit.deleted_page_ids {
+            self.retire_page(*page_id);
         }
     }
 
@@ -800,6 +905,9 @@ impl<S: PageStore> TreeCore<S> {
         entries: Vec<(Vec<u8>, ValueCell)>,
         path: Vec<(PageId, usize)>,
     ) -> Result<(), Error> {
+        // The old leaf is no longer reachable from the replacement root.
+        // Checkpoint rollback restores this intent if allocation fails.
+        self.retire_page(page_id);
         let page = Page::Leaf { entries };
         let replacement = if self.page_fits(&page)? {
             PageReplacement::One(self.allocate_page(page)?)
@@ -826,10 +934,36 @@ impl<S: PageStore> TreeCore<S> {
         self.publish_replacement(replacement, path)
     }
 
+    fn retire_page(&mut self, page_id: PageId) {
+        self.retired.insert(page_id);
+    }
+
+    fn retire_value(&mut self, value: &ValueCell) -> Result<(), Error> {
+        let ValueCell::Overflow { head, .. } = value else {
+            return Ok(());
+        };
+        let mut current = Some(*head);
+        let mut visited = HashSet::new();
+        while let Some(page_id) = current {
+            if !visited.insert(page_id) {
+                return Err(Error::InvalidPage(
+                    "value overflow chain contains a cycle".to_owned(),
+                ));
+            }
+            let Some(Page::Overflow { next, .. }) = self.pages.get(&page_id) else {
+                return Err(Error::MissingPage(page_id));
+            };
+            current = *next;
+            self.retire_page(page_id);
+        }
+        Ok(())
+    }
+
     /// Rebuild every changed ancestor under fresh page ids. A committed root
-    /// therefore names a complete immutable closure. Reclamation is deferred
-    /// to a reachability-based maintenance pass, rather than deleting pages
-    /// while an older root could still name them.
+    /// therefore names a complete immutable closure. Under the production
+    /// single-owner epoch, each replaced ancestor is retired in the same
+    /// commit as its replacement. Historical roots/readers are outside this
+    /// scoped guarantee; a separate historical collector may be added later.
     fn publish_replacement(
         &mut self,
         mut replacement: PageReplacement,
@@ -849,6 +983,7 @@ impl<S: PageStore> TreeCore<S> {
                     "descent parent is not internal".to_owned(),
                 ));
             };
+            self.retire_page(parent_id);
             replacement = match replacement {
                 PageReplacement::One(page_id) => {
                     children[child_index] = page_id;
@@ -902,8 +1037,9 @@ impl<S: PageStore> TreeCore<S> {
             })?,
         };
         self.metadata.root_page_id = Some(root);
-        // The old closure remains durable until a future mark/sweep collector
-        // proves it unreachable from the published root.
+        // The replaced closure is retired in this commit under the
+        // single-owner browser-worker epoch. Historical readers are outside
+        // this guarantee; historical mark/sweep cleanup is separate work.
         Ok(())
     }
 
@@ -1030,7 +1166,7 @@ impl<S: PageStore> TreeCore<S> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
+    use std::cell::{Cell, RefCell};
     use std::future::Future;
     use std::pin::Pin;
     use std::rc::Rc;
@@ -1119,9 +1255,47 @@ mod tests {
     }
 
     #[test]
-    fn point_updates_publish_a_fresh_root_without_deleting_the_old_closure() {
+    fn overflow_replacement_reclaims_only_the_replaced_value_chain() {
         futures::executor::block_on(async {
-            let store = MemoryPageStore::default();
+            let store = MemoryPageStore::reclaiming();
+            let options = Options { page_size: 1024 };
+            let tree = IdbTree::open(store.clone(), options).await.unwrap();
+            tree.put(b"a".to_vec(), vec![1; 5_000]).await.unwrap();
+            tree.put(b"z".to_vec(), vec![2; 5_000]).await.unwrap();
+            tree.flush().await.unwrap();
+            let old_a_chain = overflow_ids(&tree, b"a");
+            let old_z_chain = overflow_ids(&tree, b"z");
+
+            tree.put(b"a".to_vec(), vec![3; 4_000]).await.unwrap();
+            let prepared = tree.inner.borrow_mut().prepare_commit().unwrap().unwrap();
+            for page_id in &old_a_chain {
+                assert!(prepared.commit().deleted_page_ids.contains(page_id));
+            }
+            for page_id in &old_z_chain {
+                assert!(!prepared.commit().deleted_page_ids.contains(page_id));
+            }
+            let outcome = store.commit(prepared.commit()).await.unwrap();
+            tree.inner
+                .borrow_mut()
+                .complete_commit(prepared, Ok(outcome))
+                .unwrap();
+
+            for page_id in old_a_chain {
+                assert_eq!(store.read_page(page_id).await.unwrap(), None);
+            }
+            for page_id in old_z_chain {
+                assert!(store.read_page(page_id).await.unwrap().is_some());
+            }
+            let reopened = IdbTree::open(store, options).await.unwrap();
+            assert_eq!(reopened.get(b"a").await.unwrap(), Some(vec![3; 4_000]));
+            assert_eq!(reopened.get(b"z").await.unwrap(), Some(vec![2; 5_000]));
+        });
+    }
+
+    #[test]
+    fn point_updates_reclaim_the_old_closure_after_publication() {
+        futures::executor::block_on(async {
+            let store = MemoryPageStore::reclaiming();
             let options = Options { page_size: 1024 };
             let tree = IdbTree::open(store.clone(), options).await.unwrap();
             tree.put(b"key".to_vec(), b"before".to_vec()).await.unwrap();
@@ -1139,10 +1313,18 @@ mod tests {
                     .iter()
                     .any(|(id, _)| *id == new_root)
             );
-            assert!(prepared.commit().deleted_page_ids.is_empty());
+            assert!(prepared.commit().deleted_page_ids.contains(&old_root));
+            assert!(
+                prepared
+                    .commit()
+                    .pages
+                    .iter()
+                    .all(|(id, _)| { !prepared.commit().deleted_page_ids.contains(id) })
+            );
 
-            // Until root publication, a separate opener still sees the old
-            // immutable closure.
+            // Until root publication, an independently opened reader still
+            // sees the old immutable closure. Post-publication stale-reader
+            // usability is intentionally outside the single-owner contract.
             let before_publish = IdbTree::open(store.clone(), options).await.unwrap();
             assert_eq!(
                 before_publish.get(b"key").await.unwrap(),
@@ -1158,6 +1340,156 @@ mod tests {
                 after_publish.get(b"key").await.unwrap(),
                 Some(b"after".to_vec())
             );
+        });
+    }
+
+    #[test]
+    fn non_reclaiming_store_retains_durable_old_closure() {
+        futures::executor::block_on(async {
+            let store = MemoryPageStore::default();
+            let options = Options { page_size: 1024 };
+            let tree = IdbTree::open(store.clone(), options).await.unwrap();
+            tree.put(b"key".to_vec(), b"before".to_vec()).await.unwrap();
+            tree.flush().await.unwrap();
+            let old_root = tree.metadata().root_page_id.unwrap();
+
+            tree.put(b"key".to_vec(), b"after".to_vec()).await.unwrap();
+            let prepared = tree.inner.borrow_mut().prepare_commit().unwrap().unwrap();
+            assert!(prepared.commit().deleted_page_ids.is_empty());
+            let outcome = store.commit(prepared.commit()).await.unwrap();
+            tree.inner
+                .borrow_mut()
+                .complete_commit(prepared, Ok(outcome))
+                .unwrap();
+
+            assert!(store.read_page(old_root).await.unwrap().is_some());
+            let reopened = IdbTree::open(store, options).await.unwrap();
+            assert_eq!(reopened.get(b"key").await.unwrap(), Some(b"after".to_vec()));
+        });
+    }
+
+    #[test]
+    fn capability_loss_defers_durable_retirement_until_reenabled() {
+        futures::executor::block_on(async {
+            let durable = MemoryPageStore::default();
+            let store = DynamicCapabilityPageStore::new(durable.clone());
+            let options = Options { page_size: 1024 };
+            let tree = IdbTree::open(store.clone(), options).await.unwrap();
+            tree.put(b"key".to_vec(), b"before".to_vec()).await.unwrap();
+            tree.flush().await.unwrap();
+            let old_root = tree.metadata().root_page_id.unwrap();
+
+            tree.put(b"key".to_vec(), b"after".to_vec()).await.unwrap();
+            store.set_reclamation_enabled(false);
+            tree.flush().await.unwrap();
+            assert!(durable.read_page(old_root).await.unwrap().is_some());
+            assert_eq!(store.deleted_commits()[1], Vec::<PageId>::new());
+
+            store.set_reclamation_enabled(true);
+            tree.flush().await.unwrap();
+            assert_eq!(store.deleted_commits()[2], vec![old_root]);
+            assert_eq!(durable.read_page(old_root).await.unwrap(), None);
+        });
+    }
+
+    #[test]
+    fn fresh_retired_pages_are_not_written_or_deleted() {
+        futures::executor::block_on(async {
+            let store = MemoryPageStore::default();
+            let options = Options { page_size: 1024 };
+            let tree = IdbTree::open(store.clone(), options).await.unwrap();
+            tree.put(b"key".to_vec(), b"first".to_vec()).await.unwrap();
+            tree.put(b"key".to_vec(), b"second".to_vec()).await.unwrap();
+            let current_root = tree.metadata().root_page_id.unwrap();
+
+            let prepared = tree.inner.borrow_mut().prepare_commit().unwrap().unwrap();
+            assert_eq!(
+                prepared
+                    .commit()
+                    .pages
+                    .iter()
+                    .map(|(id, _)| *id)
+                    .collect::<Vec<_>>(),
+                vec![current_root]
+            );
+            assert!(prepared.commit().deleted_page_ids.is_empty());
+            {
+                let tree = tree.inner.borrow();
+                for page_id in 0..current_root {
+                    assert!(!tree.pages.contains_key(&page_id));
+                }
+            }
+            let outcome = store.commit(prepared.commit()).await.unwrap();
+            tree.inner
+                .borrow_mut()
+                .complete_commit(prepared, Ok(outcome))
+                .unwrap();
+
+            let reopened = IdbTree::open(store, options).await.unwrap();
+            assert_eq!(
+                reopened.get(b"key").await.unwrap(),
+                Some(b"second".to_vec())
+            );
+        });
+    }
+
+    #[test]
+    fn write_many_reclaims_disjoint_replacements_atomically() {
+        futures::executor::block_on(async {
+            let store = MemoryPageStore::reclaiming();
+            let options = Options { page_size: 1024 };
+            let tree = IdbTree::open(store.clone(), options).await.unwrap();
+            for ordinal in 0..100 {
+                tree.put(
+                    format!("key-{ordinal:03}").into_bytes(),
+                    vec![ordinal as u8; 20],
+                )
+                .await
+                .unwrap();
+            }
+            tree.flush().await.unwrap();
+
+            tree.write_many(vec![
+                WriteOperation::Set {
+                    key: b"key-001".to_vec(),
+                    value: b"updated".to_vec(),
+                },
+                WriteOperation::Delete {
+                    key: b"key-098".to_vec(),
+                },
+                WriteOperation::Set {
+                    key: b"key-050".to_vec(),
+                    value: b"also-updated".to_vec(),
+                },
+            ])
+            .await
+            .unwrap();
+            let prepared = tree.inner.borrow_mut().prepare_commit().unwrap().unwrap();
+            assert!(!prepared.commit().deleted_page_ids.is_empty());
+            assert!(
+                prepared
+                    .commit()
+                    .pages
+                    .iter()
+                    .all(|(id, _)| { !prepared.commit().deleted_page_ids.contains(id) })
+            );
+            let outcome = store.commit(prepared.commit()).await.unwrap();
+            tree.inner
+                .borrow_mut()
+                .complete_commit(prepared, Ok(outcome))
+                .unwrap();
+
+            let reopened = IdbTree::open(store, options).await.unwrap();
+            assert_eq!(
+                reopened.get(b"key-001").await.unwrap(),
+                Some(b"updated".to_vec())
+            );
+            assert_eq!(reopened.get(b"key-098").await.unwrap(), None);
+            assert_eq!(
+                reopened.get(b"key-050").await.unwrap(),
+                Some(b"also-updated".to_vec())
+            );
+            assert_eq!(reopened.get(b"key-049").await.unwrap(), Some(vec![49; 20]));
         });
     }
 
@@ -1642,6 +1974,79 @@ mod tests {
     }
 
     #[test]
+    fn failed_commit_with_a_resident_next_generation_restores_deletions_for_retry() {
+        futures::executor::block_on(async {
+            let store = MemoryPageStore::reclaiming();
+            let options = Options::default();
+            let tree = IdbTree::open(store.clone(), options).await.unwrap();
+            tree.put(b"base".to_vec(), b"old".to_vec()).await.unwrap();
+            tree.flush().await.unwrap();
+            let old_root = tree.metadata().root_page_id.unwrap();
+
+            tree.put(b"base".to_vec(), b"new".to_vec()).await.unwrap();
+            let first_commit = tree.inner.borrow_mut().prepare_commit().unwrap().unwrap();
+            assert!(first_commit.commit().deleted_page_ids.contains(&old_root));
+            tree.put(b"during".to_vec(), b"value".to_vec())
+                .await
+                .unwrap();
+
+            assert!(
+                tree.inner
+                    .borrow_mut()
+                    .complete_commit(first_commit, Err("injected failure".to_owned()))
+                    .is_err()
+            );
+            let retry = tree.inner.borrow_mut().prepare_commit().unwrap().unwrap();
+            assert!(retry.commit().deleted_page_ids.contains(&old_root));
+            assert!(
+                retry
+                    .commit()
+                    .pages
+                    .iter()
+                    .all(|(id, _)| { !retry.commit().deleted_page_ids.contains(id) })
+            );
+            let outcome = store.commit(retry.commit()).await.unwrap();
+            tree.inner
+                .borrow_mut()
+                .complete_commit(retry, Ok(outcome))
+                .unwrap();
+
+            let reopened = IdbTree::open(store, options).await.unwrap();
+            assert_eq!(reopened.get(b"base").await.unwrap(), Some(b"new".to_vec()));
+            assert_eq!(
+                reopened.get(b"during").await.unwrap(),
+                Some(b"value".to_vec())
+            );
+        });
+    }
+
+    #[test]
+    fn delayed_public_get_retries_after_reclaiming_write() {
+        futures::executor::block_on(async {
+            let durable = MemoryPageStore::reclaiming();
+            let options = Options { page_size: 1024 };
+            let seed = IdbTree::open(durable.clone(), options).await.unwrap();
+            seed.put(b"warm".to_vec(), vec![1; 16]).await.unwrap();
+            seed.put(b"target".to_vec(), vec![2; 5_000]).await.unwrap();
+            seed.flush().await.unwrap();
+            drop(seed);
+
+            let delayed = YieldingPageStore::new(durable);
+            let tree = IdbTree::open(delayed, options).await.unwrap();
+            // Hydrate only the structural page and inline value. The target's
+            // overflow chain remains a cold, durable read.
+            assert_eq!(tree.get(b"warm").await.unwrap(), Some(vec![1; 16]));
+            let mut cold = Box::pin(tree.get(b"target"));
+            assert!(matches!(poll_once(cold.as_mut()), Poll::Pending));
+
+            tree.put(b"target".to_vec(), b"new".to_vec()).await.unwrap();
+            tree.flush().await.unwrap();
+
+            assert_eq!(cold.await.unwrap(), Some(b"new".to_vec()));
+        });
+    }
+
+    #[test]
     fn cold_read_does_not_block_a_resident_write() {
         futures::executor::block_on(async {
             let durable = MemoryPageStore::default();
@@ -1708,6 +2113,78 @@ mod tests {
         });
     }
 
+    fn overflow_ids<S: PageStore>(tree: &IdbTree<S>, key: &[u8]) -> Vec<PageId> {
+        let tree = tree.inner.borrow();
+        let (_, entries, _, _) = tree.resident_descent(key).unwrap().unwrap();
+        let (_, value) = entries
+            .into_iter()
+            .find(|(candidate, _)| candidate.as_slice() == key)
+            .unwrap();
+        let ValueCell::Overflow { head, .. } = value else {
+            panic!("expected overflow value");
+        };
+        let mut ids = Vec::new();
+        let mut current = Some(head);
+        while let Some(page_id) = current {
+            ids.push(page_id);
+            let Page::Overflow { next, .. } = tree.pages.get(&page_id).unwrap() else {
+                panic!("expected overflow page");
+            };
+            current = *next;
+        }
+        ids
+    }
+
+    #[derive(Clone)]
+    struct DynamicCapabilityPageStore {
+        inner: MemoryPageStore,
+        reclamation_enabled: Rc<Cell<bool>>,
+        deleted_commits: Rc<RefCell<Vec<Vec<PageId>>>>,
+    }
+
+    impl DynamicCapabilityPageStore {
+        fn new(inner: MemoryPageStore) -> Self {
+            Self {
+                inner,
+                reclamation_enabled: Rc::new(Cell::new(true)),
+                deleted_commits: Rc::new(RefCell::new(Vec::new())),
+            }
+        }
+
+        fn set_reclamation_enabled(&self, enabled: bool) {
+            self.reclamation_enabled.set(enabled);
+        }
+
+        fn deleted_commits(&self) -> Vec<Vec<PageId>> {
+            self.deleted_commits.borrow().clone()
+        }
+    }
+
+    impl PageStore for DynamicCapabilityPageStore {
+        fn load_metadata(&self) -> BoxFuture<'_, Result<Option<Metadata>, String>> {
+            self.inner.load_metadata()
+        }
+
+        fn read_page(&self, page_id: PageId) -> BoxFuture<'_, Result<Option<Vec<u8>>, String>> {
+            self.inner.read_page(page_id)
+        }
+
+        fn reclamation_token(&self) -> Option<PageReclamationToken> {
+            self.reclamation_enabled
+                .get()
+                .then(PageReclamationToken::new)
+        }
+
+        fn commit<'a>(&'a self, commit: &'a Commit) -> BoxFuture<'a, Result<Metadata, String>> {
+            let deleted = commit.deleted_page_ids.clone();
+            let deleted_commits = self.deleted_commits.clone();
+            Box::pin(async move {
+                deleted_commits.borrow_mut().push(deleted);
+                self.inner.commit(commit).await
+            })
+        }
+    }
+
     #[derive(Clone)]
     struct YieldingPageStore {
         inner: MemoryPageStore,
@@ -1734,6 +2211,9 @@ mod tests {
                 YieldOnce(false).await;
                 self.inner.read_page(page_id).await
             })
+        }
+        fn reclamation_token(&self) -> Option<PageReclamationToken> {
+            self.inner.reclamation_token()
         }
 
         fn commit<'a>(&'a self, commit: &'a Commit) -> BoxFuture<'a, Result<Metadata, String>> {

--- a/crates/idb-tree/src/store.rs
+++ b/crates/idb-tree/src/store.rs
@@ -34,18 +34,61 @@ pub struct Commit {
     pub deleted_page_ids: Vec<PageId>,
 }
 
+/// Opaque proof that a page store has exclusive ownership for path-local
+/// reclamation. Only adapters in this crate can construct it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageReclamationToken {
+    _private: (),
+}
+
+impl PageReclamationToken {
+    pub(crate) fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
 pub trait PageStore {
     fn load_metadata(&self) -> BoxFuture<'_, Result<Option<Metadata>, String>>;
     fn read_page(&self, page_id: PageId) -> BoxFuture<'_, Result<Option<Vec<u8>>, String>>;
     fn commit<'a>(&'a self, commit: &'a Commit) -> BoxFuture<'a, Result<Metadata, String>>;
+
+    /// Capability proving that this store currently has exclusive ownership
+    /// of the page namespace. Generic stores are safe by default and retain
+    /// retired pages.
+    fn reclamation_token(&self) -> Option<PageReclamationToken> {
+        None
+    }
 }
 
 /// Deterministic store used by the engine contract tests. Async/failure
 /// injection belongs here rather than in IDBTree so the same tree exercises
 /// resident and genuinely pending I/O.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct MemoryPageStore {
     inner: Rc<RefCell<MemoryPageStoreState>>,
+    reclamation_enabled: bool,
+}
+
+impl Default for MemoryPageStore {
+    fn default() -> Self {
+        Self {
+            inner: Rc::new(RefCell::new(MemoryPageStoreState::default())),
+            reclamation_enabled: false,
+        }
+    }
+}
+
+impl MemoryPageStore {
+    /// Reclaiming is reserved for engine tests that provide an exclusive
+    /// ownership adapter; ordinary memory stores model a generic multi-handle
+    /// PageStore and therefore retain retired pages.
+    #[cfg(test)]
+    pub(crate) fn reclaiming() -> Self {
+        Self {
+            reclamation_enabled: true,
+            ..Self::default()
+        }
+    }
 }
 
 #[derive(Default)]
@@ -87,5 +130,8 @@ impl PageStore for MemoryPageStore {
             state.metadata = Some(metadata.clone());
             Ok(metadata)
         })
+    }
+    fn reclamation_token(&self) -> Option<PageReclamationToken> {
+        self.reclamation_enabled.then(PageReclamationToken::new)
     }
 }

--- a/crates/idb-tree/src/web.rs
+++ b/crates/idb-tree/src/web.rs
@@ -1,9 +1,9 @@
-use js_sys::{Array, Promise, Reflect, Uint8Array};
+use js_sys::{Array, Function, Promise, Reflect, Uint8Array};
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
-use crate::{BoxFuture, Commit, Metadata, PageStore};
+use crate::{BoxFuture, Commit, Metadata, PageReclamationToken, PageStore};
 
 #[wasm_bindgen]
 extern "C" {
@@ -69,6 +69,18 @@ impl PageStore for IndexedDbPageStore {
             Ok(Some(Uint8Array::new(&value).to_vec()))
         })
     }
+    fn reclamation_token(&self) -> Option<PageReclamationToken> {
+        let enabled = Reflect::get(
+            self.handle.as_ref(),
+            &JsValue::from_str("pageReclamationEnabled"),
+        )
+        .ok()
+        .and_then(|method| method.dyn_into::<Function>().ok())
+        .and_then(|method| method.call0(self.handle.as_ref()).ok())
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+        enabled.then(PageReclamationToken::new)
+    }
 
     fn commit<'a>(&'a self, commit: &'a Commit) -> BoxFuture<'a, Result<Metadata, String>> {
         Box::pin(async move {
@@ -79,8 +91,10 @@ impl PageStore for IndexedDbPageStore {
                 page_bytes.push(&Uint8Array::from(bytes.as_slice()));
             }
             let deleted_page_ids = Array::new();
-            for page_id in &commit.deleted_page_ids {
-                deleted_page_ids.push(&JsValue::from_f64(page_id_to_f64(*page_id)?));
+            if self.reclamation_token().is_some() {
+                for page_id in &commit.deleted_page_ids {
+                    deleted_page_ids.push(&JsValue::from_f64(page_id_to_f64(*page_id)?));
+                }
             }
             let root_page_id = match commit.metadata.root_page_id {
                 Some(page_id) => page_id_to_f64(page_id)?,

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
@@ -115,6 +115,27 @@ describe("IndexedDbPageStore", () => {
     first.close();
   });
 
+  it("enables page reclamation only during the claimed worker epoch", async () => {
+    const name = databaseName();
+    const store = await IndexedDbPageStore.open(name, { owner: "app:alice" });
+    expect(store.pageReclamationEnabled()).toBe(false);
+
+    const epoch = "33333333-3333-4333-8333-333333333333";
+    const successor = "44444444-4444-4444-8444-444444444444";
+    await store.claimBrowserWorkerEpoch(epoch);
+    expect(store.pageReclamationEnabled()).toBe(true);
+
+    await store.releaseBrowserWorkerEpoch(successor);
+    expect(store.pageReclamationEnabled()).toBe(true);
+    await store.releaseBrowserWorkerEpoch(epoch);
+    expect(store.pageReclamationEnabled()).toBe(false);
+
+    await store.claimBrowserWorkerEpoch(successor);
+    expect(store.pageReclamationEnabled()).toBe(true);
+    store.close();
+    expect(store.pageReclamationEnabled()).toBe(false);
+  });
+
   it("retains an exact long canonical owner marker rather than requiring a lossy digest", async () => {
     const name = databaseName();
     const owner = JSON.stringify({

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
@@ -160,6 +160,8 @@ export class IndexedDbStorageInvalidatedError extends Error {
  */
 export class IndexedDbPageStore {
   private invalidated = false;
+  private closed = false;
+  private claimedWorkerEpoch: string | null = null;
   private replicaNodeBytes: Uint8Array | null = null;
   private readonly invalidationListeners = new Set<
     (error: IndexedDbStorageInvalidatedError) => void
@@ -348,6 +350,17 @@ export class IndexedDbPageStore {
       INDEXEDDB_BROWSER_WORKER_EPOCH_KEY,
     );
     await done;
+    if (!this.closed && !this.invalidated) this.claimedWorkerEpoch = epoch;
+  }
+
+  /**
+   * Whether this handle still owns a successfully claimed worker epoch.
+   *
+   * The worker must release or close this exact handle before releasing its
+   * Web Lock, and must not commit tree pages after this becomes false.
+   */
+  pageReclamationEnabled(): boolean {
+    return !this.closed && !this.invalidated && this.claimedWorkerEpoch !== null;
   }
 
   /** Delete only this realm's epoch; a stale realm must never clear its successor. */
@@ -358,16 +371,17 @@ export class IndexedDbPageStore {
     const done = transactionDone(tx);
     const store = tx.objectStore(INDEXEDDB_STORAGE_MANIFEST_STORE);
     const current = await requestResult(store.get(INDEXEDDB_BROWSER_WORKER_EPOCH_KEY));
-    if (
+    const matches =
       current &&
       typeof current === "object" &&
       (current as { format?: unknown; epoch?: unknown }).format ===
         INDEXEDDB_BROWSER_WORKER_EPOCH_FORMAT &&
-      (current as { epoch?: unknown }).epoch === epoch
-    ) {
+      (current as { epoch?: unknown }).epoch === epoch;
+    if (matches) {
       store.delete(INDEXEDDB_BROWSER_WORKER_EPOCH_KEY);
     }
     await done;
+    if (matches && this.claimedWorkerEpoch === epoch) this.claimedWorkerEpoch = null;
   }
 
   async metadata(): Promise<IndexedDbBtreeMetadata | null> {
@@ -581,6 +595,8 @@ export class IndexedDbPageStore {
   }
 
   close(): void {
+    this.closed = true;
+    this.claimedWorkerEpoch = null;
     this.removeInvalidationListeners();
     this.db.close();
   }
@@ -623,6 +639,8 @@ export class IndexedDbPageStore {
   private invalidate(): void {
     if (this.invalidated) return;
     this.invalidated = true;
+    this.closed = true;
+    this.claimedWorkerEpoch = null;
     this.removeInvalidationListeners();
     const error = new IndexedDbStorageInvalidatedError(this.name);
     for (const listener of this.invalidationListeners) listener(error);


### PR DESCRIPTION
## Summary
- Reclaim pages replaced by browser IndexedDB B-tree copy-on-write writes only while the owning worker epoch is held.
- Closes #2747.

## Before
Copy-on-write updates left replaced pages durable, allowing browser storage to grow indefinitely. Reclaiming unconditionally would risk readers using another or stale store handle.

## After
- Browser worker-epoch ownership gates path-local page deletion; generic and non-browser stores retain old pages.
- Replaced leaves, internal ancestors, and owned overflow chains are retired atomically, with deferred retry when capability is lost.
- Reads that race publication retry against the current generation; historical reachability cleanup remains separate.

## Test plan
- [ ] `cargo test -p idb-tree`
- [ ] `cargo test -p groove storage::idb --lib`
- [ ] `cargo check -p idb-tree --target wasm32-unknown-unknown`
- [ ] `pnpm --filter jazz-tools check`
- [ ] Run the focused browser IndexedDB adapter tests