### PR TITLE
Integrate browser storage and update performance fixes

### DIFF
--- a/.changeset/browser-exact-write-merge.md
+++ b/.changeset/browser-exact-write-merge.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Avoid full-table reads when staging browser transaction updates, and prevent failed write-merge reads from leaving patches staged for a later commit.

--- a/.changeset/browser-page-reclamation.md
+++ b/.changeset/browser-page-reclamation.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reclaim obsolete IndexedDB pages during writes under exclusive ownership, and safely retire browser runtime storage handles during schema changes and reconnects. Existing unused pages are not automatically collected.

--- a/.changeset/browser-pending-upload-reopen.md
+++ b/.changeset/browser-pending-upload-reopen.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix browser startup freezing when restoring pending uploads requires a cold IndexedDB read. Recovery now yields to asynchronous storage instead of blocking its callbacks.

--- a/.changeset/browser-worker-startup-budget.md
+++ b/.changeset/browser-worker-startup-budget.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Avoid opening a competing browser worker generation when runtime startup is slow; preserve a bounded initialization deadline and explicit worker handoff.

--- a/.changeset/canonical-record-validation.md
+++ b/.changeset/canonical-record-validation.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reduce CPU work and allocations when validating nested records during local query delivery, without changing storage encoding or accepted values.

--- a/.changeset/exact-parent-history-lookup.md
+++ b/.changeset/exact-parent-history-lookup.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Avoid scanning every sibling version in a large transaction when validating an existing exact parent row. Preserve branch, layer, identity and incomplete-parent checks.

--- a/.changeset/transaction-status-projection.md
+++ b/.changeset/transaction-status-projection.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reduce transaction-status polling cost by reading fate and durability fields without decoding unrelated transaction payloads. Preserve pending-persistence and rejection checks.

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ data-multi/
 
 # Lane-local Android SDK, NDK, JDK and emulator cache.
 /.cache/android-device-acceptance/
+# Generated browser benchmark phase receipts.
+packages/jazz-tools/.vitest-browser-bench/

--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -40,3 +40,7 @@ harness = false
 [[bench]]
 name = "micro"
 harness = false
+
+[[bench]]
+name = "record_validation"
+harness = false

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -468,9 +468,18 @@ Tree writes are copy-on-write: the changed leaf and every changed ancestor get
 fresh page ids, then one IndexedDB transaction writes the new immutable closure
 and replaces `current` after checking the observed generation. A crash before
 publication leaves at most unreachable new pages; a published root never names
-a torn or missing child. Reclamation is a separate reachability operation and
-may delete only pages proven unreachable from the published root, never pages
-merely replaced by an in-flight write. Reopening observes either the old root
+a torn or missing child. Reclamation may delete only pages proven unreachable
+from the published root. Path-local retirement atomically deletes replaced leaves,
+ancestors, and the overflow chains owned by replaced/deleted values together with
+publication, only when the PageStore proves exclusive tree ownership. Generic and
+memory stores default to retaining durable pages so independent cold handles can
+finish reading their older complete closure and reach generation-conflict recovery.
+The browser capability consumes one live database Web Lock/worker epoch proof for
+one tree; tree clones share its root. It expires before release/close/invalidation,
+and deletion commits recheck it at publication. Unpublished superseded fresh pages
+are omitted from the commit regardless of ownership. A separate reachability
+collector is still required for historical garbage; this policy changes neither
+the durable page encoding nor the storage epoch. Reopening observes either the old root
 and complete closure or the new root and complete closure.
 Before persistence, one logical write—including every operation in a
 `write_many` call—is also locally atomic. If page construction or validation

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -479,7 +479,11 @@ handles may not coexist with an exclusive browser worker owner.
 The browser capability consumes one live database Web Lock/worker epoch proof for
 one live tree at a time; tree clones share its root, and the last clone dropping
 releases tree admission for a fresh open. It expires before release/close/invalidation,
-and deletion commits recheck it at publication. Unpublished superseded fresh pages
+and deletion commits recheck it at publication. An idle browser runtime is reused
+while foreground lease work retains its physical owner; once that work ends, the
+worker retires the page-store/epoch before a successor opens another tree. This
+boundary must not depend on garbage collection of closed WASM wrappers.
+Unpublished superseded fresh pages
 are omitted from the commit regardless of ownership. A separate reachability
 collector is still required for historical garbage; this policy changes neither
 the durable page encoding nor the storage epoch. Reopening observes either the old root

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -479,10 +479,16 @@ handles may not coexist with an exclusive browser worker owner.
 The browser capability consumes one live database Web Lock/worker epoch proof for
 one live tree at a time; tree clones share its root, and the last clone dropping
 releases tree admission for a fresh open. It expires before release/close/invalidation,
-and deletion commits recheck it at publication. An idle browser runtime is reused
-while foreground lease work retains its physical owner; once that work ends, the
-worker retires the page-store/epoch before a successor opens another tree. This
-boundary must not depend on garbage collection of closed WASM wrappers.
+and deletion commits recheck it at publication. A worker runtime owns a revocable
+tree token independent of foreground identity leases. After the last admitted
+peer's flush barrier, retirement revokes that token synchronously and drains its
+already-started page transactions before permitting a new runtime/schema to claim
+a successor token. Every cached read/write and pending hydration/open completion
+checks liveness; every token-bearing commit rechecks its exact token before page
+publication, including commits with no deletions. A late old guard release cannot
+release its successor. Foreground lease operations retain the same page store and
+Web Lock across this handoff. No boundary depends on garbage collection of closed
+WASM wrappers.
 Unpublished superseded fresh pages
 are omitted from the commit regardless of ownership. A separate reachability
 collector is still required for historical garbage; this policy changes neither

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -474,8 +474,11 @@ ancestors, and the overflow chains owned by replaced/deleted values together wit
 publication, only when the PageStore proves exclusive tree ownership. Generic and
 memory stores default to retaining durable pages so independent cold handles can
 finish reading their older complete closure and reach generation-conflict recovery.
+All writers sharing those handles must remain non-reclaiming: low-level direct
+handles may not coexist with an exclusive browser worker owner.
 The browser capability consumes one live database Web Lock/worker epoch proof for
-one tree; tree clones share its root. It expires before release/close/invalidation,
+one live tree at a time; tree clones share its root, and the last clone dropping
+releases tree admission for a fresh open. It expires before release/close/invalidation,
 and deletion commits recheck it at publication. Unpublished superseded fresh pages
 are omitted from the commit regardless of ownership. A separate reachability
 collector is still required for historical garbage; this policy changes neither

--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -508,10 +508,16 @@ bytes of each element descriptor; no second outer-record layout is introduced.
 Record values are admitted only when their embedded descriptor equals the
 declared `ValueType::Record` descriptor and their raw bytes are canonical for
 that descriptor: decode every child value, recreate the record, and require
-byte equality. Validation alone is insufficient because `OwnedRecord::new`
-currently accepts arbitrary raw bytes (`src/records/mod.rs:1577-1582`). The
-recreate-and-compare rule is required for byte-based weighted consolidation and
-deterministic final tie-breaking.
+byte equality. This defines the acceptance rule; tuple-free descriptors may
+use an equivalent recursive canonical-byte validator without allocating the
+intermediate values or recreated bytes. That validator checks the entire packed
+layout, offsets, null padding, enum tags, scalar envelopes, and nested records.
+Generic structural validation alone is insufficient because `OwnedRecord::new`
+accepts arbitrary raw bytes. Descriptors recursively containing tuples retain
+the decode/recreate/compare implementation, including its historical tuple
+constructibility and nullable-member byte-order behavior. Exact canonical
+admission is required for byte-based weighted consolidation and deterministic
+final tie-breaking; this optimization changes no persisted encoding.
 
 `Record`, `Array<Record>`, and any recursively containing value type MUST be
 rejected as a durable primary-key part. The primary-key codec has no

--- a/crates/groove/benches/record_validation.rs
+++ b/crates/groove/benches/record_validation.rs
@@ -1,0 +1,75 @@
+//! Isolated nested record admission receipt. Run with
+//! `cargo bench -p groove --bench record_validation --profile perf`.
+use groove::records::{OwnedRecord, RecordDescriptor, Value, ValueType};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Instant;
+
+struct CountingAllocator;
+static COUNT: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNT.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        if COUNT.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(size, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, size) }
+    }
+}
+fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    let iterations: usize = std::env::var("GROOVE_RECORD_ITERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(10_000);
+    for depth in [1, 3, 6] {
+        let setup_start = Instant::now();
+        let mut descriptor =
+            RecordDescriptor::new([("id", ValueType::U64), ("text", ValueType::String)]);
+        let mut raw = descriptor
+            .create(&[Value::U64(7), Value::String("synthetic payload".repeat(8))])
+            .unwrap();
+        for _ in 1..depth {
+            let value = Value::Record(OwnedRecord::new(raw, descriptor));
+            descriptor =
+                RecordDescriptor::new([("child", ValueType::Record(Box::new(descriptor)))]);
+            raw = descriptor.create(&[value]).unwrap();
+        }
+        let values = [Value::Record(OwnedRecord::new(raw, descriptor))];
+        let parent = RecordDescriptor::new([("child", ValueType::Record(Box::new(descriptor)))]);
+        let setup_ns = setup_start.elapsed().as_nanos();
+        for _ in 0..100 {
+            black_box(parent.create(black_box(&values)).unwrap());
+        }
+        let start = Instant::now();
+        for _ in 0..iterations {
+            black_box(parent.create(black_box(&values)).unwrap());
+        }
+        let encode_ns = start.elapsed().as_nanos();
+        ALLOCATIONS.store(0, Ordering::Relaxed);
+        BYTES.store(0, Ordering::Relaxed);
+        COUNT.store(true, Ordering::Relaxed);
+        black_box(parent.create(black_box(&values)).unwrap());
+        COUNT.store(false, Ordering::Relaxed);
+        println!(
+            "{{\"depth\":{depth},\"iterations\":{iterations},\"setup_ns\":{setup_ns},\"encode_ns\":{encode_ns},\"allocations_per_encode\":{},\"bytes_per_encode\":{}}}",
+            ALLOCATIONS.load(Ordering::Relaxed),
+            BYTES.load(Ordering::Relaxed)
+        );
+    }
+}

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -2398,6 +2398,26 @@ fn embedded_record_admission_matches_legacy_roundtrip_corpus() {
         ),
     ];
     let mut cases = cases;
+    // Exercise recursive tuple detection through every containing type. Raw
+    // wrappers are intentional: public encoding rejects some legacy tuple
+    // representations before they can reach the embedding admission boundary.
+    for (inner, raw) in cases.clone() {
+        let record_type = ValueType::Record(Box::new(inner));
+        cases.push((descriptor([record_type.clone()]), raw.clone()));
+        cases.push((
+            descriptor([ValueType::Array(Box::new(record_type.clone()))]),
+            [1u32.to_le_bytes().as_slice(), raw.as_slice()].concat(),
+        ));
+        cases.push((
+            descriptor([ValueType::Nullable(Box::new(record_type))]),
+            [b"\x01".as_slice(), raw.as_slice()].concat(),
+        ));
+        let schema = EnumSchema::new("wrapper", [EnumCase::new("value", inner)]).unwrap();
+        cases.push((
+            descriptor([ValueType::Enum(Box::new(schema))]),
+            [b"\x00".as_slice(), raw.as_slice()].concat(),
+        ));
+    }
     for value_type in [
         ValueType::String,
         ValueType::Bytes,

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -2374,6 +2374,14 @@ fn embedded_record_admission_matches_legacy_roundtrip_corpus() {
             epoch_1_scalar_record_descriptor(),
             EPOCH_1_SCALAR_RECORD_FIXTURE.to_vec(),
         ),
+        (
+            descriptor([ValueType::F64]),
+            f64::NAN.to_le_bytes().to_vec(),
+        ),
+        (
+            descriptor([ValueType::Nullable(Box::new(ValueType::F64))]),
+            [b"\x01".as_slice(), f64::NAN.to_le_bytes().as_slice()].concat(),
+        ),
         (descriptor([ValueType::raw_bytes()]), vec![]),
         (descriptor([ValueType::raw_string()]), b"text".to_vec()),
         (

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -2324,3 +2324,166 @@ fn unwrap_nested_nullable_preserves_outer_none_as_inner_null() {
         assert_eq!(target.get_idx(&output[span], 0).unwrap(), expected);
     }
 }
+
+// Internal byte-admission coverage is necessary here: database APIs cannot
+// construct malformed OwnedRecord payloads or expose canonicality errors.
+#[test]
+fn embedded_record_admission_matches_legacy_roundtrip_corpus() {
+    fn check(descriptor: RecordDescriptor, raw: &[u8]) {
+        let expected = descriptor.bind(raw).to_values().and_then(|values| {
+            if descriptor.create(&values)? == raw {
+                Ok(())
+            } else {
+                Err(Error::NonCanonicalRecord)
+            }
+        });
+        let record = OwnedRecord::new(raw.to_vec(), descriptor);
+        let actual = values::ensure_value_type(
+            &Value::Record(record.clone()),
+            &ValueType::Record(Box::new(descriptor)),
+        );
+        assert_eq!(
+            actual, expected,
+            "record {descriptor:?}: {raw:?}, old={expected:?}, new={actual:?}"
+        );
+        let schema = EnumSchema::new("fixture", [EnumCase::new("payload", descriptor)]).unwrap();
+        let actual = values::ensure_value_type(
+            &Value::Enum(EnumValue::new(0, record)),
+            &ValueType::Enum(Box::new(schema)),
+        );
+        assert_eq!(
+            actual, expected,
+            "enum {descriptor:?}: {raw:?}, old={expected:?}, new={actual:?}"
+        );
+    }
+    let child = descriptor([
+        ValueType::Bool,
+        ValueType::Nullable(Box::new(ValueType::U16)),
+    ]);
+    let event = EnumSchema::new(
+        "event",
+        [
+            EnumCase::new("empty", RecordDescriptor::default()),
+            EnumCase::new("value", child),
+        ],
+    )
+    .unwrap();
+    let cases = vec![
+        (RecordDescriptor::default(), vec![]),
+        (
+            epoch_1_scalar_record_descriptor(),
+            EPOCH_1_SCALAR_RECORD_FIXTURE.to_vec(),
+        ),
+        (descriptor([ValueType::raw_bytes()]), vec![]),
+        (descriptor([ValueType::raw_string()]), b"text".to_vec()),
+        (
+            descriptor([ValueType::Tuple(vec![ValueType::F64])]),
+            1.0f64.to_le_bytes().to_vec(),
+        ),
+        (
+            descriptor([ValueType::Tuple(vec![ValueType::Nullable(Box::new(
+                ValueType::U32,
+            ))])]),
+            vec![1, 1, 2, 3, 4],
+        ),
+        (
+            descriptor([ValueType::Nullable(Box::new(ValueType::Tuple(vec![
+                ValueType::F64,
+            ])))]),
+            vec![0; 9],
+        ),
+        (
+            descriptor([ValueType::Array(Box::new(ValueType::Tuple(vec![])))]),
+            vec![],
+        ),
+    ];
+    let mut cases = cases;
+    for value_type in [
+        ValueType::String,
+        ValueType::Bytes,
+        ValueType::stored_scalar(crate::large_values::LargeValueKind::Json),
+    ] {
+        let value = if value_type == ValueType::Bytes {
+            Value::Bytes(vec![0, 128, 255])
+        } else {
+            Value::String("null".into())
+        };
+        let d = descriptor([value_type]);
+        cases.push((d, d.create(&[value]).unwrap()));
+        // Primitive, chunked, unknown/future format and nonminimal envelopes.
+        for raw in [
+            vec![2],
+            vec![2, 255],
+            vec![3],
+            vec![3, 255],
+            vec![4, 0],
+            vec![0x82, 0, 1],
+        ] {
+            cases.push((d, raw));
+        }
+    }
+    for (kind, logical) in [
+        (
+            crate::large_values::LargeValueKind::Bytes,
+            b"bytes".as_slice(),
+        ),
+        (
+            crate::large_values::LargeValueKind::String,
+            b"text".as_slice(),
+        ),
+        (
+            crate::large_values::LargeValueKind::Json,
+            b"null".as_slice(),
+        ),
+    ] {
+        let prepared = crate::large_values::prepare(kind, logical).unwrap();
+        let d = descriptor([ValueType::stored_scalar(kind)]);
+        cases.push((d, d.create(&[Value::Large(prepared.value_ref)]).unwrap()));
+    }
+    let composite = descriptor([
+        ValueType::Record(Box::new(child)),
+        ValueType::Enum(Box::new(event)),
+        ValueType::Array(Box::new(ValueType::Nullable(Box::new(ValueType::String)))),
+        ValueType::Array(Box::new(ValueType::Record(Box::new(child)))),
+        ValueType::EnumTag(ScalarEnumSchema::new("status", ["one", "two"]).unwrap()),
+    ]);
+    let child_value = OwnedRecord::new(
+        child
+            .create(&[Value::Bool(true), Value::Nullable(None)])
+            .unwrap(),
+        child,
+    );
+    cases.push((
+        composite,
+        composite
+            .create(&[
+                Value::Record(child_value.clone()),
+                Value::Enum(EnumValue::new(1, child_value.clone())),
+                Value::Array(vec![
+                    Value::Nullable(None),
+                    Value::Nullable(Some(Box::new(Value::String("abc".into())))),
+                ]),
+                Value::Array(vec![Value::Record(child_value)]),
+                Value::EnumTag(1),
+            ])
+            .unwrap(),
+    ));
+    for (descriptor, raw) in cases {
+        check(descriptor, &raw);
+        for length in 0..raw.len() {
+            check(descriptor, &raw[..length]);
+        }
+        for extra in [0, 1, 255] {
+            let mut changed = raw.clone();
+            changed.push(extra);
+            check(descriptor, &changed);
+        }
+        for index in 0..raw.len() {
+            for byte in [0, 1, 2, 3, 127, 128, 254, 255] {
+                let mut changed = raw.clone();
+                changed[index] = byte;
+                check(descriptor, &changed);
+            }
+        }
+    }
+}

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -2203,11 +2203,7 @@ pub(super) fn ensure_value_type(value: &Value, value_type: &ValueType) -> Result
                     expected: value_type.clone(),
                 });
             }
-            let values = record.to_values()?;
-            if descriptor.create(&values)? != record.raw() {
-                return Err(Error::NonCanonicalRecord);
-            }
-            Ok(())
+            validate_embedded_record(record.borrowed())
         }
         (Value::Enum(enum_value), ValueType::Enum(schema)) => ensure_enum_value(enum_value, schema),
         _ => Err(Error::TypeMismatch {
@@ -2223,8 +2219,47 @@ fn ensure_enum_value(value: &EnumValue, schema: &EnumSchema) -> Result<(), Error
             expected: ValueType::Enum(Box::new(schema.clone())),
         });
     }
