### PR TITLE
fix: await cold pending-upload recovery in browser startup

### DIFF
--- a/.changeset/browser-pending-upload-reopen.md
+++ b/.changeset/browser-pending-upload-reopen.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix browser startup freezing when restoring pending uploads requires a cold IndexedDB read. Recovery now yields to asynchronous storage instead of blocking its callbacks.

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1831,6 +1831,7 @@ impl WasmDb {
             .await
             .map_err(to_js_error)?;
         db.restore_browser_relay_pending_uploads()
+            .await
             .map_err(to_js_error)?;
         db.set_deferred_local_persistence(true);
         Ok(Self {
@@ -1866,6 +1867,7 @@ impl WasmDb {
             .await
             .map_err(to_js_error)?;
         db.restore_browser_relay_pending_uploads()
+            .await
             .map_err(to_js_error)?;
         db.set_deferred_local_persistence(true);
         Ok(Self {

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -142,7 +142,7 @@ where
         let node =
             NodeState::new(config.identity.node, config.schema.clone(), config.storage).await?;
         let node = Node::new(node);
-        node.restore_pending_uploads(config.identity)?;
+        node.restore_pending_uploads(config.identity).await?;
         let row_id_source_guarantees_fresh = config.id_source.is_none();
         Ok(Self {
             schema: config.schema,
@@ -333,7 +333,7 @@ where
         let node =
             NodeState::new_catalogue_uninitialized(config.identity.node, config.storage).await?;
         let node = Node::new(node);
-        node.restore_pending_uploads(config.identity)?;
+        node.restore_pending_uploads(config.identity).await?;
         node.restore_edge_authority_uploads().await?;
         let row_id_source_guarantees_fresh = config.id_source.is_none();
         Ok(Self {
@@ -761,9 +761,10 @@ where
     /// node differs from the worker node, so ordinary local-origin recovery
     /// cannot discover them after a cold worker restart.
     #[doc(hidden)]
-    pub fn restore_browser_relay_pending_uploads(&self) -> Result<(), Error> {
+    pub async fn restore_browser_relay_pending_uploads(&self) -> Result<(), Error> {
         self.node
             .restore_browser_relay_pending_uploads(self.identity.author)
+            .await
     }
 
     /// Let a single-threaded host return resident writes synchronously while

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -878,11 +878,13 @@ where
 
     /// Restore locally originated, unsettled durable writes into the
     /// process-local upload queue after reopening client storage.
-    pub(super) fn restore_pending_uploads(&self, identity: DbIdentity) -> Result<(), Error> {
-        let mut node = self.node.borrow_mut();
-        let pending = node.pending_transaction_ids_for(identity.node, identity.author);
-        let pending = crate::db::block_on(pending)?;
-        drop(node);
+    pub(super) async fn restore_pending_uploads(&self, identity: DbIdentity) -> Result<(), Error> {
+        let pending = self
+            .node
+            .lock()
+            .await
+            .pending_transaction_ids_for(identity.node, identity.author)
+            .await?;
         let mut restored = HashSet::new();
         for tx_id in pending {
             if restored.insert(tx_id) {
@@ -908,14 +910,16 @@ where
         Ok(())
     }
 
-    pub(super) fn restore_browser_relay_pending_uploads(
+    pub(super) async fn restore_browser_relay_pending_uploads(
         &self,
         author: AuthorSubject,
     ) -> Result<(), Error> {
-        let mut node = self.node.borrow_mut();
-        let pending = node.pending_transaction_ids_for_author(author);
-        let pending = crate::db::block_on(pending)?;
-        drop(node);
+        let pending = self
+            .node
+            .lock()
+            .await
+            .pending_transaction_ids_for_author(author)
+            .await?;
         self.browser_relay_recovered_tx_ids
             .borrow_mut()
             .extend(pending.iter().copied());

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -3377,3 +3377,148 @@ fn cold_runtime_replacement_defers_empty_facade_until_local_snapshot_arrives() {
         "a subscription opened after the replacement must not inherit the retained facade"
     );
 }
+
+// These tests must reach the internal recovery boundary after evicting its
+// storage cache. Public open also hydrates unrelated metadata, which can hide
+// this particular cold scan. A child watchdog contains the historical busy
+// loop so a regression fails one test instead of hanging the suite.
+fn pending_restore_child(test_name: &str) -> bool {
+    const CHILD: &str = "JAZZ_PENDING_RESTORE_CHILD";
+    if std::env::var(CHILD).as_deref() == Ok(test_name) {
+        return true;
+    }
+    let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", test_name, "--nocapture"])
+        .env(CHILD, test_name)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            let output = child.wait_with_output().unwrap();
+            assert!(
+                status.success(),
+                "recovery child failed: {}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return false;
+        }
+        if std::time::Instant::now() >= deadline {
+            child.kill().unwrap();
+            let output = child.wait_with_output().unwrap();
+            panic!(
+                "recovery did not yield to asynchronous storage within 20s: {}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
+fn cold_pending_restore_yields_and_recovers(relay: bool) {
+    use std::future::Future;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::task::{Context, Poll};
+    struct WakeCount(AtomicUsize);
+    impl futures::task::ArcWake for WakeCount {
+        fn wake_by_ref(this: &Arc<Self>) {
+            this.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+    let schema = schema();
+    let identity = DbIdentity {
+        node: NodeUuid::from_bytes([0xdb; 16]),
+        author: AuthorSubject::for_test_bytes([0xdc; 16]),
+    };
+    let families = schema.column_families();
+    let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, _) = TestStorage::controlled(&refs);
+    let saved = storage.clone();
+    let db = block_on(Db::open(DbConfig::new(schema.clone(), storage, identity))).unwrap();
+    let tx_id = db
+        .insert(
+            "todos",
+            cells("pending recovery", false, identity.author),
+            Default::default(),
+        )
+        .unwrap()
+        .mergeable_tx_id();
+    block_on(db.close()).unwrap();
+    drop(db);
+    let storage = block_on(saved.reopen(families)).unwrap();
+    let control = storage.control();
+    let eviction = storage.clone();
+    let owner_node = if relay {
+        NodeUuid::from_bytes([0xdd; 16])
+    } else {
+        identity.node
+    };
+    let node = Node::new(block_on(NodeState::new(owner_node, schema, storage)).unwrap());
+    eviction.evict_all();
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let before = control.poll_count(TestStorageOperation::ScanOpen);
+    let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+    let waker = futures::task::waker(wakes.clone());
+    let mut cx = Context::from_waker(&waker);
+    let mut restore = Box::pin(async {
+        if relay {
+            node.restore_browser_relay_pending_uploads(identity.author)
+                .await
+        } else {
+            node.restore_pending_uploads(identity).await
+        }
+    });
+    assert!(matches!(restore.as_mut().poll(&mut cx), Poll::Pending));
+    assert_eq!(
+        control.poll_count(TestStorageOperation::ScanOpen),
+        before + 1
+    );
+    // The first storage poll deliberately self-wakes; the second parks on the
+    // externally controlled read. Recovery must preserve that real waker.
+    assert!(matches!(restore.as_mut().poll(&mut cx), Poll::Pending));
+    assert!(node.outbox.borrow().iter().next().is_none());
+    wakes.0.store(0, Ordering::SeqCst);
+    control.resume();
+    assert!(wakes.0.load(Ordering::SeqCst) > 0);
+    block_on(restore).unwrap();
+    assert_eq!(
+        node.outbox
+            .borrow()
+            .iter()
+            .map(|entry| entry.tx_id)
+            .collect::<Vec<_>>(),
+        vec![tx_id]
+    );
+    if relay {
+        assert!(
+            node.browser_relay_recovered_tx_ids
+                .borrow()
+                .contains(&tx_id)
+        );
+    }
+}
+
+#[test]
+fn cold_pending_upload_restore_yields_to_storage() {
+    if pending_restore_child(
+        "db::tests::node_runtime::cold_pending_upload_restore_yields_to_storage",
+    ) {
+        cold_pending_restore_yields_and_recovers(false);
+    }
+}
+
+#[test]
+fn cold_browser_relay_restore_yields_to_storage() {
+    if pending_restore_child(
+        "db::tests::node_runtime::cold_browser_relay_restore_yields_to_storage",
+    ) {
+        cold_pending_restore_yields_and_recovers(true);
+    }
+}

--- a/crates/jazz/tests/browser_relay_durability.rs
+++ b/crates/jazz/tests/browser_relay_durability.rs
@@ -414,7 +414,7 @@ fn open_persistent_browser_worker(
         },
     )))
     .expect("open persistent browser worker");
-    db.restore_browser_relay_pending_uploads()
+    block_on(db.restore_browser_relay_pending_uploads())
         .expect("restore browser relay pending uploads");
     db
 }


### PR DESCRIPTION
🤖 Fixes #2762. Reopening browser storage with pending uploads can freeze the shared worker when restoring those uploads needs an uncached IndexedDB read.

For example, create local rows while offline, update them, close the database, then reopen it. Startup scans pending transactions so they can upload later. Previously that asynchronous scan was driven by a synchronous polling loop. On WASM the loop never yielded the JavaScript event loop, so the IndexedDB callback could not resolve its own read. A live profile of the reproduced failure spent essentially its entire sample in this loop.

Pending-upload restoration now awaits storage. The normal and catalogue-backed open paths, plus both browser relay bootstrap variants, propagate that await. Identity selection, deduplication, relay recovery markers, queue ordering and storage encodings are unchanged. A failed scan still fails initialization before recovered entries are queued.

Regression tests force the restore scan to return Pending, verify that the executor receives its real waker, then resume and check the upload queue. They cover normal client and browser relay restoration. The old busy loop is contained by a subprocess watchdog so a regression cannot hang the entire suite.

Focused regressions, host clippy and the WASM-target compile passed. Independent review found no correctness or security blockers. Both deliberately restored blocking loops fail their watchdog tests; the restored fix passes. The coordinator independently reran both recovery regressions on the isolated PR branch. The captured post-update browser database will be reopened through the fixed runtime; that end-to-end acceptance is pending. This fixes a startup deadlock, not the separate ordinary-update CPU cost being investigated alongside it.
