### PR TITLE
perf: read transaction status without decoding its payload

### DIFF
--- a/.changeset/transaction-status-projection.md
+++ b/.changeset/transaction-status-projection.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reduce transaction-status polling cost by reading fate and durability fields without decoding unrelated transaction payloads. Preserve pending-persistence and rejection checks.

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -8,6 +8,11 @@
 use super::*;
 use crate::schema::RuntimeSchema;
 
+#[cfg(test)]
+thread_local! {
+    pub(super) static TRANSACTION_PAYLOAD_DECODES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
@@ -883,8 +888,41 @@ where
         &mut self,
         tx_id: TxId,
     ) -> Result<Option<StoredTransaction>, Error> {
+        self.query_transaction_fields(tx_id, |state, alias, record| {
+            state.stored_transaction_from_record(tx_id, alias, record)
+        })
+        .await
+    }
+
+    pub(super) async fn query_transaction_state(
+        &mut self,
+        tx_id: TxId,
+    ) -> Result<Option<(Fate, Option<GlobalTime>, DurabilityTier)>, Error> {
+        // Status is a projection, not a payload audit. Full transaction readers
+        // continue validating author and contribution identities independently.
+        self.query_transaction_fields(tx_id, |_, _, record| {
+            Ok((
+                fate_from_encoded_fields(record)?,
+                record
+                    .get_nullable_u64(TransactionRowRecord::FIELD_GLOBAL_TIME_IDX)?
+                    .map(GlobalTime),
+                durability_from_discriminant(
+                    record.get_enum(TransactionRowRecord::FIELD_DURABILITY_IDX)?,
+                )?,
+            ))
+        })
+        .await
+    }
+
+    async fn query_transaction_fields<T>(
+        &mut self,
+        tx_id: TxId,
+        decode: impl Fn(&Self, NodeAlias, BorrowedRecord<'_>) -> Result<T, Error>,
+    ) -> Result<Option<T>, Error> {
         if let Some(alias) = self.node_aliases.get(&tx_id.node).copied()
-            && let Some(tx) = self.query_transaction_by_alias(tx_id, alias).await?
+            && let Some(tx) = self
+                .query_transaction_fields_by_alias(tx_id, alias, &decode)
+                .await?
         {
             return Ok(Some(tx));
         }
@@ -902,7 +940,7 @@ where
         }
         for expected_alias in aliases {
             if let Some(tx) = self
-                .query_transaction_by_alias(tx_id, expected_alias)
+                .query_transaction_fields_by_alias(tx_id, expected_alias, &decode)
                 .await?
             {
                 self.node_aliases.insert(tx_id.node, expected_alias);
@@ -984,6 +1022,18 @@ where
         tx_id: TxId,
         expected_alias: NodeAlias,
     ) -> Result<Option<StoredTransaction>, Error> {
+        self.query_transaction_fields_by_alias(tx_id, expected_alias, &|state, alias, record| {
+            state.stored_transaction_from_record(tx_id, alias, record)
+        })
+        .await
+    }
+
+    async fn query_transaction_fields_by_alias<T>(
+        &self,
+        tx_id: TxId,
+        expected_alias: NodeAlias,
+        decode: &impl Fn(&Self, NodeAlias, BorrowedRecord<'_>) -> Result<T, Error>,
+    ) -> Result<Option<T>, Error> {
         let Some(raw) = self
             .database
             .primary_key_get_raw(
@@ -1000,8 +1050,7 @@ where
         if node_alias != expected_alias || time != tx_id.time {
             return Ok(None);
         }
-        self.stored_transaction_from_record(tx_id, expected_alias, record)
-            .map(Some)
+        decode(self, expected_alias, record).map(Some)
     }
 
     fn stored_transaction_from_record(
@@ -1010,6 +1059,8 @@ where
         expected_alias: NodeAlias,
         record: BorrowedRecord<'_>,
     ) -> Result<StoredTransaction, Error> {
+        #[cfg(test)]
+        TRANSACTION_PAYLOAD_DECODES.with(|count| count.set(count.get() + 1));
         let tx = Transaction {
             tx_id,
             kind: tx_kind_from_discriminant(

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -437,7 +437,9 @@ where
         }
     }
 
-    /// Return the legacy transaction fate tuple.
+    /// Return the legacy transaction fate tuple by projecting stored status.
+    /// Payload author/contribution validation belongs to full transaction reads;
+    /// this read retains storage framing and status-field validation.
     pub async fn transaction_state(
         &mut self,
         tx_id: TxId,

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -442,14 +442,18 @@ where
         &mut self,
         tx_id: TxId,
     ) -> Option<(Fate, Option<GlobalTime>, DurabilityTier)> {
-        self.transaction_record(tx_id).await.map(|record| {
-            let durability = if self.pending_persistence.contains(&tx_id) {
-                DurabilityTier::None
-            } else {
-                record.durability
-            };
-            (record.fate, record.global_time, durability)
-        })
+        self.query_transaction_state(tx_id)
+            .await
+            .ok()
+            .flatten()
+            .map(|(fate, global_time, stored_durability)| {
+                let durability = if self.pending_persistence.contains(&tx_id) {
+                    DurabilityTier::None
+                } else {
+                    stored_durability
+                };
+                (fate, global_time, durability)
+            })
     }
 
     /// Return the durable audit record for a transaction, including rejected

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -2687,3 +2687,91 @@ fn transaction_metadata_round_trips_through_recovery() {
         Some(r#"{"source":"exclusive"}"#.to_owned())
     );
 }
+
+
+#[test]
+fn transaction_status_projects_state_without_decoding_payloads() {
+    // Internal coverage is required to plant semantically invalid durable
+    // payloads and measure decoder work: neither is exposed by public APIs.
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut core = open_node_at(&temp_dir, schema);
+    let tx_id = core.commit_mergeable_settled(
+        MergeableCommit::new("todos", row(9), 10)
+            .cells(BTreeMap::from([("title".to_owned(), "status".to_owned())])),
+    ).unwrap();
+    let mut stored = core.query_transaction(tx_id).unwrap().unwrap();
+    let expected = (stored.fate.clone(), stored.global_time, stored.durability);
+
+    // Exercise both the cached-alias path and durable alias discovery.
+    core.node_aliases.remove(&tx_id.node);
+    assert_eq!(core.transaction_state_settled(tx_id), Some(expected.clone()));
+    assert_eq!(core.node_aliases.get(&tx_id.node), Some(&stored.node_alias));
+    assert!(core.transaction_state_settled(TxId::new(TxTime::from(999), tx_id.node)).is_none());
+    core.pending_persistence.insert(tx_id);
+    assert_eq!(core.transaction_state_settled(tx_id), Some((expected.0.clone(), expected.1, DurabilityTier::None)));
+    core.pending_persistence.remove(&tx_id);
+
+    assert!(core.transaction_state_settled(TxId::new(tx_id.time, node(0x72))).is_none());
+    for fate in [
+        Fate::Pending,
+        Fate::Accepted,
+        Fate::Rejected(RejectionReason::AuthorizationDenied),
+        Fate::Rejected(RejectionReason::Cascade { root: tx_id }),
+        Fate::Rejected(RejectionReason::MalformedCommit("detail".to_owned())),
+    ] {
+        for durability in [DurabilityTier::None, DurabilityTier::Local, DurabilityTier::Edge, DurabilityTier::Global] {
+            for global_time in [None, Some(GlobalTime(42))] {
+                let mut batch = core.database.open_batch();
+                batch.update("jazz_transactions", transaction_values(
+                    stored.node_alias, &stored.tx, fate.clone(), global_time, durability,
+                    core.contribution_merge_storage_value(None).unwrap(),
+                ).unwrap());
+                let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
+                let persisted = crate::db::block_on(applied.persist());
+                core.database.finish_persistence(persisted).unwrap();
+                assert_eq!(core.transaction_state_settled(tx_id), Some((fate.clone(), global_time, durability)));
+            }
+        }
+    }
+
+    for payload_bytes in [16, 1024 * 1024] {
+        stored.tx.user_metadata_json = Some("x".repeat(payload_bytes));
+        let mut provenance = canonical_contribution_provenance(tx_id);
+        let duplicate = provenance.substitutions[0].sources[0].clone();
+        provenance.substitutions[0].sources.push(duplicate);
+        stored.tx.contribution_merge = Some(provenance);
+        let values = transaction_values(
+            stored.node_alias, &stored.tx, stored.fate.clone(), stored.global_time,
+            stored.durability,
+            core.contribution_merge_storage_value(stored.tx.contribution_merge.as_ref()).unwrap(),
+        ).unwrap();
+        let mut batch = core.database.open_batch();
+        batch.update("jazz_transactions", values.clone());
+        let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
+        let persisted = crate::db::block_on(applied.persist());
+        core.database.finish_persistence(persisted).unwrap();
+
+        super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.set(0));
+        for _ in 0..1500 {
+            assert_eq!(core.transaction_state_settled(tx_id), Some(expected.clone()));
+        }
+        assert_eq!(super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.get()), 0,
+            "status polling must do zero payload decodes regardless of payload size or poll count");
+        assert!(core.query_transaction(tx_id).resolve().is_err(),
+            "full durable reads must still reject malformed contribution identities");
+        assert!(core.transaction_record(tx_id).is_none());
+
+        // Valid record framing does not make an incomplete rejected fate valid.
+        let mut invalid_state = values;
+        invalid_state[TransactionRowRecord::FIELD_FATE_IDX] = Value::String("rejected".to_owned());
+        invalid_state[TransactionRowRecord::FIELD_REJECTION_REASON_IDX] = Value::Nullable(None);
+        let mut batch = core.database.open_batch();
+        batch.update("jazz_transactions", invalid_state);
+        let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
+        let persisted = crate::db::block_on(applied.persist());
+        core.database.finish_persistence(persisted).unwrap();
+        assert!(core.transaction_state_settled(tx_id).is_none(),
+            "status must fail closed on malformed fate fields");
+    }
+}

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -2696,41 +2696,79 @@ fn transaction_status_projects_state_without_decoding_payloads() {
     let schema = schema();
     let temp_dir = tempfile::tempdir().unwrap();
     let mut core = open_node_at(&temp_dir, schema);
-    let tx_id = core.commit_mergeable_settled(
-        MergeableCommit::new("todos", row(9), 10)
-            .cells(BTreeMap::from([("title".to_owned(), "status".to_owned())])),
-    ).unwrap();
+    let tx_id = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row(9), 10)
+                .cells(BTreeMap::from([("title".to_owned(), "status".to_owned())])),
+        )
+        .unwrap();
     let mut stored = core.query_transaction(tx_id).unwrap().unwrap();
     let expected = (stored.fate.clone(), stored.global_time, stored.durability);
 
     // Exercise both the cached-alias path and durable alias discovery.
     core.node_aliases.remove(&tx_id.node);
-    assert_eq!(core.transaction_state_settled(tx_id), Some(expected.clone()));
+    assert_eq!(
+        core.transaction_state_settled(tx_id),
+        Some(expected.clone())
+    );
     assert_eq!(core.node_aliases.get(&tx_id.node), Some(&stored.node_alias));
-    assert!(core.transaction_state_settled(TxId::new(TxTime::from(999), tx_id.node)).is_none());
+    assert!(
+        core.transaction_state_settled(TxId::new(TxTime::from(999), tx_id.node))
+            .is_none()
+    );
     core.pending_persistence.insert(tx_id);
-    assert_eq!(core.transaction_state_settled(tx_id), Some((expected.0.clone(), expected.1, DurabilityTier::None)));
+    assert_eq!(
+        core.transaction_state_settled(tx_id),
+        Some((expected.0.clone(), expected.1, DurabilityTier::None))
+    );
     core.pending_persistence.remove(&tx_id);
 
-    assert!(core.transaction_state_settled(TxId::new(tx_id.time, node(0x72))).is_none());
+    assert!(
+        core.transaction_state_settled(TxId::new(tx_id.time, node(0x72)))
+            .is_none()
+    );
     for fate in [
         Fate::Pending,
         Fate::Accepted,
         Fate::Rejected(RejectionReason::AuthorizationDenied),
+        Fate::Rejected(RejectionReason::ClientClockTooFarAhead),
+        Fate::Rejected(RejectionReason::ExclusiveConflict),
+        Fate::Rejected(RejectionReason::CausalityViolation),
         Fate::Rejected(RejectionReason::Cascade { root: tx_id }),
         Fate::Rejected(RejectionReason::MalformedCommit("detail".to_owned())),
     ] {
-        for durability in [DurabilityTier::None, DurabilityTier::Local, DurabilityTier::Edge, DurabilityTier::Global] {
+        for durability in [
+            DurabilityTier::None,
+            DurabilityTier::Local,
+            DurabilityTier::Edge,
+            DurabilityTier::Global,
+        ] {
             for global_time in [None, Some(GlobalTime(42))] {
                 let mut batch = core.database.open_batch();
-                batch.update("jazz_transactions", transaction_values(
-                    stored.node_alias, &stored.tx, fate.clone(), global_time, durability,
-                    core.contribution_merge_storage_value(None).unwrap(),
-                ).unwrap());
+                batch.update(
+                    "jazz_transactions",
+                    transaction_values(
+                        stored.node_alias,
+                        &stored.tx,
+                        fate.clone(),
+                        global_time,
+                        durability,
+                        core.contribution_merge_storage_value(None).unwrap(),
+                    )
+                    .unwrap(),
+                );
                 let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
                 let persisted = crate::db::block_on(applied.persist());
                 core.database.finish_persistence(persisted).unwrap();
-                assert_eq!(core.transaction_state_settled(tx_id), Some((fate.clone(), global_time, durability)));
+                assert_eq!(
+                    core.transaction_state_settled(tx_id),
+                    Some((fate.clone(), global_time, durability))
+                );
+                let audit = core.transaction_record(tx_id).unwrap();
+                assert_eq!(
+                    core.transaction_state_settled(tx_id),
+                    Some((audit.fate, audit.global_time, audit.durability))
+                );
             }
         }
     }
@@ -2742,10 +2780,15 @@ fn transaction_status_projects_state_without_decoding_payloads() {
         provenance.substitutions[0].sources.push(duplicate);
         stored.tx.contribution_merge = Some(provenance);
         let values = transaction_values(
-            stored.node_alias, &stored.tx, stored.fate.clone(), stored.global_time,
+            stored.node_alias,
+            &stored.tx,
+            stored.fate.clone(),
+            stored.global_time,
             stored.durability,
-            core.contribution_merge_storage_value(stored.tx.contribution_merge.as_ref()).unwrap(),
-        ).unwrap();
+            core.contribution_merge_storage_value(stored.tx.contribution_merge.as_ref())
+                .unwrap(),
+        )
+        .unwrap();
         let mut batch = core.database.open_batch();
         batch.update("jazz_transactions", values.clone());
         let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
@@ -2754,24 +2797,44 @@ fn transaction_status_projects_state_without_decoding_payloads() {
 
         super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.set(0));
         for _ in 0..1500 {
-            assert_eq!(core.transaction_state_settled(tx_id), Some(expected.clone()));
+            assert_eq!(
+                core.transaction_state_settled(tx_id),
+                Some(expected.clone())
+            );
         }
-        assert_eq!(super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.get()), 0,
-            "status polling must do zero payload decodes regardless of payload size or poll count");
-        assert!(core.query_transaction(tx_id).resolve().is_err(),
-            "full durable reads must still reject malformed contribution identities");
+        assert_eq!(
+            super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.get()),
+            0,
+            "status polling must do zero payload decodes regardless of payload size or poll count"
+        );
+        assert!(
+            core.query_transaction(tx_id).resolve().is_err(),
+            "full durable reads must still reject malformed contribution identities"
+        );
         assert!(core.transaction_record(tx_id).is_none());
 
         // Valid record framing does not make an incomplete rejected fate valid.
-        let mut invalid_state = values;
-        invalid_state[TransactionRowRecord::FIELD_FATE_IDX] = Value::String("rejected".to_owned());
-        invalid_state[TransactionRowRecord::FIELD_REJECTION_REASON_IDX] = Value::Nullable(None);
-        let mut batch = core.database.open_batch();
-        batch.update("jazz_transactions", invalid_state);
-        let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
-        let persisted = crate::db::block_on(applied.persist());
-        core.database.finish_persistence(persisted).unwrap();
-        assert!(core.transaction_state_settled(tx_id).is_none(),
-            "status must fail closed on malformed fate fields");
+        for reason in [None, Some("cascade")] {
+            let mut invalid_state = values.clone();
+            invalid_state[TransactionRowRecord::FIELD_FATE_IDX] =
+                Value::String("rejected".to_owned());
+            invalid_state[TransactionRowRecord::FIELD_REJECTION_REASON_IDX] =
+                Value::Nullable(reason.map(|reason| Box::new(Value::String(reason.to_owned()))));
+            let mut batch = core.database.open_batch();
+            batch.update("jazz_transactions", invalid_state);
+            let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
+            let persisted = crate::db::block_on(applied.persist());
+            core.database.finish_persistence(persisted).unwrap();
+            for pending in [false, true] {
+                if pending {
+                    core.pending_persistence.insert(tx_id);
+                }
+                assert!(
+                    core.transaction_state_settled(tx_id).is_none(),
+                    "pending durability override must not hide malformed fate fields"
+                );
+                core.pending_persistence.remove(&tx_id);
+            }
+        }
     }
 }