-    let values = value.record.to_values()?;
-    if case.payload.create(&values)? != value.record.raw() {
+    validate_embedded_record(value.record.borrowed())
+}
+
+// Tuple decoding and encoding have historically different constructibility
+// rules (including nullable member byte order). Preserve the exact round-trip
+// admission rule for those descriptors rather than broadening accepted bytes.
+fn contains_tuple(value_type: &ValueType) -> bool {
+    match value_type {
+        ValueType::Tuple(_) => true,
+        ValueType::Array(inner) | ValueType::Nullable(inner) => contains_tuple(inner),
+        ValueType::Record(descriptor) => descriptor
+            .fields()
+            .iter()
+            .any(|field| contains_tuple(&field.value_type)),
+        ValueType::Enum(schema) => schema.cases.iter().any(|case| {
+            case.payload
+                .fields()
+                .iter()
+                .any(|field| contains_tuple(&field.value_type))
+        }),
+        _ => false,
+    }
+}
+
+fn validate_embedded_record(record: super::BorrowedRecord<'_>) -> Result<(), Error> {
+    let descriptor = record.descriptor();
+    if !descriptor
+        .fields()
+        .iter()
+        .any(|field| contains_tuple(&field.value_type))
+        && record.validate_canonical().is_ok()
+    {
+        // Record spans cover the complete packed layout; scalar, offset,
+        // nullable and enum validators enforce canonical encodings.
+        return Ok(());
+    }
+    // The diagnostic error ordering of structural validation differs from
+    // decoding (for example malformed UTF-8 scalar payloads). Preserve legacy
+    // errors on invalid input as well as legacy tuple admission semantics.
+    let values = record.to_values()?;
+    if descriptor.create(&values)? != record.raw() {
         return Err(Error::NonCanonicalRecord);
     }
     Ok(())

--- a/crates/groove/src/storage/idb.rs
+++ b/crates/groove/src/storage/idb.rs
@@ -24,7 +24,6 @@ const MAX_CONFLICT_BACKOFF_YIELDS: usize = 16;
 #[derive(Clone)]
 pub struct IdbStorage<S> {
     tree: Rc<RefCell<IdbTree<S>>>,
-    store: S,
     column_families: Rc<RefCell<BTreeSet<String>>>,
     mutation_gate: Rc<Mutex<()>>,
     needs_reset: Rc<Cell<bool>>,
@@ -41,7 +40,6 @@ where
             tree: Rc::new(RefCell::new(
                 IdbTree::open(store.clone(), Options::default()).await?,
             )),
-            store,
             column_families: Rc::new(RefCell::new(
                 column_families.iter().map(|cf| (*cf).to_owned()).collect(),
             )),
@@ -125,8 +123,7 @@ where
         // commit between our read and flush. Discard this stale cache rather
         // than replaying its dirty pages, then recompute the whole logical
         // batch from the newly durable tree.
-        let tree = IdbTree::open(self.store.clone(), Options::default()).await?;
-        *self.tree.borrow_mut() = tree;
+        self.tree().reload().await?;
         self.tree_epoch.set(self.tree_epoch.get().wrapping_add(1));
         self.needs_reset.set(false);
         Ok(())

--- a/crates/idb-tree/src/lib.rs
+++ b/crates/idb-tree/src/lib.rs
@@ -65,6 +65,8 @@ pub enum Error {
     Store(String),
     #[error("IDBTree generation conflict: {0}")]
     GenerationConflict(String),
+    #[error("IDBTree ownership has expired")]
+    OwnershipExpired,
     #[error("an IDBTree commit is already in flight")]
     CommitInFlight,
 }
@@ -151,6 +153,9 @@ impl<S: PageStore + Clone> IdbTree<S> {
     pub async fn open(store: S, options: Options) -> Result<Self, Error> {
         let ownership = store.claim_tree_ownership().map_err(Error::Store)?;
         let tree = TreeCore::open(store, options).await?;
+        if !ownership.is_live() {
+            return Err(Error::OwnershipExpired);
+        }
         Ok(Self {
             inner: Rc::new(RefCell::new(tree)),
             _ownership: Rc::new(ownership),
@@ -158,9 +163,18 @@ impl<S: PageStore + Clone> IdbTree<S> {
         })
     }
 
+    fn ensure_live(&self) -> Result<(), Error> {
+        if self._ownership.is_live() {
+            Ok(())
+        } else {
+            Err(Error::OwnershipExpired)
+        }
+    }
+
     /// Discard staged writes and reload the durable root while retaining this
     /// handle's ownership. Callers must serialize this with writes/flushes.
     pub async fn reload(&self) -> Result<(), Error> {
+        self.ensure_live()?;
         let (store, options) = {
             let tree = self.inner.borrow();
             if tree.commit_in_flight {
@@ -169,6 +183,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
             (tree.store.clone(), tree.options)
         };
         let fresh = TreeCore::open(store, options).await?;
+        self.ensure_live()?;
         *self.inner.borrow_mut() = fresh;
         self.reload_epoch
             .set(self.reload_epoch.get().wrapping_add(1));
@@ -185,6 +200,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
 
     pub async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         loop {
+            self.ensure_live()?;
             let attempt = self.inner.borrow().try_get(key)?;
             match attempt {
                 Attempt::Ready(value) => return Ok(value),
@@ -195,6 +211,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
 
     pub async fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error> {
         loop {
+            self.ensure_live()?;
             let attempt = self
                 .inner
                 .borrow_mut()
@@ -208,6 +225,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
 
     pub async fn delete(&self, key: &[u8]) -> Result<bool, Error> {
         loop {
+            self.ensure_live()?;
             let attempt = self
                 .inner
                 .borrow_mut()
@@ -220,11 +238,13 @@ impl<S: PageStore + Clone> IdbTree<S> {
     }
 
     pub async fn write_many(&self, operations: Vec<WriteOperation>) -> Result<(), Error> {
+        self.ensure_live()?;
         for operation in &operations {
             let key = match operation {
                 WriteOperation::Set { key, .. } | WriteOperation::Delete { key } => key,
             };
             loop {
+                self.ensure_live()?;
                 let attempt = self.inner.borrow().write_path_resident(key)?;
                 match attempt {
                     Attempt::Ready(()) => break,
@@ -251,6 +271,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
         limit: usize,
     ) -> Result<Vec<KeyValue>, Error> {
         loop {
+            self.ensure_live()?;
             let attempt = self.inner.borrow().try_range(start, end, limit)?;
             match attempt {
                 Attempt::Ready(rows) => return Ok(rows),
@@ -266,6 +287,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
         limit: usize,
     ) -> Result<Vec<KeyValue>, Error> {
         loop {
+            self.ensure_live()?;
             let attempt = self.inner.borrow().try_range_reverse(start, end, limit)?;
             match attempt {
                 Attempt::Ready(rows) => return Ok(rows),
@@ -275,6 +297,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
     }
 
     pub async fn flush(&self) -> Result<(), Error> {
+        self.ensure_live()?;
         let (store, prepared) = {
             let mut tree = self.inner.borrow_mut();
             (tree.store.clone(), tree.prepare_commit()?)
@@ -297,6 +320,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
         let root_before = self.inner.borrow().metadata.root_page_id;
         let reload_before = self.reload_epoch.get();
         let result = store.read_page(page_id).await;
+        self.ensure_live()?;
         // The operation retries from the current root, so never import an old
         // completion (including an error) across publication or failure reset.
         // Reset can reuse fresh page IDs, making a cache insert unsafe even if

--- a/crates/idb-tree/src/lib.rs
+++ b/crates/idb-tree/src/lib.rs
@@ -10,7 +10,7 @@ mod store;
 #[cfg(target_arch = "wasm32")]
 mod web;
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
@@ -106,6 +106,7 @@ struct TreeCore<S> {
     pages: HashMap<PageId, Page>,
     dirty: BTreeMap<PageId, Page>,
     deleted: BTreeSet<PageId>,
+    retirement_undo: Vec<PageId>,
     commit_in_flight: bool,
 }
 
@@ -114,7 +115,6 @@ struct TreeCore<S> {
 /// cache for every operation.
 struct WriteCheckpoint {
     metadata: Metadata,
-    deleted: BTreeSet<PageId>,
 }
 
 #[derive(Debug)]
@@ -144,6 +144,7 @@ impl<T> Attempt<T> {
 pub struct IdbTree<S> {
     inner: Rc<RefCell<TreeCore<S>>>,
     _ownership: Rc<TreeOwnership>,
+    reload_epoch: Rc<Cell<u64>>,
 }
 
 impl<S: PageStore + Clone> IdbTree<S> {
@@ -153,6 +154,7 @@ impl<S: PageStore + Clone> IdbTree<S> {
         Ok(Self {
             inner: Rc::new(RefCell::new(tree)),
             _ownership: Rc::new(ownership),
+            reload_epoch: Rc::new(Cell::new(0)),
         })
     }
 
@@ -168,6 +170,8 @@ impl<S: PageStore + Clone> IdbTree<S> {
         };
         let fresh = TreeCore::open(store, options).await?;
         *self.inner.borrow_mut() = fresh;
+        self.reload_epoch
+            .set(self.reload_epoch.get().wrapping_add(1));
         Ok(())
     }
 
@@ -291,13 +295,20 @@ impl<S: PageStore + Clone> IdbTree<S> {
             tree.store.clone()
         };
         let root_before = self.inner.borrow().metadata.root_page_id;
-        let bytes = store.read_page(page_id).await.map_err(Error::Store)?;
-        let Some(bytes) = bytes else {
-            if self.inner.borrow().metadata.root_page_id != root_before {
-                return Ok(());
-            }
-            return Err(Error::MissingPage(page_id));
-        };
+        let reload_before = self.reload_epoch.get();
+        let result = store.read_page(page_id).await;
+        // The operation retries from the current root, so never import an old
+        // completion (including an error) across publication or failure reset.
+        // Reset can reuse fresh page IDs, making a cache insert unsafe even if
+        // the old read returned successfully.
+        if self.reload_epoch.get() != reload_before
+            || self.inner.borrow().metadata.root_page_id != root_before
+        {
+            return Ok(());
+        }
+        let bytes = result
+            .map_err(Error::Store)?
+            .ok_or(Error::MissingPage(page_id))?;
         let page_size = self.inner.borrow().options.page_size;
         if bytes.len() > page_size {
             return Err(Error::PageTooLarge { page_id, page_size });
@@ -333,7 +344,6 @@ impl<S: PageStore> TreeCore<S> {
     fn write_checkpoint(&self) -> WriteCheckpoint {
         WriteCheckpoint {
             metadata: self.metadata.clone(),
-            deleted: self.deleted.clone(),
         }
     }
 
@@ -343,7 +353,10 @@ impl<S: PageStore> TreeCore<S> {
     ) -> Result<T, Error> {
         let checkpoint = self.write_checkpoint();
         match write(self) {
-            Ok(value) => Ok(value),
+            Ok(value) => {
+                self.retirement_undo.clear();
+                Ok(value)
+            }
             Err(error) => {
                 self.rollback_write(checkpoint);
                 Err(error)
@@ -357,7 +370,10 @@ impl<S: PageStore> TreeCore<S> {
     ) -> Result<Attempt<T>, Error> {
         let checkpoint = self.write_checkpoint();
         match write(self) {
-            Ok(Attempt::Ready(value)) => Ok(Attempt::Ready(value)),
+            Ok(Attempt::Ready(value)) => {
+                self.retirement_undo.clear();
+                Ok(Attempt::Ready(value))
+            }
             Ok(Attempt::Missing(page_id)) => {
                 self.rollback_write(checkpoint);
                 Ok(Attempt::Missing(page_id))
@@ -377,7 +393,9 @@ impl<S: PageStore> TreeCore<S> {
             self.pages.remove(&page_id);
             self.dirty.remove(&page_id);
         }
-        self.deleted = checkpoint.deleted;
+        for page_id in self.retirement_undo.drain(..) {
+            self.deleted.remove(&page_id);
+        }
         self.metadata = checkpoint.metadata;
     }
 
@@ -391,6 +409,7 @@ impl<S: PageStore> TreeCore<S> {
             pages: HashMap::new(),
             dirty: BTreeMap::new(),
             deleted: BTreeSet::new(),
+            retirement_undo: Vec::new(),
             commit_in_flight: false,
         };
         if tree.metadata.page_size != options.page_size {
@@ -861,7 +880,7 @@ impl<S: PageStore> TreeCore<S> {
                 })?,
             }
         };
-        self.deleted.insert(page_id);
+        self.retire_page(page_id);
         self.publish_replacement(replacement, path)
     }
 
@@ -887,7 +906,7 @@ impl<S: PageStore> TreeCore<S> {
                     "descent parent is not internal".to_owned(),
                 ));
             };
-            self.deleted.insert(parent_id);
+            self.retire_page(parent_id);
             replacement = match replacement {
                 PageReplacement::One(page_id) => {
                     children[child_index] = page_id;
@@ -945,6 +964,15 @@ impl<S: PageStore> TreeCore<S> {
         Ok(())
     }
 
+    // Track only new retirements in the current attempt. A failed operation
+    // removes these IDs; successful writes retain the set and discard the log.
+    // Cloning the whole growing set at every checkpoint made staged writes O(n²).
+    fn retire_page(&mut self, page_id: PageId) {
+        if self.deleted.insert(page_id) {
+            self.retirement_undo.push(page_id);
+        }
+    }
+
     // The complete leaf ownership graph has already been validated and hydrated.
     // Only the replaced value owns this chain; surviving values retain theirs.
     fn retire_value(&mut self, value: &ValueCell) {
@@ -959,7 +987,7 @@ impl<S: PageStore> TreeCore<S> {
                 unreachable!()
             };
             current = *next;
-            self.deleted.insert(id);
+            self.retire_page(id);
         }
     }
 

--- a/crates/idb-tree/src/lib.rs
+++ b/crates/idb-tree/src/lib.rs
@@ -11,10 +11,10 @@ mod store;
 mod web;
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
-pub use store::{BoxFuture, Commit, MemoryPageStore, Metadata, PageStore};
+pub use store::{BoxFuture, Commit, MemoryPageStore, Metadata, PageStore, TreeOwnership};
 #[cfg(target_arch = "wasm32")]
 pub use web::IndexedDbPageStore;
 
@@ -105,7 +105,7 @@ struct TreeCore<S> {
     metadata: Metadata,
     pages: HashMap<PageId, Page>,
     dirty: BTreeMap<PageId, Page>,
-    deleted: Vec<PageId>,
+    deleted: BTreeSet<PageId>,
     commit_in_flight: bool,
 }
 
@@ -114,12 +114,13 @@ struct TreeCore<S> {
 /// cache for every operation.
 struct WriteCheckpoint {
     metadata: Metadata,
-    deleted: Vec<PageId>,
+    deleted: BTreeSet<PageId>,
 }
 
 #[derive(Debug)]
 pub struct PreparedCommit {
     commit: Commit,
+    retired: BTreeSet<PageId>,
 }
 
 enum Attempt<T> {
@@ -142,13 +143,32 @@ impl<T> Attempt<T> {
 #[derive(Clone)]
 pub struct IdbTree<S> {
     inner: Rc<RefCell<TreeCore<S>>>,
+    _ownership: Rc<TreeOwnership>,
 }
 
 impl<S: PageStore + Clone> IdbTree<S> {
     pub async fn open(store: S, options: Options) -> Result<Self, Error> {
+        let ownership = store.claim_tree_ownership().map_err(Error::Store)?;
+        let tree = TreeCore::open(store, options).await?;
         Ok(Self {
-            inner: Rc::new(RefCell::new(TreeCore::open(store, options).await?)),
+            inner: Rc::new(RefCell::new(tree)),
+            _ownership: Rc::new(ownership),
         })
+    }
+
+    /// Discard staged writes and reload the durable root while retaining this
+    /// handle's ownership. Callers must serialize this with writes/flushes.
+    pub async fn reload(&self) -> Result<(), Error> {
+        let (store, options) = {
+            let tree = self.inner.borrow();
+            if tree.commit_in_flight {
+                return Err(Error::CommitInFlight);
+            }
+            (tree.store.clone(), tree.options)
+        };
+        let fresh = TreeCore::open(store, options).await?;
+        *self.inner.borrow_mut() = fresh;
+        Ok(())
     }
 
     pub fn metadata(&self) -> Metadata {
@@ -270,11 +290,14 @@ impl<S: PageStore + Clone> IdbTree<S> {
             }
             tree.store.clone()
         };
-        let bytes = store
-            .read_page(page_id)
-            .await
-            .map_err(Error::Store)?
-            .ok_or(Error::MissingPage(page_id))?;
+        let root_before = self.inner.borrow().metadata.root_page_id;
+        let bytes = store.read_page(page_id).await.map_err(Error::Store)?;
+        let Some(bytes) = bytes else {
+            if self.inner.borrow().metadata.root_page_id != root_before {
+                return Ok(());
+            }
+            return Err(Error::MissingPage(page_id));
+        };
         let page_size = self.inner.borrow().options.page_size;
         if bytes.len() > page_size {
             return Err(Error::PageTooLarge { page_id, page_size });
@@ -367,7 +390,7 @@ impl<S: PageStore> TreeCore<S> {
             metadata: metadata.unwrap_or_else(|| Metadata::empty(options.page_size)),
             pages: HashMap::new(),
             dirty: BTreeMap::new(),
-            deleted: Vec::new(),
+            deleted: BTreeSet::new(),
             commit_in_flight: false,
         };
         if tree.metadata.page_size != options.page_size {
@@ -417,6 +440,7 @@ impl<S: PageStore> TreeCore<S> {
         let new_value = self.build_value(value.to_vec())?;
         match entries.binary_search_by(|(candidate, _)| candidate.as_slice().cmp(key)) {
             Ok(index) => {
+                self.retire_value(&entries[index].1);
                 entries[index].1 = new_value;
             }
             Err(index) => entries.insert(index, (key.to_vec(), new_value)),
@@ -438,6 +462,7 @@ impl<S: PageStore> TreeCore<S> {
             return Ok(Attempt::Missing(page_id));
         }
         let mut entries = entries;
+        self.retire_value(&entries[index].1);
         entries.remove(index);
         self.finish_leaf_write(page_id, entries, path)?;
         Ok(Attempt::Ready(true))
@@ -518,6 +543,9 @@ impl<S: PageStore> TreeCore<S> {
         }
         let mut pages = Vec::with_capacity(self.dirty.len());
         for (&page_id, page) in &self.dirty {
+            if self.deleted.contains(&page_id) {
+                continue;
+            }
             let bytes = encode_page(page).map_err(Error::InvalidPage)?;
             if bytes.len() > self.options.page_size {
                 return Err(Error::PageTooLarge {
@@ -532,10 +560,21 @@ impl<S: PageStore> TreeCore<S> {
             expected_generation: self.metadata.generation,
             metadata: self.metadata.clone(),
             pages,
-            deleted_page_ids: std::mem::take(&mut self.deleted),
+            deleted_page_ids: if self.store.can_reclaim_obsolete_pages() {
+                self.deleted
+                    .iter()
+                    .filter(|id| !self.dirty.contains_key(id))
+                    .copied()
+                    .collect()
+            } else {
+                Vec::new()
+            },
         };
         self.dirty.clear();
-        Ok(Some(PreparedCommit { commit }))
+        Ok(Some(PreparedCommit {
+            commit,
+            retired: std::mem::take(&mut self.deleted),
+        }))
     }
 
     /// Reconcile an atomic commit result with writes made after
@@ -563,6 +602,9 @@ impl<S: PageStore> TreeCore<S> {
                 }
                 // Root and allocation metadata may already describe writes in
                 // the next dirty generation. Only advance its durable base.
+                for page_id in prepared.retired {
+                    self.pages.remove(&page_id);
+                }
                 self.metadata.generation = committed.generation;
                 Ok(())
             }
@@ -575,11 +617,7 @@ impl<S: PageStore> TreeCore<S> {
                         self.dirty.insert(page_id, page.clone());
                     }
                 }
-                for page_id in prepared.commit.deleted_page_ids {
-                    if !self.pages.contains_key(&page_id) && !self.deleted.contains(&page_id) {
-                        self.deleted.push(page_id);
-                    }
-                }
+                self.deleted.extend(prepared.retired);
                 if error.contains("generation changed") {
                     Err(Error::GenerationConflict(error))
                 } else {
@@ -823,13 +861,13 @@ impl<S: PageStore> TreeCore<S> {
                 })?,
             }
         };
+        self.deleted.insert(page_id);
         self.publish_replacement(replacement, path)
     }
 
     /// Rebuild every changed ancestor under fresh page ids. A committed root
-    /// therefore names a complete immutable closure. Reclamation is deferred
-    /// to a reachability-based maintenance pass, rather than deleting pages
-    /// while an older root could still name them.
+    /// therefore names a complete immutable closure. Retire the replaced path
+    /// atomically with publication, only when the store proves exclusive ownership.
     fn publish_replacement(
         &mut self,
         mut replacement: PageReplacement,
@@ -849,6 +887,7 @@ impl<S: PageStore> TreeCore<S> {
                     "descent parent is not internal".to_owned(),
                 ));
             };
+            self.deleted.insert(parent_id);
             replacement = match replacement {
                 PageReplacement::One(page_id) => {
                     children[child_index] = page_id;
@@ -902,9 +941,26 @@ impl<S: PageStore> TreeCore<S> {
             })?,
         };
         self.metadata.root_page_id = Some(root);
-        // The old closure remains durable until a future mark/sweep collector
-        // proves it unreachable from the published root.
+
         Ok(())
+    }
+
+    // The complete leaf ownership graph has already been validated and hydrated.
+    // Only the replaced value owns this chain; surviving values retain theirs.
+    fn retire_value(&mut self, value: &ValueCell) {
+        let ValueCell::Overflow { head, .. } = value else {
+            return;
+        };
+        let mut current = Some(*head);
+        while let Some(id) = current {
+            let Page::Overflow { next, .. } =
+                self.pages.get(&id).expect("validated overflow is resident")
+            else {
+                unreachable!()
+            };
+            current = *next;
+            self.deleted.insert(id);
+        }
     }
 
     fn page_fits(&self, page: &Page) -> Result<bool, Error> {

--- a/crates/idb-tree/src/store.rs
+++ b/crates/idb-tree/src/store.rs
@@ -34,7 +34,38 @@ pub struct Commit {
     pub deleted_page_ids: Vec<PageId>,
 }
 
+/// Keeps a store's single-tree admission alive until the last tree clone drops.
+#[derive(Default)]
+pub struct TreeOwnership(Option<Box<dyn FnOnce()>>);
+
+impl TreeOwnership {
+    pub fn new(release: impl FnOnce() + 'static) -> Self {
+        Self(Some(Box::new(release)))
+    }
+}
+
+impl Drop for TreeOwnership {
+    fn drop(&mut self) {
+        if let Some(release) = self.0.take() {
+            release();
+        }
+    }
+}
+
 pub trait PageStore {
+    /// Opt in only while this tree exclusively owns the store: no independent
+    /// handle may retain an older root. The store must also reject reclamation
+    /// commits after ownership expires, including already prepared commits.
+    /// Clones of one IdbTree share a root and are permitted. Independent trees
+    /// (including ones built from cloned stores) require this to remain false.
+    fn claim_tree_ownership(&self) -> Result<TreeOwnership, String> {
+        Ok(TreeOwnership::default())
+    }
+
+    fn can_reclaim_obsolete_pages(&self) -> bool {
+        false
+    }
+
     fn load_metadata(&self) -> BoxFuture<'_, Result<Option<Metadata>, String>>;
     fn read_page(&self, page_id: PageId) -> BoxFuture<'_, Result<Option<Vec<u8>>, String>>;
     fn commit<'a>(&'a self, commit: &'a Commit) -> BoxFuture<'a, Result<Metadata, String>>;

--- a/crates/idb-tree/src/store.rs
+++ b/crates/idb-tree/src/store.rs
@@ -34,19 +34,40 @@ pub struct Commit {
     pub deleted_page_ids: Vec<PageId>,
 }
 
-/// Keeps a store's single-tree admission alive until the last tree clone drops.
+/// Keeps a store's single-tree admission alive until it is revoked or the
+/// last tree clone drops. Revocation fences even resident reads and writes.
 #[derive(Default)]
-pub struct TreeOwnership(Option<Box<dyn FnOnce()>>);
+pub struct TreeOwnership {
+    is_live: Option<Box<dyn Fn() -> bool>>,
+    release: Option<Box<dyn FnOnce()>>,
+}
 
 impl TreeOwnership {
     pub fn new(release: impl FnOnce() + 'static) -> Self {
-        Self(Some(Box::new(release)))
+        Self {
+            is_live: None,
+            release: Some(Box::new(release)),
+        }
+    }
+
+    pub fn revocable(
+        is_live: impl Fn() -> bool + 'static,
+        release: impl FnOnce() + 'static,
+    ) -> Self {
+        Self {
+            is_live: Some(Box::new(is_live)),
+            release: Some(Box::new(release)),
+        }
+    }
+
+    pub fn is_live(&self) -> bool {
+        self.is_live.as_ref().is_none_or(|check| check())
     }
 }
 
 impl Drop for TreeOwnership {
     fn drop(&mut self) {
-        if let Some(release) = self.0.take() {
+        if let Some(release) = self.release.take() {
             release();
         }
     }

--- a/crates/idb-tree/src/store.rs
+++ b/crates/idb-tree/src/store.rs
@@ -57,7 +57,9 @@ pub trait PageStore {
     /// handle may retain an older root. The store must also reject reclamation
     /// commits after ownership expires, including already prepared commits.
     /// Clones of one IdbTree share a root and are permitted. Independent trees
-    /// (including ones built from cloned stores) require this to remain false.
+    /// (including ones built from cloned stores) require this to remain false
+    /// for every writer sharing their store. Default-off does not make a reader
+    /// safe alongside another writer that violates this exclusivity contract.
     fn claim_tree_ownership(&self) -> Result<TreeOwnership, String> {
         Ok(TreeOwnership::default())
     }

--- a/crates/idb-tree/src/web.rs
+++ b/crates/idb-tree/src/web.rs
@@ -1,4 +1,6 @@
 use js_sys::{Array, Promise, Reflect, Uint8Array};
+use std::cell::Cell;
+use std::rc::Rc;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -12,10 +14,16 @@ extern "C" {
     type IndexedDbPageStoreHandle;
 
     #[wasm_bindgen(method, catch, js_name = claimTreeOwnership)]
-    fn claim_tree_ownership_js(this: &IndexedDbPageStoreHandle) -> Result<(), JsValue>;
+    fn claim_tree_ownership_js(this: &IndexedDbPageStoreHandle) -> Result<f64, JsValue>;
 
     #[wasm_bindgen(method, js_name = releaseTreeOwnership)]
-    fn release_tree_ownership_js(this: &IndexedDbPageStoreHandle);
+    fn release_tree_ownership_js(this: &IndexedDbPageStoreHandle, token: f64);
+
+    #[wasm_bindgen(method, catch, js_name = isTreeOwnershipActive)]
+    fn tree_ownership_active_js(
+        this: &IndexedDbPageStoreHandle,
+        token: f64,
+    ) -> Result<bool, JsValue>;
 
     #[wasm_bindgen(method, getter, js_name = canReclaimObsoletePages)]
     fn can_reclaim_obsolete_pages_js(this: &IndexedDbPageStoreHandle) -> bool;
@@ -36,6 +44,7 @@ extern "C" {
         page_ids: &Array,
         page_bytes: &Array,
         deleted_page_ids: &Array,
+        tree_token: JsValue,
     ) -> Promise;
 }
 
@@ -44,12 +53,14 @@ extern "C" {
 #[derive(Clone)]
 pub struct IndexedDbPageStore {
     handle: IndexedDbPageStoreHandle,
+    tree_token: Rc<Cell<Option<f64>>>,
 }
 
 impl IndexedDbPageStore {
     pub fn from_js(handle: JsValue) -> Self {
         Self {
             handle: handle.unchecked_into(),
+            tree_token: Rc::new(Cell::new(None)),
         }
     }
 
@@ -57,12 +68,16 @@ impl IndexedDbPageStore {
     // They remain non-reclaiming unless they explicitly implement the complete
     // single-tree ownership contract as well.
     fn supports_tree_ownership(&self) -> bool {
-        ["claimTreeOwnership", "releaseTreeOwnership"]
-            .into_iter()
-            .all(|name| {
-                Reflect::get(&self.handle, &JsValue::from_str(name))
-                    .is_ok_and(|value| value.is_function())
-            })
+        [
+            "claimTreeOwnership",
+            "releaseTreeOwnership",
+            "isTreeOwnershipActive",
+        ]
+        .into_iter()
+        .all(|name| {
+            Reflect::get(&self.handle, &JsValue::from_str(name))
+                .is_ok_and(|value| value.is_function())
+        })
     }
 }
 
@@ -71,15 +86,27 @@ impl PageStore for IndexedDbPageStore {
         if !self.supports_tree_ownership() {
             return Ok(TreeOwnership::default());
         }
-        self.handle.claim_tree_ownership_js().map_err(js_error)?;
-        let handle = self.handle.clone();
-        Ok(TreeOwnership::new(move || {
-            handle.release_tree_ownership_js()
-        }))
+        let token = self.handle.claim_tree_ownership_js().map_err(js_error)?;
+        self.tree_token.set(Some(token));
+        let live_handle = self.handle.clone();
+        let release_handle = self.handle.clone();
+        let current_token = self.tree_token.clone();
+        Ok(TreeOwnership::revocable(
+            move || live_handle.tree_ownership_active_js(token).unwrap_or(false),
+            move || {
+                release_handle.release_tree_ownership_js(token);
+                if current_token.get() == Some(token) {
+                    current_token.set(None);
+                }
+            },
+        ))
     }
 
     fn can_reclaim_obsolete_pages(&self) -> bool {
-        self.supports_tree_ownership() && self.handle.can_reclaim_obsolete_pages_js()
+        self.tree_token.get().is_some_and(|token| {
+            self.handle.tree_ownership_active_js(token).unwrap_or(false)
+                && self.handle.can_reclaim_obsolete_pages_js()
+        })
     }
 
     fn load_metadata(&self) -> BoxFuture<'_, Result<Option<Metadata>, String>> {
@@ -132,6 +159,9 @@ impl PageStore for IndexedDbPageStore {
                     &page_ids,
                     &page_bytes,
                     &deleted_page_ids,
+                    self.tree_token
+                        .get()
+                        .map_or(JsValue::UNDEFINED, JsValue::from_f64),
                 ),
             )
             .await

--- a/crates/idb-tree/src/web.rs
+++ b/crates/idb-tree/src/web.rs
@@ -1,6 +1,5 @@
 use js_sys::{Array, Promise, Reflect, Uint8Array};
 use std::cell::Cell;
-use std::rc::Rc;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -53,14 +52,16 @@ extern "C" {
 #[derive(Clone)]
 pub struct IndexedDbPageStore {
     handle: IndexedDbPageStoreHandle,
-    tree_token: Rc<Cell<Option<f64>>>,
+    // Clones used by one TreeCore retain its token; a separate open only
+    // replaces the token in its own adapter, never in another live tree.
+    tree_token: Cell<Option<f64>>,
 }
 
 impl IndexedDbPageStore {
     pub fn from_js(handle: JsValue) -> Self {
         Self {
             handle: handle.unchecked_into(),
-            tree_token: Rc::new(Cell::new(None)),
+            tree_token: Cell::new(None),
         }
     }
 
@@ -90,15 +91,9 @@ impl PageStore for IndexedDbPageStore {
         self.tree_token.set(Some(token));
         let live_handle = self.handle.clone();
         let release_handle = self.handle.clone();
-        let current_token = self.tree_token.clone();
         Ok(TreeOwnership::revocable(
             move || live_handle.tree_ownership_active_js(token).unwrap_or(false),
-            move || {
-                release_handle.release_tree_ownership_js(token);
-                if current_token.get() == Some(token) {
-                    current_token.set(None);
-                }
-            },
+            move || release_handle.release_tree_ownership_js(token),
         ))
     }
 

--- a/crates/idb-tree/src/web.rs
+++ b/crates/idb-tree/src/web.rs
@@ -52,10 +52,25 @@ impl IndexedDbPageStore {
             handle: handle.unchecked_into(),
         }
     }
+
+    // Existing/custom JS stores implement only metadata/readPage/commitPages.
+    // They remain non-reclaiming unless they explicitly implement the complete
+    // single-tree ownership contract as well.
+    fn supports_tree_ownership(&self) -> bool {
+        ["claimTreeOwnership", "releaseTreeOwnership"]
+            .into_iter()
+            .all(|name| {
+                Reflect::get(&self.handle, &JsValue::from_str(name))
+                    .is_ok_and(|value| value.is_function())
+            })
+    }
 }
 
 impl PageStore for IndexedDbPageStore {
     fn claim_tree_ownership(&self) -> Result<TreeOwnership, String> {
+        if !self.supports_tree_ownership() {
+            return Ok(TreeOwnership::default());
+        }
         self.handle.claim_tree_ownership_js().map_err(js_error)?;
         let handle = self.handle.clone();
         Ok(TreeOwnership::new(move || {
@@ -64,7 +79,7 @@ impl PageStore for IndexedDbPageStore {
     }
 
     fn can_reclaim_obsolete_pages(&self) -> bool {
-        self.handle.can_reclaim_obsolete_pages_js()
+        self.supports_tree_ownership() && self.handle.can_reclaim_obsolete_pages_js()
     }
 
     fn load_metadata(&self) -> BoxFuture<'_, Result<Option<Metadata>, String>> {

--- a/crates/idb-tree/src/web.rs
+++ b/crates/idb-tree/src/web.rs
@@ -3,13 +3,22 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
-use crate::{BoxFuture, Commit, Metadata, PageStore};
+use crate::{BoxFuture, Commit, Metadata, PageStore, TreeOwnership};
 
 #[wasm_bindgen]
 extern "C" {
     #[derive(Clone)]
     #[wasm_bindgen(typescript_type = "IndexedDbPageStore")]
     type IndexedDbPageStoreHandle;
+
+    #[wasm_bindgen(method, catch, js_name = claimTreeOwnership)]
+    fn claim_tree_ownership_js(this: &IndexedDbPageStoreHandle) -> Result<(), JsValue>;
+
+    #[wasm_bindgen(method, js_name = releaseTreeOwnership)]
+    fn release_tree_ownership_js(this: &IndexedDbPageStoreHandle);
+
+    #[wasm_bindgen(method, getter, js_name = canReclaimObsoletePages)]
+    fn can_reclaim_obsolete_pages_js(this: &IndexedDbPageStoreHandle) -> bool;
 
     #[wasm_bindgen(method, js_name = metadata)]
     fn metadata_js(this: &IndexedDbPageStoreHandle) -> Promise;
@@ -46,6 +55,18 @@ impl IndexedDbPageStore {
 }
 
 impl PageStore for IndexedDbPageStore {
+    fn claim_tree_ownership(&self) -> Result<TreeOwnership, String> {
+        self.handle.claim_tree_ownership_js().map_err(js_error)?;
+        let handle = self.handle.clone();
+        Ok(TreeOwnership::new(move || {
+            handle.release_tree_ownership_js()
+        }))
+    }
+
+    fn can_reclaim_obsolete_pages(&self) -> bool {
+        self.handle.can_reclaim_obsolete_pages_js()
+    }
+
     fn load_metadata(&self) -> BoxFuture<'_, Result<Option<Metadata>, String>> {
         Box::pin(async move {
             let value = JsFuture::from(self.handle.metadata_js())

--- a/crates/idb-tree/tests/reclamation.rs
+++ b/crates/idb-tree/tests/reclamation.rs
@@ -20,6 +20,7 @@ struct Store {
     live: Rc<RefCell<BTreeSet<u64>>>,
     deleted: Rc<RefCell<BTreeSet<u64>>>,
     pause: Rc<Cell<bool>>,
+    fail_paused_read: Rc<Cell<bool>>,
     commit_resume: Rc<RefCell<Option<futures::channel::oneshot::Receiver<()>>>>,
     read_resume: Rc<RefCell<Option<futures::channel::oneshot::Receiver<()>>>>,
 }
@@ -57,6 +58,9 @@ impl PageStore for Store {
             };
             if let Some(resume) = resume {
                 resume.await.map_err(|e| e.to_string())?;
+                if self.fail_paused_read.replace(false) {
+                    return Err("old read failed".into());
+                }
             }
             self.memory.read_page(id).await
         })
@@ -247,5 +251,110 @@ fn reload_retains_exclusive_admission_and_discards_failed_staging() {
         tree.put(b"key".to_vec(), vec![3; 4000]).await.unwrap();
         tree.flush().await.unwrap();
         assert!(store.live.borrow().len() <= 6);
+    });
+}
+
+#[test]
+fn pending_read_error_from_before_reload_retries_even_when_root_id_is_unchanged() {
+    block_on(async {
+        let store = Store::exclusive();
+        let initial = IdbTree::open(store.clone(), options()).await.unwrap();
+        initial.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        initial.flush().await.unwrap();
+        drop(initial);
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        let (resume, receiver) = futures::channel::oneshot::channel();
+        *store.read_resume.borrow_mut() = Some(receiver);
+        store.pause.set(true);
+        store.fail_paused_read.set(true);
+        let mut read = Box::pin(tree.get(b"key"));
+        assert!(read.as_mut().now_or_never().is_none());
+        let root = tree.metadata().root_page_id;
+        tree.reload().await.unwrap();
+        assert_eq!(tree.metadata().root_page_id, root);
+        resume.send(()).unwrap();
+        assert_eq!(read.await.unwrap(), Some(vec![1; 4000]));
+    });
+}
+
+#[test]
+fn failed_batch_restores_retirement_and_multilevel_replacements_stay_bounded() {
+    block_on(async {
+        let store = Store::exclusive();
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        for n in 0u32..1000 {
+            tree.put(n.to_be_bytes().to_vec(), vec![1; 80])
+                .await
+                .unwrap();
+        }
+        tree.flush().await.unwrap();
+        let initial_pages = store.live.borrow().len();
+        assert!(initial_pages > 100, "fixture must span multiple leaves");
+        for generation in 2..6 {
+            let operations = (0u32..1000)
+                .map(|n| WriteOperation::Set {
+                    key: n.to_be_bytes().to_vec(),
+                    value: vec![generation; 80],
+                })
+                .collect();
+            tree.write_many(operations).await.unwrap();
+            tree.flush().await.unwrap();
+            assert!(
+                store.live.borrow().len() <= initial_pages,
+                "replaced ancestors leaked"
+            );
+        }
+        let failed = tree
+            .write_many(vec![
+                WriteOperation::Set {
+                    key: 0u32.to_be_bytes().to_vec(),
+                    value: vec![7; 5000],
+                },
+                WriteOperation::Set {
+                    key: vec![255; 2000],
+                    value: vec![8; 5000],
+                },
+            ])
+            .await;
+        assert!(failed.is_err());
+        tree.put(999u32.to_be_bytes().to_vec(), vec![9; 80])
+            .await
+            .unwrap();
+        tree.flush().await.unwrap();
+        drop(tree);
+        let reopened = IdbTree::open(store.clone(), options()).await.unwrap();
+        assert_eq!(
+            reopened.get(&0u32.to_be_bytes()).await.unwrap(),
+            Some(vec![5; 80])
+        );
+        assert_eq!(
+            reopened.get(&999u32.to_be_bytes()).await.unwrap(),
+            Some(vec![9; 80])
+        );
+        assert!(store.live.borrow().len() <= initial_pages);
+    });
+}
+
+#[test]
+fn successful_publication_keeps_newer_staged_generation_and_reclaims_it_on_next_flush() {
+    block_on(async {
+        let store = Store::exclusive();
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        tree.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        tree.flush().await.unwrap();
+        tree.put(b"key".to_vec(), vec![2; 4000]).await.unwrap();
+        let (resume, receiver) = futures::channel::oneshot::channel();
+        *store.commit_resume.borrow_mut() = Some(receiver);
+        let mut flush = Box::pin(tree.flush());
+        assert!(flush.as_mut().now_or_never().is_none());
+        tree.put(b"key".to_vec(), vec![3; 4000]).await.unwrap();
+        resume.send(()).unwrap();
+        flush.await.unwrap();
+        assert_eq!(tree.get(b"key").await.unwrap(), Some(vec![3; 4000]));
+        tree.flush().await.unwrap();
+        assert!(store.live.borrow().len() <= 6);
+        drop(tree);
+        let reopened = IdbTree::open(store, options()).await.unwrap();
+        assert_eq!(reopened.get(b"key").await.unwrap(), Some(vec![3; 4000]));
     });
 }

--- a/crates/idb-tree/tests/reclamation.rs
+++ b/crates/idb-tree/tests/reclamation.rs
@@ -14,6 +14,8 @@ struct Store {
     memory: MemoryPageStore,
     exclusive: Rc<Cell<bool>>,
     claimed: Rc<Cell<bool>>,
+    ownership_generation: Rc<Cell<u64>>,
+    metadata_resume: Rc<RefCell<Option<futures::channel::oneshot::Receiver<()>>>>,
     fail: Rc<Cell<bool>>,
     fail_metadata: Rc<Cell<bool>>,
     metadata_reads: Rc<Cell<usize>>,
@@ -33,12 +35,28 @@ impl Store {
 }
 impl PageStore for Store {
     fn claim_tree_ownership(&self) -> Result<TreeOwnership, String> {
-        if self.exclusive.get() && self.claimed.replace(true) {
+        if !self.exclusive.get() {
+            return Ok(TreeOwnership::default());
+        }
+        if self.claimed.replace(true) {
             return Err("owner already has a tree".into());
         }
-        let claimed = self.claimed.clone();
-        Ok(TreeOwnership::new(move || claimed.set(false)))
+        let token = self.ownership_generation.get() + 1;
+        self.ownership_generation.set(token);
+        let live = self.claimed.clone();
+        let generation = self.ownership_generation.clone();
+        let release_live = live.clone();
+        let release_generation = generation.clone();
+        Ok(TreeOwnership::revocable(
+            move || live.get() && generation.get() == token,
+            move || {
+                if release_generation.get() == token {
+                    release_live.set(false);
+                }
+            },
+        ))
     }
+
     fn can_reclaim_obsolete_pages(&self) -> bool {
         self.exclusive.get()
     }
@@ -47,7 +65,14 @@ impl PageStore for Store {
         if self.fail_metadata.replace(false) {
             return Box::pin(async { Err("metadata unavailable".into()) });
         }
-        self.memory.load_metadata()
+        Box::pin(async move {
+            let metadata = self.memory.load_metadata().await?;
+            let resume = self.metadata_resume.borrow_mut().take();
+            if let Some(resume) = resume {
+                resume.await.map_err(|e| e.to_string())?;
+            }
+            Ok(metadata)
+        })
     }
     fn read_page(&self, id: u64) -> BoxFuture<'_, Result<Option<Vec<u8>>, String>> {
         Box::pin(async move {
@@ -356,5 +381,102 @@ fn successful_publication_keeps_newer_staged_generation_and_reclaims_it_on_next_
         drop(tree);
         let reopened = IdbTree::open(store, options()).await.unwrap();
         assert_eq!(reopened.get(b"key").await.unwrap(), Some(vec![3; 4000]));
+    });
+}
+
+#[test]
+fn revoked_cached_and_pending_handles_cannot_access_or_release_successor() {
+    block_on(async {
+        let store = Store::exclusive();
+        let old = IdbTree::open(store.clone(), options()).await.unwrap();
+        old.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        old.flush().await.unwrap();
+        assert_eq!(old.get(b"key").await.unwrap(), Some(vec![1; 4000]));
+        let retained = old.clone();
+        store.claimed.set(false); // synchronous runtime retirement
+        let successor = IdbTree::open(store.clone(), options()).await.unwrap();
+        assert!(matches!(
+            old.get(b"key").await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.put(b"key".to_vec(), vec![2]).await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.delete(b"key").await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.write_many(vec![]).await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.range(b"", b"z").await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.range_limit(b"", b"z", 0).await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.range_reverse(b"", b"z", 0).await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.range_reverse(b"", b"z", 1).await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.flush().await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(matches!(
+            old.reload().await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        drop(old);
+        drop(retained);
+        assert!(IdbTree::open(store.clone(), options()).await.is_err());
+        successor.put(b"key".to_vec(), vec![3; 4000]).await.unwrap();
+        successor.flush().await.unwrap();
+        successor.reload().await.unwrap();
+        let (resume, receiver) = futures::channel::oneshot::channel();
+        *store.read_resume.borrow_mut() = Some(receiver);
+        store.pause.set(true);
+        let mut read = Box::pin(successor.get(b"key"));
+        assert!(read.as_mut().now_or_never().is_none());
+        store.claimed.set(false);
+        let final_owner = IdbTree::open(store.clone(), options()).await.unwrap();
+        final_owner
+            .put(b"key".to_vec(), vec![4; 4000])
+            .await
+            .unwrap();
+        final_owner.flush().await.unwrap();
+        resume.send(()).unwrap();
+        assert!(matches!(read.await, Err(idb_tree::Error::OwnershipExpired)));
+        assert_eq!(final_owner.get(b"key").await.unwrap(), Some(vec![4; 4000]));
+    });
+}
+
+#[test]
+fn revocation_during_open_rejects_old_metadata_and_preserves_new_guard() {
+    block_on(async {
+        let store = Store::exclusive();
+        let (resume, receiver) = futures::channel::oneshot::channel();
+        *store.metadata_resume.borrow_mut() = Some(receiver);
+        let mut old_open = Box::pin(IdbTree::open(store.clone(), options()));
+        assert!(old_open.as_mut().now_or_never().is_none());
+        store.claimed.set(false);
+        let new = IdbTree::open(store.clone(), options()).await.unwrap();
+        new.put(b"key".to_vec(), vec![7]).await.unwrap();
+        new.flush().await.unwrap();
+        resume.send(()).unwrap();
+        assert!(matches!(
+            old_open.await,
+            Err(idb_tree::Error::OwnershipExpired)
+        ));
+        assert!(IdbTree::open(store.clone(), options()).await.is_err());
+        assert_eq!(new.get(b"key").await.unwrap(), Some(vec![7]));
     });
 }

--- a/crates/idb-tree/tests/reclamation.rs
+++ b/crates/idb-tree/tests/reclamation.rs
@@ -1,0 +1,251 @@
+use futures::{FutureExt, executor::block_on};
+use idb_tree::{
+    BoxFuture, Commit, IdbTree, MemoryPageStore, Metadata, Options, PageStore, TreeOwnership,
+    WriteOperation,
+};
+use std::{
+    cell::{Cell, RefCell},
+    collections::BTreeSet,
+    rc::Rc,
+};
+
+#[derive(Clone, Default)]
+struct Store {
+    memory: MemoryPageStore,
+    exclusive: Rc<Cell<bool>>,
+    claimed: Rc<Cell<bool>>,
+    fail: Rc<Cell<bool>>,
+    fail_metadata: Rc<Cell<bool>>,
+    metadata_reads: Rc<Cell<usize>>,
+    live: Rc<RefCell<BTreeSet<u64>>>,
+    deleted: Rc<RefCell<BTreeSet<u64>>>,
+    pause: Rc<Cell<bool>>,
+    commit_resume: Rc<RefCell<Option<futures::channel::oneshot::Receiver<()>>>>,
+    read_resume: Rc<RefCell<Option<futures::channel::oneshot::Receiver<()>>>>,
+}
+impl Store {
+    fn exclusive() -> Self {
+        let store = Self::default();
+        store.exclusive.set(true);
+        store
+    }
+}
+impl PageStore for Store {
+    fn claim_tree_ownership(&self) -> Result<TreeOwnership, String> {
+        if self.exclusive.get() && self.claimed.replace(true) {
+            return Err("owner already has a tree".into());
+        }
+        let claimed = self.claimed.clone();
+        Ok(TreeOwnership::new(move || claimed.set(false)))
+    }
+    fn can_reclaim_obsolete_pages(&self) -> bool {
+        self.exclusive.get()
+    }
+    fn load_metadata(&self) -> BoxFuture<'_, Result<Option<Metadata>, String>> {
+        self.metadata_reads.set(self.metadata_reads.get() + 1);
+        if self.fail_metadata.replace(false) {
+            return Box::pin(async { Err("metadata unavailable".into()) });
+        }
+        self.memory.load_metadata()
+    }
+    fn read_page(&self, id: u64) -> BoxFuture<'_, Result<Option<Vec<u8>>, String>> {
+        Box::pin(async move {
+            let resume = if self.pause.replace(false) {
+                self.read_resume.borrow_mut().take()
+            } else {
+                None
+            };
+            if let Some(resume) = resume {
+                resume.await.map_err(|e| e.to_string())?;
+            }
+            self.memory.read_page(id).await
+        })
+    }
+    fn commit<'a>(&'a self, commit: &'a Commit) -> BoxFuture<'a, Result<Metadata, String>> {
+        Box::pin(async move {
+            let resume = self.commit_resume.borrow_mut().take();
+            if let Some(resume) = resume {
+                resume.await.map_err(|e| e.to_string())?;
+            }
+            if self.fail.replace(false) {
+                return Err("injected failure".into());
+            }
+            if !commit.deleted_page_ids.is_empty() && !self.exclusive.get() {
+                return Err("ownership expired".into());
+            }
+            let metadata = self.memory.commit(commit).await?;
+            let mut live = self.live.borrow_mut();
+            live.extend(commit.pages.iter().map(|(id, _)| *id));
+            for id in &commit.deleted_page_ids {
+                live.remove(id);
+                self.deleted.borrow_mut().insert(*id);
+            }
+            Ok(metadata)
+        })
+    }
+}
+fn options() -> Options {
+    Options { page_size: 1024 }
+}
+
+#[test]
+fn exclusive_replacement_bounds_live_pages_and_preserves_sibling_overflow_on_reopen() {
+    block_on(async {
+        let store = Store::exclusive();
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        let sibling = vec![9; 5000];
+        tree.put(b"sibling".to_vec(), sibling.clone())
+            .await
+            .unwrap();
+        for n in 0..80 {
+            tree.write_many(vec![
+                WriteOperation::Set {
+                    key: b"changing".to_vec(),
+                    value: vec![n; 4000],
+                },
+                WriteOperation::Set {
+                    key: b"temporary".to_vec(),
+                    value: vec![n; 3000],
+                },
+                WriteOperation::Delete {
+                    key: b"temporary".to_vec(),
+                },
+            ])
+            .await
+            .unwrap();
+            tree.flush().await.unwrap();
+            assert!(
+                store.live.borrow().len() <= 12,
+                "historical COW pages leaked"
+            );
+            assert_eq!(tree.get(b"sibling").await.unwrap(), Some(sibling.clone()));
+        }
+        tree.delete(b"changing").await.unwrap();
+        tree.flush().await.unwrap();
+        assert!(store.live.borrow().len() <= 7);
+        drop(tree);
+        let reopened = IdbTree::open(store.clone(), options()).await.unwrap();
+        assert_eq!(reopened.get(b"sibling").await.unwrap(), Some(sibling));
+        assert_eq!(reopened.get(b"changing").await.unwrap(), None);
+        assert!(!store.deleted.borrow().is_empty());
+    });
+}
+
+#[test]
+fn generic_independent_cold_handle_keeps_its_complete_old_closure() {
+    block_on(async {
+        let store = Store::default();
+        let writer = IdbTree::open(store.clone(), options()).await.unwrap();
+        writer.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        writer.flush().await.unwrap();
+        let cold = IdbTree::open(store.clone(), options()).await.unwrap();
+        writer.put(b"key".to_vec(), vec![2; 4000]).await.unwrap();
+        writer.flush().await.unwrap();
+        assert_eq!(cold.get(b"key").await.unwrap(), Some(vec![1; 4000]));
+        cold.put(b"other".to_vec(), vec![3]).await.unwrap();
+        assert!(matches!(
+            cold.flush().await,
+            Err(idb_tree::Error::GenerationConflict(_))
+        ));
+        assert!(store.deleted.borrow().is_empty());
+        let reopened = IdbTree::open(store, options()).await.unwrap();
+        assert_eq!(reopened.get(b"key").await.unwrap(), Some(vec![2; 4000]));
+    });
+}
+
+#[test]
+fn failed_publication_with_newer_writes_retries_complete_closure() {
+    block_on(async {
+        let store = Store::exclusive();
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        tree.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        tree.flush().await.unwrap();
+        tree.put(b"key".to_vec(), vec![2; 4000]).await.unwrap();
+        let (resume, receiver) = futures::channel::oneshot::channel();
+        *store.commit_resume.borrow_mut() = Some(receiver);
+        store.fail.set(true);
+        let mut flush = Box::pin(tree.flush());
+        assert!(flush.as_mut().now_or_never().is_none());
+        tree.put(b"key".to_vec(), vec![3; 4000]).await.unwrap();
+        resume.send(()).unwrap();
+        flush.await.unwrap_err();
+        tree.flush().await.unwrap();
+        drop(tree);
+        let reopened = IdbTree::open(store.clone(), options()).await.unwrap();
+        assert_eq!(reopened.get(b"key").await.unwrap(), Some(vec![3; 4000]));
+        assert!(store.live.borrow().len() <= 6);
+    });
+}
+
+#[test]
+fn same_handle_pending_cold_read_retries_after_old_page_is_reclaimed() {
+    block_on(async {
+        let store = Store::exclusive();
+        let initial = IdbTree::open(store.clone(), options()).await.unwrap();
+        initial.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        initial.flush().await.unwrap();
+        drop(initial);
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        let (resume, receiver) = futures::channel::oneshot::channel();
+        *store.read_resume.borrow_mut() = Some(receiver);
+        store.pause.set(true);
+        let mut read = Box::pin(tree.get(b"key"));
+        assert!(read.as_mut().now_or_never().is_none());
+        tree.put(b"key".to_vec(), vec![2; 4000]).await.unwrap();
+        tree.flush().await.unwrap();
+        resume.send(()).unwrap();
+        assert_eq!(read.await.unwrap(), Some(vec![2; 4000]));
+    });
+}
+
+#[test]
+fn exclusive_admission_precedes_metadata_io_and_failed_open_releases_it() {
+    block_on(async {
+        let store = Store::exclusive();
+        let initial = IdbTree::open(store.clone(), options()).await.unwrap();
+        initial.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        initial.flush().await.unwrap();
+        let reads = store.metadata_reads.get();
+        assert!(IdbTree::open(store.clone(), options()).await.is_err());
+        assert_eq!(
+            store.metadata_reads.get(),
+            reads,
+            "competing open must not observe a stale root before admission"
+        );
+        initial.put(b"key".to_vec(), vec![2; 4000]).await.unwrap();
+        initial.flush().await.unwrap();
+        let retained = initial.clone();
+        drop(initial);
+        assert!(IdbTree::open(store.clone(), options()).await.is_err());
+        drop(retained);
+        store.fail_metadata.set(true);
+        assert!(IdbTree::open(store.clone(), options()).await.is_err());
+        assert!(
+            IdbTree::open(store.clone(), Options { page_size: 2048 })
+                .await
+                .is_err()
+        );
+        let reopened = IdbTree::open(store.clone(), options()).await.unwrap();
+        assert_eq!(reopened.get(b"key").await.unwrap(), Some(vec![2; 4000]));
+    });
+}
+
+#[test]
+fn reload_retains_exclusive_admission_and_discards_failed_staging() {
+    block_on(async {
+        let store = Store::exclusive();
+        let tree = IdbTree::open(store.clone(), options()).await.unwrap();
+        tree.put(b"key".to_vec(), vec![1; 4000]).await.unwrap();
+        tree.flush().await.unwrap();
+        tree.put(b"key".to_vec(), vec![2; 4000]).await.unwrap();
+        store.fail.set(true);
+        tree.flush().await.unwrap_err();
+        let clone = tree.clone();
+        tree.reload().await.unwrap();
+        assert!(IdbTree::open(store.clone(), options()).await.is_err());
+        assert_eq!(clone.get(b"key").await.unwrap(), Some(vec![1; 4000]));
+        tree.put(b"key".to_vec(), vec![3; 4000]).await.unwrap();
+        tree.flush().await.unwrap();
+        assert!(store.live.borrow().len() <= 6);
+    });
+}

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1957,6 +1957,17 @@ impl WasmDb {
             .map_err(to_js_error)
     }
 
+    /// Exact local state for the write-merge bridge, matching NAPI. Write
+    /// authorization remains at the mutation boundary; this is not a query.
+    #[wasm_bindgen(js_name = localCurrentRow)]
+    pub fn local_current_row(&self, table: String, row_id: Vec<u8>) -> Result<Vec<u8>, JsValue> {
+        let row_id = row_uuid_from_bytes(&row_id)?;
+        let inner = self.open_inner()?;
+        let row = with_wasm_db!(&inner, |db| block_on(db.local_current_row(&table, row_id)))
+            .map_err(to_js_error)?;
+        encode_rows(&row.into_iter().collect::<Vec<_>>()).map_err(to_js_error)
+    }
+
     #[wasm_bindgen(js_name = prepareQuery)]
     pub fn prepare_query(
         &self,

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1831,6 +1831,7 @@ impl WasmDb {
             .await
             .map_err(to_js_error)?;
         db.restore_browser_relay_pending_uploads()
+            .await
             .map_err(to_js_error)?;
         db.set_deferred_local_persistence(true);
         Ok(Self {
@@ -1866,6 +1867,7 @@ impl WasmDb {
             .await
             .map_err(to_js_error)?;
         db.restore_browser_relay_pending_uploads()
+            .await
             .map_err(to_js_error)?;
         db.set_deferred_local_persistence(true);
         Ok(Self {

--- a/crates/jazz-wasm/src/lib.rs
+++ b/crates/jazz-wasm/src/lib.rs
@@ -1965,7 +1965,7 @@ impl WasmDb {
         let inner = self.open_inner()?;
         let row = with_wasm_db!(&inner, |db| block_on(db.local_current_row(&table, row_id)))
             .map_err(to_js_error)?;
-        encode_rows(&row.into_iter().collect::<Vec<_>>()).map_err(to_js_error)
+        encode_synchronous_rows(&row.into_iter().collect::<Vec<_>>())
     }
 
     #[wasm_bindgen(js_name = prepareQuery)]

--- a/crates/jazz/src/db/lifecycle.rs
+++ b/crates/jazz/src/db/lifecycle.rs
@@ -142,7 +142,7 @@ where
         let node =
             NodeState::new(config.identity.node, config.schema.clone(), config.storage).await?;
         let node = Node::new(node);
-        node.restore_pending_uploads(config.identity)?;
+        node.restore_pending_uploads(config.identity).await?;
         let row_id_source_guarantees_fresh = config.id_source.is_none();
         Ok(Self {
             schema: config.schema,
@@ -333,7 +333,7 @@ where
         let node =
             NodeState::new_catalogue_uninitialized(config.identity.node, config.storage).await?;
         let node = Node::new(node);
-        node.restore_pending_uploads(config.identity)?;
+        node.restore_pending_uploads(config.identity).await?;
         node.restore_edge_authority_uploads().await?;
         let row_id_source_guarantees_fresh = config.id_source.is_none();
         Ok(Self {
@@ -761,9 +761,10 @@ where
     /// node differs from the worker node, so ordinary local-origin recovery
     /// cannot discover them after a cold worker restart.
     #[doc(hidden)]
-    pub fn restore_browser_relay_pending_uploads(&self) -> Result<(), Error> {
+    pub async fn restore_browser_relay_pending_uploads(&self) -> Result<(), Error> {
         self.node
             .restore_browser_relay_pending_uploads(self.identity.author)
+            .await
     }
 
     /// Let a single-threaded host return resident writes synchronously while

--- a/crates/jazz/src/db/node_runtime.rs
+++ b/crates/jazz/src/db/node_runtime.rs
@@ -878,11 +878,13 @@ where
 
     /// Restore locally originated, unsettled durable writes into the
     /// process-local upload queue after reopening client storage.
-    pub(super) fn restore_pending_uploads(&self, identity: DbIdentity) -> Result<(), Error> {
-        let mut node = self.node.borrow_mut();
-        let pending = node.pending_transaction_ids_for(identity.node, identity.author);
-        let pending = crate::db::block_on(pending)?;
-        drop(node);
+    pub(super) async fn restore_pending_uploads(&self, identity: DbIdentity) -> Result<(), Error> {
+        let pending = self
+            .node
+            .lock()
+            .await
+            .pending_transaction_ids_for(identity.node, identity.author)
+            .await?;
         let mut restored = HashSet::new();
         for tx_id in pending {
             if restored.insert(tx_id) {
@@ -908,14 +910,16 @@ where
         Ok(())
     }
 
-    pub(super) fn restore_browser_relay_pending_uploads(
+    pub(super) async fn restore_browser_relay_pending_uploads(
         &self,
         author: AuthorSubject,
     ) -> Result<(), Error> {
-        let mut node = self.node.borrow_mut();
-        let pending = node.pending_transaction_ids_for_author(author);
-        let pending = crate::db::block_on(pending)?;
-        drop(node);
+        let pending = self
+            .node
+            .lock()
+            .await
+            .pending_transaction_ids_for_author(author)
+            .await?;
         self.browser_relay_recovered_tx_ids
             .borrow_mut()
             .extend(pending.iter().copied());

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -3377,3 +3377,148 @@ fn cold_runtime_replacement_defers_empty_facade_until_local_snapshot_arrives() {
         "a subscription opened after the replacement must not inherit the retained facade"
     );
 }
+
+// These tests must reach the internal recovery boundary after evicting its
+// storage cache. Public open also hydrates unrelated metadata, which can hide
+// this particular cold scan. A child watchdog contains the historical busy
+// loop so a regression fails one test instead of hanging the suite.
+fn pending_restore_child(test_name: &str) -> bool {
+    const CHILD: &str = "JAZZ_PENDING_RESTORE_CHILD";
+    if std::env::var(CHILD).as_deref() == Ok(test_name) {
+        return true;
+    }
+    let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", test_name, "--nocapture"])
+        .env(CHILD, test_name)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            let output = child.wait_with_output().unwrap();
+            assert!(
+                status.success(),
+                "recovery child failed: {}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return false;
+        }
+        if std::time::Instant::now() >= deadline {
+            child.kill().unwrap();
+            let output = child.wait_with_output().unwrap();
+            panic!(
+                "recovery did not yield to asynchronous storage within 20s: {}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
+fn cold_pending_restore_yields_and_recovers(relay: bool) {
+    use std::future::Future;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::task::{Context, Poll};
+    struct WakeCount(AtomicUsize);
+    impl futures::task::ArcWake for WakeCount {
+        fn wake_by_ref(this: &Arc<Self>) {
+            this.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+    let schema = schema();
+    let identity = DbIdentity {
+        node: NodeUuid::from_bytes([0xdb; 16]),
+        author: AuthorSubject::for_test_bytes([0xdc; 16]),
+    };
+    let families = schema.column_families();
+    let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, _) = TestStorage::controlled(&refs);
+    let saved = storage.clone();
+    let db = block_on(Db::open(DbConfig::new(schema.clone(), storage, identity))).unwrap();
+    let tx_id = db
+        .insert(
+            "todos",
+            cells("pending recovery", false, identity.author),
+            Default::default(),
+        )
+        .unwrap()
+        .mergeable_tx_id();
+    block_on(db.close()).unwrap();
+    drop(db);
+    let storage = block_on(saved.reopen(families)).unwrap();
+    let control = storage.control();
+    let eviction = storage.clone();
+    let owner_node = if relay {
+        NodeUuid::from_bytes([0xdd; 16])
+    } else {
+        identity.node
+    };
+    let node = Node::new(block_on(NodeState::new(owner_node, schema, storage)).unwrap());
+    eviction.evict_all();
+    control.pause_on(TestStorageOperation::ScanOpen);
+    let before = control.poll_count(TestStorageOperation::ScanOpen);
+    let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+    let waker = futures::task::waker(wakes.clone());
+    let mut cx = Context::from_waker(&waker);
+    let mut restore = Box::pin(async {
+        if relay {
+            node.restore_browser_relay_pending_uploads(identity.author)
+                .await
+        } else {
+            node.restore_pending_uploads(identity).await
+        }
+    });
+    assert!(matches!(restore.as_mut().poll(&mut cx), Poll::Pending));
+    assert_eq!(
+        control.poll_count(TestStorageOperation::ScanOpen),
+        before + 1
+    );
+    // The first storage poll deliberately self-wakes; the second parks on the
+    // externally controlled read. Recovery must preserve that real waker.
+    assert!(matches!(restore.as_mut().poll(&mut cx), Poll::Pending));
+    assert!(node.outbox.borrow().iter().next().is_none());
+    wakes.0.store(0, Ordering::SeqCst);
+    control.resume();
+    assert!(wakes.0.load(Ordering::SeqCst) > 0);
+    block_on(restore).unwrap();
+    assert_eq!(
+        node.outbox
+            .borrow()
+            .iter()
+            .map(|entry| entry.tx_id)
+            .collect::<Vec<_>>(),
+        vec![tx_id]
+    );
+    if relay {
+        assert!(
+            node.browser_relay_recovered_tx_ids
+                .borrow()
+                .contains(&tx_id)
+        );
+    }
+}
+
+#[test]
+fn cold_pending_upload_restore_yields_to_storage() {
+    if pending_restore_child(
+        "db::tests::node_runtime::cold_pending_upload_restore_yields_to_storage",
+    ) {
+        cold_pending_restore_yields_and_recovers(false);
+    }
+}
+
+#[test]
+fn cold_browser_relay_restore_yields_to_storage() {
+    if pending_restore_child(
+        "db::tests::node_runtime::cold_browser_relay_restore_yields_to_storage",
+    ) {
+        cold_pending_restore_yields_and_recovers(true);
+    }
+}

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -8,6 +8,11 @@
 use super::*;
 use crate::schema::RuntimeSchema;
 
+#[cfg(test)]
+thread_local! {
+    pub(super) static TRANSACTION_PAYLOAD_DECODES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
@@ -883,8 +888,41 @@ where
         &mut self,
         tx_id: TxId,
     ) -> Result<Option<StoredTransaction>, Error> {
+        self.query_transaction_fields(tx_id, |state, alias, record| {
+            state.stored_transaction_from_record(tx_id, alias, record)
+        })
+        .await
+    }
+
+    pub(super) async fn query_transaction_state(
+        &mut self,
+        tx_id: TxId,
+    ) -> Result<Option<(Fate, Option<GlobalTime>, DurabilityTier)>, Error> {
+        // Status is a projection, not a payload audit. Full transaction readers
+        // continue validating author and contribution identities independently.
+        self.query_transaction_fields(tx_id, |_, _, record| {
+            Ok((
+                fate_from_encoded_fields(record)?,
+                record
+                    .get_nullable_u64(TransactionRowRecord::FIELD_GLOBAL_TIME_IDX)?
+                    .map(GlobalTime),
+                durability_from_discriminant(
+                    record.get_enum(TransactionRowRecord::FIELD_DURABILITY_IDX)?,
+                )?,
+            ))
+        })
+        .await
+    }
+
+    async fn query_transaction_fields<T>(
+        &mut self,
+        tx_id: TxId,
+        decode: impl Fn(&Self, NodeAlias, BorrowedRecord<'_>) -> Result<T, Error>,
+    ) -> Result<Option<T>, Error> {
         if let Some(alias) = self.node_aliases.get(&tx_id.node).copied()
-            && let Some(tx) = self.query_transaction_by_alias(tx_id, alias).await?
+            && let Some(tx) = self
+                .query_transaction_fields_by_alias(tx_id, alias, &decode)
+                .await?
         {
             return Ok(Some(tx));
         }
@@ -902,7 +940,7 @@ where
         }
         for expected_alias in aliases {
             if let Some(tx) = self
-                .query_transaction_by_alias(tx_id, expected_alias)
+                .query_transaction_fields_by_alias(tx_id, expected_alias, &decode)
                 .await?
             {
                 self.node_aliases.insert(tx_id.node, expected_alias);
@@ -984,6 +1022,18 @@ where
         tx_id: TxId,
         expected_alias: NodeAlias,
     ) -> Result<Option<StoredTransaction>, Error> {
+        self.query_transaction_fields_by_alias(tx_id, expected_alias, &|state, alias, record| {
+            state.stored_transaction_from_record(tx_id, alias, record)
+        })
+        .await
+    }
+
+    async fn query_transaction_fields_by_alias<T>(
+        &self,
+        tx_id: TxId,
+        expected_alias: NodeAlias,
+        decode: &impl Fn(&Self, NodeAlias, BorrowedRecord<'_>) -> Result<T, Error>,
+    ) -> Result<Option<T>, Error> {
         let Some(raw) = self
             .database
             .primary_key_get_raw(
@@ -1000,8 +1050,7 @@ where
         if node_alias != expected_alias || time != tx_id.time {
             return Ok(None);
         }
-        self.stored_transaction_from_record(tx_id, expected_alias, record)
-            .map(Some)
+        decode(self, expected_alias, record).map(Some)
     }
 
     fn stored_transaction_from_record(
@@ -1010,6 +1059,8 @@ where
         expected_alias: NodeAlias,
         record: BorrowedRecord<'_>,
     ) -> Result<StoredTransaction, Error> {
+        #[cfg(test)]
+        TRANSACTION_PAYLOAD_DECODES.with(|count| count.set(count.get() + 1));
         let tx = Transaction {
             tx_id,
             kind: tx_kind_from_discriminant(

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -10,6 +10,7 @@ use crate::schema::RuntimeSchema;
 
 #[cfg(test)]
 thread_local! {
+    pub(super) static HISTORY_PAYLOAD_DECODES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     pub(super) static TRANSACTION_PAYLOAD_DECODES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
@@ -548,6 +549,50 @@ where
         Ok(versions)
     }
 
+    /// Probe one parent witness using the existing immutable history key.
+    /// This does not replace transaction-wide reads used to decide completeness
+    /// when the requested witness has not arrived.
+    pub(super) async fn query_exact_parent_version(
+        &mut self,
+        tx_id: TxId,
+        tx_node_alias: NodeAlias,
+        coordinate: &ParentCoordinate,
+    ) -> Result<Option<VersionRow>, Error> {
+        if !self.catalogue.physical_mappings.values().any(|mapping| {
+            mapping
+                .tables
+                .values()
+                .any(|table| table.table_id == coordinate.physical_table_id)
+        }) {
+            return Ok(None);
+        }
+        let mut key = vec![Value::Bytes(coordinate.branch_key.canonical_bytes())];
+        let storage_table = match coordinate.layer {
+            VersionLayer::Content => physical_history_table_name(coordinate.physical_table_id),
+            VersionLayer::Deletion => {
+                key.push(Value::U64(coordinate.physical_table_id.0));
+                SHARED_DELETION_HISTORY_TABLE.to_owned()
+            }
+        };
+        key.extend([
+            Value::Uuid(coordinate.row_uuid.0),
+            Value::U64(tx_id.time.0),
+            Value::U64(tx_node_alias.0),
+        ]);
+        let raw = self
+            .database
+            .primary_key_get_raw(&storage_table, &key)
+            .await?
+            .map(|raw| raw.owned_record());
+        let Some(record) = raw else {
+            return Ok(None);
+        };
+        // Physical history carries its authored schema, including old logical
+        // names after a rename. Resolve from that schema instead of today's name.
+        self.decode_history_owned_record("", &storage_table, record)
+            .map(Some)
+    }
+
     pub(super) async fn query_versions_for_tx_physical_coordinate(
         &mut self,
         tx_id: TxId,
@@ -740,6 +785,8 @@ where
         storage_table: &str,
         record: OwnedRecord,
     ) -> Result<VersionRow, Error> {
+        #[cfg(test)]
+        HISTORY_PAYLOAD_DECODES.with(|count| count.set(count.get() + 1));
         if storage_table == SHARED_DELETION_HISTORY_TABLE {
             let shared = record.to_values()?;
             let Value::U64(table_id) = shared.get(1).ok_or(Error::InvalidStoredValue(

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -566,7 +566,12 @@ where
         }) {
             return Ok(None);
         }
-        let mut key = vec![Value::Bytes(coordinate.branch_key.canonical_bytes())];
+        let Ok(branch_bytes) = coordinate.branch_key.try_canonical_bytes() else {
+            // No stored witness can have a noncanonical key. Let the caller's
+            // existing missing-coordinate rules decide rejection/completeness.
+            return Ok(None);
+        };
+        let mut key = vec![Value::Bytes(branch_bytes)];
         let storage_table = match coordinate.layer {
             VersionLayer::Content => physical_history_table_name(coordinate.physical_table_id),
             VersionLayer::Deletion => {

--- a/crates/jazz/src/node/ingest/validation.rs
+++ b/crates/jazz/src/node/ingest/validation.rs
@@ -20,6 +20,22 @@ where
         let Some(parent_tx) = self.query_transaction(parent).await? else {
             return Ok(ParentCoordinateValidation::Inconclusive);
         };
+        // Retain the resident cache's all-branch/all-layer lookup. On a cold
+        // cache, a valid parent needs one exact history read rather than every
+        // sibling row in its transaction. A miss still uses the completeness
+        // and wrong-coordinate rules below without changing their semantics.
+        if !self.query.tx_versions_cache.contains_key(&parent)
+            && let Some(candidate) = self
+                .query_exact_parent_version(parent, parent_tx.node_alias, coordinate)
+                .await?
+        {
+            if self.version_tx_id(&candidate)? != parent
+                || !self.version_row_matches_parent_coordinate(&candidate, coordinate)?
+            {
+                return Err(Error::InvalidStoredValue("parent history key does not match stored coordinate"));
+            }
+            return Ok(ParentCoordinateValidation::Exact);
+        }
         let coordinate_versions = self
             .query_versions_for_tx_physical_coordinate(
                 parent,

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -437,7 +437,9 @@ where
         }
     }
 
-    /// Return the legacy transaction fate tuple.
+    /// Return the legacy transaction fate tuple by projecting stored status.
+    /// Payload author/contribution validation belongs to full transaction reads;
+    /// this read retains storage framing and status-field validation.
     pub async fn transaction_state(
         &mut self,
         tx_id: TxId,

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -442,14 +442,18 @@ where
         &mut self,
         tx_id: TxId,
     ) -> Option<(Fate, Option<GlobalTime>, DurabilityTier)> {
-        self.transaction_record(tx_id).await.map(|record| {
-            let durability = if self.pending_persistence.contains(&tx_id) {
-                DurabilityTier::None
-            } else {
-                record.durability
-            };
-            (record.fate, record.global_time, durability)
-        })
+        self.query_transaction_state(tx_id)
+            .await
+            .ok()
+            .flatten()
+            .map(|(fate, global_time, stored_durability)| {
+                let durability = if self.pending_persistence.contains(&tx_id) {
+                    DurabilityTier::None
+                } else {
+                    stored_durability
+                };
+                (fate, global_time, durability)
+            })
     }
 
     /// Return the durable audit record for a transaction, including rejected

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -2770,11 +2770,18 @@ fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
     // Internal coverage is necessary to evict the transaction-version cache
     // and count actual storage decodes around parent validation in isolation.
     // Fixture creation still uses the ordinary public schema/commit builders.
-    for width in [1_u128, 1500] {
+    for width in [1500_u128, 1] {
         let schema = branch_view_schema();
         let branch = branch_selector(0x71);
         let branch_key = schema
-            .project_branch_view_selector(schema.tables.iter().find(|table| table.name == "todos").unwrap(), &branch)
+            .project_branch_view_selector(
+                schema
+                    .tables
+                    .iter()
+                    .find(|table| table.name == "todos")
+                    .unwrap(),
+                &branch,
+            )
             .unwrap()
             .0;
         let (_dir, mut core) = open_history_complete_node_with_schema(
@@ -2820,6 +2827,7 @@ fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
             };
             core.invalidate_tx_version_tables_cache(parent);
             super::super::currency::HISTORY_PAYLOAD_DECODES.with(|count| count.set(0));
+            super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.set(0));
             core.reset_storage_read_metrics();
             assert_eq!(
                 core.validate_known_parent_coordinate(parent, &coordinate)
@@ -2834,6 +2842,11 @@ fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
                 "one parent witness must decode one history row even for a {width}-row transaction"
             );
             assert_eq!(
+                super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.get()),
+                1,
+                "the parent transaction must still cross the full payload audit before exact lookup"
+            );
+            assert_eq!(
                 reads.history_indexes.ranges, 0,
                 "exact parent lookup must not scan by_tx: {reads:?}"
             );
@@ -2844,7 +2857,14 @@ fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
 
             let wrong_branch = ParentCoordinate {
                 branch_key: schema
-                    .project_branch_view_selector(schema.tables.iter().find(|table| table.name == "todos").unwrap(), &branch_selector(0x74))
+                    .project_branch_view_selector(
+                        schema
+                            .tables
+                            .iter()
+                            .find(|table| table.name == "todos")
+                            .unwrap(),
+                        &branch_selector(0x74),
+                    )
                     .unwrap()
                     .0,
                 ..coordinate.clone()
@@ -2866,7 +2886,22 @@ fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
                     .unwrap(),
                 ..coordinate.clone()
             };
-            for wrong in [wrong_branch, wrong_row, wrong_layer, wrong_table] {
+            let malformed_branch = ParentCoordinate {
+                branch_key: BranchKey {
+                    values: vec![(
+                        "branch_id".to_owned(),
+                        crate::protocol::BranchColumnValue(vec![0xff]),
+                    )],
+                },
+                ..coordinate.clone()
+            };
+            for wrong in [
+                wrong_branch,
+                wrong_row,
+                wrong_layer,
+                wrong_table,
+                malformed_branch,
+            ] {
                 assert!(
                     matches!(
                         core.validate_known_parent_coordinate(parent, &wrong)

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -2764,3 +2764,127 @@ fn branch_column_evolution_accepts_monotone_addition_with_default() {
     NodeState::<RocksDbStorage>::validate_migration_lens_between(&lens, &source, &target)
         .expect("a branch column can be added monotonically with an immutable default");
 }
+
+#[test]
+fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
+    // Internal coverage is necessary to evict the transaction-version cache
+    // and count actual storage decodes around parent validation in isolation.
+    // Fixture creation still uses the ordinary public schema/commit builders.
+    for width in [1_u128, 1500] {
+        let schema = branch_view_schema();
+        let branch = branch_selector(0x71);
+        let branch_key = schema
+            .project_branch_view_selector(schema.tables.iter().find(|table| table.name == "todos").unwrap(), &branch)
+            .unwrap()
+            .0;
+        let (_dir, mut core) = open_history_complete_node_with_schema(
+            NodeUuid::from_bytes([0x72; 16]),
+            schema.clone(),
+        );
+        let owner = AuthorSubject::for_test_bytes([0x73; 16]);
+        let target = RowUuid(uuid::Uuid::from_u128(1));
+        let commits = (1..=width)
+            .map(|index| {
+                MergeableCommit::new("todos", RowUuid(uuid::Uuid::from_u128(index)), 10)
+                    .branch(branch.clone())
+                    .cells(BTreeMap::from([
+                        ("title".to_owned(), v("parent")),
+                        ("owner".to_owned(), Value::Uuid(owner.test_uuid())),
+                    ]))
+            })
+            .collect();
+        let content_parent = core.commit_mergeable_many_settled(commits).unwrap();
+        let deletion_parent = core
+            .commit_mergeable_many_settled(
+                (1..=width)
+                    .map(|index| {
+                        MergeableCommit::new("todos", RowUuid(uuid::Uuid::from_u128(index)), 20)
+                            .branch(branch.clone())
+                            .deletion(DeletionEvent::Deleted)
+                    })
+                    .collect(),
+            )
+            .unwrap();
+        let physical_table_id = core
+            .physical_table_id_for_schema(schema.version_id(), "todos")
+            .unwrap();
+        for (parent, layer) in [
+            (content_parent, VersionLayer::Content),
+            (deletion_parent, VersionLayer::Deletion),
+        ] {
+            let coordinate = ParentCoordinate {
+                physical_table_id,
+                branch_key: branch_key.clone(),
+                row_uuid: target,
+                layer,
+            };
+            core.invalidate_tx_version_tables_cache(parent);
+            super::super::currency::HISTORY_PAYLOAD_DECODES.with(|count| count.set(0));
+            core.reset_storage_read_metrics();
+            assert_eq!(
+                core.validate_known_parent_coordinate(parent, &coordinate)
+                    .resolve()
+                    .unwrap(),
+                super::super::ingest::ParentCoordinateValidation::Exact
+            );
+            let reads = core.take_storage_read_metrics();
+            assert_eq!(
+                super::super::currency::HISTORY_PAYLOAD_DECODES.with(|count| count.get()),
+                1,
+                "one parent witness must decode one history row even for a {width}-row transaction"
+            );
+            assert_eq!(
+                reads.history_indexes.ranges, 0,
+                "exact parent lookup must not scan by_tx: {reads:?}"
+            );
+            assert!(
+                reads.total.reads <= 2,
+                "exact parent lookup should read transaction plus witness: {reads:?}"
+            );
+
+            let wrong_branch = ParentCoordinate {
+                branch_key: schema
+                    .project_branch_view_selector(schema.tables.iter().find(|table| table.name == "todos").unwrap(), &branch_selector(0x74))
+                    .unwrap()
+                    .0,
+                ..coordinate.clone()
+            };
+            let wrong_row = ParentCoordinate {
+                row_uuid: RowUuid(uuid::Uuid::from_u128(width + 1)),
+                ..coordinate.clone()
+            };
+            let wrong_layer = ParentCoordinate {
+                layer: match layer {
+                    VersionLayer::Content => VersionLayer::Deletion,
+                    VersionLayer::Deletion => VersionLayer::Content,
+                },
+                ..coordinate.clone()
+            };
+            let wrong_table = ParentCoordinate {
+                physical_table_id: core
+                    .physical_table_id_for_schema(schema.version_id(), "users")
+                    .unwrap(),
+                ..coordinate.clone()
+            };
+            for wrong in [wrong_branch, wrong_row, wrong_layer, wrong_table] {
+                assert!(
+                    matches!(
+                        core.validate_known_parent_coordinate(parent, &wrong)
+                            .resolve(),
+                        Err(Error::InvalidMergeableCommit(_))
+                    ),
+                    "a known complete parent cannot resolve outside its exact coordinate"
+                );
+            }
+            assert_eq!(
+                core.validate_known_parent_coordinate(
+                    TxId::new(TxTime::from(99), parent.node),
+                    &coordinate
+                )
+                .resolve()
+                .unwrap(),
+                super::super::ingest::ParentCoordinateValidation::Inconclusive
+            );
+        }
+    }
+}

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -2687,3 +2687,91 @@ fn transaction_metadata_round_trips_through_recovery() {
         Some(r#"{"source":"exclusive"}"#.to_owned())
     );
 }
+
+
+#[test]
+fn transaction_status_projects_state_without_decoding_payloads() {
+    // Internal coverage is required to plant semantically invalid durable
+    // payloads and measure decoder work: neither is exposed by public APIs.
+    let schema = schema();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut core = open_node_at(&temp_dir, schema);
+    let tx_id = core.commit_mergeable_settled(
+        MergeableCommit::new("todos", row(9), 10)
+            .cells(BTreeMap::from([("title".to_owned(), "status".to_owned())])),
+    ).unwrap();
+    let mut stored = core.query_transaction(tx_id).unwrap().unwrap();
+    let expected = (stored.fate.clone(), stored.global_time, stored.durability);
+
+    // Exercise both the cached-alias path and durable alias discovery.
+    core.node_aliases.remove(&tx_id.node);
+    assert_eq!(core.transaction_state_settled(tx_id), Some(expected.clone()));
+    assert_eq!(core.node_aliases.get(&tx_id.node), Some(&stored.node_alias));
+    assert!(core.transaction_state_settled(TxId::new(TxTime::from(999), tx_id.node)).is_none());
+    core.pending_persistence.insert(tx_id);
+    assert_eq!(core.transaction_state_settled(tx_id), Some((expected.0.clone(), expected.1, DurabilityTier::None)));
+    core.pending_persistence.remove(&tx_id);
+
+    assert!(core.transaction_state_settled(TxId::new(tx_id.time, node(0x72))).is_none());
+    for fate in [
+        Fate::Pending,
+        Fate::Accepted,
+        Fate::Rejected(RejectionReason::AuthorizationDenied),
+        Fate::Rejected(RejectionReason::Cascade { root: tx_id }),
+        Fate::Rejected(RejectionReason::MalformedCommit("detail".to_owned())),
+    ] {
+        for durability in [DurabilityTier::None, DurabilityTier::Local, DurabilityTier::Edge, DurabilityTier::Global] {
+            for global_time in [None, Some(GlobalTime(42))] {
+                let mut batch = core.database.open_batch();
+                batch.update("jazz_transactions", transaction_values(
+                    stored.node_alias, &stored.tx, fate.clone(), global_time, durability,
+                    core.contribution_merge_storage_value(None).unwrap(),
+                ).unwrap());
+                let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
+                let persisted = crate::db::block_on(applied.persist());
+                core.database.finish_persistence(persisted).unwrap();
+                assert_eq!(core.transaction_state_settled(tx_id), Some((fate.clone(), global_time, durability)));
+            }
+        }
+    }
+
+    for payload_bytes in [16, 1024 * 1024] {
+        stored.tx.user_metadata_json = Some("x".repeat(payload_bytes));
+        let mut provenance = canonical_contribution_provenance(tx_id);
+        let duplicate = provenance.substitutions[0].sources[0].clone();
+        provenance.substitutions[0].sources.push(duplicate);
+        stored.tx.contribution_merge = Some(provenance);
+        let values = transaction_values(
+            stored.node_alias, &stored.tx, stored.fate.clone(), stored.global_time,
+            stored.durability,
+            core.contribution_merge_storage_value(stored.tx.contribution_merge.as_ref()).unwrap(),
+        ).unwrap();
+        let mut batch = core.database.open_batch();
+        batch.update("jazz_transactions", values.clone());
+        let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
+        let persisted = crate::db::block_on(applied.persist());
+        core.database.finish_persistence(persisted).unwrap();
+
+        super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.set(0));
+        for _ in 0..1500 {
+            assert_eq!(core.transaction_state_settled(tx_id), Some(expected.clone()));
+        }
+        assert_eq!(super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.get()), 0,
+            "status polling must do zero payload decodes regardless of payload size or poll count");
+        assert!(core.query_transaction(tx_id).resolve().is_err(),
+            "full durable reads must still reject malformed contribution identities");
+        assert!(core.transaction_record(tx_id).is_none());
+
+        // Valid record framing does not make an incomplete rejected fate valid.
+        let mut invalid_state = values;
+        invalid_state[TransactionRowRecord::FIELD_FATE_IDX] = Value::String("rejected".to_owned());
+        invalid_state[TransactionRowRecord::FIELD_REJECTION_REASON_IDX] = Value::Nullable(None);
+        let mut batch = core.database.open_batch();
+        batch.update("jazz_transactions", invalid_state);
+        let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
+        let persisted = crate::db::block_on(applied.persist());
+        core.database.finish_persistence(persisted).unwrap();
+        assert!(core.transaction_state_settled(tx_id).is_none(),
+            "status must fail closed on malformed fate fields");
+    }
+}

--- a/crates/jazz/src/node/tests/recovery.rs
+++ b/crates/jazz/src/node/tests/recovery.rs
@@ -2696,41 +2696,79 @@ fn transaction_status_projects_state_without_decoding_payloads() {
     let schema = schema();
     let temp_dir = tempfile::tempdir().unwrap();
     let mut core = open_node_at(&temp_dir, schema);
-    let tx_id = core.commit_mergeable_settled(
-        MergeableCommit::new("todos", row(9), 10)
-            .cells(BTreeMap::from([("title".to_owned(), "status".to_owned())])),
-    ).unwrap();
+    let tx_id = core
+        .commit_mergeable_settled(
+            MergeableCommit::new("todos", row(9), 10)
+                .cells(BTreeMap::from([("title".to_owned(), "status".to_owned())])),
+        )
+        .unwrap();
     let mut stored = core.query_transaction(tx_id).unwrap().unwrap();
     let expected = (stored.fate.clone(), stored.global_time, stored.durability);
 
     // Exercise both the cached-alias path and durable alias discovery.
     core.node_aliases.remove(&tx_id.node);
-    assert_eq!(core.transaction_state_settled(tx_id), Some(expected.clone()));
+    assert_eq!(
+        core.transaction_state_settled(tx_id),
+        Some(expected.clone())
+    );
     assert_eq!(core.node_aliases.get(&tx_id.node), Some(&stored.node_alias));
-    assert!(core.transaction_state_settled(TxId::new(TxTime::from(999), tx_id.node)).is_none());
+    assert!(
+        core.transaction_state_settled(TxId::new(TxTime::from(999), tx_id.node))
+            .is_none()
+    );
     core.pending_persistence.insert(tx_id);
-    assert_eq!(core.transaction_state_settled(tx_id), Some((expected.0.clone(), expected.1, DurabilityTier::None)));
+    assert_eq!(
+        core.transaction_state_settled(tx_id),
+        Some((expected.0.clone(), expected.1, DurabilityTier::None))
+    );
     core.pending_persistence.remove(&tx_id);
 
-    assert!(core.transaction_state_settled(TxId::new(tx_id.time, node(0x72))).is_none());
+    assert!(
+        core.transaction_state_settled(TxId::new(tx_id.time, node(0x72)))
+            .is_none()
+    );
     for fate in [
         Fate::Pending,
         Fate::Accepted,
         Fate::Rejected(RejectionReason::AuthorizationDenied),
+        Fate::Rejected(RejectionReason::ClientClockTooFarAhead),
+        Fate::Rejected(RejectionReason::ExclusiveConflict),
+        Fate::Rejected(RejectionReason::CausalityViolation),
         Fate::Rejected(RejectionReason::Cascade { root: tx_id }),
         Fate::Rejected(RejectionReason::MalformedCommit("detail".to_owned())),
     ] {
-        for durability in [DurabilityTier::None, DurabilityTier::Local, DurabilityTier::Edge, DurabilityTier::Global] {
+        for durability in [
+            DurabilityTier::None,
+            DurabilityTier::Local,
+            DurabilityTier::Edge,
+            DurabilityTier::Global,
+        ] {
             for global_time in [None, Some(GlobalTime(42))] {
                 let mut batch = core.database.open_batch();
-                batch.update("jazz_transactions", transaction_values(
-                    stored.node_alias, &stored.tx, fate.clone(), global_time, durability,
-                    core.contribution_merge_storage_value(None).unwrap(),
-                ).unwrap());
+                batch.update(
+                    "jazz_transactions",
+                    transaction_values(
+                        stored.node_alias,
+                        &stored.tx,
+                        fate.clone(),
+                        global_time,
+                        durability,
+                        core.contribution_merge_storage_value(None).unwrap(),
+                    )
+                    .unwrap(),
+                );
                 let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
                 let persisted = crate::db::block_on(applied.persist());
                 core.database.finish_persistence(persisted).unwrap();
-                assert_eq!(core.transaction_state_settled(tx_id), Some((fate.clone(), global_time, durability)));
+                assert_eq!(
+                    core.transaction_state_settled(tx_id),
+                    Some((fate.clone(), global_time, durability))
+                );
+                let audit = core.transaction_record(tx_id).unwrap();
+                assert_eq!(
+                    core.transaction_state_settled(tx_id),
+                    Some((audit.fate, audit.global_time, audit.durability))
+                );
             }
         }
     }
@@ -2742,10 +2780,15 @@ fn transaction_status_projects_state_without_decoding_payloads() {
         provenance.substitutions[0].sources.push(duplicate);
         stored.tx.contribution_merge = Some(provenance);
         let values = transaction_values(
-            stored.node_alias, &stored.tx, stored.fate.clone(), stored.global_time,
+            stored.node_alias,
+            &stored.tx,
+            stored.fate.clone(),
+            stored.global_time,
             stored.durability,
-            core.contribution_merge_storage_value(stored.tx.contribution_merge.as_ref()).unwrap(),
-        ).unwrap();
+            core.contribution_merge_storage_value(stored.tx.contribution_merge.as_ref())
+                .unwrap(),
+        )
+        .unwrap();
         let mut batch = core.database.open_batch();
         batch.update("jazz_transactions", values.clone());
         let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
@@ -2754,24 +2797,44 @@ fn transaction_status_projects_state_without_decoding_payloads() {
 
         super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.set(0));
         for _ in 0..1500 {
-            assert_eq!(core.transaction_state_settled(tx_id), Some(expected.clone()));
+            assert_eq!(
+                core.transaction_state_settled(tx_id),
+                Some(expected.clone())
+            );
         }
-        assert_eq!(super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.get()), 0,
-            "status polling must do zero payload decodes regardless of payload size or poll count");
-        assert!(core.query_transaction(tx_id).resolve().is_err(),
-            "full durable reads must still reject malformed contribution identities");
+        assert_eq!(
+            super::super::currency::TRANSACTION_PAYLOAD_DECODES.with(|count| count.get()),
+            0,
+            "status polling must do zero payload decodes regardless of payload size or poll count"
+        );
+        assert!(
+            core.query_transaction(tx_id).resolve().is_err(),
+            "full durable reads must still reject malformed contribution identities"
+        );
         assert!(core.transaction_record(tx_id).is_none());
 
         // Valid record framing does not make an incomplete rejected fate valid.
-        let mut invalid_state = values;
-        invalid_state[TransactionRowRecord::FIELD_FATE_IDX] = Value::String("rejected".to_owned());
-        invalid_state[TransactionRowRecord::FIELD_REJECTION_REASON_IDX] = Value::Nullable(None);
-        let mut batch = core.database.open_batch();
-        batch.update("jazz_transactions", invalid_state);
-        let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
-        let persisted = crate::db::block_on(applied.persist());
-        core.database.finish_persistence(persisted).unwrap();
-        assert!(core.transaction_state_settled(tx_id).is_none(),
-            "status must fail closed on malformed fate fields");
+        for reason in [None, Some("cascade")] {
+            let mut invalid_state = values.clone();
+            invalid_state[TransactionRowRecord::FIELD_FATE_IDX] =
+                Value::String("rejected".to_owned());
+            invalid_state[TransactionRowRecord::FIELD_REJECTION_REASON_IDX] =
+                Value::Nullable(reason.map(|reason| Box::new(Value::String(reason.to_owned()))));
+            let mut batch = core.database.open_batch();
+            batch.update("jazz_transactions", invalid_state);
+            let applied = crate::db::block_on(core.database.apply_batch(batch)).unwrap();
+            let persisted = crate::db::block_on(applied.persist());
+            core.database.finish_persistence(persisted).unwrap();
+            for pending in [false, true] {
+                if pending {
+                    core.pending_persistence.insert(tx_id);
+                }
+                assert!(
+                    core.transaction_state_settled(tx_id).is_none(),
+                    "pending durability override must not hide malformed fate fields"
+                );
+                core.pending_persistence.remove(&tx_id);
+            }
+        }
     }
 }

--- a/crates/jazz/tests/browser_relay_durability.rs
+++ b/crates/jazz/tests/browser_relay_durability.rs
@@ -414,7 +414,7 @@ fn open_persistent_browser_worker(
         },
     )))
     .expect("open persistent browser worker");
-    db.restore_browser_relay_pending_uploads()
+    block_on(db.restore_browser_relay_pending_uploads())
         .expect("restore browser relay pending uploads");
     db
 }

--- a/dev/artifacts/release-staging-contract.test.mjs
+++ b/dev/artifacts/release-staging-contract.test.mjs
@@ -311,6 +311,48 @@ test("release fingerprint staging verifies downloaded WASM bytes before deriving
   assert.throws(() => stageNativeFingerprints(root), /downloaded WASM artifact hash mismatch/);
 });
 
+test("profiling fingerprint staging requires explicit admission, matching hashes and release NAPI", () => {
+  const root = releaseFixture();
+  writeWasmRelease(root);
+  const wasmManifestPath = join(root, "crates/jazz-wasm/pkg/.jazz-artifact-manifest.json");
+  const wasmManifest = JSON.parse(readFileSync(wasmManifestPath, "utf8"));
+  wasmManifest.profile = "profiling";
+  writeFileSync(wasmManifestPath, JSON.stringify(wasmManifest));
+  const generation = join(root, "crates/jazz-napi/.native-artifacts/generation-profiling-test");
+  mkdirSync(generation, { recursive: true });
+  writeFileSync(
+    join(root, "crates/jazz-napi/native-binding.pointer.cjs"),
+    'require("./.native-artifacts/generation-profiling-test/index.js");',
+  );
+  const napiManifestPath = join(generation, ".jazz-artifact-manifest.json");
+  const napiManifest = { kind: "napi", profile: "release", nativeArtifactFingerprint: fingerprint };
+  writeFileSync(napiManifestPath, JSON.stringify(napiManifest));
+  assert.throws(() => stageNativeFingerprints(root, { workspace: true }), /wrong kind\/profile/);
+  assert.throws(() => stageNativeFingerprints(root, { local: true }), /wrong kind\/profile/);
+  assert.throws(
+    () => stageNativeFingerprints(root, { local: true, profiling: true }),
+    /mutually exclusive/,
+  );
+  stageNativeFingerprints(root, { profiling: true });
+  assert.match(
+    readFileSync(
+      join(root, "packages/jazz-tools/src/runtime/native-artifact-fingerprint-wasm.ts"),
+      "utf8",
+    ),
+    new RegExp(fingerprint),
+  );
+  napiManifest.profile = "fast";
+  writeFileSync(napiManifestPath, JSON.stringify(napiManifest));
+  assert.throws(
+    () => stageNativeFingerprints(root, { profiling: true }),
+    /NAPI manifest has the wrong kind\/profile/,
+  );
+  napiManifest.profile = "release";
+  writeFileSync(napiManifestPath, JSON.stringify(napiManifest));
+  writeFileSync(join(root, "crates/jazz-wasm/pkg/jazz_wasm_bg.wasm"), "tampered bytes");
+  assert.throws(() => stageNativeFingerprints(root, { profiling: true }), /artifact hash mismatch/);
+});
+
 test("release fingerprint staging rejects omitted, duplicate, empty, and malformed WASM artifact entries", () => {
   const cases = [
     { name: "omitted", artifacts: [], expected: /list each generated artifact exactly once/ },

--- a/dev/artifacts/stage-native-fingerprints.mjs
+++ b/dev/artifacts/stage-native-fingerprints.mjs
@@ -11,11 +11,15 @@ const wasmArtifactFiles = [
   "jazz_wasm.d.ts",
   "jazz_wasm.js",
 ];
-export function stageNativeFingerprints(root, { local = false, workspace = false } = {}) {
-  if (local && workspace) throw new Error("--local and --workspace are mutually exclusive");
+export function stageNativeFingerprints(
+  root,
+  { local = false, workspace = false, profiling = false } = {},
+) {
+  if ([local, workspace, profiling].filter(Boolean).length > 1)
+    throw new Error("--local, --workspace and --profiling are mutually exclusive");
   const wasm = read(join(root, "crates/jazz-wasm/pkg/.jazz-artifact-manifest.json"));
   const napi =
-    local || workspace
+    local || workspace || profiling
       ? read(
           join(
             root,
@@ -33,7 +37,10 @@ export function stageNativeFingerprints(root, { local = false, workspace = false
   ])
     if (!/^[a-f0-9]{64}$/.test(manifest.nativeArtifactFingerprint ?? ""))
       throw new Error(`${name} manifest lacks a native fingerprint`);
-  if (wasm.kind !== "wasm" || wasm.profile !== (local ? "fast" : "release"))
+  if (
+    wasm.kind !== "wasm" ||
+    wasm.profile !== (profiling ? "profiling" : local ? "fast" : "release")
+  )
     throw new Error("downloaded WASM manifest has the wrong kind/profile");
   const artifacts = wasm.artifacts;
   if (!Array.isArray(artifacts) || artifacts.length !== wasmArtifactFiles.length)
@@ -78,6 +85,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     stageNativeFingerprints(root, {
       local: process.argv.includes("--local"),
       workspace: process.argv.includes("--workspace"),
+      profiling: process.argv.includes("--profiling"),
     });
   } catch (error) {
     console.error(`stage native fingerprints: ${error.message}`);

--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -97,6 +97,17 @@ terminate_children() {
 
 interrupt() {
   local signal_status=$1
+  # Replay before waiting for children: a stuck shutdown must not hide the
+  # last test output. Bound bytes as well as lines (a test may print one huge
+  # line), and retain the complete regular files at the printed paths.
+  echo "TypeScript suites interrupted (exit ${signal_status}); retained log tails:"
+  for suite_log in "${node_tests_log}" "${browser_tests_log}"; do
+    echo "--- ${suite_log} (last 16 KiB, at most 100 lines) ---"
+    if [[ -f "${suite_log}" ]]; then
+      tail -c 16384 "${suite_log}" | tail -n 100 || true
+      echo
+    fi
+  done
   terminate_children
   exit "${signal_status}"
 }

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -2145,3 +2145,58 @@ test("parallel TypeScript runner terminates both child process groups", async ()
   assert.equal(fs.existsSync(browserMarker), false, "browser descendant survived TERM");
   fs.rmSync(fixture, { recursive: true, force: true });
 });
+
+for (const [signal, expected] of [
+  ["SIGINT", 130],
+  ["SIGTERM", 143],
+]) {
+  test(`parallel TypeScript runner retains bounded diagnostics on ${signal}`, async () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-ts-ci-tails-"));
+    const command = (suite) =>
+      `printf '%20000s\\n' x; echo ${suite}-last-test; touch "$RUNNER_TEMP/${suite}-ready"; sleep 30`;
+    const child = spawn("bash", [path.join(root, "dev/gates/run-ts-tests.sh")], {
+      cwd: root,
+      env: {
+        ...process.env,
+        RUNNER_TEMP: fixture,
+        JAZZ_SKIP_JAZZ_TOOLS_BUILD: "1",
+        JAZZ_NODE_TEST_COMMAND: command("node"),
+        JAZZ_BROWSER_TEST_COMMAND: command("browser"),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+      output += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      output += chunk;
+    });
+    const closed = new Promise((resolve) => child.once("close", (code) => resolve(code)));
+    const watchdog = setTimeout(() => child.kill("SIGKILL"), 5000);
+    try {
+      const deadline = Date.now() + 3000;
+      while (
+        !["node", "browser"].every((suite) => fs.existsSync(path.join(fixture, `${suite}-ready`)))
+      ) {
+        assert.ok(Date.now() < deadline, "synthetic suites did not start");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      child.kill(signal);
+      assert.equal(await closed, expected, output);
+      assert.match(output, /node-last-test/);
+      assert.match(output, /browser-last-test/);
+      assert.ok(Buffer.byteLength(output) < 34000, "interruption diagnostics were not bounded");
+      for (const suite of ["node", "browser"]) {
+        const log = fs.readdirSync(fixture).find((name) => name.startsWith(`jazz-${suite}-tests-`));
+        assert.ok(log, "complete suite log was not retained");
+        assert.ok(fs.statSync(path.join(fixture, log)).size > 20000);
+      }
+    } finally {
+      clearTimeout(watchdog);
+      if (child.exitCode === null) child.kill("SIGTERM");
+      await closed;
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+}

--- a/docs/content/docs/auth/lifecycle.mdx
+++ b/docs/content/docs/auth/lifecycle.mdx
@@ -98,4 +98,10 @@ Use the same secret with `BrowserPasskeyBackup` for a passkey backup. Export req
 
 `createAccountManager`, opaque `AccountHandle`, and `createJazzClient` remain available for applications that intentionally own their lifecycle. The manager handles credentials and registry operations only. Contexts accept valid handles and never change identity; low-level callers must arrange graceful shutdown before linking or replacing contexts themselves. The session abstraction composes these primitives in shared TypeScript; framework adapters only observe state and acknowledge consumer cleanup.
 
-`db.deleteClientStorage()` resets supported browser database storage without erasing retained account signing roots. It is a development reset, not account registration or linking.
+## Storage reset
+
+`await db.deleteClientStorage()` resets the active browser IndexedDB namespace and keeps the live client usable. **It permanently deletes unsynced writes and local-only data.** Resync requires the data to already exist on the configured server and the same account to retain access. Ordinary close or shutdown is not a server-sync receipt.
+
+Reset preserves default local-first signing roots in `localStorage` and does not sign out the account or external auth provider. Preserve browser credentials and other databases; verify custom credential stores separately. Logout changes the selected account state, while a storage reset clears the selected data cache. Reset does not register or link an account.
+
+The [browser console helper](/docs/faq#reset-browser-storage) provides the same scoped reset and requires a live registered client. Keep the client open until the reset finishes.

--- a/docs/content/docs/faq.mdx
+++ b/docs/content/docs/faq.mdx
@@ -10,7 +10,9 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
 <Accordion id="reset-browser-storage" title="How do I reset browser storage?">
 
-In browser apps using the React, Vue, Svelte, or Solid Jazz clients, open the devtools console and run:
+**Reset permanently deletes unsynced writes and local-only data in the selected namespace.** Before resetting a cache you intend to resync, confirm that the required data is already on the configured server and that the same account can still access it. Reconnect to that server with the same account after resetting; app queries and subscriptions can then fetch the data permitted by current access rules. Local durability and ordinary shutdown do not prove server sync completed.
+
+In browser apps using the React, Vue, Svelte, or Solid Jazz clients, keep the client open and run this in the devtools console:
 
 ```ts
 await window.__jazz.clearStorage();
@@ -23,13 +25,15 @@ window.__jazz.listLiveStorageNamespaces();
 await window.__jazz.clearStorage("my-app::alice");
 ```
 
+The helper requires a live registered client on this page. Do not shut it down before calling the helper. If the client never finishes opening or no live namespace is listed, this helper cannot perform the reset.
+
 If you're working directly with a `Db` handle instead of the window helper, `await db.deleteClientStorage()` is the underlying API. See [Auth Lifecycle](/docs/auth/lifecycle#storage-reset) for how this differs from logout and local-first identity storage.
 
 - Browser persistent storage only.
 - If exactly one live namespace exists, `clearStorage()` uses it automatically.
 - If multiple live namespaces exist, Jazz throws and lists the available namespaces until you choose one.
 - Can be initiated from either leader or follower tabs; Jazz coordinates the reset across tabs for that namespace.
-- Deletes IndexedDB storage only. It does not clear `localStorage` local-first auth data.
+- Deletes only the selected IndexedDB namespace. Preserve `localStorage`, `sessionStorage`, cookies, and other databases; default local-first credentials are stored outside this data database. Apps with custom credential stores must check those separately.
 - Reopens a clean worker/runtime so the same live client remains usable after the wipe.
 
 This is useful when iterating on your schema during development.

--- a/packages/jazz-tools/src/runtime/browser-physical-database-epoch.ts
+++ b/packages/jazz-tools/src/runtime/browser-physical-database-epoch.ts
@@ -29,6 +29,28 @@ export type BrowserPhysicalDatabaseEpoch = {
   release(): Promise<void>;
 };
 
+const liveEpochs = new WeakMap<
+  BrowserPhysicalDatabaseEpoch,
+  {
+    databaseName: string;
+    active: () => boolean;
+    claimed: boolean;
+  }
+>();
+
+/** Consume the live lock proof once, for one page-store/tree owner. */
+export function claimBrowserReclamationOwnership(
+  epoch: BrowserPhysicalDatabaseEpoch,
+  databaseName: string,
+): () => boolean {
+  const state = liveEpochs.get(epoch);
+  if (!state || state.databaseName !== databaseName || !state.active() || state.claimed) {
+    throw new Error("IndexedDB reclamation requires an unclaimed live database Web Lock");
+  }
+  state.claimed = true;
+  return state.active;
+}
+
 type WebLock = object;
 type LockManagerLike = {
   request<T>(
@@ -78,7 +100,7 @@ export async function acquireBrowserPhysicalDatabaseEpoch(
           rejectEpoch(new BrowserPhysicalDatabaseBusyError(databaseName));
           return;
         }
-        resolveEpoch({
+        const owner: BrowserPhysicalDatabaseEpoch = {
           id,
           release: () => {
             if (!releaseRequested) {
@@ -87,13 +109,19 @@ export async function acquireBrowserPhysicalDatabaseEpoch(
             }
             return lockReleased;
           },
-        });
+        };
+        liveEpochs.set(owner, { databaseName, active: () => !releaseRequested, claimed: false });
+        resolveEpoch(owner);
         await released;
       },
     )
     .then(
-      () => resolveLockReleased(),
+      () => {
+        releaseRequested = true;
+        resolveLockReleased();
+      },
       (error: unknown) => {
+        releaseRequested = true;
         resolveLockReleased();
         rejectEpoch(error instanceof Error ? error : new Error(String(error)));
       },

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
@@ -26,8 +26,8 @@ async function ownReclamation(store: IndexedDbPageStore) {
     },
   });
   await store.claimBrowserWorkerEpoch(epoch.id, epoch);
-  store.claimTreeOwnership();
-  return epoch;
+  const treeToken = store.claimTreeOwnership();
+  return Object.assign(epoch, { treeToken });
 }
 
 const databaseNames: string[] = [];
@@ -209,7 +209,7 @@ describe("IndexedDbPageStore", () => {
     const epoch = await ownReclamation(store);
     expect(store.canReclaimObsoletePages).toBe(true);
     expect(() => store.claimTreeOwnership()).toThrow("already has a tree");
-    store.releaseTreeOwnership();
+    await store.retireTreeOwnership();
     expect(store.canReclaimObsoletePages).toBe(false);
     store.claimTreeOwnership();
     const pending = store.commit(retirement);
@@ -220,6 +220,69 @@ describe("IndexedDbPageStore", () => {
     expect(await store.readPage(2)).toEqual(new Uint8Array([2]));
     expect((await store.metadata())?.generation).toBe(1);
     store.close();
+  });
+
+  it("revokes exact tree generations and drains stale non-deletion commits before a successor", async () => {
+    const store = await IndexedDbPageStore.open(databaseName());
+    const epoch = await ownReclamation(store);
+    const oldToken = epoch.treeToken;
+    await store.commitPages(
+      0,
+      INDEXEDDB_BTREE_PAGE_SIZE,
+      1,
+      2,
+      [1],
+      [new Uint8Array([1])],
+      [],
+      oldToken,
+    );
+    const pending = store.commitPages(
+      1,
+      INDEXEDDB_BTREE_PAGE_SIZE,
+      2,
+      3,
+      [2],
+      [new Uint8Array([2])],
+      [],
+      oldToken,
+    );
+    const rejected = expect(pending).rejects.toThrow("tree ownership expired");
+    const retirement = store.retireTreeOwnership();
+    expect(store.isTreeOwnershipActive(oldToken)).toBe(false);
+    expect(() => store.claimTreeOwnership()).toThrow("pending transaction");
+    await retirement;
+    await rejected;
+    const successor = store.claimTreeOwnership();
+    store.releaseTreeOwnership(oldToken); // late destructor must not retire the successor
+    expect(store.isTreeOwnershipActive(successor)).toBe(true);
+    expect(store.canReclaimObsoletePages).toBe(true);
+    await expect(
+      store.commitPages(
+        1,
+        INDEXEDDB_BTREE_PAGE_SIZE,
+        3,
+        4,
+        [3],
+        [new Uint8Array([3])],
+        [],
+        oldToken,
+      ),
+    ).rejects.toThrow("tree ownership has expired");
+    await store.commitPages(
+      1,
+      INDEXEDDB_BTREE_PAGE_SIZE,
+      4,
+      5,
+      [4],
+      [new Uint8Array([4])],
+      [1],
+      successor,
+    );
+    expect((await store.metadata())?.rootPageId).toBe(4);
+    expect(await store.readPage(2)).toBeNull();
+    expect(await store.readPage(3)).toBeNull();
+    store.close();
+    await epoch.release();
   });
 
   it("rejects forged, mismatched and multiply consumed reclamation proofs", async () => {

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
@@ -1,3 +1,4 @@
+import { acquireBrowserPhysicalDatabaseEpoch } from "./browser-physical-database-epoch.js";
 import { IDBFactory, indexedDB as fakeIndexedDb } from "fake-indexeddb";
 import { readFile } from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -17,6 +18,17 @@ import {
   INDEXEDDB_REPLICA_NODE_KEY,
   IndexedDbPageStore,
 } from "./indexeddb-page-store.js";
+
+async function ownReclamation(store: IndexedDbPageStore) {
+  const epoch = await acquireBrowserPhysicalDatabaseEpoch(store.name, {
+    async request(_name, _options, callback) {
+      return await callback({});
+    },
+  });
+  await store.claimBrowserWorkerEpoch(epoch.id, epoch);
+  store.claimTreeOwnership();
+  return epoch;
+}
 
 const databaseNames: string[] = [];
 
@@ -151,6 +163,7 @@ describe("IndexedDbPageStore", () => {
   it("persists only supplied dirty pages and can delete retired pages", async () => {
     const name = databaseName();
     let store = await IndexedDbPageStore.open(name);
+    const epoch = await ownReclamation(store);
     await store.commit({
       expectedGeneration: 0,
       metadata: { pageSize: INDEXEDDB_BTREE_PAGE_SIZE, rootPageId: 1, nextPageId: 3 },
@@ -172,6 +185,64 @@ describe("IndexedDbPageStore", () => {
     expect(await store.readPage(2)).toBeNull();
     expect((await store.metadata())?.generation).toBe(2);
     store.close();
+    await epoch.release();
+  });
+
+  it("requires live single-tree ownership and fences a queued retirement on release", async () => {
+    const store = await IndexedDbPageStore.open(databaseName());
+    await store.commit({
+      expectedGeneration: 0,
+      metadata: { pageSize: INDEXEDDB_BTREE_PAGE_SIZE, rootPageId: 1, nextPageId: 3 },
+      pages: new Map([
+        [1, new Uint8Array([1])],
+        [2, new Uint8Array([2])],
+      ]),
+    });
+    const retirement = {
+      expectedGeneration: 1,
+      metadata: { pageSize: INDEXEDDB_BTREE_PAGE_SIZE, rootPageId: 1, nextPageId: 3 },
+      pages: new Map<number, Uint8Array>(),
+      deletedPageIds: [2],
+    };
+    expect(store.canReclaimObsoletePages).toBe(false);
+    await expect(store.commit(retirement)).rejects.toThrow("ownership is not active");
+    const epoch = await ownReclamation(store);
+    expect(store.canReclaimObsoletePages).toBe(true);
+    expect(() => store.claimTreeOwnership()).toThrow("already has a tree");
+    store.releaseTreeOwnership();
+    expect(store.canReclaimObsoletePages).toBe(false);
+    store.claimTreeOwnership();
+    const pending = store.commit(retirement);
+    const release = epoch.release();
+    expect(store.canReclaimObsoletePages).toBe(false);
+    await expect(pending).rejects.toThrow("ownership expired before publication");
+    await release;
+    expect(await store.readPage(2)).toEqual(new Uint8Array([2]));
+    expect((await store.metadata())?.generation).toBe(1);
+    store.close();
+  });
+
+  it("rejects forged, mismatched and multiply consumed reclamation proofs", async () => {
+    const name = databaseName();
+    const first = await IndexedDbPageStore.open(name);
+    const second = await IndexedDbPageStore.open(name);
+    const epoch = await ownReclamation(first);
+    await expect(second.claimBrowserWorkerEpoch(epoch.id, epoch)).rejects.toThrow("unclaimed live");
+    await expect(
+      second.claimBrowserWorkerEpoch(epoch.id, {
+        id: epoch.id,
+        release: async () => undefined,
+      }),
+    ).rejects.toThrow("unclaimed live");
+    const other = await IndexedDbPageStore.open(databaseName());
+    await expect(other.claimBrowserWorkerEpoch(epoch.id, epoch)).rejects.toThrow("unclaimed live");
+    const release = first.releaseBrowserWorkerEpoch(epoch.id);
+    expect(first.canReclaimObsoletePages).toBe(false);
+    await release;
+    first.close();
+    second.close();
+    other.close();
+    await epoch.release();
   });
 
   it("rejects a stale generation instead of overwriting a newer root", async () => {

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.test.ts
@@ -245,6 +245,28 @@ describe("IndexedDbPageStore", () => {
     await epoch.release();
   });
 
+  it("does not reactivate a pending ownership claim after close or release", async () => {
+    for (const close of [false, true]) {
+      const store = await IndexedDbPageStore.open(databaseName());
+      const epoch = await acquireBrowserPhysicalDatabaseEpoch(store.name, {
+        async request(_name, _options, callback) {
+          return await callback({});
+        },
+      });
+      const claim = store.claimBrowserWorkerEpoch(epoch.id, epoch);
+      const rejected = expect(claim).rejects.toThrow();
+      if (close) {
+        store.close();
+      } else {
+        await store.releaseBrowserWorkerEpoch(epoch.id);
+      }
+      await rejected;
+      expect(store.canReclaimObsoletePages).toBe(false);
+      store.close();
+      await epoch.release();
+    }
+  });
+
   it("rejects a stale generation instead of overwriting a newer root", async () => {
     const name = databaseName();
     const store = await IndexedDbPageStore.open(name);

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
@@ -167,6 +167,7 @@ export class IndexedDbPageStore {
   private invalidated = false;
   private reclamationOwnership: (() => boolean) | null = null;
   private treeClaims = 0;
+  private ownershipRevision = 0;
 
   /** One independently opened tree per exclusive owner; IdbTree clones share it. */
   claimTreeOwnership(): void {
@@ -372,6 +373,7 @@ export class IndexedDbPageStore {
     if (ownership && (ownership.id !== epoch || this.treeClaims > 0)) {
       throw new Error("IndexedDB reclamation ownership must precede tree construction");
     }
+    const revision = this.ownershipRevision;
     const proof = ownership ? claimBrowserReclamationOwnership(ownership, this.name) : null;
     const tx = this.db.transaction(INDEXEDDB_STORAGE_MANIFEST_STORE, "readwrite");
     const done = transactionDone(tx);
@@ -380,11 +382,16 @@ export class IndexedDbPageStore {
       INDEXEDDB_BROWSER_WORKER_EPOCH_KEY,
     );
     await done;
+    this.assertValid();
+    if (revision !== this.ownershipRevision) {
+      throw new Error("IndexedDB worker ownership was released while claiming");
+    }
     this.reclamationOwnership = proof;
   }
 
   /** Delete only this realm's epoch; a stale realm must never clear its successor. */
   async releaseBrowserWorkerEpoch(epoch: string): Promise<void> {
+    this.ownershipRevision++;
     this.reclamationOwnership = null;
     if (!isBrowserWorkerEpoch(epoch)) throw new Error("Invalid browser worker epoch");
     this.assertValid();
@@ -622,6 +629,8 @@ export class IndexedDbPageStore {
   }
 
   close(): void {
+    this.invalidated = true;
+    this.ownershipRevision++;
     this.reclamationOwnership = null;
     this.removeInvalidationListeners();
     this.db.close();

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
@@ -166,24 +166,46 @@ export class IndexedDbStorageInvalidatedError extends Error {
 export class IndexedDbPageStore {
   private invalidated = false;
   private reclamationOwnership: (() => boolean) | null = null;
-  private treeClaims = 0;
+  private readonly treeClaims = new Set<number>();
+  private nextTreeToken = 0;
+  private readonly treeTransactions = new Set<Promise<unknown>>();
   private ownershipRevision = 0;
 
   /** One independently opened tree per exclusive owner; IdbTree clones share it. */
-  claimTreeOwnership(): void {
+  claimTreeOwnership(): number {
     this.assertValid();
-    if (this.reclamationOwnership && this.treeClaims > 0) {
-      throw new Error("IndexedDB reclamation owner already has a tree");
+    if (this.reclamationOwnership && (this.treeClaims.size > 0 || this.treeTransactions.size > 0)) {
+      throw new Error("IndexedDB reclamation owner already has a tree or pending transaction");
     }
-    this.treeClaims++;
+    if (this.nextTreeToken === Number.MAX_SAFE_INTEGER)
+      throw new Error("IndexedDB tree token space exhausted");
+    const token = ++this.nextTreeToken;
+    this.treeClaims.add(token);
+    return token;
   }
 
-  releaseTreeOwnership(): void {
-    this.treeClaims--;
+  releaseTreeOwnership(token: number): void {
+    this.treeClaims.delete(token);
+  }
+
+  isTreeOwnershipActive(token: number): boolean {
+    return (
+      !this.invalidated &&
+      this.treeClaims.has(token) &&
+      (this.reclamationOwnership === null || this.reclamationOwnership())
+    );
+  }
+
+  /** Revoke cached handles first, then drain every already-started tree commit. */
+  async retireTreeOwnership(): Promise<void> {
+    this.treeClaims.clear();
+    await Promise.allSettled(this.treeTransactions);
   }
 
   get canReclaimObsoletePages(): boolean {
-    return !this.invalidated && this.treeClaims === 1 && this.reclamationOwnership?.() === true;
+    return (
+      !this.invalidated && this.treeClaims.size === 1 && this.reclamationOwnership?.() === true
+    );
   }
 
   private replicaNodeBytes: Uint8Array | null = null;
@@ -370,7 +392,7 @@ export class IndexedDbPageStore {
   ): Promise<void> {
     if (!isBrowserWorkerEpoch(epoch)) throw new Error("Invalid browser worker epoch");
     this.assertValid();
-    if (ownership && (ownership.id !== epoch || this.treeClaims > 0)) {
+    if (ownership && (ownership.id !== epoch || this.treeClaims.size > 0)) {
       throw new Error("IndexedDB reclamation ownership must precede tree construction");
     }
     const revision = this.ownershipRevision;
@@ -391,6 +413,7 @@ export class IndexedDbPageStore {
 
   /** Delete only this realm's epoch; a stale realm must never clear its successor. */
   async releaseBrowserWorkerEpoch(epoch: string): Promise<void> {
+    this.treeClaims.clear();
     this.ownershipRevision++;
     this.reclamationOwnership = null;
     if (!isBrowserWorkerEpoch(epoch)) throw new Error("Invalid browser worker epoch");
@@ -535,9 +558,12 @@ export class IndexedDbPageStore {
     return bytes.slice();
   }
 
-  async commit(commit: IndexedDbPageCommit): Promise<IndexedDbBtreeMetadata> {
+  async commit(commit: IndexedDbPageCommit, treeToken?: number): Promise<IndexedDbBtreeMetadata> {
     this.assertValid();
     assertCommit(commit);
+    if (treeToken !== undefined && !this.isTreeOwnershipActive(treeToken)) {
+      throw new Error("IndexedDB tree ownership has expired");
+    }
     const requiresOwnership = (commit.deletedPageIds?.length ?? 0) > 0;
     if (requiresOwnership && !this.canReclaimObsoletePages) {
       throw new Error("IndexedDB page reclamation ownership is not active");
@@ -577,6 +603,9 @@ export class IndexedDbPageStore {
       ) {
         throw new Error(`IndexedDB B-tree root page ${metadata.rootPageId} is missing`);
       }
+      if (treeToken !== undefined && !this.isTreeOwnershipActive(treeToken)) {
+        throw new Error("IndexedDB tree ownership expired before publication");
+      }
       if (requiresOwnership && !this.canReclaimObsoletePages) {
         throw new Error("IndexedDB page reclamation ownership expired before publication");
       }
@@ -612,23 +641,36 @@ export class IndexedDbPageStore {
     pageIds: readonly number[],
     pageBytes: readonly Uint8Array[],
     deletedPageIds: readonly number[],
+    treeToken?: number,
   ): Promise<IndexedDbBtreeMetadata> {
     if (pageIds.length !== pageBytes.length) {
       return Promise.reject(new Error("IDBTree page ids and page bytes have different lengths"));
     }
-    return this.commit({
-      expectedGeneration,
-      metadata: {
-        pageSize,
-        rootPageId: rootPageId < 0 ? null : rootPageId,
-        nextPageId,
+    const operation = this.commit(
+      {
+        expectedGeneration,
+        metadata: {
+          pageSize,
+          rootPageId: rootPageId < 0 ? null : rootPageId,
+          nextPageId,
+        },
+        pages: new Map(pageIds.map((pageId, index) => [pageId, pageBytes[index]!])),
+        deletedPageIds,
       },
-      pages: new Map(pageIds.map((pageId, index) => [pageId, pageBytes[index]!])),
-      deletedPageIds,
-    });
+      treeToken,
+    );
+    if (treeToken !== undefined) {
+      this.treeTransactions.add(operation);
+      void operation.then(
+        () => this.treeTransactions.delete(operation),
+        () => this.treeTransactions.delete(operation),
+      );
+    }
+    return operation;
   }
 
   close(): void {
+    this.treeClaims.clear();
     this.invalidated = true;
     this.ownershipRevision++;
     this.reclamationOwnership = null;
@@ -674,6 +716,7 @@ export class IndexedDbPageStore {
   private invalidate(): void {
     if (this.invalidated) return;
     this.invalidated = true;
+    this.treeClaims.clear();
     this.reclamationOwnership = null;
     this.removeInvalidationListeners();
     const error = new IndexedDbStorageInvalidatedError(this.name);

--- a/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
+++ b/packages/jazz-tools/src/runtime/indexeddb-page-store.ts
@@ -1,3 +1,8 @@
+import {
+  claimBrowserReclamationOwnership,
+  type BrowserPhysicalDatabaseEpoch,
+} from "./browser-physical-database-epoch.js";
+
 /** Durable IndexedDB metadata/page-store format, independent of browser IDB's schema version. */
 export const INDEXEDDB_BTREE_FORMAT_VERSION = 1;
 export const INDEXEDDB_BTREE_FORMAT_MAGIC = "jazz-idb-tree";
@@ -160,6 +165,26 @@ export class IndexedDbStorageInvalidatedError extends Error {
  */
 export class IndexedDbPageStore {
   private invalidated = false;
+  private reclamationOwnership: (() => boolean) | null = null;
+  private treeClaims = 0;
+
+  /** One independently opened tree per exclusive owner; IdbTree clones share it. */
+  claimTreeOwnership(): void {
+    this.assertValid();
+    if (this.reclamationOwnership && this.treeClaims > 0) {
+      throw new Error("IndexedDB reclamation owner already has a tree");
+    }
+    this.treeClaims++;
+  }
+
+  releaseTreeOwnership(): void {
+    this.treeClaims--;
+  }
+
+  get canReclaimObsoletePages(): boolean {
+    return !this.invalidated && this.treeClaims === 1 && this.reclamationOwnership?.() === true;
+  }
+
   private replicaNodeBytes: Uint8Array | null = null;
   private readonly invalidationListeners = new Set<
     (error: IndexedDbStorageInvalidatedError) => void
@@ -338,9 +363,16 @@ export class IndexedDbPageStore {
    * origin-wide Web Lock. A successor may replace an epoch only after that
    * lock proves the preceding realm is no longer alive.
    */
-  async claimBrowserWorkerEpoch(epoch: string): Promise<void> {
+  async claimBrowserWorkerEpoch(
+    epoch: string,
+    ownership?: BrowserPhysicalDatabaseEpoch,
+  ): Promise<void> {
     if (!isBrowserWorkerEpoch(epoch)) throw new Error("Invalid browser worker epoch");
     this.assertValid();
+    if (ownership && (ownership.id !== epoch || this.treeClaims > 0)) {
+      throw new Error("IndexedDB reclamation ownership must precede tree construction");
+    }
+    const proof = ownership ? claimBrowserReclamationOwnership(ownership, this.name) : null;
     const tx = this.db.transaction(INDEXEDDB_STORAGE_MANIFEST_STORE, "readwrite");
     const done = transactionDone(tx);
     tx.objectStore(INDEXEDDB_STORAGE_MANIFEST_STORE).put(
@@ -348,10 +380,12 @@ export class IndexedDbPageStore {
       INDEXEDDB_BROWSER_WORKER_EPOCH_KEY,
     );
     await done;
+    this.reclamationOwnership = proof;
   }
 
   /** Delete only this realm's epoch; a stale realm must never clear its successor. */
   async releaseBrowserWorkerEpoch(epoch: string): Promise<void> {
+    this.reclamationOwnership = null;
     if (!isBrowserWorkerEpoch(epoch)) throw new Error("Invalid browser worker epoch");
     this.assertValid();
     const tx = this.db.transaction(INDEXEDDB_STORAGE_MANIFEST_STORE, "readwrite");
@@ -497,6 +531,10 @@ export class IndexedDbPageStore {
   async commit(commit: IndexedDbPageCommit): Promise<IndexedDbBtreeMetadata> {
     this.assertValid();
     assertCommit(commit);
+    const requiresOwnership = (commit.deletedPageIds?.length ?? 0) > 0;
+    if (requiresOwnership && !this.canReclaimObsoletePages) {
+      throw new Error("IndexedDB page reclamation ownership is not active");
+    }
     const tx = relaxedReadWriteTransaction(this.db, [
       INDEXEDDB_BTREE_PAGES_STORE,
       INDEXEDDB_BTREE_METADATA_STORE,
@@ -531,6 +569,9 @@ export class IndexedDbPageStore {
         (await requestResult(pages.get(metadata.rootPageId))) === undefined
       ) {
         throw new Error(`IndexedDB B-tree root page ${metadata.rootPageId} is missing`);
+      }
+      if (requiresOwnership && !this.canReclaimObsoletePages) {
+        throw new Error("IndexedDB page reclamation ownership expired before publication");
       }
       for (const [pageId, bytes] of commit.pages) {
         if (bytes.byteLength > metadata.pageSize) {
@@ -581,6 +622,7 @@ export class IndexedDbPageStore {
   }
 
   close(): void {
+    this.reclamationOwnership = null;
     this.removeInvalidationListeners();
     this.db.close();
   }
@@ -623,6 +665,7 @@ export class IndexedDbPageStore {
   private invalidate(): void {
     if (this.invalidated) return;
     this.invalidated = true;
+    this.reclamationOwnership = null;
     this.removeInvalidationListeners();
     const error = new IndexedDbStorageInvalidatedError(this.name);
     for (const listener of this.invalidationListeners) listener(error);

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.test.ts
@@ -695,6 +695,30 @@ describe("browser SharedWorker realm identity", () => {
     expect(port.closed).toBe(true);
   });
 
+  it("does not restart the startup budget when the first alive reply arrives late", async () => {
+    vi.useFakeTimers();
+    const { connection, port, sent } = runtimeBootstrapFixture(299_000);
+    let outcome = "pending";
+    void connection.ready().then(
+      () => {
+        outcome = "ready";
+      },
+      () => {
+        outcome = "failed";
+      },
+    );
+    await vi.advanceTimersByTimeAsync(299_000);
+    expect(outcome).toBe("pending");
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(outcome).toBe("failed");
+    await expect(connection.ready()).rejects.toBeInstanceOf(BrowserWorkerUnresponsiveError);
+    expect(sent.filter((message) => message.type === "connect-runtime")).toHaveLength(1);
+    expect(sent.filter((message) => message.type === "cancel-runtime-bootstrap")).toHaveLength(1);
+    port.emit({ type: "runtime-bootstrap-cancelled" });
+    await connection.shutdown();
+    expect(port.closed).toBe(true);
+  });
+
   it("does not let duplicate alive messages extend runtime startup", async () => {
     vi.useFakeTimers();
     const { connection, port, sent } = runtimeBootstrapFixture();

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.test.ts
@@ -153,11 +153,14 @@ class ScriptedRuntimePort {
   }
 }
 
-function runtimeBootstrapFixture() {
+function runtimeBootstrapFixture(aliveDelayMs = 0) {
   const sent: Array<{ type?: string; id?: number }> = [];
   const port = new ScriptedRuntimePort((message) => {
     sent.push(message);
-    if (message.type === "connect-runtime") port.emit({ type: "worker-alive" });
+    if (message.type === "connect-runtime") {
+      if (aliveDelayMs === 0) port.emit({ type: "worker-alive" });
+      else setTimeout(() => port.emit({ type: "worker-alive" }), aliveDelayMs);
+    }
     if (message.type === "init") port.emit({ type: "result", id: message.id });
   });
   vi.stubGlobal(
@@ -659,6 +662,36 @@ describe("browser SharedWorker realm identity", () => {
     // The follower has finished admission and owns normal close acknowledgement.
     port.emit({ type: "result", id: sent.find((message) => message.type === "close")?.id });
     await shutdown;
+    expect(port.closed).toBe(true);
+  });
+
+  it("keeps runtime admission in the same realm when its alive reply is delayed", async () => {
+    vi.useFakeTimers();
+    const { connection, port, sent } = runtimeBootstrapFixture(1_100);
+    await vi.advanceTimersByTimeAsync(1_100);
+    expect(sent.filter((message) => message.type === "connect-runtime")).toHaveLength(1);
+    expect(sent.filter((message) => message.type === "cancel-runtime-bootstrap")).toHaveLength(0);
+    port.emit({ type: "runtime-ready" });
+    await expect(connection.ready()).resolves.toBeUndefined();
+    const shutdown = connection.shutdown();
+    await vi.advanceTimersByTimeAsync(0);
+    port.emit({ type: "result", id: sent.find((message) => message.type === "close")?.id });
+    await shutdown;
+    expect(port.closed).toBe(true);
+  });
+
+  it("rejects a silent runtime without opening a competing worker generation", async () => {
+    vi.useFakeTimers();
+    const { connection, port, sent } = runtimeBootstrapFixture(6 * 60_000);
+    const rejected = expect(connection.ready()).rejects.toBeInstanceOf(
+      BrowserWorkerUnresponsiveError,
+    );
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    await rejected;
+    expect(sent.filter((message) => message.type === "connect-runtime")).toHaveLength(1);
+    expect(sent.filter((message) => message.type === "cancel-runtime-bootstrap")).toHaveLength(1);
+    port.emit({ type: "runtime-bootstrap-cancelled" });
+    await connection.shutdown();
     expect(port.closed).toBe(true);
   });
 

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -530,7 +530,10 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
       let closingLatePeer = false;
       let alive = false;
       let lastTick = Date.now();
-      let deadline = lastTick + 1_000;
+      // A delayed alive reply is not evidence that this realm released its
+      // physical database lock. Only worker-closing authorizes a generation
+      // change; apply the bounded startup grace even before the first reply.
+      let deadline = lastTick + RUNTIME_STARTUP_TIMEOUT_MS;
       let suspended = typeof document !== "undefined" && document.hidden;
       let bootstrapTimer: ReturnType<typeof setTimeout> | undefined;
       const settle = (outcome: { connected: boolean; error?: Error }) => {
@@ -564,7 +567,7 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
       this.cancelBootstrap = cancelForShutdown;
       const refreshGrace = () => {
         lastTick = Date.now();
-        deadline = lastTick + (alive ? RUNTIME_STARTUP_TIMEOUT_MS : 1_000);
+        deadline = lastTick + RUNTIME_STARTUP_TIMEOUT_MS;
       };
       const onVisibilityChange = () => {
         const hidden = typeof document !== "undefined" && document.hidden;
@@ -579,16 +582,12 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
         if (suspended || now - lastTick > RUNTIME_STARTUP_CLOCK_INTERVAL_MS * 2) refreshGrace();
         lastTick = now;
         if (now >= deadline) {
-          cancel(
-            alive
-              ? {
-                  connected: false,
-                  error: new BrowserWorkerUnresponsiveError(
-                    "Shared browser runtime did not finish initialization within five minutes",
-                  ),
-                }
-              : { connected: false },
-          );
+          cancel({
+            connected: false,
+            error: new BrowserWorkerUnresponsiveError(
+              "Shared browser runtime did not finish initialization within five minutes",
+            ),
+          });
           return;
         }
         bootstrapTimer = setTimeout(

--- a/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/browser-shared-worker-connection.ts
@@ -528,7 +528,6 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
       let settled = false;
       let cancelled = false;
       let closingLatePeer = false;
-      let alive = false;
       let lastTick = Date.now();
       // A delayed alive reply is not evidence that this realm released its
       // physical database lock. Only worker-closing authorizes a generation
@@ -626,13 +625,9 @@ export class SharedBrowserWorkerConnection implements BrowserWorkerConnection {
           port.close();
           return;
         }
-        if (event.data?.type === "worker-alive") {
-          if (!alive) {
-            alive = true;
-            refreshGrace();
-          }
-          return;
-        }
+        // Liveness is not completed initialization. A first or repeated
+        // alive reply must not restart the single startup budget.
+        if (event.data?.type === "worker-alive") return;
         if (event.data?.type === "runtime-error") {
           cleanup();
           port.close();

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1440,6 +1440,10 @@ export class NativeRuntimeAdapter implements Runtime {
     const patch = encodeCellsForPatch(this.table(table), values);
     if (tx) {
       this.assertTransactionWriteIdentity(tx, attribution ? undefined : writeIdentity);
+      // Resolve the synchronous preimage before staging. A rejected merge
+      // (for example an indirect large value) must not leave a native patch
+      // that a caller can accidentally commit after catching the error.
+      const row = this.mergeRowState(table, rowId, values, tx, writeIdentity);
       this.db.updateInTransaction(tx.id, table, rowId, patch, {
         head: branchView?.head,
         base: branchView?.base,
@@ -1448,7 +1452,7 @@ export class NativeRuntimeAdapter implements Runtime {
       tx.writes.push({
         table,
         rowId,
-        row: this.mergeRowState(table, rowId, values, tx, writeIdentity),
+        row,
       });
       return { kind: "staged", openTransactionId: txIdFromContext(writeContext)! };
     }
@@ -1540,6 +1544,9 @@ export class NativeRuntimeAdapter implements Runtime {
     }
     if (tx) {
       this.assertTransactionWriteIdentity(tx, attribution ? undefined : writeIdentity);
+      const row = existing
+        ? this.mergeRowState(table, rowId, values, tx, writeIdentity)
+        : this.rowStateFromValues(table, rowId, values);
       this.db.upsertInTransaction(tx.id, table, rowId, cells, {
         head: branchView?.head,
         base: branchView?.base,
@@ -1548,9 +1555,7 @@ export class NativeRuntimeAdapter implements Runtime {
       tx.writes.push({
         table,
         rowId,
-        row: existing
-          ? this.mergeRowState(table, rowId, values, tx, writeIdentity)
-          : this.rowStateFromValues(table, rowId, values),
+        row,
       });
       return { kind: "staged", openTransactionId: txIdFromContext(writeContext)! };
     }

--- a/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
@@ -346,7 +346,7 @@ async function openPhysicalDatabaseOwner(
   let pageStore: IndexedDbPageStore | null = null;
   try {
     pageStore = await IndexedDbPageStore.open(dbName, { owner: storageOwner });
-    await pageStore.claimBrowserWorkerEpoch(epoch.id);
+    await pageStore.claimBrowserWorkerEpoch(epoch.id, epoch);
     const owner: PhysicalDatabaseOwner = {
       epoch,
       pageStore,

--- a/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
@@ -1972,7 +1972,12 @@ async function finalizeContextStorageReset(context: RuntimeContext): Promise<voi
 }
 
 async function releaseIdleContext(context: RuntimeContext): Promise<void> {
+  if (contexts.get(context.key) !== context) return;
   if (context.peers.size !== 0 || context.pendingAdmissionTasks !== 0) return;
+  // Foreground lease handoff can outlive the last runtime peer. Reuse this
+  // exact tree until the physical owner can retire; dropping only the wrapper
+  // would leave its storage alive through GC-retained WASM transport handles.
+  if (pendingBootstrapOperations !== 0 || hasForegroundLeaseWork(context.options.dbName)) return;
   if (!context.closing) {
     context.closing = (async () => {
       for (const peer of context.peers.values()) {
@@ -1993,6 +1998,16 @@ async function releaseIdleContext(context: RuntimeContext): Promise<void> {
       context.disposeTelemetry = null;
       context.disposeAuxiliaryTrace?.();
       context.disposeAuxiliaryTrace = null;
+      // No lease work remains; remove its alias before a successor bootstrap
+      // can mistake the closing page store for a reusable lease owner.
+      foregroundLeaseOwners.delete(context.options.dbName);
+      // Start retirement before removing the context. A successor can create
+      // its context immediately, but ensurePhysicalDatabaseOwner waits for this
+      // exact release before opening a fresh page store. Close acknowledgement
+      // must not wait on a slow epoch transaction after the flush barrier.
+      void releasePhysicalDatabaseOwner(context.options.dbName)
+        .catch(() => undefined)
+        .then(maybeCloseWorker);
       if (contexts.get(context.key) === context) contexts.delete(context.key);
     })();
   }
@@ -2011,6 +2026,23 @@ function scheduleIdleContextRelease(context: RuntimeContext): void {
 }
 
 function maybeCloseWorker(): void {
+  // Final lease return/retirement must break the retained-context ownership
+  // cycle, even if another database or inspector keeps this realm alive.
+  if (pendingBootstrapOperations === 0) {
+    for (const context of contexts.values()) {
+      if (
+        context.peers.size === 0 &&
+        context.pendingAdmissionTasks === 0 &&
+        !context.closing &&
+        !context.idleReleaseTimer &&
+        !hasForegroundLeaseWork(context.options.dbName)
+      ) {
+        void releaseIdleContext(context)
+          .catch(() => undefined)
+          .then(maybeCloseWorker);
+      }
+    }
+  }
   if (!workerHasLiveWork()) {
     if (pendingWorkerClose) return;
     const closeToken = Symbol("worker-idle-close");
@@ -2066,12 +2098,13 @@ function workerHasLiveWork(): boolean {
   );
 }
 
-function hasForegroundLeaseWork(): boolean {
-  return [...foregroundLeaseOwners.values()].some(
-    (owner) =>
-      owner.activeLeaseIds.size > 0 ||
-      owner.pendingLeaseAllocations > 0 ||
-      owner.pendingLeaseFinalizations > 0,
+function hasForegroundLeaseWork(dbName?: string): boolean {
+  return [...foregroundLeaseOwners.entries()].some(
+    ([name, owner]) =>
+      (dbName === undefined || name === dbName) &&
+      (owner.activeLeaseIds.size > 0 ||
+        owner.pendingLeaseAllocations > 0 ||
+        owner.pendingLeaseFinalizations > 0),
   );
 }
 

--- a/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker-core.ts
@@ -911,9 +911,10 @@ async function retireForegroundNodeLease(
 function retireUnclaimedRuntimeOwners(): void {
   if (pendingBootstrapOperations !== 0) return;
   for (const [dbName, owner] of pendingRuntimeOwnerRetirements) {
-    pendingRuntimeOwnerRetirements.delete(dbName);
-    if (physicalDatabaseOwners.get(dbName) !== owner) continue;
-    if (contexts.has(dbName)) continue;
+    if (physicalDatabaseOwners.get(dbName) !== owner || contexts.has(dbName)) {
+      pendingRuntimeOwnerRetirements.delete(dbName);
+      continue;
+    }
     const leaseOwner = foregroundLeaseOwners.get(dbName);
     if (
       leaseOwner &&
@@ -922,6 +923,7 @@ function retireUnclaimedRuntimeOwners(): void {
         leaseOwner.pendingLeaseFinalizations > 0)
     )
       continue;
+    pendingRuntimeOwnerRetirements.delete(dbName);
     foregroundLeaseOwners.delete(dbName);
     void releasePhysicalDatabaseOwner(dbName).catch(() => undefined);
   }
@@ -1974,10 +1976,6 @@ async function finalizeContextStorageReset(context: RuntimeContext): Promise<voi
 async function releaseIdleContext(context: RuntimeContext): Promise<void> {
   if (contexts.get(context.key) !== context) return;
   if (context.peers.size !== 0 || context.pendingAdmissionTasks !== 0) return;
-  // Foreground lease handoff can outlive the last runtime peer. Reuse this
-  // exact tree until the physical owner can retire; dropping only the wrapper
-  // would leave its storage alive through GC-retained WASM transport handles.
-  if (pendingBootstrapOperations !== 0 || hasForegroundLeaseWork(context.options.dbName)) return;
   if (!context.closing) {
     context.closing = (async () => {
       for (const peer of context.peers.values()) {
@@ -1989,6 +1987,10 @@ async function releaseIdleContext(context: RuntimeContext): Promise<void> {
       // The last peer's flush barrier already drained evaluator persistence.
       // Do not retain a graceful close future after every page has gone: a
       // suspended cold/query lifecycle cannot add durability at this point.
+      // Revoke every old cached tree before dropping GC-retained WASM wrappers.
+      // Foreground leases belong to the physical owner, not to this schema pin.
+      const physicalOwner = physicalDatabaseOwners.get(context.options.dbName);
+      const treeRetirement = context.pageStore?.retireTreeOwnership();
       context.runtime?.discard();
       context.runtime = null;
       context.disposePageStoreInvalidation?.();
@@ -1998,17 +2000,13 @@ async function releaseIdleContext(context: RuntimeContext): Promise<void> {
       context.disposeTelemetry = null;
       context.disposeAuxiliaryTrace?.();
       context.disposeAuxiliaryTrace = null;
-      // No lease work remains; remove its alias before a successor bootstrap
-      // can mistake the closing page store for a reusable lease owner.
-      foregroundLeaseOwners.delete(context.options.dbName);
-      // Start retirement before removing the context. A successor can create
-      // its context immediately, but ensurePhysicalDatabaseOwner waits for this
-      // exact release before opening a fresh page store. Close acknowledgement
-      // must not wait on a slow epoch transaction after the flush barrier.
-      void releasePhysicalDatabaseOwner(context.options.dbName)
-        .catch(() => undefined)
-        .then(maybeCloseWorker);
-      if (contexts.get(context.key) === context) contexts.delete(context.key);
+      await treeRetirement;
+      if (contexts.get(context.key) !== context) return;
+      contexts.delete(context.key);
+      if (physicalOwner && physicalDatabaseOwners.get(context.options.dbName) === physicalOwner) {
+        pendingRuntimeOwnerRetirements.set(context.options.dbName, physicalOwner);
+      }
+      retireUnclaimedRuntimeOwners();
     })();
   }
   await context.closing;
@@ -2026,23 +2024,7 @@ function scheduleIdleContextRelease(context: RuntimeContext): void {
 }
 
 function maybeCloseWorker(): void {
-  // Final lease return/retirement must break the retained-context ownership
-  // cycle, even if another database or inspector keeps this realm alive.
-  if (pendingBootstrapOperations === 0) {
-    for (const context of contexts.values()) {
-      if (
-        context.peers.size === 0 &&
-        context.pendingAdmissionTasks === 0 &&
-        !context.closing &&
-        !context.idleReleaseTimer &&
-        !hasForegroundLeaseWork(context.options.dbName)
-      ) {
-        void releaseIdleContext(context)
-          .catch(() => undefined)
-          .then(maybeCloseWorker);
-      }
-    }
-  }
+  retireUnclaimedRuntimeOwners();
   if (!workerHasLiveWork()) {
     if (pendingWorkerClose) return;
     const closeToken = Symbol("worker-idle-close");

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => {
   const pageStores: Array<{
     close: Mock;
     claimBrowserWorkerEpoch: Mock;
+    retireTreeOwnership: Mock;
     releaseBrowserWorkerEpoch: Mock;
     onInvalidated: Mock;
     acquireForegroundNodeLease: Mock;
@@ -92,6 +93,7 @@ const mocks = vi.hoisted(() => {
         const pageStore = {
           close: vi.fn(),
           claimBrowserWorkerEpoch: vi.fn(async () => undefined),
+          retireTreeOwnership: vi.fn(async () => undefined),
           releaseBrowserWorkerEpoch: vi.fn(async () => undefined),
           onInvalidated: vi.fn(() => () => undefined),
           acquireForegroundNodeLease: vi.fn(async () => ({
@@ -1402,11 +1404,16 @@ describe("broker worker context initialization", () => {
     expect(mocks.openPageStore).toHaveBeenCalledOnce();
   });
 
-  it("reuses the leased physical tree and retires it before a fresh successor beside a healthy root", async () => {
+  it("retires schema pins while keeping the leased physical owner and fences its final successor", async () => {
     const openedStores = new Set<unknown>();
     mocks.openBrowser.mockImplementation(async (pageStore: unknown) => {
       if (openedStores.has(pageStore)) throw new Error("physical owner already has a tree");
       openedStores.add(pageStore);
+      (pageStore as (typeof mocks.pageStores)[number]).retireTreeOwnership.mockImplementation(
+        async () => {
+          openedStores.delete(pageStore);
+        },
+      );
       return mocks.createBrowserDb();
     });
     const unrelated = await connect(options("reclamation-unrelated-root"), "unrelated");
@@ -1422,11 +1429,11 @@ describe("broker worker context initialization", () => {
     await initializeFollower(first.port, 1);
     const originalStore = mocks.pageStores[1]!;
     await followerResult(first.port, { type: "close", id: 2, releaseContext: true });
-    expect(mocks.runtimes[1]?.discard).not.toHaveBeenCalled();
+    expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce();
     expect(originalStore.close).not.toHaveBeenCalled();
-    const sameOwner = await connect(target, "same-owner");
+    const sameOwner = await connect(target, "same-owner", "next-schema-fingerprint");
     expect(sameOwner.outcome.type).toBe("runtime-ready");
-    expect(mocks.openBrowser).toHaveBeenCalledTimes(2);
+    expect(mocks.openBrowser).toHaveBeenCalledTimes(3);
     await followerResult(sameOwner.port, { type: "close", id: 1, releaseContext: true });
     lease.port.emitMessage({ type: "retire-foreground-node-lease" });
     await vi.waitFor(() => expect(originalStore.close).toHaveBeenCalledOnce());
@@ -1449,6 +1456,35 @@ describe("broker worker context initialization", () => {
     successorLease.port.emitMessage({ type: "retire-foreground-node-lease" });
     await vi.waitFor(() => expect(mocks.pageStores[2]?.close).toHaveBeenCalledOnce());
     await followerResult(unrelated.port, { type: "close", id: 2, releaseContext: true });
+  });
+
+  it("waits for revoked tree transactions before admitting a new schema on the leased store", async () => {
+    const target = options("tree-generation-barrier");
+    const lease = connectLease({
+      type: "acquire-foreground-node-lease",
+      dbName: target.dbName,
+      storageOwner: target.storageOwner,
+    });
+    await lease.outcome;
+    const first = await connect(target, "first", "old-schema");
+    const retirement = deferred<void>();
+    mocks.pageStores[0]!.retireTreeOwnership.mockImplementationOnce(() => retirement.promise);
+    const closed = first.port.waitForEvent((event) => event.type === "result" && event.id === 1);
+    first.port.emitMessage({ type: "close", id: 1, releaseContext: true });
+    await vi.waitFor(() => expect(mocks.pageStores[0]?.retireTreeOwnership).toHaveBeenCalledOnce());
+    const successor = connect(target, "second", "new-schema");
+    await nextTask();
+    expect(mocks.openBrowser).toHaveBeenCalledOnce();
+    expect(mocks.pageStores[0]?.close).not.toHaveBeenCalled();
+    retirement.resolve();
+    await closed;
+    const second = await successor;
+    expect(second.outcome.type).toBe("runtime-ready");
+    expect(mocks.openBrowser).toHaveBeenCalledTimes(2);
+    expect(mocks.pageStores).toHaveLength(1);
+    await followerResult(second.port, { type: "close", id: 1, releaseContext: true });
+    lease.port.emitMessage({ type: "retire-foreground-node-lease" });
+    await vi.waitFor(() => expect(mocks.pageStores[0]?.close).toHaveBeenCalledOnce());
   });
 
   it("retires an unleased tree on close even when another database keeps the worker alive", async () => {
@@ -1643,6 +1679,7 @@ describe("broker worker context initialization", () => {
       const pageStore = {
         close: vi.fn(),
         claimBrowserWorkerEpoch: vi.fn(async () => undefined),
+        retireTreeOwnership: vi.fn(async () => undefined),
         releaseBrowserWorkerEpoch: vi.fn(() => releasePhysicalOwner.promise),
         onInvalidated: vi.fn(() => () => undefined),
         acquireForegroundNodeLease: vi.fn(async () => ({
@@ -2492,7 +2529,7 @@ describe("broker worker context initialization", () => {
       await cancelled.waitFor("runtime-bootstrap-cancelled");
       opened.resolve(db);
       await nextTask();
-      expect(mocks.runtimes[1]?.discard).not.toHaveBeenCalled();
+      expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce();
       expect(pageStore.close).not.toHaveBeenCalled();
       expect(pageStore.releaseBrowserWorkerEpoch).not.toHaveBeenCalled();
 
@@ -2564,7 +2601,7 @@ describe("broker worker context initialization", () => {
       await cancelled.waitFor("runtime-bootstrap-cancelled");
       opened.resolve(db);
       await vi.waitFor(() => expect(mocks.runtimes).toHaveLength(2));
-      expect(mocks.runtimes[1]?.discard).not.toHaveBeenCalled();
+      expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce();
       expect(pageStore.close).not.toHaveBeenCalled();
       expect(pageStore.releaseBrowserWorkerEpoch).not.toHaveBeenCalled();
       pendingLease.port.emitMessage({

--- a/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
+++ b/packages/jazz-tools/src/worker/jazz-broker-worker.initialisation.test.ts
@@ -1402,6 +1402,76 @@ describe("broker worker context initialization", () => {
     expect(mocks.openPageStore).toHaveBeenCalledOnce();
   });
 
+  it("reuses the leased physical tree and retires it before a fresh successor beside a healthy root", async () => {
+    const openedStores = new Set<unknown>();
+    mocks.openBrowser.mockImplementation(async (pageStore: unknown) => {
+      if (openedStores.has(pageStore)) throw new Error("physical owner already has a tree");
+      openedStores.add(pageStore);
+      return mocks.createBrowserDb();
+    });
+    const unrelated = await connect(options("reclamation-unrelated-root"), "unrelated");
+    await initializeFollower(unrelated.port, 1);
+    const target = options("reclamation-leased-root");
+    const lease = connectLease({
+      type: "acquire-foreground-node-lease",
+      dbName: target.dbName,
+      storageOwner: target.storageOwner,
+    });
+    await lease.outcome;
+    const first = await connect(target, "first");
+    await initializeFollower(first.port, 1);
+    const originalStore = mocks.pageStores[1]!;
+    await followerResult(first.port, { type: "close", id: 2, releaseContext: true });
+    expect(mocks.runtimes[1]?.discard).not.toHaveBeenCalled();
+    expect(originalStore.close).not.toHaveBeenCalled();
+    const sameOwner = await connect(target, "same-owner");
+    expect(sameOwner.outcome.type).toBe("runtime-ready");
+    expect(mocks.openBrowser).toHaveBeenCalledTimes(2);
+    await followerResult(sameOwner.port, { type: "close", id: 1, releaseContext: true });
+    lease.port.emitMessage({ type: "retire-foreground-node-lease" });
+    await vi.waitFor(() => expect(originalStore.close).toHaveBeenCalledOnce());
+    expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce();
+    expect(mocks.pageStores[0]?.close).not.toHaveBeenCalled();
+    const successorLease = connectLease({
+      type: "acquire-foreground-node-lease",
+      dbName: target.dbName,
+      storageOwner: target.storageOwner,
+    });
+    await successorLease.outcome;
+    expect(mocks.pageStores).toHaveLength(3);
+    const successor = await connect(
+      { ...target, author: new Uint8Array([7]) },
+      "successor",
+      "new-fingerprint",
+    );
+    expect(successor.outcome.type).toBe("runtime-ready");
+    await followerResult(successor.port, { type: "close", id: 1, releaseContext: true });
+    successorLease.port.emitMessage({ type: "retire-foreground-node-lease" });
+    await vi.waitFor(() => expect(mocks.pageStores[2]?.close).toHaveBeenCalledOnce());
+    await followerResult(unrelated.port, { type: "close", id: 2, releaseContext: true });
+  });
+
+  it("retires an unleased tree on close even when another database keeps the worker alive", async () => {
+    const openedStores = new Set<unknown>();
+    mocks.openBrowser.mockImplementation(async (pageStore: unknown) => {
+      if (openedStores.has(pageStore)) throw new Error("physical owner already has a tree");
+      openedStores.add(pageStore);
+      return mocks.createBrowserDb();
+    });
+    const unrelated = await connect(options("reclamation-keepalive-root"), "unrelated");
+    const target = options("reclamation-reopened-root");
+    const first = await connect(target, "first");
+    await followerResult(first.port, { type: "close", id: 1, releaseContext: true });
+    const second = await connect(target, "second");
+    expect(second.outcome.type).toBe("runtime-ready");
+    expect(mocks.pageStores[1]?.releaseBrowserWorkerEpoch).toHaveBeenCalledOnce();
+    expect(mocks.pageStores[1]?.close).toHaveBeenCalledOnce();
+    expect(mocks.pageStores).toHaveLength(3);
+    expect(mocks.pageStores[0]?.close).not.toHaveBeenCalled();
+    await followerResult(second.port, { type: "close", id: 1, releaseContext: true });
+    await followerResult(unrelated.port, { type: "close", id: 1, releaseContext: true });
+  });
+
   it("can immediately reopen an account root for a linked identity after close acknowledgement", async () => {
     const initial = options("linked-account-handoff");
     const first = await connect(initial, "identity-a", "identity-a-fingerprint");
@@ -2422,7 +2492,7 @@ describe("broker worker context initialization", () => {
       await cancelled.waitFor("runtime-bootstrap-cancelled");
       opened.resolve(db);
       await nextTask();
-      expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce();
+      expect(mocks.runtimes[1]?.discard).not.toHaveBeenCalled();
       expect(pageStore.close).not.toHaveBeenCalled();
       expect(pageStore.releaseBrowserWorkerEpoch).not.toHaveBeenCalled();
 
@@ -2493,7 +2563,8 @@ describe("broker worker context initialization", () => {
       cancelled.port.postMessage({ type: "cancel-runtime-bootstrap" });
       await cancelled.waitFor("runtime-bootstrap-cancelled");
       opened.resolve(db);
-      await vi.waitFor(() => expect(mocks.runtimes[1]?.discard).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(mocks.runtimes).toHaveLength(2));
+      expect(mocks.runtimes[1]?.discard).not.toHaveBeenCalled();
       expect(pageStore.close).not.toHaveBeenCalled();
       expect(pageStore.releaseBrowserWorkerEpoch).not.toHaveBeenCalled();
       pendingLease.port.emitMessage({

--- a/packages/jazz-tools/tests/browser/cold-load.abstract-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/cold-load.abstract-bench.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { schema as s } from "../../src/index.js";
-import { createBrowserTestDb as createDb, acquireBrowserTestAccount } from "./account-fixtures.js";
+import { commands } from "vitest/browser";
+import { schema as s, generateAuthSecret } from "../../src/index.js";
+import { createBrowserTestDb as createDb } from "./account-fixtures.js";
 import type { Db } from "../../src/runtime/db.js";
 
 declare const __JAZZ_ABSTRACT_BENCH__: string;
@@ -9,16 +10,22 @@ const app = s.defineApp({ tasks: s.table({ title: s.string(), done: s.boolean() 
 
 // Opt-in diagnostic receipt, not a wall-clock correctness gate. Reopen is a
 // fresh runtime in the same browser session (the WASM module cache stays warm).
+// Build with `pnpm --filter jazz-wasm build:profiling`, then admit its verified
+// manifest with `node dev/artifacts/stage-native-fingerprints.mjs --profiling`.
+// Run this file with JAZZ_ABSTRACT_BENCH=1 and vitest.config.browser.ts.
+// Phase reports and synthetic pre-update physical fixtures are written to
+// .vitest-browser-bench. The 1500-row cases include ordinary updates while a
+// subscription remains active; they are distinct from transaction staging.
 describe.skipIf(__JAZZ_ABSTRACT_BENCH__ !== "1")("local cold-load phase receipt", () => {
   for (const count of [150, 300, 1500]) {
     for (const storage of ["memory", "persistent"] as const) {
       it(`${storage}: ${count} synthetic rows`, async () => {
         const appId = crypto.randomUUID();
-        const account = await acquireBrowserTestAccount({ appId });
+        const secret = generateAuthSecret();
         const dbName = `cold-load-receipt-${count}-${crypto.randomUUID()}`;
         const config = {
           appId,
-          account,
+          secret,
           driver:
             storage === "memory"
               ? { type: "memory" as const }
@@ -33,6 +40,11 @@ describe.skipIf(__JAZZ_ABSTRACT_BENCH__ !== "1")("local cold-load phase receipt"
             return await operation();
           } finally {
             phases[name] = performance.now() - start;
+            await commands.writeRealisticBrowserReport(`cold-load-phases-${storage}-${count}`, {
+              storage,
+              count,
+              phases,
+            });
             console.info(
               "[cold-load-phase]",
               JSON.stringify({ storage, count, name, ms: phases[name] }),
@@ -82,12 +94,145 @@ describe.skipIf(__JAZZ_ABSTRACT_BENCH__ !== "1")("local cold-load phase receipt"
             await db.shutdown();
             db = await measure("subscription_first_reopen_runtime", () => createDb(config));
             await measure("reopen_subscription_without_all", firstSubscription);
+            await db.shutdown();
+            const physical = (await indexedDB.databases()).filter(({ name }) =>
+              name?.startsWith(`${dbName}::jazz-browser-v1::`),
+            );
+            expect(physical).toHaveLength(1);
+            console.info(
+              "[cold-load-page-stats]",
+              JSON.stringify({
+                count,
+                after: "seed_reopens",
+                ...(await pageStats(physical[0]!.name!)),
+              }),
+            );
+            const records = await snapshot(physical[0]!.name!);
+            await commands.writeRealisticBrowserReport(`cold-load-fixture-${count}`, {
+              appId,
+              secret,
+              dbName,
+              physicalDbName: physical[0]!.name,
+              records: Object.fromEntries(
+                Object.entries(records).filter(([name]) => name !== "pages"),
+              ),
+              pageChunks: Math.ceil(records.pages.length / 128),
+            });
+            for (let offset = 0; offset < records.pages.length; offset += 128) {
+              await commands.writeRealisticBrowserReport(
+                `cold-load-fixture-${count}-pages-${offset / 128}`,
+                records.pages.slice(offset, offset + 128),
+              );
+            }
+            db = await createDb(config);
+          }
+          if (count === 1500) {
+            const rows = await db.all(app.tasks, { tier: "local" });
+            let completed = 0;
+            const stop = db.subscribe(
+              app.tasks,
+              (rows) => {
+                completed = rows.filter((row) => row.done).length;
+              },
+              { tier: "local" },
+            );
+            try {
+              await measure("ordinary_updates_with_active_subscription", async () => {
+                for (const row of rows.slice(0, 1350)) {
+                  await db!.update(app.tasks, row.id, { done: true }).wait({ tier: "local" });
+                }
+              });
+              expect(
+                (await db.all(app.tasks, { tier: "local" })).filter((row) => row.done),
+              ).toHaveLength(1350);
+              await measure("final_subscription_delivery", async () => {
+                const deadline = performance.now() + 30_000;
+                while (completed !== 1350 && performance.now() < deadline) {
+                  await new Promise((resolve) => setTimeout(resolve, 10));
+                }
+                expect(completed).toBe(1350);
+              });
+            } finally {
+              stop();
+            }
+            if (storage === "persistent") {
+              const names = (await indexedDB.databases()).filter(({ name }) =>
+                name?.startsWith(`${dbName}::jazz-browser-v1::`),
+              );
+              const stats = await pageStats(names[0]!.name!);
+              await commands.writeRealisticBrowserReport(`cold-load-pages-after-${count}`, stats);
+              console.info(
+                "[cold-load-page-stats]",
+                JSON.stringify({ count, after: "ordinary_updates", ...stats }),
+              );
+            }
           }
           console.info("[cold-load-receipt]", JSON.stringify({ storage, count, dbName, phases }));
         } finally {
           await db?.shutdown();
         }
-      }, 300_000);
+      }, 600_000);
     }
   }
 });
+
+async function snapshot(name: string) {
+  const request = <T>(req: IDBRequest<T>) =>
+    new Promise<T>((resolve, reject) => {
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  const database = await request(indexedDB.open(name));
+  try {
+    const stores = Array.from(database.objectStoreNames);
+    const tx = database.transaction(stores, "readonly");
+    const entries = await Promise.all(
+      stores.map(async (name) => {
+        const store = tx.objectStore(name);
+        const [keys, values] = await Promise.all([
+          request(store.getAllKeys()),
+          request(store.getAll()),
+        ]);
+        return [name, keys.map((key, index) => [key, values[index]])];
+      }),
+    );
+    return JSON.parse(
+      JSON.stringify(Object.fromEntries(entries), (_key, value) =>
+        value instanceof ArrayBuffer ? { base64: binaryBase64(new Uint8Array(value)) } : value,
+      ),
+    );
+  } finally {
+    database.close();
+  }
+}
+
+function binaryBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 8192) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + 8192));
+  }
+  return btoa(binary);
+}
+
+async function pageStats(name: string) {
+  const database = await new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open(name);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  try {
+    const counts = await Promise.all(
+      Array.from(database.objectStoreNames).map(
+        (name) =>
+          new Promise<[string, number]>((resolve, reject) => {
+            const req = database.transaction(name, "readonly").objectStore(name).count();
+            req.onsuccess = () => resolve([name, req.result]);
+            req.onerror = () => reject(req.error);
+          }),
+      ),
+    );
+    return Object.fromEntries(counts);
+  } finally {
+    database.close();
+  }
+}

--- a/packages/jazz-tools/tests/browser/cold-load.abstract-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/cold-load.abstract-bench.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { schema as s } from "../../src/index.js";
+import { createBrowserTestDb as createDb, acquireBrowserTestAccount } from "./account-fixtures.js";
+import type { Db } from "../../src/runtime/db.js";
+
+declare const __JAZZ_ABSTRACT_BENCH__: string;
+
+const app = s.defineApp({ tasks: s.table({ title: s.string(), done: s.boolean() }) });
+
+// Opt-in diagnostic receipt, not a wall-clock correctness gate. Reopen is a
+// fresh runtime in the same browser session (the WASM module cache stays warm).
+describe.skipIf(__JAZZ_ABSTRACT_BENCH__ !== "1")("local cold-load phase receipt", () => {
+  for (const count of [150, 300, 1500]) {
+    for (const storage of ["memory", "persistent"] as const) {
+      it(`${storage}: ${count} synthetic rows`, async () => {
+        const appId = crypto.randomUUID();
+        const account = await acquireBrowserTestAccount({ appId });
+        const dbName = `cold-load-receipt-${count}-${crypto.randomUUID()}`;
+        const config = {
+          appId,
+          account,
+          driver:
+            storage === "memory"
+              ? { type: "memory" as const }
+              : { type: "persistent" as const, dbName },
+          logLevel: "warn" as const,
+        };
+        let db: Db | undefined;
+        const phases: Record<string, number> = {};
+        const measure = async <T>(name: string, operation: () => Promise<T>): Promise<T> => {
+          const start = performance.now();
+          try {
+            return await operation();
+          } finally {
+            phases[name] = performance.now() - start;
+            console.info(
+              "[cold-load-phase]",
+              JSON.stringify({ storage, count, name, ms: phases[name] }),
+            );
+          }
+        };
+        const firstSubscription = async () => {
+          let stop = () => {};
+          try {
+            await new Promise<void>((resolve, reject) => {
+              stop = db!.subscribe(
+                app.tasks,
+                {
+                  onUpdate(rows) {
+                    if (rows.length === count) resolve();
+                  },
+                  onError: reject,
+                },
+                { tier: "local" },
+              );
+            });
+          } finally {
+            stop();
+          }
+        };
+        try {
+          db = await measure("initial_open", () => createDb(config));
+          await measure("initial_empty_all", () => db!.all(app.tasks, { tier: "local" }));
+          await measure("seed_local_durable", async () => {
+            const result = await db!.transaction((tx) => {
+              for (let i = 0; i < count; i++)
+                tx.insert(app.tasks, { title: `Task ${i}`, done: false });
+            });
+            await result.wait({ tier: "local" });
+          });
+          expect(
+            await measure("first_all_after_seed", () => db!.all(app.tasks, { tier: "local" })),
+          ).toHaveLength(count);
+          await measure("initial_subscription_after_all", firstSubscription);
+          if (storage === "persistent") {
+            await measure("shutdown_before_reopen", () => db!.shutdown());
+            db = await measure("reopen_runtime", () => createDb(config));
+            expect(
+              await measure("reopen_first_all", () => db!.all(app.tasks, { tier: "local" })),
+            ).toHaveLength(count);
+            await measure("reopen_subscription_after_all", firstSubscription);
+            await db.shutdown();
+            db = await measure("subscription_first_reopen_runtime", () => createDb(config));
+            await measure("reopen_subscription_without_all", firstSubscription);
+          }
+          console.info("[cold-load-receipt]", JSON.stringify({ storage, count, dbName, phases }));
+        } finally {
+          await db?.shutdown();
+        }
+      }, 300_000);
+    }
+  }
+});

--- a/packages/jazz-tools/tests/browser/cold-load.abstract-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/cold-load.abstract-bench.test.ts
@@ -3,8 +3,11 @@ import { commands } from "vitest/browser";
 import { schema as s, generateAuthSecret } from "../../src/index.js";
 import { createBrowserTestDb as createDb } from "./account-fixtures.js";
 import type { Db } from "../../src/runtime/db.js";
+import { INDEXEDDB_BTREE_DATABASE_VERSION } from "../../src/runtime/indexeddb-page-store.js";
 
 declare const __JAZZ_ABSTRACT_BENCH__: string;
+declare const __JAZZ_COLD_LOAD_FIXTURE__: string;
+declare const __JAZZ_COLD_LOAD_RESPONSIVENESS__: boolean;
 
 const app = s.defineApp({ tasks: s.table({ title: s.string(), done: s.boolean() }) });
 
@@ -16,6 +19,9 @@ const app = s.defineApp({ tasks: s.table({ title: s.string(), done: s.boolean() 
 // Phase reports and synthetic pre-update physical fixtures are written to
 // .vitest-browser-bench. The 1500-row cases include ordinary updates while a
 // subscription remains active; they are distinct from transaction staging.
+// Set JAZZ_COLD_LOAD_FIXTURE_DIR to a previous receipt directory for the upgrade
+// case. JAZZ_COLD_LOAD_RESPONSIVENESS=1 adds a timer observer; leave it unset for
+// the primary comparison with earlier uninstrumented timing receipts.
 describe.skipIf(__JAZZ_ABSTRACT_BENCH__ !== "1")("local cold-load phase receipt", () => {
   for (const count of [150, 300, 1500]) {
     for (const storage of ["memory", "persistent"] as const) {
@@ -34,16 +40,23 @@ describe.skipIf(__JAZZ_ABSTRACT_BENCH__ !== "1")("local cold-load phase receipt"
         };
         let db: Db | undefined;
         const phases: Record<string, number> = {};
+        const responsiveness: Record<
+          string,
+          ReturnType<ReturnType<typeof watchPageResponsiveness>>
+        > = {};
         const measure = async <T>(name: string, operation: () => Promise<T>): Promise<T> => {
           const start = performance.now();
+          const stopWatching = watchPageResponsiveness();
           try {
             return await operation();
           } finally {
             phases[name] = performance.now() - start;
+            responsiveness[name] = stopWatching();
             await commands.writeRealisticBrowserReport(`cold-load-phases-${storage}-${count}`, {
               storage,
               count,
               phases,
+              responsiveness,
             });
             console.info(
               "[cold-load-phase]",
@@ -99,13 +112,14 @@ describe.skipIf(__JAZZ_ABSTRACT_BENCH__ !== "1")("local cold-load phase receipt"
               name?.startsWith(`${dbName}::jazz-browser-v1::`),
             );
             expect(physical).toHaveLength(1);
+            const seededPageStats = await pageStats(physical[0]!.name!);
+            await commands.writeRealisticBrowserReport(
+              `cold-load-pages-before-${count}`,
+              seededPageStats,
+            );
             console.info(
               "[cold-load-page-stats]",
-              JSON.stringify({
-                count,
-                after: "seed_reopens",
-                ...(await pageStats(physical[0]!.name!)),
-              }),
+              JSON.stringify({ count, after: "seed_reopens", ...seededPageStats }),
             );
             const records = await snapshot(physical[0]!.name!);
             await commands.writeRealisticBrowserReport(`cold-load-fixture-${count}`, {
@@ -142,9 +156,7 @@ describe.skipIf(__JAZZ_ABSTRACT_BENCH__ !== "1")("local cold-load phase receipt"
                   await db!.update(app.tasks, row.id, { done: true }).wait({ tier: "local" });
                 }
               });
-              expect(
-                (await db.all(app.tasks, { tier: "local" })).filter((row) => row.done),
-              ).toHaveLength(1350);
+              assertSelectedRows(rows, await db.all(app.tasks, { tier: "local" }));
               await measure("final_subscription_delivery", async () => {
                 const deadline = performance.now() + 30_000;
                 while (completed !== 1350 && performance.now() < deadline) {
@@ -159,6 +171,12 @@ describe.skipIf(__JAZZ_ABSTRACT_BENCH__ !== "1")("local cold-load phase receipt"
               const names = (await indexedDB.databases()).filter(({ name }) =>
                 name?.startsWith(`${dbName}::jazz-browser-v1::`),
               );
+              await db.shutdown();
+              db = await measure("post_update_reopen_runtime", () => createDb(config));
+              const reopened = await measure("post_update_reopen_all", () =>
+                db!.all(app.tasks, { tier: "local" }),
+              );
+              assertSelectedRows(rows, reopened);
               const stats = await pageStats(names[0]!.name!);
               await commands.writeRealisticBrowserReport(`cold-load-pages-after-${count}`, stats);
               console.info(
@@ -175,6 +193,217 @@ describe.skipIf(__JAZZ_ABSTRACT_BENCH__ !== "1")("local cold-load phase receipt"
     }
   }
 });
+
+type FixtureEntries = [IDBValidKey, unknown][];
+type ColdLoadFixture = {
+  appId: string;
+  secret: string;
+  dbName: string;
+  physicalDbName: string;
+  records: Record<string, FixtureEntries>;
+  pageChunks: number;
+};
+
+// The fixture directory is produced by a separate, pre-upgrade source run.
+// Raw installation is setup only: the current production WASM reader performs
+// checksum/format admission and verifies the logical rows through public Db APIs.
+it.skipIf(__JAZZ_ABSTRACT_BENCH__ !== "1" || !__JAZZ_COLD_LOAD_FIXTURE__)(
+  "reopens and updates 1500 pre-upgrade synthetic rows through the production reader",
+  async () => {
+    const fixtureCommands = commands as unknown as {
+      readColdLoadFixture(chunk?: number): Promise<ColdLoadFixture | FixtureEntries>;
+    };
+    const fixture = (await fixtureCommands.readColdLoadFixture()) as ColdLoadFixture;
+    expect(Number.isSafeInteger(fixture.pageChunks) && fixture.pageChunks > 0).toBe(true);
+    expect((await indexedDB.databases()).some(({ name }) => name === fixture.physicalDbName)).toBe(
+      false,
+    );
+    const open = indexedDB.open(fixture.physicalDbName, INDEXEDDB_BTREE_DATABASE_VERSION);
+    open.onupgradeneeded = () => {
+      for (const name of ["metadata", "pages", "storage-manifest"])
+        open.result.createObjectStore(name);
+    };
+    const physical = await idbRequest(open);
+    try {
+      for (const [name, entries] of Object.entries(fixture.records)) {
+        await putFixtureEntries(physical, name, entries);
+      }
+      for (let chunk = 0; chunk < fixture.pageChunks; chunk++) {
+        const entries = (await fixtureCommands.readColdLoadFixture(chunk)) as FixtureEntries;
+        await putFixtureEntries(physical, "pages", entries);
+      }
+    } finally {
+      physical.close();
+    }
+
+    const before = await pageStats(fixture.physicalDbName);
+    const phases: Record<string, number> = {};
+    const responsiveness: Record<
+      string,
+      ReturnType<ReturnType<typeof watchPageResponsiveness>>
+    > = {};
+    const measure = async <T>(name: string, operation: () => Promise<T>) => {
+      const started = performance.now();
+      const stopWatching = watchPageResponsiveness();
+      try {
+        return await operation();
+      } finally {
+        phases[name] = performance.now() - started;
+        responsiveness[name] = stopWatching();
+        await commands.writeRealisticBrowserReport("cold-load-upgrade-phases", {
+          phases,
+          before,
+          responsiveness,
+        });
+      }
+    };
+    const config = {
+      appId: fixture.appId,
+      secret: fixture.secret,
+      driver: { type: "persistent" as const, dbName: fixture.dbName },
+      logLevel: "warn" as const,
+    };
+    let db: Db | undefined;
+    let stop = () => {};
+    try {
+      db = await measure("reopen_runtime", () => createDb(config));
+      const rows = await measure("reopen_first_all", () => db!.all(app.tasks, { tier: "local" }));
+      expect(rows).toHaveLength(1500);
+      expect(rows.map((row) => row.title).sort()).toEqual(
+        Array.from({ length: 1500 }, (_, i) => `Task ${i}`).sort(),
+      );
+      expect(rows.every((row) => !row.done)).toBe(true);
+      let completed = 0;
+      await measure(
+        "initial_subscription_after_all",
+        () =>
+          new Promise<void>((resolve, reject) => {
+            stop = db!.subscribe(
+              app.tasks,
+              {
+                onUpdate(snapshot) {
+                  completed = snapshot.filter((row) => row.done).length;
+                  if (snapshot.length === 1500) resolve();
+                },
+                onError: reject,
+              },
+              { tier: "local" },
+            );
+          }),
+      );
+      await measure("ordinary_updates_with_active_subscription", async () => {
+        for (const row of rows.slice(0, 1350)) {
+          await db!.update(app.tasks, row.id, { done: true }).wait({ tier: "local" });
+        }
+      });
+      await measure("final_subscription_delivery", async () => {
+        const deadline = performance.now() + 30_000;
+        while (completed !== 1350 && performance.now() < deadline)
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(completed).toBe(1350);
+      });
+      stop();
+      await db.shutdown();
+      db = await measure("post_update_reopen_runtime", () => createDb(config));
+      const reopened = await measure("post_update_reopen_all", () =>
+        db!.all(app.tasks, { tier: "local" }),
+      );
+      assertSelectedRows(rows, reopened);
+      await commands.writeRealisticBrowserReport("cold-load-upgrade-result", {
+        phases,
+        responsiveness,
+        before,
+        after: await pageStats(fixture.physicalDbName),
+      });
+    } finally {
+      stop();
+      await db?.shutdown();
+    }
+  },
+  600_000,
+);
+
+function idbRequest<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function assertSelectedRows(
+  original: { id: string; title: string; done: boolean }[],
+  current: { id: string; title: string; done: boolean }[],
+) {
+  expect(current.map((row) => [row.id, row.title]).sort()).toEqual(
+    original.map((row) => [row.id, row.title]).sort(),
+  );
+  expect(
+    current
+      .filter((row) => row.done === true)
+      .map((row) => row.id)
+      .sort(),
+  ).toEqual(
+    original
+      .slice(0, 1350)
+      .map((row) => row.id)
+      .sort(),
+  );
+  expect(
+    current
+      .filter((row) => row.done === false)
+      .map((row) => row.id)
+      .sort(),
+  ).toEqual(
+    original
+      .slice(1350)
+      .map((row) => row.id)
+      .sort(),
+  );
+}
+
+// A page-event-loop observation, not a React paint or user-input latency claim.
+// Measure the trailing gap too, so a phase that blocks every timer is visible.
+function watchPageResponsiveness() {
+  if (!__JAZZ_COLD_LOAD_RESPONSIVENESS__) return () => ({ enabled: false as const });
+  let last = performance.now();
+  let maxGapMs = 0;
+  let ticks = 0;
+  const timer = setInterval(() => {
+    const now = performance.now();
+    maxGapMs = Math.max(maxGapMs, now - last);
+    last = now;
+    ticks++;
+  }, 16);
+  return () => {
+    clearInterval(timer);
+    return {
+      enabled: true as const,
+      max_timer_gap_ms: Math.max(maxGapMs, performance.now() - last),
+      timer_ticks: ticks,
+    };
+  };
+}
+
+async function putFixtureEntries(database: IDBDatabase, name: string, entries: FixtureEntries) {
+  const tx = database.transaction(name, "readwrite");
+  const completed = new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onabort = () => reject(tx.error ?? new Error("Fixture import aborted"));
+  });
+  for (const [key, value] of entries) tx.objectStore(name).put(reviveFixtureValue(value), key);
+  await completed;
+}
+
+function reviveFixtureValue(value: unknown): unknown {
+  if (!value || typeof value !== "object") return value;
+  if ("base64" in value && typeof value.base64 === "string") {
+    return Uint8Array.from(atob(value.base64), (character) => character.charCodeAt(0)).buffer;
+  }
+  if (Array.isArray(value)) return value.map(reviveFixtureValue);
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nested]) => [key, reviveFixtureValue(nested)]),
+  );
+}
 
 async function snapshot(name: string) {
   const request = <T>(req: IDBRequest<T>) =>
@@ -231,7 +460,25 @@ async function pageStats(name: string) {
           }),
       ),
     );
-    return Object.fromEntries(counts);
+    let pageBytes = 0;
+    let lastKey: IDBValidKey | undefined;
+    for (;;) {
+      const tx = database.transaction("pages", "readonly");
+      const store = tx.objectStore("pages");
+      const range = lastKey === undefined ? undefined : IDBKeyRange.lowerBound(lastKey, true);
+      const [keys, values] = await Promise.all([
+        idbRequest(store.getAllKeys(range, 128)),
+        idbRequest(store.getAll(range, 128)),
+      ]);
+      for (const value of values) {
+        if (!(value instanceof ArrayBuffer) && !ArrayBuffer.isView(value))
+          throw new Error("Page fixture contains a non-binary page");
+        pageBytes += value.byteLength;
+      }
+      if (keys.length < 128) break;
+      lastKey = keys[keys.length - 1];
+    }
+    return { ...Object.fromEntries(counts), page_bytes: pageBytes };
   } finally {
     database.close();
   }

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -8,6 +8,66 @@ const app = schema.defineApp({
 });
 
 describe("exact local transaction write merging", () => {
+  it("does not commit a rejected large-row patch after its error is caught", async () => {
+    const db = await createBrowserTestDb({
+      appId: "transaction-staging-large-rejection",
+      driver: { type: "memory" },
+    });
+    try {
+      const title = "large text ".repeat(20_000);
+      const large = db.insert(app.todos, { title, done: false });
+      await large.wait({ tier: "local" });
+      const small = db.insert(app.todos, { title: "small", done: false });
+      await small.wait({ tier: "local" });
+      const tx = db.beginTransaction();
+      expect(() => tx.update(app.todos, large.value.id, { done: true })).toThrow(
+        "synchronous WASM all/transaction reads cannot materialize a large value",
+      );
+      tx.update(app.todos, small.value.id, { done: true });
+      await tx.commit().wait({ tier: "local" });
+      expect(await db.all(app.todos)).toEqual(
+        expect.arrayContaining([
+          { id: large.value.id, title, done: false },
+          { id: small.value.id, title: "small", done: true },
+        ]),
+      );
+    } finally {
+      await db.shutdown();
+    }
+  }, 30_000);
+
+  it("retains the previous staged state when native staging rejects a later patch", async () => {
+    const db = await createBrowserTestDb({
+      appId: "transaction-staging-native-rejection",
+      driver: { type: "memory" },
+    });
+    try {
+      const inserted = db.insert(app.todos, { title: "original", done: false });
+      await inserted.wait({ tier: "local" });
+      const tx = db.beginTransaction();
+      tx.update(app.todos, inserted.value.id, { title: "first patch" });
+      const { WasmDb } = await loadWasmModule();
+      const nativeUpdate = vi.spyOn(WasmDb.prototype, "updateInTransaction");
+      nativeUpdate.mockImplementationOnce(() => {
+        throw new Error("synthetic staging failure");
+      });
+      try {
+        expect(() => tx.update(app.todos, inserted.value.id, { title: "rejected patch" })).toThrow(
+          "synthetic staging failure",
+        );
+      } finally {
+        nativeUpdate.mockRestore();
+      }
+      tx.update(app.todos, inserted.value.id, { done: true });
+      await tx.commit().wait({ tier: "local" });
+      expect(await db.all(app.todos)).toEqual([
+        { id: inserted.value.id, title: "first patch", done: true },
+      ]);
+    } finally {
+      await db.shutdown();
+    }
+  });
+
   for (const count of [150, 300, 1500]) {
     it(`stages 90% of ${count} rows without table reads`, async () => {
       const db = await createBrowserTestDb({

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -9,7 +9,7 @@ const app = schema.defineApp({
 });
 
 describe("exact local transaction write merging", () => {
-  it("preserves large content and does not commit a patch whose merge read failed", async () => {
+  it("preserves large content after commit rejection and a caught merge-read failure", async () => {
     const db = await createBrowserTestDb({
       appId: "transaction-staging-large-rejection",
       driver: { type: "memory" },
@@ -25,9 +25,11 @@ describe("exact local transaction write merging", () => {
       await large.wait({ tier: "local" });
       const small = db.insert(app.todos, { title: "small", done: false });
       await small.wait({ tier: "local" });
-      const successful = db.beginTransaction();
-      successful.update(app.todos, large.value.id, { done: true });
-      await successful.commit().wait({ tier: "local" });
+      const unsupported = db.beginTransaction();
+      unsupported.update(app.todos, large.value.id, { done: true });
+      await expect(unsupported.commit().wait({ tier: "local" })).rejects.toThrow(
+        "callers must author logical scalar values, not physical large descriptors",
+      );
       const tx = db.beginTransaction();
       const { WasmDb } = await loadWasmModule();
       const exact = vi.spyOn(WasmDb.prototype, "localCurrentRow");
@@ -35,7 +37,7 @@ describe("exact local transaction write merging", () => {
         throw new Error("synthetic exact read failure");
       });
       try {
-        expect(() => tx.update(app.todos, large.value.id, { done: false })).toThrow(
+        expect(() => tx.update(app.todos, large.value.id, { done: true })).toThrow(
           "synthetic exact read failure",
         );
       } finally {
@@ -45,7 +47,7 @@ describe("exact local transaction write merging", () => {
       await tx.commit().wait({ tier: "local" });
       expect(await db.all(app.todos)).toEqual(
         expect.arrayContaining([
-          { id: large.value.id, title, done: true },
+          { id: large.value.id, title, done: false },
           { id: small.value.id, title: "small", done: true },
         ]),
       );

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -9,7 +9,7 @@ const app = schema.defineApp({
 });
 
 describe("exact local transaction write merging", () => {
-  it("does not commit a rejected large-row patch after its error is caught", async () => {
+  it("preserves large content and does not commit a patch whose merge read failed", async () => {
     const db = await createBrowserTestDb({
       appId: "transaction-staging-large-rejection",
       driver: { type: "memory" },
@@ -25,15 +25,27 @@ describe("exact local transaction write merging", () => {
       await large.wait({ tier: "local" });
       const small = db.insert(app.todos, { title: "small", done: false });
       await small.wait({ tier: "local" });
+      const successful = db.beginTransaction();
+      successful.update(app.todos, large.value.id, { done: true });
+      await successful.commit().wait({ tier: "local" });
       const tx = db.beginTransaction();
-      expect(() => tx.update(app.todos, large.value.id, { done: true })).toThrow(
-        "synchronous WASM all/transaction reads cannot materialize a large value",
-      );
+      const { WasmDb } = await loadWasmModule();
+      const exact = vi.spyOn(WasmDb.prototype, "localCurrentRow");
+      exact.mockImplementationOnce(() => {
+        throw new Error("synthetic exact read failure");
+      });
+      try {
+        expect(() => tx.update(app.todos, large.value.id, { done: false })).toThrow(
+          "synthetic exact read failure",
+        );
+      } finally {
+        exact.mockRestore();
+      }
       tx.update(app.todos, small.value.id, { done: true });
       await tx.commit().wait({ tier: "local" });
       expect(await db.all(app.todos)).toEqual(
         expect.arrayContaining([
-          { id: large.value.id, title, done: false },
+          { id: large.value.id, title, done: true },
           { id: small.value.id, title: "small", done: true },
         ]),
       );

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { commands } from "vitest/browser";
 import { schema } from "../../src/index.js";
 import { loadWasmModule } from "../../src/runtime/wasm-loader.js";
 import { createBrowserTestDb } from "./account-fixtures.js";
@@ -124,17 +125,14 @@ describe("exact local transaction write merging", () => {
           title: "Second patch",
           done: true,
         });
-        console.info(
-          "transaction-staging-receipt",
-          JSON.stringify({
-            count,
-            updated: updates.length,
-            seedMs,
-            readMs,
-            stageMs,
-            commitMs,
-          }),
-        );
+        await commands.writeRealisticBrowserReport(`transaction-staging-${count}`, {
+          count,
+          updated: updates.length,
+          seedMs,
+          readMs,
+          stageMs,
+          commitMs,
+        });
       } finally {
         await db.shutdown();
       }

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -15,7 +15,12 @@ describe("exact local transaction write merging", () => {
     });
     try {
       const title = "large text ".repeat(20_000);
-      const large = db.insert(app.todos, { title, done: false });
+      const large = await db.insertStreaming(app.todos, {
+        title: (async function* () {
+          yield title;
+        })(),
+        done: false,
+      });
       await large.wait({ tier: "local" });
       const small = db.insert(app.todos, { title: "small", done: false });
       await small.wait({ tier: "local" });
@@ -36,7 +41,7 @@ describe("exact local transaction write merging", () => {
     }
   }, 30_000);
 
-  it("retains the previous staged state when native staging rejects a later patch", async () => {
+  it("does not cache a patch rejected by native staging", async () => {
     const db = await createBrowserTestDb({
       appId: "transaction-staging-native-rejection",
       driver: { type: "memory" },
@@ -45,8 +50,8 @@ describe("exact local transaction write merging", () => {
       const inserted = db.insert(app.todos, { title: "original", done: false });
       await inserted.wait({ tier: "local" });
       const tx = db.beginTransaction();
-      tx.update(app.todos, inserted.value.id, { title: "first patch" });
       const { WasmDb } = await loadWasmModule();
+      const exact = vi.spyOn(WasmDb.prototype, "localCurrentRow");
       const nativeUpdate = vi.spyOn(WasmDb.prototype, "updateInTransaction");
       nativeUpdate.mockImplementationOnce(() => {
         throw new Error("synthetic staging failure");
@@ -58,10 +63,15 @@ describe("exact local transaction write merging", () => {
       } finally {
         nativeUpdate.mockRestore();
       }
-      tx.update(app.todos, inserted.value.id, { done: true });
+      try {
+        tx.update(app.todos, inserted.value.id, { done: true });
+        expect(exact).toHaveBeenCalledTimes(2);
+      } finally {
+        exact.mockRestore();
+      }
       await tx.commit().wait({ tier: "local" });
       expect(await db.all(app.todos)).toEqual([
-        { id: inserted.value.id, title: "first patch", done: true },
+        { id: inserted.value.id, title: "original", done: true },
       ]);
     } finally {
       await db.shutdown();

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { schema } from "../../src/index.js";
+import { loadWasmModule } from "../../src/runtime/wasm-loader.js";
+import { createBrowserTestDb } from "./account-fixtures.js";
+
+const app = schema.defineApp({
+  todos: schema.table({ title: schema.string(), done: schema.boolean() }),
+});
+
+describe("exact local transaction write merging", () => {
+  for (const count of [150, 300, 1500]) {
+    it(`stages 90% of ${count} rows without table reads`, async () => {
+      const db = await createBrowserTestDb({
+        appId: `transaction-staging-${count}`,
+        driver: { type: "memory" },
+      });
+      try {
+        await db.all(app.todos);
+        const seedStart = performance.now();
+        const seed = await db.transaction((tx) => {
+          for (let index = 0; index < count; index++) {
+            tx.insert(app.todos, { title: `Item ${index}`, done: false });
+          }
+        });
+        await seed.wait({ tier: "local" });
+        const seedMs = performance.now() - seedStart;
+        const readStart = performance.now();
+        const rows = await db.all(app.todos);
+        const readMs = performance.now() - readStart;
+        const updates = rows.slice(0, Math.floor(count * 0.9));
+        const { WasmDb } = await loadWasmModule();
+        const all = vi.spyOn(WasmDb.prototype, "all");
+        const exact = vi.spyOn(WasmDb.prototype, "localCurrentRow");
+        const tx = db.beginTransaction();
+        const stageStart = performance.now();
+        try {
+          for (const row of updates) tx.update(app.todos, row.id, { done: true });
+          // A second patch must merge with this transaction's first patch.
+          tx.update(app.todos, updates[0].id, { title: "Second patch" });
+          expect(all).not.toHaveBeenCalled();
+          expect(exact).toHaveBeenCalledTimes(updates.length);
+        } finally {
+          all.mockRestore();
+          exact.mockRestore();
+        }
+        const stageMs = performance.now() - stageStart;
+        const commitStart = performance.now();
+        await tx.commit().wait({ tier: "local" });
+        const commitMs = performance.now() - commitStart;
+        const committed = await db.all(app.todos);
+        expect(committed.filter((row) => row.done)).toHaveLength(updates.length);
+        expect(committed.find((row) => row.id === updates[0].id)).toEqual({
+          ...updates[0],
+          title: "Second patch",
+          done: true,
+        });
+        console.info(
+          "transaction-staging-receipt",
+          JSON.stringify({
+            count,
+            updated: updates.length,
+            seedMs,
+            readMs,
+            stageMs,
+            commitMs,
+          }),
+        );
+      } finally {
+        await db.shutdown();
+      }
+    }, 120_000);
+  }
+});

--- a/packages/jazz-tools/tests/browser/indexeddb-physical-epoch.test.ts
+++ b/packages/jazz-tools/tests/browser/indexeddb-physical-epoch.test.ts
@@ -1,3 +1,4 @@
+import { acquireBrowserPhysicalDatabaseEpoch } from "../../src/runtime/browser-physical-database-epoch.js";
 /**
  * Real-browser physical epoch receipts for the raw IndexedDB page store.
  * This intentionally bypasses MemoryPageStore and the SharedWorker: it writes
@@ -28,6 +29,46 @@ afterEach(async () => {
 });
 
 describe("IndexedDB physical epoch", () => {
+  it("reclaims pages only during one live Web Lock epoch and reopens the published closure", async () => {
+    const name = databaseName();
+    const epoch = await acquireBrowserPhysicalDatabaseEpoch(name);
+    const store = await IndexedDbPageStore.open(name);
+    try {
+      await store.claimBrowserWorkerEpoch(epoch.id, epoch);
+      store.claimTreeOwnership();
+      expect(store.canReclaimObsoletePages).toBe(true);
+      await expect(acquireBrowserPhysicalDatabaseEpoch(name)).rejects.toThrow("active in another");
+      await store.commit({
+        expectedGeneration: 0,
+        metadata: { pageSize: INDEXEDDB_BTREE_PAGE_SIZE, rootPageId: 1, nextPageId: 2 },
+        pages: new Map([[1, new Uint8Array([1])]]),
+      });
+      await store.commit({
+        expectedGeneration: 1,
+        metadata: { pageSize: INDEXEDDB_BTREE_PAGE_SIZE, rootPageId: 2, nextPageId: 3 },
+        pages: new Map([[2, new Uint8Array([2])]]),
+        deletedPageIds: [1],
+      });
+      expect(await store.readPage(1)).toBeNull();
+      expect(await store.readPage(2)).toEqual(new Uint8Array([2]));
+      const release = store.releaseBrowserWorkerEpoch(epoch.id);
+      expect(store.canReclaimObsoletePages).toBe(false);
+      await release;
+    } finally {
+      store.close();
+      await epoch.release();
+    }
+    const reopened = await IndexedDbPageStore.open(name);
+    try {
+      expect(reopened.canReclaimObsoletePages).toBe(false);
+      expect((await reopened.metadata())?.rootPageId).toBe(2);
+      expect(await reopened.readPage(2)).toEqual(new Uint8Array([2]));
+      expect(await reopened.readPage(1)).toBeNull();
+    } finally {
+      reopened.close();
+    }
+  });
+
   it("atomically installs one replica node when concurrent first opens share a physical database", async () => {
     const name = databaseName();
     const [first, second] = await Promise.all([

--- a/packages/jazz-tools/vitest.config.browser.ts
+++ b/packages/jazz-tools/vitest.config.browser.ts
@@ -6,7 +6,7 @@ import {
   liveEdgeBackendInsert,
   liveEdgeBackendClose,
 } from "./tests/browser/live-edge-replay-node.js";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { defineConfig } from "vitest/config";
 import wasm from "vite-plugin-wasm";
 import topLevelAwait from "vite-plugin-top-level-await";
@@ -69,6 +69,10 @@ export default defineConfig({
   define: {
     __JAZZ_BROWSER_SOAK__: JSON.stringify(process.env.JAZZ_BROWSER_SOAK ?? ""),
     __JAZZ_ABSTRACT_BENCH__: JSON.stringify(abstractBench),
+    __JAZZ_COLD_LOAD_FIXTURE__: JSON.stringify(process.env.JAZZ_COLD_LOAD_FIXTURE_DIR ?? ""),
+    __JAZZ_COLD_LOAD_RESPONSIVENESS__: JSON.stringify(
+      process.env.JAZZ_COLD_LOAD_RESPONSIVENESS === "1",
+    ),
     __JAZZ_REALISTIC_BROWSER_SCENARIOS__: JSON.stringify(realisticBrowserScenarios),
     __JAZZ_REALISTIC_BROWSER_RUN_ID__: JSON.stringify(realisticBrowserRunId),
     __JAZZ_REALISTIC_BROWSER_LIMIT_OVERRIDES_JSON__: JSON.stringify(realisticBrowserLimitOverrides),
@@ -129,6 +133,17 @@ export default defineConfig({
         },
       ],
       commands: {
+        readColdLoadFixture: async (_context, chunk?: number) => {
+          const directory = process.env.JAZZ_COLD_LOAD_FIXTURE_DIR;
+          if (!directory) throw new Error("JAZZ_COLD_LOAD_FIXTURE_DIR is required");
+          if (chunk !== undefined && (!Number.isSafeInteger(chunk) || chunk < 0))
+            throw new Error("Cold-load fixture chunk must be a non-negative integer");
+          const file =
+            chunk === undefined
+              ? "cold-load-fixture-1500.json"
+              : `cold-load-fixture-1500-pages-${chunk}.json`;
+          return JSON.parse(readFileSync(resolve(directory, file), "utf8"));
+        },
         workerFaultBundleUrl: async () => workerFaultBundle.url(),
         recoverPendingIndexedDbWrites: async ({ context, page }, config) =>
           recoverPendingIndexedDbWrites(context, page, config),


### PR DESCRIPTION
🤖 Base integration PR for the browser performance fixes behind #2746/#2747. Review and merge this together with its follow-up stack: #2772 → #2774 → #2775 → #2778 → #2779. The complete stack passed fresh CI and the full local TypeScript consumer gate at 6b9f0a2a9c; later optimization work remains separate.

This base combines the independently reviewed changes from #2749 (exact row lookup), #2751 (safe IndexedDB reclamation), #2757 (worker startup deadline), #2758 (record validation), #2763 (asynchronous pending-upload recovery), #2764 (transaction-status projection), #2765 (exact parent-history lookup), #2768 (reset guidance) and #2769 (the earlier cancellation-log diagnostics; its final periodic-log amendment is included in #2778), plus the #2750 profiling harness.

Before these fixes, repeated writes accumulated obsolete IndexedDB pages, transaction staging could read a whole table for one row, and reopening a database with pending writes could block the browser event loop. The stack stops future page growth under proven exclusive ownership, reduces repeated decoding/history work, and keeps recovery asynchronous. Its follow-ups fix deferred transaction subscription delivery (#2774), remove synchronous transaction-staging preflight reads entirely (#2778), and stop rereading already locally acknowledged transaction history (#2779).

For an app with 1,500 tasks, the optimized synthetic Chromium measurements were:

- Seed plus local durability: 22.459s → 1.123s.
- Reopen first local all-row query: 2.883s → 1.424s.
- Subscription-first reopen: 1.697s → 0.686s.
- Update 1,350 specific tasks, awaiting local durability after each write with an active subscription: 135.948s → 49.112s. This remains a performance target; it is not a claim that bulk latency is solved.
- Fresh seed storage: 24,200 pages / 209.845MB → 336 pages / 2.77MB; the earlier integrated post-update receipt retained 702 pages / 5.926MB instead of 61,017 pages.

These are synthetic single-run measurements, not guarantees for the reporter’s app or device. A separate clean batched-update receipt staged 1,350 updates in 85ms and committed locally in 7.764s, but reopening after that large batch took 6.628s. The 1.424s reopen result is for the initial seeded state; large batched history remains a cold-load performance target. Correctness checks verify exact changed and untouched row identities, titles, subscription delivery and reopen results. The seven-case compatibility run also loaded an old physical database without resetting it. The memory transaction subscription bug found during batching is fixed by #2774 and verified in the final browser run.

Historical orphan pages are not collected. As agreed, #2753 is deferred: scoped reset/resync guidance explicitly warns that unsynced or local-only data is permanently lost, and preserves account credentials and unrelated databases. Existing databases remain readable without a reset.

Final integrated validation: all CI categories passed in run 34517812150. The local consumer gate passed all 28 Node tasks, 2,245 SDK Node tests, 326 SDK browser tests, five transport checks, framework suites and BandChat/WorkOS/RecordPlayer examples. Existing skips remain explicit. The intermittent BandChat invitation symptom remains tracked under #2655 with the previously agreed nonblocking disposition; passing runs are not claimed as its causal fix.

