### PR TITLE
perf: avoid copying sibling values during browser point reads

### DIFF
--- a/.changeset/browser-point-read-copy.md
+++ b/.changeset/browser-point-read-copy.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reduce browser storage lookup overhead by copying only the requested row value instead of unrelated values in the same page.

--- a/crates/idb-tree/src/lib.rs
+++ b/crates/idb-tree/src/lib.rs
@@ -30,9 +30,9 @@ type LeafEntry = (Vec<u8>, ValueCell);
 /// operation, rather than merely to the structural descent: an overflow chain
 /// must not alias a structural page, and a caller which goes on to inspect a
 /// value must continue using this same ownership set.
-type Descent = (
+type Descent<'a> = (
     PageId,
-    Vec<LeafEntry>,
+    &'a [LeafEntry],
     Vec<(PageId, usize)>,
     HashSet<PageId>,
 );
@@ -456,14 +456,15 @@ impl<S: PageStore> TreeCore<S> {
         let value = entries
             .binary_search_by(|(candidate, _)| candidate.as_slice().cmp(key))
             .ok()
-            .map(|index| entries[index].1.clone());
+            .map(|index| &entries[index].1);
         match value {
-            Some(value) => self
-                .read_value_resident(&value, &mut visited)
-                .map(|attempt| match attempt {
-                    Attempt::Ready(value) => Attempt::Ready(Some(value)),
-                    Attempt::Missing(page_id) => Attempt::Missing(page_id),
-                }),
+            Some(value) => {
+                self.read_value_resident(value, &mut visited)
+                    .map(|attempt| match attempt {
+                        Attempt::Ready(value) => Attempt::Ready(Some(value)),
+                        Attempt::Missing(page_id) => Attempt::Missing(page_id),
+                    })
+            }
             None => Ok(Attempt::Ready(None)),
         }
     }