### PR DESCRIPTION
🤖 Checking whether a transaction is durable currently materializes its entire audit record, including author identities, contribution payloads and user metadata. Browser bulk-update profiling spent about 72 of 113 sampled worker seconds under this status path; these samples are inclusive and are not additive with its child functions.

This change reads only fate, global time and durability from the transaction row. For example, forwarding a locally persisted update can determine its status without reconstructing row authorship or decoding unrelated metadata. The shared lookup still verifies the exact transaction time and node alias, supports the existing durable alias fallback, and validates the required status fields. Pending persistence still forces durability to None.

Status is deliberately a projection, not a full payload audit. It no longer rejects a status request solely because an unrelated contribution payload cannot be decoded. Full transaction/recovery readers keep their existing contribution-identity validation before those payloads can influence merge calculations. No stored encoding, authorization decision, or settlement threshold changes.

Focused coverage checks alias restoration and missing IDs, fate/time/durability combinations, pending persistence, malformed rejection fields, and repeated status reads with small versus large metadata without full-payload decoding. Full payload readers still reject malformed contribution identities. Independent review found no correctness or security blockers. Six focused tests passed, including persistence-failure and authority-publication boundaries. Mutations removing the durability clamp, restoring the full reader, or redundantly decoding payloads were all detected. The coordinator independently reran the expanded status regression on the isolated PR branch. End-to-end performance validation and final CI remain pending.

Related: #2746 and #2747. This addresses the remaining transaction-status CPU cost after the exact write lookup and IndexedDB reclamation fixes.
