### PR TITLE
perf: validate inline scalar bytes without owned round trips

### DIFF
--- a/.changeset/borrowed-inline-scalar-validation.md
+++ b/.changeset/borrowed-inline-scalar-validation.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reduce validation overhead when reading inline scalar values without changing their storage encoding.

--- a/crates/groove/SPEC/9_large_values.md
+++ b/crates/groove/SPEC/9_large_values.md
@@ -92,6 +92,10 @@ parameterized by the immutable kind supplied by schema lowering, so neither
 physical arm duplicates that context. Inline payloads are interpreted as the
 primitive selected by that schema; the same raw UTF-8 content can therefore be
 a valid string or JSON value when stored under the corresponding column kind.
+The primitive arm contains only slot 1, a trailing raw field: its payload is
+exactly the logical bytes, without record headers, offsets, or reserved slots.
+Borrowed inline access validates the enum framing and logical kind directly;
+this preserves decode/recreate acceptance without constructing owned values.
 Every independently addressed immutable tree node carries and authenticates its
 own format and kind before traversal. Internal raw string/bytes backing primitives
 only terminate this self-hosting enum encoding and are impossible at the public

--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -2323,30 +2323,18 @@ pub fn decode_stored_scalar(kind: LargeValueKind, encoded: &[u8]) -> Result<Stor
 }
 
 pub fn inline_scalar_bytes(kind: LargeValueKind, encoded: &[u8]) -> Result<&[u8], Error> {
-    let schema = stored_scalar_schema(kind);
     let (tag, payload) =
         crate::records::split_variant_record(encoded).map_err(|_| Error::MalformedScalar)?;
     match tag {
         2 => {
-            let descriptor = schema.case(2).map_err(|_| Error::MalformedScalar)?.payload;
-            let values = descriptor
-                .bind(payload)
-                .to_values()
-                .map_err(|_| Error::MalformedScalar)?;
-            let mut fields = primitive_payload_schema(kind).decode_values(&values)?;
-            let value = take_durable_large_value_field(&mut fields, PRIMITIVE_VALUE_FIELD)?;
-            if primitive_bytes(kind, &value).is_err()
-                || descriptor
-                    .create(&values)
-                    .map_err(|_| Error::MalformedScalar)?
-                    != payload
-            {
-                return Err(Error::MalformedScalar);
-            }
-            let span = descriptor
-                .field_span(payload, usize::from(PRIMITIVE_VALUE_FIELD - 1))
-                .map_err(|_| Error::MalformedScalar)?;
-            Ok(&payload[span])
+            // Primitive has exactly one field, slot 1: raw bytes or raw string.
+            // A sole trailing raw field has no header, offsets, padding, or
+            // reserved slots: its canonical record is the payload itself.
+            // split_variant_record already validates the complete tag framing.
+            // Thus logical validation is precisely the old decode/recreate
+            // acceptance check, without allocating copies merely to borrow it.
+            validate_logical(kind, payload).map_err(|_| Error::MalformedScalar)?;
+            Ok(payload)
         }
         3 => {
             // Validate the complete descriptor before reporting that materialization is needed.
@@ -8098,6 +8086,108 @@ mod tests {
             0,
             "an already-inline current row must pass through without scalar re-encoding"
         );
+    }
+
+    fn reference_inline_scalar_bytes(kind: LargeValueKind, encoded: &[u8]) -> Result<&[u8], Error> {
+        let schema = stored_scalar_schema(kind);
+        let (tag, payload) =
+            crate::records::split_variant_record(encoded).map_err(|_| Error::MalformedScalar)?;
+        match tag {
+            2 => {
+                let descriptor = schema.case(2).map_err(|_| Error::MalformedScalar)?.payload;
+                let values = descriptor
+                    .bind(payload)
+                    .to_values()
+                    .map_err(|_| Error::MalformedScalar)?;
+                let mut fields = primitive_payload_schema(kind).decode_values(&values)?;
+                let value = take_durable_large_value_field(&mut fields, PRIMITIVE_VALUE_FIELD)?;
+                if primitive_bytes(kind, &value).is_err()
+                    || descriptor
+                        .create(&values)
+                        .map_err(|_| Error::MalformedScalar)?
+                        != payload
+                {
+                    return Err(Error::MalformedScalar);
+                }
+                let span = descriptor
+                    .field_span(payload, usize::from(PRIMITIVE_VALUE_FIELD - 1))
+                    .map_err(|_| Error::MalformedScalar)?;
+                Ok(&payload[span])
+            }
+            3 => {
+                // Validate the complete descriptor before reporting that materialization is needed.
+                let _ = decode_stored_scalar(kind, encoded)?;
+                Err(Error::RequiresEvaluation)
+            }
+            _ => Err(Error::MalformedScalar),
+        }
+    }
+
+    #[test]
+    fn borrowed_inline_scalar_matches_roundtrip_oracle() {
+        // Pin the premise of the borrowed path: slot 1 is the sole trailing
+        // raw field. There are no reserved slots, offsets, or padding to skip.
+        for kind in [
+            LargeValueKind::Bytes,
+            LargeValueKind::String,
+            LargeValueKind::Json,
+        ] {
+            let schema = primitive_payload_schema(kind);
+            assert_eq!(schema.slots, [DurableLargeValueRecordSlot::Known(1)]);
+            assert_eq!(schema.descriptor.fields().len(), 1);
+            assert_eq!(
+                schema.descriptor.fields()[0].value_type,
+                if kind == LargeValueKind::Bytes {
+                    ValueType::raw_bytes()
+                } else {
+                    ValueType::raw_string()
+                }
+            );
+            let check = |bytes: &[u8]| {
+                assert_eq!(
+                    inline_scalar_bytes(kind, bytes),
+                    reference_inline_scalar_bytes(kind, bytes),
+                    "kind={kind:?}, bytes={bytes:?}"
+                );
+            };
+            for payload in [
+                b"".as_slice(),
+                b"plain",
+                b"{}",
+                b"null",
+                b" {\"a\":1,\"a\":2} ",
+                b"{}x",
+                b"[1,",
+                b"\xff",
+                b"\0",
+                "text 🙂".as_bytes(),
+            ] {
+                let encoded = [b"\x02".as_slice(), payload].concat();
+                check(&encoded);
+                for end in 0..encoded.len() {
+                    check(&encoded[..end]);
+                }
+                for index in 0..encoded.len() {
+                    for replacement in 0..=255 {
+                        let mut changed = encoded.clone();
+                        changed[index] = replacement;
+                        check(&changed);
+                    }
+                }
+                for prefix in [
+                    vec![0],
+                    vec![1],
+                    vec![4],
+                    vec![0x82, 0],
+                    vec![0x82, 0x80, 0],
+                    vec![0xff; 12],
+                ] {
+                    check(&[prefix.as_slice(), payload].concat());
+                }
+            }
+            let large = vec![b' '; 65536];
+            check(&[b"\x02".as_slice(), &large].concat());
+        }
     }
 
     #[test]

--- a/crates/groove/tests/inline_scalar_allocations.rs
+++ b/crates/groove/tests/inline_scalar_allocations.rs
@@ -1,0 +1,51 @@
+//! Borrowing inline bytes/string payloads must not allocate owned copies.
+use groove::large_values::{
+    LargeValueKind, StoredScalar, encode_stored_scalar, inline_scalar_bytes,
+};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::hint::black_box;
+
+struct CountingAllocator;
+thread_local! {
+    static ACTIVE: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+}
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+fn record_allocation() {
+    if ACTIVE.try_with(Cell::get).unwrap_or(false) {
+        let _ = ALLOCATIONS.try_with(|count| count.set(count.get() + 1));
+    }
+}
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        record_allocation();
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        record_allocation();
+        unsafe { System.realloc(ptr, layout, size) }
+    }
+}
+#[test]
+fn inline_scalar_borrowing_does_not_allocate() {
+    for kind in [LargeValueKind::Bytes, LargeValueKind::String] {
+        for size in [0, 32, 65536] {
+            let encoded =
+                encode_stored_scalar(kind, &StoredScalar::Primitive(vec![b'a'; size])).unwrap();
+            inline_scalar_bytes(kind, &encoded).unwrap();
+            ALLOCATIONS.with(|count| count.set(0));
+            ACTIVE.with(|active| active.set(true));
+            let result = black_box(inline_scalar_bytes(black_box(kind), black_box(&encoded)));
+            ACTIVE.with(|active| active.set(false));
+            let borrowed = result.unwrap();
+            assert_eq!(borrowed.len(), size);
+            assert_eq!(borrowed.as_ptr(), encoded[1..].as_ptr());
+            assert_eq!(ALLOCATIONS.with(Cell::get), 0, "kind={kind:?}, size={size}");
+        }
+    }
+}


