### PR TITLE
docs: clarify scoped storage reset and resync

### DIFF
--- a/docs/content/docs/auth/lifecycle.mdx
+++ b/docs/content/docs/auth/lifecycle.mdx
@@ -98,4 +98,10 @@ Use the same secret with `BrowserPasskeyBackup` for a passkey backup. Export req
 
 `createAccountManager`, opaque `AccountHandle`, and `createJazzClient` remain available for applications that intentionally own their lifecycle. The manager handles credentials and registry operations only. Contexts accept valid handles and never change identity; low-level callers must arrange graceful shutdown before linking or replacing contexts themselves. The session abstraction composes these primitives in shared TypeScript; framework adapters only observe state and acknowledge consumer cleanup.
 
-`db.deleteClientStorage()` resets supported browser database storage without erasing retained account signing roots. It is a development reset, not account registration or linking.
+## Storage reset
+
+`await db.deleteClientStorage()` resets the active browser IndexedDB namespace and keeps the live client usable. **It permanently deletes unsynced writes and local-only data.** Resync requires the data to already exist on the configured server and the same account to retain access. Ordinary close or shutdown is not a server-sync receipt.
+
+Reset preserves default local-first signing roots in `localStorage` and does not sign out the account or external auth provider. Preserve browser credentials and other databases; verify custom credential stores separately. Logout changes the selected account state, while a storage reset clears the selected data cache. Reset does not register or link an account.
+
+The [browser console helper](/docs/faq#reset-browser-storage) provides the same scoped reset and requires a live registered client. Keep the client open until the reset finishes.

--- a/docs/content/docs/faq.mdx
+++ b/docs/content/docs/faq.mdx
@@ -10,7 +10,9 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
 <Accordion id="reset-browser-storage" title="How do I reset browser storage?">
 
-In browser apps using the React, Vue, Svelte, or Solid Jazz clients, open the devtools console and run:
+**Reset permanently deletes unsynced writes and local-only data in the selected namespace.** Before resetting a cache you intend to resync, confirm that the required data is already on the configured server and that the same account can still access it. Reconnect to that server with the same account after resetting; app queries and subscriptions can then fetch the data permitted by current access rules. Local durability and ordinary shutdown do not prove server sync completed.
+
+In browser apps using the React, Vue, Svelte, or Solid Jazz clients, keep the client open and run this in the devtools console:
 
 ```ts
 await window.__jazz.clearStorage();
@@ -23,13 +25,15 @@ window.__jazz.listLiveStorageNamespaces();
 await window.__jazz.clearStorage("my-app::alice");
 ```
 
+The helper requires a live registered client on this page. Do not shut it down before calling the helper. If the client never finishes opening or no live namespace is listed, this helper cannot perform the reset.
+
 If you're working directly with a `Db` handle instead of the window helper, `await db.deleteClientStorage()` is the underlying API. See [Auth Lifecycle](/docs/auth/lifecycle#storage-reset) for how this differs from logout and local-first identity storage.
 
 - Browser persistent storage only.
 - If exactly one live namespace exists, `clearStorage()` uses it automatically.
 - If multiple live namespaces exist, Jazz throws and lists the available namespaces until you choose one.
 - Can be initiated from either leader or follower tabs; Jazz coordinates the reset across tabs for that namespace.
-- Deletes IndexedDB storage only. It does not clear `localStorage` local-first auth data.
+- Deletes only the selected IndexedDB namespace. Preserve `localStorage`, `sessionStorage`, cookies, and other databases; default local-first credentials are stored outside this data database. Apps with custom credential stores must check those separately.
 - Reopens a clean worker/runtime so the same live client remains usable after the wipe.
 
 This is useful when iterating on your schema during development.


### PR DESCRIPTION
🤖 Clarifies the scoped browser reset workaround for #2753 without adding a historical page collector.

The FAQ now warns that resetting permanently deletes unsynced writes and local-only data, explains that resync requires server-held data and continued access by the same account, and preserves default credentials and unrelated browser storage. It also documents that the console helper needs a live registered client. The auth lifecycle page now has the missing Storage reset anchor and explains how reset differs from logout.

Validation: documentation formatting and type generation passed; the coordinator independently reviewed the two-page diff and checked the corrected link targets. No runtime behavior changes.