@@ -476,10 +477,10 @@ impl<S: PageStore> TreeCore<S> {
         // every retained value edge under the same ownership set before doing
         // so; otherwise a point update could silently perpetuate a malformed
         // sibling overflow graph.
-        if let Attempt::Missing(page_id) = self.leaf_values_resident(&entries, &mut visited)? {
+        if let Attempt::Missing(page_id) = self.leaf_values_resident(entries, &mut visited)? {
             return Ok(Attempt::Missing(page_id));
         }
-        let mut entries = entries;
+        let mut entries = entries.to_vec();
         let new_value = self.build_value(value.to_vec())?;
         match entries.binary_search_by(|(candidate, _)| candidate.as_slice().cmp(key)) {
             Ok(index) => {
@@ -501,10 +502,10 @@ impl<S: PageStore> TreeCore<S> {
             return Ok(Attempt::Ready(false));
         };
         // Deletion also republishes all surviving cells in this leaf.
-        if let Attempt::Missing(page_id) = self.leaf_values_resident(&entries, &mut visited)? {
+        if let Attempt::Missing(page_id) = self.leaf_values_resident(entries, &mut visited)? {
             return Ok(Attempt::Missing(page_id));
         }
-        let mut entries = entries;
+        let mut entries = entries.to_vec();
         self.retire_value(&entries[index].1);
         entries.remove(index);
         self.finish_leaf_write(page_id, entries, path)?;
@@ -515,7 +516,7 @@ impl<S: PageStore> TreeCore<S> {
         let Some((_, entries, _, mut visited)) = self.resident_descent(key)? else {
             return Ok(Attempt::Missing(self.missing_page_for_key(key)?));
         };
-        self.leaf_values_resident(&entries, &mut visited)
+        self.leaf_values_resident(entries, &mut visited)
     }
 
     fn try_range(
@@ -676,7 +677,7 @@ impl<S: PageStore> TreeCore<S> {
             .expect("open always installs a root page")
     }
 
-    fn resident_descent(&self, key: &[u8]) -> Result<Option<Descent>, Error> {
+    fn resident_descent(&self, key: &[u8]) -> Result<Option<Descent<'_>>, Error> {
         let mut page_id = self.root_page_id();
         let mut path = Vec::new();
         let mut visited = HashSet::new();
@@ -691,7 +692,7 @@ impl<S: PageStore> TreeCore<S> {
             };
             match page {
                 Page::Leaf { entries } => {
-                    return Ok(Some((page_id, entries.clone(), path, visited)));
+                    return Ok(Some((page_id, entries, path, visited)));
                 }
                 Page::Internal { keys, children } => {
                     let child_index = keys.partition_point(|separator| separator.as_slice() <= key);

--- a/crates/idb-tree/tests/point_read_allocations.rs
+++ b/crates/idb-tree/tests/point_read_allocations.rs
@@ -1,0 +1,77 @@
+//! Public point reads must copy their result, not resident sibling payloads.
+//! Allocation instrumentation is needed because returned rows alone cannot
+//! distinguish a borrowed lookup from cloning the complete resident leaf.
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    cell::Cell,
+};
+
+use futures::{FutureExt, executor::block_on};
+use idb_tree::{IdbTree, MemoryPageStore, Options};
+
+thread_local! {
+    static COUNT_PAYLOADS: Cell<bool> = const { Cell::new(false) };
+    static PAYLOAD_COPIES: Cell<usize> = const { Cell::new(0) };
+}
+
+struct CountingAllocator;
+// Only this integration-test binary uses the allocator. Counts are thread-local
+// and enabled around a warm public read, excluding setup and assertion work.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if layout.size() == 1000 && COUNT_PAYLOADS.try_with(Cell::get).unwrap_or(false) {
+            let _ = PAYLOAD_COPIES.try_with(|count| count.set(count.get() + 1));
+        }
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn payload_copies<T>(read: impl FnOnce() -> T) -> (T, usize) {
+    PAYLOAD_COPIES.set(0);
+    COUNT_PAYLOADS.set(true);
+    let result = read();
+    COUNT_PAYLOADS.set(false);
+    (result, PAYLOAD_COPIES.get())
+}
+
+#[test]
+fn resident_point_reads_copy_only_the_requested_payload() {
+    block_on(async {
+        let store = MemoryPageStore::default();
+        let tree = IdbTree::open(store.clone(), Options::default())
+            .await
+            .unwrap();
+        for key in 0..10_u8 {
+            tree.put(vec![key], vec![key; 1000]).await.unwrap();
+        }
+        tree.put(vec![20], vec![20; 40_000]).await.unwrap();
+        tree.flush().await.unwrap();
+        drop(tree);
+        let tree = IdbTree::open(store, Options::default()).await.unwrap();
+        assert_eq!(tree.get(&[3]).await.unwrap(), Some(vec![3; 1000]));
+        let (result, copies) =
+            payload_copies(|| tree.get(&[3]).now_or_never().expect("resident read"));
+        assert_eq!(result.unwrap(), Some(vec![3; 1000]));
+        assert_eq!(copies, 1, "only the returned inline payload may be copied");
+        let (result, copies) =
+            payload_copies(|| tree.get(&[11]).now_or_never().expect("resident miss"));
+        assert_eq!(result.unwrap(), None);
+        assert_eq!(copies, 0, "missing keys must not copy sibling payloads");
+        // Cold overflow hydration and subsequent cached reads retain exact bytes.
+        assert_eq!(tree.get(&[20]).await.unwrap(), Some(vec![20; 40_000]));
+        assert_eq!(tree.get(&[20]).await.unwrap(), Some(vec![20; 40_000]));
+        tree.put(vec![3], vec![33; 1000]).await.unwrap();
+        tree.delete(&[4]).await.unwrap();
+        assert_eq!(tree.get(&[3]).await.unwrap(), Some(vec![33; 1000]));
+        assert_eq!(tree.get(&[4]).await.unwrap(), None);
+        assert_eq!(tree.get(&[5]).await.unwrap(), Some(vec![5; 1000]));
+        assert_eq!(tree.get(&[20]).await.unwrap(), Some(vec![20; 40_000]));
+    });
+}


### PR DESCRIPTION
🤖 Stacked on #2771. The remaining bulk-update profile spends substantial time on point reads: looking up one transaction-status record clones every value in its B-tree leaf, then clones the selected value again. A status poll therefore copies unrelated sibling payloads even though it never decodes them.

Borrow the resident leaf entries during descent and pass the requested value by reference to the existing reader. The returned value remains owned. Writes still copy their leaf only after validating every retained value edge. Existing cycle/shared-page checks, overflow hydration, missing-page retries, and corruption errors remain in place. There is no storage-format change.

A public-API allocation canary proves a warm hit copies one 1,000-byte payload and a miss copies none, with sibling records in the leaf. Restoring the previous implementation produces 12 allocations and fails the canary. It also checks cold overflow hydration, warm overflow reads, and sibling-preserving writes/deletes. Independent storage correctness/security review passed all 31 IDB tests and reproduced the old-clone mutation failure. The coordinator independently reran the allocation canary. Combined browser measurement is pending.
