### PR TITLE
fix(browser): refresh subscriptions after deferred transaction commits

### DIFF
--- a/.changeset/deferred-transaction-subscriptions.md
+++ b/.changeset/deferred-transaction-subscriptions.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix browser subscriptions remaining stale after a transaction commits with deferred local persistence.

--- a/crates/jazz/src/db/tests/transactions.rs
+++ b/crates/jazz/src/db/tests/transactions.rs
@@ -2891,3 +2891,128 @@ fn mergeable_tx_emits_one_subscription_delta_for_many_writes() {
     assert!(removed.is_empty());
     assert!(subscription.try_next_event().is_none());
 }
+
+// Internal binding-contract coverage: the WASM memory owner defers persistence
+// and drives queued synchronous staging. A pending stream must receive its
+// wake without an unrelated peer, query, or write triggering a refresh.
+#[test]
+fn deferred_queued_mergeable_commit_wakes_existing_subscription() {
+    let schema = doctest_support::schema();
+    let empty = build_public_db_test_schema(PublicSchemaBuilder::new());
+    let families = empty.column_families();
+    let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let db = block_on(Db::open_history_complete(DbConfig::new(
+        empty,
+        doctest_support::MemoryStorage::new(&refs).unwrap(),
+        DbIdentity {
+            node: NodeUuid::from_bytes([0x91; 16]),
+            author: AuthorSubject::for_test_bytes([0xa1; 16]),
+        },
+    )))
+    .unwrap();
+    db.set_deferred_local_persistence(true);
+    let view = db.register_schema_view(schema.clone()).unwrap();
+    let seed = OpenTransactionId::new();
+    db.begin_mergeable(seed).unwrap();
+    let mut ids = Vec::new();
+    for index in 0..20 {
+        ids.push(
+            view.mergeable_tx_ref(seed)
+                .insert(
+                    "todos",
+                    doctest_support::todo_cells(&format!("row {index}"), false),
+                    Default::default(),
+                )
+                .unwrap(),
+        );
+    }
+    db.commit_mergeable_handle(seed).unwrap();
+    for _ in 0..4 {
+        block_on(db.tick()).unwrap();
+    }
+    let query = Query::from("todos");
+    let mut setup_subscription = prepared_subscribe(&view, &query, ReadOpts::default()).unwrap();
+    assert!(
+        matches!(block_on(setup_subscription.next_event()).unwrap(), SubscriptionEvent::Delta { ref added, .. } if added.len() == 20)
+    );
+    drop(setup_subscription);
+    let mut subscription = prepared_subscribe(&view, &query, ReadOpts::default()).unwrap();
+    let initial = block_on(subscription.next_event()).unwrap();
+    assert!(matches!(initial, SubscriptionEvent::Delta { ref added, .. } if added.len() == 20));
+    struct ReaderWake(std::sync::atomic::AtomicUsize);
+    impl std::task::Wake for ReaderWake {
+        fn wake(self: std::sync::Arc<Self>) {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        fn wake_by_ref(self: &std::sync::Arc<Self>) {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+    let reader_wake = std::sync::Arc::new(ReaderWake(std::sync::atomic::AtomicUsize::new(0)));
+    let reader_waker = std::task::Waker::from(reader_wake.clone());
+    assert!(matches!(
+        futures::Stream::poll_next(
+            std::pin::Pin::new(&mut subscription),
+            &mut std::task::Context::from_waker(&reader_waker)
+        ),
+        std::task::Poll::Pending
+    ));
+    let update = OpenTransactionId::new();
+    db.enqueue_begin_mergeable(update, None, None).unwrap();
+    db.drive_queued_mutation_once();
+    for id in ids.iter().take(18) {
+        assert!(
+            block_on(view.local_current_row("todos", *id))
+                .unwrap()
+                .is_some()
+        );
+        view.enqueue_transaction_update(
+            update,
+            "todos".to_owned(),
+            *id,
+            BTreeMap::from([("done".to_owned(), Value::Bool(true))]),
+            Default::default(),
+        )
+        .unwrap();
+        db.drive_queued_mutation_once();
+    }
+    for _ in 0..4 {
+        block_on(db.tick()).unwrap();
+    }
+    let write = db.enqueue_commit_mergeable_handle(update).unwrap();
+    db.drive_queued_mutation_once();
+    for _ in 0..8 {
+        block_on(db.tick()).unwrap();
+    }
+    assert!(
+        reader_wake.0.load(std::sync::atomic::Ordering::Relaxed) > 0,
+        "live subscription reader must be woken by queued transaction publication"
+    );
+    let mut updated_rows = 0;
+    while let Some(mut event) = subscription.try_next_event() {
+        assert!(block_on(view.hydrate_subscription_event_for_binding_outcome(&mut event)).is_ok());
+
+        if let SubscriptionEvent::Delta { updated, added, .. } = event {
+            updated_rows += updated
+                .iter()
+                .chain(added.iter())
+                .filter(|row| row.cell(&schema.tables[0], "done") == Some(Value::Bool(true)))
+                .count();
+        }
+    }
+    assert_eq!(updated_rows, 18);
+    for _ in 0..8 {
+        block_on(db.tick()).unwrap();
+    }
+    let rows = prepared_all(&view, &query, ReadOpts::default());
+    assert_eq!(
+        rows.iter()
+            .filter(|row| row.cell(&schema.tables[0], "done") == Some(Value::Bool(true)))
+            .count(),
+        18
+    );
+    assert_eq!(
+        db.write_state(write.tx_id).unwrap().durability,
+        DurabilityTier::Local
+    );
+}

--- a/crates/jazz/src/db/tests/transactions.rs
+++ b/crates/jazz/src/db/tests/transactions.rs
@@ -3016,3 +3016,105 @@ fn deferred_queued_mergeable_commit_wakes_existing_subscription() {
         DurabilityTier::Local
     );
 }
+
+// Internal binding-contract coverage: controlled storage holds the persistence
+// continuation after a queued transaction has transferred publication ownership.
+#[test]
+fn deferred_queued_mergeable_visibility_does_not_claim_blocked_or_failed_durability() {
+    use groove::storage::{TestStorage, TestStorageOperation};
+    for fail_persistence in [false, true] {
+        let schema = doctest_support::schema();
+        let families = schema.column_families();
+        let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+        let (storage, control) = TestStorage::controlled(&refs);
+        let db = block_on(Db::open_history_complete(DbConfig::new(
+            schema.clone(),
+            storage,
+            DbIdentity {
+                node: NodeUuid::from_bytes([0x93; 16]),
+                author: AuthorSubject::for_test_bytes([0xa3; 16]),
+            },
+        )))
+        .unwrap();
+        db.set_deferred_local_persistence(true);
+        let mut subscription =
+            prepared_subscribe(&db, &Query::from("todos"), ReadOpts::default()).unwrap();
+        let _ = block_on(subscription.next_event()).unwrap();
+        let open = OpenTransactionId::new();
+        db.begin_mergeable(open).unwrap();
+        let inserted = db
+            .mergeable_tx_ref(open)
+            .insert(
+                "todos",
+                doctest_support::todo_cells("locally visible", false),
+                Default::default(),
+            )
+            .unwrap();
+        control.pause_on(TestStorageOperation::WriteMany);
+        let write = db.enqueue_commit_mergeable_handle(open).unwrap();
+        // Drive only the retained commit/refresh owner, never durability.
+        for _ in 0..128 {
+            db.drive_queued_mutation_once();
+            if matches!(
+                *write.queued_status.as_ref().unwrap().borrow(),
+                QueuedMutationStatus::Published
+            ) {
+                break;
+            }
+        }
+        assert!(matches!(
+            *write.queued_status.as_ref().unwrap().borrow(),
+            QueuedMutationStatus::Published
+        ));
+        let Some(SubscriptionEvent::Delta { added, .. }) = subscription.try_next_event() else {
+            panic!("local publication must refresh before persistence completes");
+        };
+        assert_eq!(added.len(), 1);
+        assert_eq!(added[0].row_uuid(), inserted);
+        assert_eq!(
+            db.write_state(write.tx_id).unwrap().durability,
+            DurabilityTier::None
+        );
+        assert_eq!(
+            block_on(write.wait(DurabilityTier::Local))
+                .unwrap_err()
+                .code,
+            ErrorCode::NotObserved
+        );
+        let mut tick = Box::pin(db.tick());
+        assert!(matches!(
+            tick.as_mut().poll(&mut Context::from_waker(Waker::noop())),
+            Poll::Pending
+        ));
+        assert!(control.poll_count(TestStorageOperation::WriteMany) > 0);
+        drop(tick); // Cancellation must retain the node-owned persistence future.
+        assert_eq!(
+            db.write_state(write.tx_id).unwrap().durability,
+            DurabilityTier::None
+        );
+        if fail_persistence {
+            control.fail_next(TestStorageOperation::WriteMany);
+        }
+        control.resume_operation(TestStorageOperation::WriteMany);
+        if fail_persistence {
+            assert!(
+                block_on(db.tick()).is_err(),
+                "persistence failure must surface"
+            );
+            assert!(
+                block_on(write.wait(DurabilityTier::Local)).is_err(),
+                "failed persistence must not issue a Local receipt"
+            );
+        } else {
+            block_on(db.tick()).unwrap();
+            assert_eq!(
+                block_on(write.wait(DurabilityTier::Local)).unwrap(),
+                write.tx_id
+            );
+            assert_eq!(
+                db.write_state(write.tx_id).unwrap().durability,
+                DurabilityTier::Local
+            );
+        }
+    }
+}

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -707,7 +707,8 @@ where
                     .await?;
                 debug_assert_eq!(published.tx_id, tx_id);
                 if db.node.defer_local_persistence.get() {
-                    db.node.queue_local_publication(published, None);
+                    db.finish_deferred_local_publication(published, None)
+                        .await?;
                 } else {
                     db.finish_publication_outcome(PublicationOutcome::published((), published))
                         .await?;

--- a/packages/jazz-tools/tests/browser/db.transaction-subscription.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-subscription.test.ts
@@ -1,0 +1,71 @@
+import { expect, it } from "vitest";
+import { generateAuthSecret, schema, type RowOf } from "../../src/index.js";
+import { createBrowserTestDb as createDb } from "./account-fixtures.js";
+import { waitForCondition } from "./support.js";
+
+const app = schema.defineApp({
+  todos: schema.table({ title: schema.string(), done: schema.boolean() }),
+});
+
+it("delivers a queued memory transaction to an existing local subscription", async () => {
+  const db = await createDb({
+    appId: crypto.randomUUID(),
+    secret: generateAuthSecret(),
+    driver: { type: "memory" },
+  });
+  let stop = () => {};
+  let visible: RowOf<typeof app.todos>[] = [];
+  const errors: Error[] = [];
+  const subscribe = () =>
+    db.subscribe(
+      app.todos,
+      {
+        onUpdate(rows) {
+          visible = rows;
+        },
+        onError(error) {
+          errors.push(error);
+        },
+      },
+      { tier: "local" },
+    );
+  try {
+    const seeded = await db.transaction((tx) => {
+      tx.insert(app.todos, { title: "pending task", done: false });
+    });
+    await seeded.wait({ tier: "local" });
+    const [row] = await db.all(app.todos, { tier: "local" });
+
+    // Reopening the same query mirrors application subscription lifetimes.
+    stop = subscribe();
+    await waitForCondition(
+      async () => visible.length === 1,
+      2_000,
+      "setup subscription did not open",
+    );
+    stop();
+    visible = [];
+    stop = subscribe();
+    await waitForCondition(
+      async () => visible.length === 1,
+      2_000,
+      "active subscription did not open",
+    );
+    expect(visible[0].done).toBe(false);
+
+    const tx = db.beginTransaction();
+    tx.update(app.todos, row.id, { done: true });
+    await Promise.resolve();
+    await tx.commit().wait({ tier: "local" });
+    await waitForCondition(
+      async () => visible.length === 1 && visible[0].done,
+      2_000,
+      "committed memory transaction did not reach its local subscription",
+    );
+    expect(errors).toEqual([]);
+    expect(await db.all(app.todos, { tier: "local" })).toEqual(visible);
+  } finally {
+    stop();
+    await db.shutdown();
+  }
+});


### PR DESCRIPTION
🤖 Stacked on #2772; fixes #2770. Browser memory runtimes defer local persistence. When an app updates several rows through one queued transaction, that path published resident state and scheduled persistence but omitted the local-subscription refresh used by ordinary writes. Direct reads therefore saw the changes while an established subscription stayed stale indefinitely.

For example, subscribe to 20 unfinished tasks, then mark 18 specific tasks done in one transaction. The subscription must receive those 18 updates without requiring another write or a direct query. Route queued mergeable commits through the existing deferred-publication helper: first hand the publication to the runtime so persistence remains owned, then refresh local subscribers. This preserves immediate local visibility and does not grant durability before persistence completes. No new tick ordering, storage format or wire behavior is introduced.

A focused authenticated, history-complete owner/schema-view test reproduces the browser lifecycle, including unsubscribe/re-subscribe and a waiting stream reader. The old implementation failed the 1,500-row diagnostic; the smaller 20/18 canary passes with the fix. The blocked/failed-persistence canary verifies resident delivery before persistence, durability None while blocked, retained ownership after cancelling a tick, successful Local durability, and failure without a Local receipt. Independent correctness/security review passed 12 focused tests; restoring the old queue-only call fails both new native canaries. A one-row public browser regression is included; fixed-artifact browser confirmation and the complete integrated browser/Node consumer gate passed at 6b9f0a2a9c.

