### PR TITLE
fix(ci): show suite log tails on cancellation

### DIFF
--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -21,7 +21,7 @@ fi
 # the suites that GitHub will run. Check this before the producer admission so
 # an unsafe inherited control always gets its own actionable diagnostic.
 if [[ "${JAZZ_REQUIRE_CI_TEST_COMMANDS:-0}" == "1" ]]; then
-  for override in JAZZ_NODE_TEST_COMMAND JAZZ_BROWSER_TEST_COMMAND JAZZ_SKIP_JAZZ_TOOLS_BUILD; do
+  for override in JAZZ_NODE_TEST_COMMAND JAZZ_BROWSER_TEST_COMMAND JAZZ_SKIP_JAZZ_TOOLS_BUILD JAZZ_TEST_LOG_INTERVAL_SECONDS; do
     if printenv "${override}" >/dev/null 2>&1; then
       echo "${override} is a test-harness override and is forbidden by the CI-equivalent partition" >&2
       exit 1
@@ -55,6 +55,12 @@ node_tests_command=${JAZZ_NODE_TEST_COMMAND:-"pnpm test --filter=!moon-lander-re
 browser_tests_command=${JAZZ_BROWSER_TEST_COMMAND:-"pnpm --parallel --filter jazz-tools --filter inspector --filter band-chat-nextjs-betterauth --filter record-player-next-betterauth --filter auth-workos-chat test:browser"}
 node_tests_pid=""
 browser_tests_pid=""
+log_monitor_pid=""
+log_interval=${JAZZ_TEST_LOG_INTERVAL_SECONDS:-30}
+if [[ ! "${log_interval}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "JAZZ_TEST_LOG_INTERVAL_SECONDS must be a positive integer" >&2
+  exit 1
+fi
 log_dir=${RUNNER_TEMP:-/tmp}
 node_tests_log="${log_dir}/jazz-node-tests-$$.log"
 browser_tests_log="${log_dir}/jazz-browser-tests-$$.log"
@@ -82,8 +88,56 @@ if [[ "${JAZZ_SKIP_JAZZ_TOOLS_BUILD:-0}" != "1" ]]; then
   export JAZZ_TEST_SEALED_TOOLS_DIST=1
 fi
 
+stop_log_monitor() {
+  if [[ -n "${log_monitor_pid}" ]]; then
+    kill -TERM -- "-${log_monitor_pid}" 2>/dev/null || true
+    wait "${log_monitor_pid}" 2>/dev/null || true
+    log_monitor_pid=""
+  fi
+}
+
+print_log_tail() {
+  local suite_log=$1
+  echo "--- ${suite_log} (last 16 KiB, at most 100 lines) ---"
+  if [[ -f "${suite_log}" ]]; then
+    tail -c 16384 "${suite_log}" | tail -n 100 || true
+    echo
+  fi
+}
+
+print_log_tails() {
+  print_log_tail "${node_tests_log}"
+  print_log_tail "${browser_tests_log}"
+}
+
+monitor_logs() {
+  # Cancellation may kill an outer Node/container process without delivering
+  # a trappable signal here. Publish progress beforehand, and stop within one
+  # tick if this runner disappears without invoking its cleanup trap.
+  local elapsed=0 index size
+  local sizes=(0 0)
+  local logs=("${node_tests_log}" "${browser_tests_log}")
+  while kill -0 "$$" 2>/dev/null; do
+    sleep 1
+    kill -0 "$$" 2>/dev/null || return
+    elapsed=$((elapsed + 1))
+    if (( elapsed >= log_interval )); then
+      for index in 0 1; do
+        size=$(wc -c < "${logs[$index]}")
+        if [[ "${size}" != "${sizes[$index]}" ]]; then
+          echo "TypeScript suites still running; bounded live log tail:"
+          print_log_tail "${logs[$index]}"
+          sizes[$index]=${size}
+        fi
+      done
+      elapsed=0
+    fi
+  done
+}
+
 terminate_children() {
   trap - INT TERM
+  stop_log_monitor
   for child_pid in "${node_tests_pid}" "${browser_tests_pid}"; do
     if [[ -n "${child_pid}" ]] && kill -0 "${child_pid}" 2>/dev/null; then
       # Each suite starts in its own session, so this reaches pnpm and every
@@ -101,13 +155,8 @@ interrupt() {
   # last test output. Bound bytes as well as lines (a test may print one huge
   # line), and retain the complete regular files at the printed paths.
   echo "TypeScript suites interrupted (exit ${signal_status}); retained log tails:"
-  for suite_log in "${node_tests_log}" "${browser_tests_log}"; do
-    echo "--- ${suite_log} (last 16 KiB, at most 100 lines) ---"
-    if [[ -f "${suite_log}" ]]; then
-      tail -c 16384 "${suite_log}" | tail -n 100 || true
-      echo
-    fi
-  done
+  stop_log_monitor
+  print_log_tails
   terminate_children
   exit "${signal_status}"
 }
@@ -126,18 +175,23 @@ bash -c "${node_tests_command}" >"${node_tests_log}" 2>&1 &
 node_tests_pid=$!
 bash -c "${browser_tests_command}" >"${browser_tests_log}" 2>&1 &
 browser_tests_pid=$!
+(trap - INT TERM; monitor_logs) &
+log_monitor_pid=$!
+echo "TypeScript live log monitor PID: ${log_monitor_pid}"
 set +m
 
 wait "${node_tests_pid}"
 node_tests_status=$?
 wait "${browser_tests_pid}"
 browser_tests_status=$?
+stop_log_monitor
 trap - INT TERM
 
 # GitHub's live log pipe can be nonblocking. Two concurrent Turbo/Vitest trees
 # writing directly to it can fail with EAGAIN even though the tests themselves
 # are healthy. Give each suite a blocking regular file, then replay both logs
-# after both process trees have terminated.
+# after both process trees have terminated. Only the bounded monitor writes
+# progress while tests run; test children never inherit the live log pipe.
 cat "${node_tests_log}"
 cat "${browser_tests_log}"
 rm -f "${node_tests_log}" "${browser_tests_log}"

--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -97,6 +97,17 @@ terminate_children() {
 
 interrupt() {
   local signal_status=$1
+  # Replay before waiting for children: a stuck shutdown must not hide the
+  # last test output. Bound bytes as well as lines (a test may print one huge
+  # line), and retain the complete regular files at the printed paths.
+  echo "TypeScript suites interrupted (exit ${signal_status}); retained log tails:"
+  for suite_log in "${node_tests_log}" "${browser_tests_log}"; do
+    echo "--- ${suite_log} (last 16 KiB, at most 100 lines) ---"
+    if [[ -f "${suite_log}" ]]; then
+      tail -c 16384 "${suite_log}" | tail -n 100 || true
+      echo
+    fi
+  done
   terminate_children
   exit "${signal_status}"
 }

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -2145,3 +2145,58 @@ test("parallel TypeScript runner terminates both child process groups", async ()
   assert.equal(fs.existsSync(browserMarker), false, "browser descendant survived TERM");
   fs.rmSync(fixture, { recursive: true, force: true });
 });
+
+for (const [signal, expected] of [
+  ["SIGINT", 130],
+  ["SIGTERM", 143],
+]) {
+  test(`parallel TypeScript runner retains bounded diagnostics on ${signal}`, async () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-ts-ci-tails-"));
+    const command = (suite) =>
+      `printf '%20000s\\n' x; echo ${suite}-last-test; touch "$RUNNER_TEMP/${suite}-ready"; sleep 30`;
+    const child = spawn("bash", [path.join(root, "dev/gates/run-ts-tests.sh")], {
+      cwd: root,
+      env: {
+        ...process.env,
+        RUNNER_TEMP: fixture,
+        JAZZ_SKIP_JAZZ_TOOLS_BUILD: "1",
+        JAZZ_NODE_TEST_COMMAND: command("node"),
+        JAZZ_BROWSER_TEST_COMMAND: command("browser"),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+      output += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      output += chunk;
+    });
+    const closed = new Promise((resolve) => child.once("close", (code) => resolve(code)));
+    const watchdog = setTimeout(() => child.kill("SIGKILL"), 5000);
+    try {
+      const deadline = Date.now() + 3000;
+      while (
+        !["node", "browser"].every((suite) => fs.existsSync(path.join(fixture, `${suite}-ready`)))
+      ) {
+        assert.ok(Date.now() < deadline, "synthetic suites did not start");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      child.kill(signal);
+      assert.equal(await closed, expected, output);
+      assert.match(output, /node-last-test/);
+      assert.match(output, /browser-last-test/);
+      assert.ok(Buffer.byteLength(output) < 34000, "interruption diagnostics were not bounded");
+      for (const suite of ["node", "browser"]) {
+        const log = fs.readdirSync(fixture).find((name) => name.startsWith(`jazz-${suite}-tests-`));
+        assert.ok(log, "complete suite log was not retained");
+        assert.ok(fs.statSync(path.join(fixture, log)).size > 20000);
+      }
+    } finally {
+      clearTimeout(watchdog);
+      if (child.exitCode === null) child.kill("SIGTERM");
+      await closed;
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+}

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1848,7 +1848,7 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   assert.match(runner, /set -m/);
   assert.match(runner, /bash -c "\$\{node_tests_command\}" >"\$\{node_tests_log\}" 2>&1 &/);
   assert.match(runner, /bash -c "\$\{browser_tests_command\}" >"\$\{browser_tests_log\}" 2>&1 &/);
-  assert.match(runner, /browser_tests_pid=\$!\nset \+m/);
+  assert.match(runner, /browser_tests_pid=\$![\s\S]*log_monitor_pid=\$![\s\S]*set \+m/);
   assert.doesNotMatch(runner, /^setsid /m);
   assert.match(runner, /trap 'interrupt 130' INT/);
   assert.match(runner, /trap 'interrupt 143' TERM/);
@@ -2200,3 +2200,121 @@ for (const [signal, expected] of [
     }
   });
 }
+
+for (const ending of ["complete", "SIGTERM", "SIGKILL"]) {
+  test(`parallel TypeScript runner publishes bounded progress before ${ending} and stops its monitor`, async () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-ts-ci-progress-"));
+    const command = (suite) =>
+      `echo $$ > "$RUNNER_TEMP/${suite}-pid"; printf '%20000s\\n' x; echo ${suite}-progress; while [ ! -f "$RUNNER_TEMP/finish" ]; do sleep 0.1; done`;
+    const child = spawn("bash", [path.join(root, "dev/gates/run-ts-tests.sh")], {
+      cwd: root,
+      env: {
+        ...process.env,
+        RUNNER_TEMP: fixture,
+        JAZZ_SKIP_JAZZ_TOOLS_BUILD: "1",
+        JAZZ_TEST_LOG_INTERVAL_SECONDS: "1",
+        JAZZ_NODE_TEST_COMMAND: command("node"),
+        JAZZ_BROWSER_TEST_COMMAND: command("browser"),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+      output += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      output += chunk;
+    });
+    const closed = new Promise((resolve) =>
+      child.once("close", (code, signal) => resolve({ code, signal })),
+    );
+    const watchdog = setTimeout(() => child.kill("SIGKILL"), 8000);
+    try {
+      const deadline = Date.now() + 5000;
+      while (!output.includes("node-progress") || !output.includes("browser-progress")) {
+        assert.ok(Date.now() < deadline, "no suite progress was published before termination");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      assert.equal(child.exitCode, null, "progress arrived only after suite completion");
+      assert.ok(Buffer.byteLength(output) < 34000, "live diagnostics were not bounded");
+      const monitor = Number(output.match(/live log monitor PID: (\d+)/)?.[1]);
+      assert.ok(monitor > 0, "monitor PID not reported");
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      assert.equal(
+        (output.match(/bounded live log tail:/g) ?? []).length,
+        2,
+        "unchanged suite logs were replayed again",
+      );
+      if (ending === "complete") fs.writeFileSync(path.join(fixture, "finish"), "");
+      else child.kill(ending);
+      let closeTimer;
+      const result = await Promise.race([
+        closed,
+        new Promise((_, reject) => {
+          closeTimer = setTimeout(
+            () => reject(new Error("monitor kept its output pipe open")),
+            3000,
+          );
+        }),
+      ]).finally(() => clearTimeout(closeTimer));
+      assert.deepEqual(
+        result,
+        ending === "SIGKILL"
+          ? { code: null, signal: "SIGKILL" }
+          : { code: ending === "complete" ? 0 : 143, signal: null },
+      );
+      // SIGKILL cannot reap its child: an init/subreaper may briefly retain an
+      // exited zombie. It must never leave a running monitor or inherited pipe.
+      const state = spawnSync("ps", ["-o", "stat=", "-p", String(monitor)], {
+        encoding: "utf8",
+      }).stdout.trim();
+      assert.ok(
+        state === "" || (ending === "SIGKILL" && state.startsWith("Z")),
+        `monitor survived: ${state}`,
+      );
+      for (const suite of ["node", "browser"]) {
+        const log = fs.readdirSync(fixture).find((name) => name.startsWith(`jazz-${suite}-tests-`));
+        if (ending === "complete") assert.equal(log, undefined);
+        else assert.ok(log && fs.statSync(path.join(fixture, log)).size > 20000);
+      }
+    } finally {
+      clearTimeout(watchdog);
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+      const monitorPid = Number(output.match(/live log monitor PID: (\d+)/)?.[1]);
+      if (monitorPid > 0) {
+        try {
+          process.kill(-monitorPid, "SIGTERM");
+        } catch (error) {
+          if (error.code !== "ESRCH") throw error;
+        }
+      }
+      // The hard-kill scenario cannot run the parent's suite cleanup trap.
+      for (const suite of ["node", "browser"]) {
+        const pidFile = path.join(fixture, `${suite}-pid`);
+        if (fs.existsSync(pidFile)) {
+          try {
+            process.kill(-Number(fs.readFileSync(pidFile, "utf8").trim()), "SIGTERM");
+          } catch (error) {
+            if (error.code !== "ESRCH") throw error;
+          }
+        }
+      }
+      await closed;
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+}
+
+test("CI rejects inherited live-log timing overrides", () => {
+  const result = spawnSync("bash", [path.join(root, "dev/gates/run-ts-tests.sh")], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      JAZZ_REQUIRE_CI_TEST_COMMANDS: "1",
+      JAZZ_TEST_LOG_INTERVAL_SECONDS: "1",
+    },
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /JAZZ_TEST_LOG_INTERVAL_SECONDS.*forbidden/);
+});


### PR DESCRIPTION
🤖 TypeScript CI buffers Node and browser suite logs into regular files because concurrent writes to the runner’s live pipe can fail. Waiting until both suites finish hides the active test when an outer runner cancellation kills the process tree.

Publish only changed, bounded log tails every 30 seconds while suites run: at most 16 KiB and 100 lines per suite. Keep complete regular log files and normal final replay. SIGINT/SIGTERM also replay tails before existing cleanup; the monitor is terminated and reaped on normal or signalled completion and exits if its parent disappears. Test children keep their regular-file output, and existing exit status behavior remains intact. No additional artifact uploads or runtime traces.

Validation: all 53 runner contract tests pass. Synthetic tests require progress before termination, verify bounds and unchanged-tail suppression, and cover normal exit, signals and hard parent termination without a surviving monitor. Suppressing live output and removing the parent-liveness check both fail their respective tests. Independent correctness/security review passed all 53 contract tests. Removing the byte bound also fails the progress tests; the coordinator independently reran the focused runner tests.
