### PR TITLE
perf: probe exact parent history before scanning sibling versions

### DIFF
--- a/.changeset/exact-parent-history-lookup.md
+++ b/.changeset/exact-parent-history-lookup.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Avoid scanning every sibling version in a large transaction when validating an existing exact parent row. Preserve branch, layer, identity and incomplete-parent checks.

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -10,6 +10,7 @@ use crate::schema::RuntimeSchema;
 
 #[cfg(test)]
 thread_local! {
+    pub(super) static HISTORY_PAYLOAD_DECODES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     pub(super) static TRANSACTION_PAYLOAD_DECODES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
@@ -548,6 +549,50 @@ where
         Ok(versions)
     }
 
+    /// Probe one parent witness using the existing immutable history key.
+    /// This does not replace transaction-wide reads used to decide completeness
+    /// when the requested witness has not arrived.
+    pub(super) async fn query_exact_parent_version(
+        &mut self,
+        tx_id: TxId,
+        tx_node_alias: NodeAlias,
+        coordinate: &ParentCoordinate,
+    ) -> Result<Option<VersionRow>, Error> {
+        if !self.catalogue.physical_mappings.values().any(|mapping| {
+            mapping
+                .tables
+                .values()
+                .any(|table| table.table_id == coordinate.physical_table_id)
+        }) {
+            return Ok(None);
+        }
+        let mut key = vec![Value::Bytes(coordinate.branch_key.canonical_bytes())];
+        let storage_table = match coordinate.layer {
+            VersionLayer::Content => physical_history_table_name(coordinate.physical_table_id),
+            VersionLayer::Deletion => {
+                key.push(Value::U64(coordinate.physical_table_id.0));
+                SHARED_DELETION_HISTORY_TABLE.to_owned()
+            }
+        };
+        key.extend([
+            Value::Uuid(coordinate.row_uuid.0),
+            Value::U64(tx_id.time.0),
+            Value::U64(tx_node_alias.0),
+        ]);
+        let raw = self
+            .database
+            .primary_key_get_raw(&storage_table, &key)
+            .await?
+            .map(|raw| raw.owned_record());
+        let Some(record) = raw else {
+            return Ok(None);
+        };
+        // Physical history carries its authored schema, including old logical
+        // names after a rename. Resolve from that schema instead of today's name.
+        self.decode_history_owned_record("", &storage_table, record)
+            .map(Some)
+    }
+
     pub(super) async fn query_versions_for_tx_physical_coordinate(
         &mut self,
         tx_id: TxId,
@@ -740,6 +785,8 @@ where
         storage_table: &str,
         record: OwnedRecord,
     ) -> Result<VersionRow, Error> {
+        #[cfg(test)]
+        HISTORY_PAYLOAD_DECODES.with(|count| count.set(count.get() + 1));
         if storage_table == SHARED_DELETION_HISTORY_TABLE {
             let shared = record.to_values()?;
             let Value::U64(table_id) = shared.get(1).ok_or(Error::InvalidStoredValue(

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -566,7 +566,12 @@ where
         }) {
             return Ok(None);
         }
-        let mut key = vec![Value::Bytes(coordinate.branch_key.canonical_bytes())];
+        let Ok(branch_bytes) = coordinate.branch_key.try_canonical_bytes() else {
+            // No stored witness can have a noncanonical key. Let the caller's
+            // existing missing-coordinate rules decide rejection/completeness.
+            return Ok(None);
+        };
+        let mut key = vec![Value::Bytes(branch_bytes)];
         let storage_table = match coordinate.layer {
             VersionLayer::Content => physical_history_table_name(coordinate.physical_table_id),
             VersionLayer::Deletion => {

--- a/crates/jazz/src/node/ingest/validation.rs
+++ b/crates/jazz/src/node/ingest/validation.rs
@@ -20,6 +20,22 @@ where
         let Some(parent_tx) = self.query_transaction(parent).await? else {
             return Ok(ParentCoordinateValidation::Inconclusive);
         };
+        // Retain the resident cache's all-branch/all-layer lookup. On a cold
+        // cache, a valid parent needs one exact history read rather than every
+        // sibling row in its transaction. A miss still uses the completeness
+        // and wrong-coordinate rules below without changing their semantics.
+        if !self.query.tx_versions_cache.contains_key(&parent)
+            && let Some(candidate) = self
+                .query_exact_parent_version(parent, parent_tx.node_alias, coordinate)
+                .await?
+        {
+            if self.version_tx_id(&candidate)? != parent
+                || !self.version_row_matches_parent_coordinate(&candidate, coordinate)?
+            {
+                return Err(Error::InvalidStoredValue("parent history key does not match stored coordinate"));
+            }
+            return Ok(ParentCoordinateValidation::Exact);
+        }
         let coordinate_versions = self
             .query_versions_for_tx_physical_coordinate(
                 parent,

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -2770,11 +2770,18 @@ fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
     // Internal coverage is necessary to evict the transaction-version cache
     // and count actual storage decodes around parent validation in isolation.
     // Fixture creation still uses the ordinary public schema/commit builders.
-    for width in [1_u128, 1500] {
+    for width in [1500_u128, 1] {
         let schema = branch_view_schema();
         let branch = branch_selector(0x71);
         let branch_key = schema
-            .project_branch_view_selector(schema.tables.iter().find(|table| table.name == "todos").unwrap(), &branch)
+            .project_branch_view_selector(
+                schema
+                    .tables
+                    .iter()
+                    .find(|table| table.name == "todos")
+                    .unwrap(),
+                &branch,
+            )
             .unwrap()
             .0;
         let (_dir, mut core) = open_history_complete_node_with_schema(
@@ -2820,6 +2827,7 @@ fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
             };
             core.invalidate_tx_version_tables_cache(parent);
             super::super::currency::HISTORY_PAYLOAD_DECODES.with(|count| count.set(0));
+            super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.set(0));
             core.reset_storage_read_metrics();
             assert_eq!(
                 core.validate_known_parent_coordinate(parent, &coordinate)
@@ -2834,6 +2842,11 @@ fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
                 "one parent witness must decode one history row even for a {width}-row transaction"
             );
             assert_eq!(
+                super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.get()),
+                1,
+                "the parent transaction must still cross the full payload audit before exact lookup"
+            );
+            assert_eq!(
                 reads.history_indexes.ranges, 0,
                 "exact parent lookup must not scan by_tx: {reads:?}"
             );
@@ -2844,7 +2857,14 @@ fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
 
             let wrong_branch = ParentCoordinate {
                 branch_key: schema
-                    .project_branch_view_selector(schema.tables.iter().find(|table| table.name == "todos").unwrap(), &branch_selector(0x74))
+                    .project_branch_view_selector(
+                        schema
+                            .tables
+                            .iter()
+                            .find(|table| table.name == "todos")
+                            .unwrap(),
+                        &branch_selector(0x74),
+                    )
                     .unwrap()
                     .0,
                 ..coordinate.clone()
@@ -2866,7 +2886,22 @@ fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
                     .unwrap(),
                 ..coordinate.clone()
             };
-            for wrong in [wrong_branch, wrong_row, wrong_layer, wrong_table] {
+            let malformed_branch = ParentCoordinate {
+                branch_key: BranchKey {
+                    values: vec![(
+                        "branch_id".to_owned(),
+                        crate::protocol::BranchColumnValue(vec![0xff]),
+                    )],
+                },
+                ..coordinate.clone()
+            };
+            for wrong in [
+                wrong_branch,
+                wrong_row,
+                wrong_layer,
+                wrong_table,
+                malformed_branch,
+            ] {
                 assert!(
                     matches!(
                         core.validate_known_parent_coordinate(parent, &wrong)

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -2764,3 +2764,127 @@ fn branch_column_evolution_accepts_monotone_addition_with_default() {
     NodeState::<RocksDbStorage>::validate_migration_lens_between(&lens, &source, &target)
         .expect("a branch column can be added monotonically with an immutable default");
 }
+
+#[test]
+fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
+    // Internal coverage is necessary to evict the transaction-version cache
+    // and count actual storage decodes around parent validation in isolation.
+    // Fixture creation still uses the ordinary public schema/commit builders.
+    for width in [1_u128, 1500] {
+        let schema = branch_view_schema();
+        let branch = branch_selector(0x71);
+        let branch_key = schema
+            .project_branch_view_selector(schema.tables.iter().find(|table| table.name == "todos").unwrap(), &branch)
+            .unwrap()
+            .0;
+        let (_dir, mut core) = open_history_complete_node_with_schema(
+            NodeUuid::from_bytes([0x72; 16]),
+            schema.clone(),
+        );
+        let owner = AuthorSubject::for_test_bytes([0x73; 16]);
+        let target = RowUuid(uuid::Uuid::from_u128(1));
+        let commits = (1..=width)
+            .map(|index| {
+                MergeableCommit::new("todos", RowUuid(uuid::Uuid::from_u128(index)), 10)
+                    .branch(branch.clone())
+                    .cells(BTreeMap::from([
+                        ("title".to_owned(), v("parent")),
+                        ("owner".to_owned(), Value::Uuid(owner.test_uuid())),
+                    ]))
+            })
+            .collect();
+        let content_parent = core.commit_mergeable_many_settled(commits).unwrap();
+        let deletion_parent = core
+            .commit_mergeable_many_settled(
+                (1..=width)
+                    .map(|index| {
+                        MergeableCommit::new("todos", RowUuid(uuid::Uuid::from_u128(index)), 20)
+                            .branch(branch.clone())
+                            .deletion(DeletionEvent::Deleted)
+                    })
+                    .collect(),
+            )
+            .unwrap();
+        let physical_table_id = core
+            .physical_table_id_for_schema(schema.version_id(), "todos")
+            .unwrap();
+        for (parent, layer) in [
+            (content_parent, VersionLayer::Content),
+            (deletion_parent, VersionLayer::Deletion),
+        ] {
+            let coordinate = ParentCoordinate {
+                physical_table_id,
+                branch_key: branch_key.clone(),
+                row_uuid: target,
+                layer,
+            };
+            core.invalidate_tx_version_tables_cache(parent);
+            super::super::currency::HISTORY_PAYLOAD_DECODES.with(|count| count.set(0));
+            core.reset_storage_read_metrics();
+            assert_eq!(
+                core.validate_known_parent_coordinate(parent, &coordinate)
+                    .resolve()
+                    .unwrap(),
+                super::super::ingest::ParentCoordinateValidation::Exact
+            );
+            let reads = core.take_storage_read_metrics();
+            assert_eq!(
+                super::super::currency::HISTORY_PAYLOAD_DECODES.with(|count| count.get()),
+                1,
+                "one parent witness must decode one history row even for a {width}-row transaction"
+            );
+            assert_eq!(
+                reads.history_indexes.ranges, 0,
+                "exact parent lookup must not scan by_tx: {reads:?}"
+            );
+            assert!(
+                reads.total.reads <= 2,
+                "exact parent lookup should read transaction plus witness: {reads:?}"
+            );
+
+            let wrong_branch = ParentCoordinate {
+                branch_key: schema
+                    .project_branch_view_selector(schema.tables.iter().find(|table| table.name == "todos").unwrap(), &branch_selector(0x74))
+                    .unwrap()
+                    .0,
+                ..coordinate.clone()
+            };
+            let wrong_row = ParentCoordinate {
+                row_uuid: RowUuid(uuid::Uuid::from_u128(width + 1)),
+                ..coordinate.clone()
+            };
+            let wrong_layer = ParentCoordinate {
+                layer: match layer {
+                    VersionLayer::Content => VersionLayer::Deletion,
+                    VersionLayer::Deletion => VersionLayer::Content,
+                },
+                ..coordinate.clone()
+            };
+            let wrong_table = ParentCoordinate {
+                physical_table_id: core
+                    .physical_table_id_for_schema(schema.version_id(), "users")
+                    .unwrap(),
+                ..coordinate.clone()
+            };
+            for wrong in [wrong_branch, wrong_row, wrong_layer, wrong_table] {
+                assert!(
+                    matches!(
+                        core.validate_known_parent_coordinate(parent, &wrong)
+                            .resolve(),
+                        Err(Error::InvalidMergeableCommit(_))
+                    ),
+                    "a known complete parent cannot resolve outside its exact coordinate"
+                );
+            }
+            assert_eq!(
+                core.validate_known_parent_coordinate(
+                    TxId::new(TxTime::from(99), parent.node),
+                    &coordinate
+                )
+                .resolve()
+                .unwrap(),
+                super::super::ingest::ParentCoordinateValidation::Inconclusive
+            );
+        }
+    }
+}


### PR DESCRIPTION
🤖 Stacked on #2764. Updating one row from a large seed transaction can decode every history row in that transaction merely to validate that one parent version exists.

For example, seed 1,500 todos in one transaction, then update a single todo. The cold path previously queried all 1,500 versions before filtering to the requested physical row, branch and layer. This change first probes the existing immutable history primary key for that exact coordinate. Content and deletion history use their respective existing keys; the returned row is decoded using its authored schema and checked against the expected transaction and full coordinate.

The full parent transaction audit still runs first. The resident-cache path is unchanged. A missing exact witness still uses the existing transaction-wide completeness rules: missing or partial evidence remains inconclusive, while a complete transaction with the wrong row/branch/layer is rejected. Noncanonical branch keys retain the existing fallback rather than introducing a new encoding panic. No index, storage format, wire protocol or authorization rule changes.

The new canary uses both 1-row and 1,500-row transactions, including content and deletion witnesses. The valid cold lookup decodes exactly one history row, reads at most two records and performs no history index range scan. It also pins the full transaction audit and checks wrong/missing coordinates. Independent correctness/security review passed with 15 focused tests. Temporarily restoring the old scan made the canary fail with 1,500 decoded rows instead of one; all mutations were restored and the tests passed again. The coordinator independently reran the canary. Final combined browser timing is pending.

This addresses another measured bulk-update CPU cost alongside #2746/#2747. It does not replace the more expensive completeness check when an exact witness is absent.