### PR DESCRIPTION
🤖 Stacked on #2774. Fresh browser cold-load profiles identify inline scalar access as repeated native CPU work: the accessor decodes owned values, builds a field map, clones the payload, and recreates the record to validate it, even though its result is a borrowed byte slice.

Primitive scalar tag 2 has exactly one raw bytes/string field in slot 1. Its canonical record payload is therefore the field itself, with no offset table, padding or reserved slots. After the existing variant framing check, validate the same logical Bytes/String/JSON rules and return that borrowed payload. Indirect tag 3 remains on the existing decoder; error mapping and validation precedence are preserved. No wire or storage bytes change.

Tests pin the schema premise, compare exact results/errors with the previous round-trip implementation over malformed framing, UTF-8/JSON, truncation and per-byte mutations, and check zero-allocation borrowed bytes/string access for several payload sizes. JSON keeps its existing logical parser and allocations. Removing logical validation fails the oracle; restoring the old implementation fails the allocation canary. Independent codec correctness/security review passed, including 57 large-value tests, the allocation canary, and 24 query tests. Supplemental checks covered indirect descriptors, error precedence and JSON/UTF-8 boundaries. The coordinator independently reran the oracle and allocation tests. A clean optimized browser run at bf942bfb5b measured reopen first-all at 1.418s versus 1.733s on the preceding measured stack, subscription-first at 0.681s versus 0.902s, and post-update reopen at 2.349s versus 2.979s. Exact identities, titles and the selected 1,350 completed / 150 untouched rows survived reopen. Ordinary updates measured 50.751s versus 52.292s; this small single-run difference is not evidence of a substantial bulk-write improvement. Final integrated correctness acceptance remains in progress.
