### PR TITLE
fix: stage transaction patches without synchronous preflight reads

### DIFF
--- a/.changeset/queued-transaction-patch-staging.md
+++ b/.changeset/queued-transaction-patch-staging.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Avoid synchronous transaction preflight reads that can block the host while queued database work holds the owner lock.

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -2477,25 +2477,7 @@ where
         // Raw Rust RowCells deliberately permit sparse rows. The typed
         // binding queue opts into complete insertion checks instead.
         if require_complete_insert && parents.is_empty() {
-            let schema = self.table_schema(table)?;
-            for column in &schema.columns {
-                if !schema.branch_by.contains(&column.name)
-                    && !cells.contains_key(&column.name)
-                    && column.default.is_none()
-                    && !matches!(
-                        column.column_type,
-                        GrooveColumnType::Nullable(_) | GrooveColumnType::Array(_)
-                    )
-                {
-                    return Err(Error::new(
-                        ErrorCode::WriteRejected,
-                        format!(
-                            "missing required field `{}` on table `{table}`",
-                            column.name
-                        ),
-                    ));
-                }
-            }
+            self.validate_complete_binding_insert(table, &cells)?;
         }
 
         self.write_mergeable_at_ms_with_authorship_in_branch(
@@ -3095,6 +3077,33 @@ where
             .iter()
             .find(|candidate| candidate.name == table)
             .ok_or_else(|| Error::new(ErrorCode::Schema, format!("unknown table {table}")))
+    }
+
+    pub(super) fn validate_complete_binding_insert(
+        &self,
+        table: &str,
+        cells: &RowCells,
+    ) -> Result<(), Error> {
+        let schema = self.table_schema(table)?;
+        for column in &schema.columns {
+            if !schema.branch_by.contains(&column.name)
+                && !cells.contains_key(&column.name)
+                && column.default.is_none()
+                && !matches!(
+                    column.column_type,
+                    GrooveColumnType::Nullable(_) | GrooveColumnType::Array(_)
+                )
+            {
+                return Err(Error::new(
+                    ErrorCode::WriteRejected,
+                    format!(
+                        "missing required field `{}` on table `{table}`",
+                        column.name
+                    ),
+                ));
+            }
+        }
+        Ok(())
     }
 
     pub(super) fn apply_insert_defaults(

--- a/crates/jazz/src/db/tests/transactions.rs
+++ b/crates/jazz/src/db/tests/transactions.rs
@@ -3123,70 +3123,165 @@ fn deferred_queued_mergeable_visibility_does_not_claim_blocked_or_failed_durabil
 // writes, without a synchronous bridge preflight or a whole-table read.
 #[test]
 fn queued_transaction_upsert_validates_insert_after_staged_overlay() {
-    let schema = doctest_support::schema();
-    let families = schema.column_families();
-    let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
-    let db = block_on(Db::open_history_complete(DbConfig::new(
-        schema.clone(),
-        doctest_support::MemoryStorage::new(&refs).unwrap(),
-        DbIdentity {
-            node: NodeUuid::from_bytes([0x95; 16]),
-            author: AuthorSubject::for_test_bytes([0xa5; 16]),
-        },
-    )))
-    .unwrap();
-    let missing = RowUuid::from_bytes([0x96; 16]);
-    let bad = OpenTransactionId::new();
-    db.begin_mergeable(bad).unwrap();
-    db.enqueue_transaction_upsert(
-        bad,
-        "todos".into(),
-        missing,
-        BTreeMap::from([("done".into(), Value::Bool(true))]),
-        Default::default(),
-    )
-    .unwrap();
-    let rejected = db.enqueue_commit_mergeable_handle(bad).unwrap();
-    for _ in 0..16 {
-        db.drive_queued_mutation_once();
-    }
-    let error = block_on(rejected.wait(DurabilityTier::Local)).unwrap_err();
-    assert!(error.message.contains("missing required field"), "{error}");
-    assert!(
-        block_on(db.local_current_row("todos", missing))
-            .unwrap()
-            .is_none()
-    );
-
-    let good = OpenTransactionId::new();
-    db.begin_mergeable(good).unwrap();
-    db.enqueue_transaction_upsert(
-        good,
-        "todos".into(),
-        missing,
-        doctest_support::todo_cells("retained title", false),
-        Default::default(),
-    )
-    .unwrap();
-    db.enqueue_transaction_upsert(
-        good,
-        "todos".into(),
-        missing,
-        BTreeMap::from([("done".into(), Value::Bool(true))]),
-        Default::default(),
-    )
-    .unwrap();
-    let committed = db.enqueue_commit_mergeable_handle(good).unwrap();
-    for _ in 0..16 {
-        db.drive_queued_mutation_once();
-    }
-    block_on(committed.wait(DurabilityTier::Local)).unwrap();
-    let row = block_on(db.local_current_row("todos", missing))
-        .unwrap()
+    for exclusive in [false, true] {
+        let schema = build_public_db_test_schema(
+            PublicSchemaBuilder::new().table(
+                PublicTableSchemaBuilder::new("todos")
+                    .column("title", PublicColumnType::Text)
+                    .column_with_default(
+                        "done",
+                        PublicColumnType::Boolean,
+                        crate::tools::public_api::types::Value::Boolean(false),
+                    ),
+            ),
+        );
+        let families = schema.column_families();
+        let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+        let db = block_on(Db::open_history_complete(DbConfig::new(
+            schema.clone(),
+            doctest_support::MemoryStorage::new(&refs).unwrap(),
+            DbIdentity {
+                node: NodeUuid::from_bytes([0x95; 16]),
+                author: AuthorSubject::for_test_bytes([0xa5; 16]),
+            },
+        )))
         .unwrap();
-    assert_eq!(
-        row.cell(&schema.tables[0], "title"),
-        Some(Value::String("retained title".into()))
-    );
-    assert_eq!(row.cell(&schema.tables[0], "done"), Some(Value::Bool(true)));
+        let missing = RowUuid::from_bytes([0x96; 16]);
+        let bad = OpenTransactionId::new();
+        if exclusive {
+            db.begin_exclusive(bad).unwrap();
+        } else {
+            db.begin_mergeable(bad).unwrap();
+        }
+        db.enqueue_transaction_upsert(
+            bad,
+            "todos".into(),
+            missing,
+            BTreeMap::from([("done".into(), Value::Bool(true))]),
+            Default::default(),
+        )
+        .unwrap();
+        let rejected = if exclusive {
+            db.enqueue_commit_exclusive_handle(bad).unwrap()
+        } else {
+            db.enqueue_commit_mergeable_handle(bad).unwrap()
+        };
+        for _ in 0..16 {
+            db.drive_queued_mutation_once();
+        }
+        let error = block_on(rejected.wait(DurabilityTier::Local)).unwrap_err();
+        assert!(error.message.contains("missing required field"), "{error}");
+        assert!(
+            block_on(db.local_current_row("todos", missing))
+                .unwrap()
+                .is_none()
+        );
+
+        let good = OpenTransactionId::new();
+        if exclusive {
+            db.begin_exclusive(good).unwrap();
+        } else {
+            db.begin_mergeable(good).unwrap();
+        }
+        db.enqueue_transaction_upsert(
+            good,
+            "todos".into(),
+            missing,
+            doctest_support::todo_cells("retained title", false),
+            Default::default(),
+        )
+        .unwrap();
+        db.enqueue_transaction_upsert(
+            good,
+            "todos".into(),
+            missing,
+            BTreeMap::from([("done".into(), Value::Bool(true))]),
+            Default::default(),
+        )
+        .unwrap();
+        let committed = if exclusive {
+            db.enqueue_commit_exclusive_handle(good).unwrap()
+        } else {
+            db.enqueue_commit_mergeable_handle(good).unwrap()
+        };
+        for _ in 0..16 {
+            db.drive_queued_mutation_once();
+        }
+        block_on(committed.wait(DurabilityTier::Local)).unwrap();
+        let row = block_on(db.local_current_row("todos", missing))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.cell(&schema.tables[0], "title"),
+            Some(Value::String("retained title".into()))
+        );
+        assert_eq!(row.cell(&schema.tables[0], "done"), Some(Value::Bool(true)));
+
+        // A new row may omit a defaulted field, but later partial patches must
+        // preserve both that field and the preceding staged title.
+        let default_row = RowUuid::from_bytes([0x97; 16]);
+        let defaults = OpenTransactionId::new();
+        if exclusive {
+            db.begin_exclusive(defaults).unwrap();
+        } else {
+            db.begin_mergeable(defaults).unwrap();
+        }
+        db.enqueue_transaction_upsert(
+            defaults,
+            "todos".into(),
+            default_row,
+            BTreeMap::from([("title".into(), Value::String("defaulted".into()))]),
+            Default::default(),
+        )
+        .unwrap();
+        let committed = if exclusive {
+            db.enqueue_commit_exclusive_handle(defaults).unwrap()
+        } else {
+            db.enqueue_commit_mergeable_handle(defaults).unwrap()
+        };
+        for _ in 0..16 {
+            db.drive_queued_mutation_once();
+        }
+        block_on(committed.wait(DurabilityTier::Local)).unwrap();
+        assert_eq!(
+            block_on(db.local_current_row("todos", default_row))
+                .unwrap()
+                .unwrap()
+                .cell(&schema.tables[0], "done"),
+            Some(Value::Bool(false))
+        );
+
+        let chain = OpenTransactionId::new();
+        if exclusive {
+            db.begin_exclusive(chain).unwrap();
+        } else {
+            db.begin_mergeable(chain).unwrap();
+        }
+        db.enqueue_transaction_delete(chain, "todos".into(), missing, Default::default())
+            .unwrap();
+        db.enqueue_transaction_upsert(
+            chain,
+            "todos".into(),
+            missing,
+            doctest_support::todo_cells("replacement", false),
+            Default::default(),
+        )
+        .unwrap();
+        let committed = if exclusive {
+            db.enqueue_commit_exclusive_handle(chain).unwrap()
+        } else {
+            db.enqueue_commit_mergeable_handle(chain).unwrap()
+        };
+        for _ in 0..16 {
+            db.drive_queued_mutation_once();
+        }
+        block_on(committed.wait(DurabilityTier::Local)).unwrap();
+        assert_eq!(
+            block_on(db.local_current_row("todos", missing))
+                .unwrap()
+                .unwrap()
+                .cell(&schema.tables[0], "title"),
+            Some(Value::String("replacement".into()))
+        );
+    }
 }

--- a/crates/jazz/src/db/tests/transactions.rs
+++ b/crates/jazz/src/db/tests/transactions.rs
@@ -3118,3 +3118,75 @@ fn deferred_queued_mergeable_visibility_does_not_claim_blocked_or_failed_durabil
         }
     }
 }
+
+// Binding-owner coverage: required fields are classified after preceding staged
+// writes, without a synchronous bridge preflight or a whole-table read.
+#[test]
+fn queued_transaction_upsert_validates_insert_after_staged_overlay() {
+    let schema = doctest_support::schema();
+    let families = schema.column_families();
+    let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let db = block_on(Db::open_history_complete(DbConfig::new(
+        schema.clone(),
+        doctest_support::MemoryStorage::new(&refs).unwrap(),
+        DbIdentity {
+            node: NodeUuid::from_bytes([0x95; 16]),
+            author: AuthorSubject::for_test_bytes([0xa5; 16]),
+        },
+    )))
+    .unwrap();
+    let missing = RowUuid::from_bytes([0x96; 16]);
+    let bad = OpenTransactionId::new();
+    db.begin_mergeable(bad).unwrap();
+    db.enqueue_transaction_upsert(
+        bad,
+        "todos".into(),
+        missing,
+        BTreeMap::from([("done".into(), Value::Bool(true))]),
+        Default::default(),
+    )
+    .unwrap();
+    let rejected = db.enqueue_commit_mergeable_handle(bad).unwrap();
+    for _ in 0..16 {
+        db.drive_queued_mutation_once();
+    }
+    let error = block_on(rejected.wait(DurabilityTier::Local)).unwrap_err();
+    assert!(error.message.contains("missing required field"), "{error}");
+    assert!(
+        block_on(db.local_current_row("todos", missing))
+            .unwrap()
+            .is_none()
+    );
+
+    let good = OpenTransactionId::new();
+    db.begin_mergeable(good).unwrap();
+    db.enqueue_transaction_upsert(
+        good,
+        "todos".into(),
+        missing,
+        doctest_support::todo_cells("retained title", false),
+        Default::default(),
+    )
+    .unwrap();
+    db.enqueue_transaction_upsert(
+        good,
+        "todos".into(),
+        missing,
+        BTreeMap::from([("done".into(), Value::Bool(true))]),
+        Default::default(),
+    )
+    .unwrap();
+    let committed = db.enqueue_commit_mergeable_handle(good).unwrap();
+    for _ in 0..16 {
+        db.drive_queued_mutation_once();
+    }
+    block_on(committed.wait(DurabilityTier::Local)).unwrap();
+    let row = block_on(db.local_current_row("todos", missing))
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        row.cell(&schema.tables[0], "title"),
+        Some(Value::String("retained title".into()))
+    );
+    assert_eq!(row.cell(&schema.tables[0], "done"), Some(Value::Bool(true)));
+}

--- a/crates/jazz/src/db/transactions.rs
+++ b/crates/jazz/src/db/transactions.rs
@@ -931,6 +931,15 @@ where
             id,
             Box::pin(async move {
                 let exclusive = db.transaction_is_exclusive(id).await?;
+                // Typed bindings submit patches without a synchronous preflight.
+                // Preserve complete-insert validation once the owner has resolved
+                // the transaction's staged overlay (raw Rust APIs allow sparse rows).
+                if matches!(&options.target, WriteTarget::Root)
+                    && db.transaction_read_raw(id, &table, row).await?.is_none()
+                {
+                    db.validate_complete_binding_insert(&table, &cells)?;
+                }
+
                 if exclusive {
                     db.exclusive_tx_ref(id)
                         .upsert(&table, row, cells, options)

--- a/dev/gates/run-ts-tests.sh
+++ b/dev/gates/run-ts-tests.sh
@@ -21,7 +21,7 @@ fi
 # the suites that GitHub will run. Check this before the producer admission so
 # an unsafe inherited control always gets its own actionable diagnostic.
 if [[ "${JAZZ_REQUIRE_CI_TEST_COMMANDS:-0}" == "1" ]]; then
-  for override in JAZZ_NODE_TEST_COMMAND JAZZ_BROWSER_TEST_COMMAND JAZZ_SKIP_JAZZ_TOOLS_BUILD; do
+  for override in JAZZ_NODE_TEST_COMMAND JAZZ_BROWSER_TEST_COMMAND JAZZ_SKIP_JAZZ_TOOLS_BUILD JAZZ_TEST_LOG_INTERVAL_SECONDS; do
     if printenv "${override}" >/dev/null 2>&1; then
       echo "${override} is a test-harness override and is forbidden by the CI-equivalent partition" >&2
       exit 1
@@ -55,6 +55,12 @@ node_tests_command=${JAZZ_NODE_TEST_COMMAND:-"pnpm test --filter=!moon-lander-re
 browser_tests_command=${JAZZ_BROWSER_TEST_COMMAND:-"pnpm --parallel --filter jazz-tools --filter inspector --filter band-chat-nextjs-betterauth --filter record-player-next-betterauth --filter auth-workos-chat test:browser"}
 node_tests_pid=""
 browser_tests_pid=""
+log_monitor_pid=""
+log_interval=${JAZZ_TEST_LOG_INTERVAL_SECONDS:-30}
+if [[ ! "${log_interval}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "JAZZ_TEST_LOG_INTERVAL_SECONDS must be a positive integer" >&2
+  exit 1
+fi
 log_dir=${RUNNER_TEMP:-/tmp}
 node_tests_log="${log_dir}/jazz-node-tests-$$.log"
 browser_tests_log="${log_dir}/jazz-browser-tests-$$.log"
@@ -82,8 +88,56 @@ if [[ "${JAZZ_SKIP_JAZZ_TOOLS_BUILD:-0}" != "1" ]]; then
   export JAZZ_TEST_SEALED_TOOLS_DIST=1
 fi
 
+stop_log_monitor() {
+  if [[ -n "${log_monitor_pid}" ]]; then
+    kill -TERM -- "-${log_monitor_pid}" 2>/dev/null || true
+    wait "${log_monitor_pid}" 2>/dev/null || true
+    log_monitor_pid=""
+  fi
+}
+
+print_log_tail() {
+  local suite_log=$1
+  echo "--- ${suite_log} (last 16 KiB, at most 100 lines) ---"
+  if [[ -f "${suite_log}" ]]; then
+    tail -c 16384 "${suite_log}" | tail -n 100 || true
+    echo
+  fi
+}
+
+print_log_tails() {
+  print_log_tail "${node_tests_log}"
+  print_log_tail "${browser_tests_log}"
+}
+
+monitor_logs() {
+  # Cancellation may kill an outer Node/container process without delivering
+  # a trappable signal here. Publish progress beforehand, and stop within one
+  # tick if this runner disappears without invoking its cleanup trap.
+  local elapsed=0 index size
+  local sizes=(0 0)
+  local logs=("${node_tests_log}" "${browser_tests_log}")
+  while kill -0 "$$" 2>/dev/null; do
+    sleep 1
+    kill -0 "$$" 2>/dev/null || return
+    elapsed=$((elapsed + 1))
+    if (( elapsed >= log_interval )); then
+      for index in 0 1; do
+        size=$(wc -c < "${logs[$index]}")
+        if [[ "${size}" != "${sizes[$index]}" ]]; then
+          echo "TypeScript suites still running; bounded live log tail:"
+          print_log_tail "${logs[$index]}"
+          sizes[$index]=${size}
+        fi
+      done
+      elapsed=0
+    fi
+  done
+}
+
 terminate_children() {
   trap - INT TERM
+  stop_log_monitor
   for child_pid in "${node_tests_pid}" "${browser_tests_pid}"; do
     if [[ -n "${child_pid}" ]] && kill -0 "${child_pid}" 2>/dev/null; then
       # Each suite starts in its own session, so this reaches pnpm and every
@@ -101,13 +155,8 @@ interrupt() {
   # last test output. Bound bytes as well as lines (a test may print one huge
   # line), and retain the complete regular files at the printed paths.
   echo "TypeScript suites interrupted (exit ${signal_status}); retained log tails:"
-  for suite_log in "${node_tests_log}" "${browser_tests_log}"; do
-    echo "--- ${suite_log} (last 16 KiB, at most 100 lines) ---"
-    if [[ -f "${suite_log}" ]]; then
-      tail -c 16384 "${suite_log}" | tail -n 100 || true
-      echo
-    fi
-  done
+  stop_log_monitor
+  print_log_tails
   terminate_children
   exit "${signal_status}"
 }
@@ -126,18 +175,23 @@ bash -c "${node_tests_command}" >"${node_tests_log}" 2>&1 &
 node_tests_pid=$!
 bash -c "${browser_tests_command}" >"${browser_tests_log}" 2>&1 &
 browser_tests_pid=$!
+(trap - INT TERM; monitor_logs) &
+log_monitor_pid=$!
+echo "TypeScript live log monitor PID: ${log_monitor_pid}"
 set +m
 
 wait "${node_tests_pid}"
 node_tests_status=$?
 wait "${browser_tests_pid}"
 browser_tests_status=$?
+stop_log_monitor
 trap - INT TERM
 
 # GitHub's live log pipe can be nonblocking. Two concurrent Turbo/Vitest trees
 # writing directly to it can fail with EAGAIN even though the tests themselves
 # are healthy. Give each suite a blocking regular file, then replay both logs
-# after both process trees have terminated.
+# after both process trees have terminated. Only the bounded monitor writes
+# progress while tests run; test children never inherit the live log pipe.
 cat "${node_tests_log}"
 cat "${browser_tests_log}"
 rm -f "${node_tests_log}" "${browser_tests_log}"

--- a/dev/gates/test/ci-rust-throughput.test.mjs
+++ b/dev/gates/test/ci-rust-throughput.test.mjs
@@ -1848,7 +1848,7 @@ test("TypeScript CI overlaps independent Node and browser suites after one artif
   assert.match(runner, /set -m/);
   assert.match(runner, /bash -c "\$\{node_tests_command\}" >"\$\{node_tests_log\}" 2>&1 &/);
   assert.match(runner, /bash -c "\$\{browser_tests_command\}" >"\$\{browser_tests_log\}" 2>&1 &/);
-  assert.match(runner, /browser_tests_pid=\$!\nset \+m/);
+  assert.match(runner, /browser_tests_pid=\$![\s\S]*log_monitor_pid=\$![\s\S]*set \+m/);
   assert.doesNotMatch(runner, /^setsid /m);
   assert.match(runner, /trap 'interrupt 130' INT/);
   assert.match(runner, /trap 'interrupt 143' TERM/);
@@ -2200,3 +2200,121 @@ for (const [signal, expected] of [
     }
   });
 }
+
+for (const ending of ["complete", "SIGTERM", "SIGKILL"]) {
+  test(`parallel TypeScript runner publishes bounded progress before ${ending} and stops its monitor`, async () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-ts-ci-progress-"));
+    const command = (suite) =>
+      `echo $$ > "$RUNNER_TEMP/${suite}-pid"; printf '%20000s\\n' x; echo ${suite}-progress; while [ ! -f "$RUNNER_TEMP/finish" ]; do sleep 0.1; done`;
+    const child = spawn("bash", [path.join(root, "dev/gates/run-ts-tests.sh")], {
+      cwd: root,
+      env: {
+        ...process.env,
+        RUNNER_TEMP: fixture,
+        JAZZ_SKIP_JAZZ_TOOLS_BUILD: "1",
+        JAZZ_TEST_LOG_INTERVAL_SECONDS: "1",
+        JAZZ_NODE_TEST_COMMAND: command("node"),
+        JAZZ_BROWSER_TEST_COMMAND: command("browser"),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+      output += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      output += chunk;
+    });
+    const closed = new Promise((resolve) =>
+      child.once("close", (code, signal) => resolve({ code, signal })),
+    );
+    const watchdog = setTimeout(() => child.kill("SIGKILL"), 8000);
+    try {
+      const deadline = Date.now() + 5000;
+      while (!output.includes("node-progress") || !output.includes("browser-progress")) {
+        assert.ok(Date.now() < deadline, "no suite progress was published before termination");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      assert.equal(child.exitCode, null, "progress arrived only after suite completion");
+      assert.ok(Buffer.byteLength(output) < 34000, "live diagnostics were not bounded");
+      const monitor = Number(output.match(/live log monitor PID: (\d+)/)?.[1]);
+      assert.ok(monitor > 0, "monitor PID not reported");
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      assert.equal(
+        (output.match(/bounded live log tail:/g) ?? []).length,
+        2,
+        "unchanged suite logs were replayed again",
+      );
+      if (ending === "complete") fs.writeFileSync(path.join(fixture, "finish"), "");
+      else child.kill(ending);
+      let closeTimer;
+      const result = await Promise.race([
+        closed,
+        new Promise((_, reject) => {
+          closeTimer = setTimeout(
+            () => reject(new Error("monitor kept its output pipe open")),
+            3000,
+          );
+        }),
+      ]).finally(() => clearTimeout(closeTimer));
+      assert.deepEqual(
+        result,
+        ending === "SIGKILL"
+          ? { code: null, signal: "SIGKILL" }
+          : { code: ending === "complete" ? 0 : 143, signal: null },
+      );
+      // SIGKILL cannot reap its child: an init/subreaper may briefly retain an
+      // exited zombie. It must never leave a running monitor or inherited pipe.
+      const state = spawnSync("ps", ["-o", "stat=", "-p", String(monitor)], {
+        encoding: "utf8",
+      }).stdout.trim();
+      assert.ok(
+        state === "" || (ending === "SIGKILL" && state.startsWith("Z")),
+        `monitor survived: ${state}`,
+      );
+      for (const suite of ["node", "browser"]) {
+        const log = fs.readdirSync(fixture).find((name) => name.startsWith(`jazz-${suite}-tests-`));
+        if (ending === "complete") assert.equal(log, undefined);
+        else assert.ok(log && fs.statSync(path.join(fixture, log)).size > 20000);
+      }
+    } finally {
+      clearTimeout(watchdog);
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+      const monitorPid = Number(output.match(/live log monitor PID: (\d+)/)?.[1]);
+      if (monitorPid > 0) {
+        try {
+          process.kill(-monitorPid, "SIGTERM");
+        } catch (error) {
+          if (error.code !== "ESRCH") throw error;
+        }
+      }
+      // The hard-kill scenario cannot run the parent's suite cleanup trap.
+      for (const suite of ["node", "browser"]) {
+        const pidFile = path.join(fixture, `${suite}-pid`);
+        if (fs.existsSync(pidFile)) {
+          try {
+            process.kill(-Number(fs.readFileSync(pidFile, "utf8").trim()), "SIGTERM");
+          } catch (error) {
+            if (error.code !== "ESRCH") throw error;
+          }
+        }
+      }
+      await closed;
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+}
+
+test("CI rejects inherited live-log timing overrides", () => {
+  const result = spawnSync("bash", [path.join(root, "dev/gates/run-ts-tests.sh")], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      JAZZ_REQUIRE_CI_TEST_COMMANDS: "1",
+      JAZZ_TEST_LOG_INTERVAL_SECONDS: "1",
+    },
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /JAZZ_TEST_LOG_INTERVAL_SECONDS.*forbidden/);
+});

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -439,7 +439,6 @@ type PendingTx = {
 type PendingTxWrite = {
   table: string;
   rowId: Uint8Array;
-  row?: RowState;
   deleted?: boolean;
 };
 
@@ -1241,7 +1240,7 @@ export class NativeRuntimeAdapter implements Runtime {
         throw new Error("Native runtime transaction insert did not return a row id");
       }
       const row = this.rowStateFromValues(table, rowId, values);
-      tx.writes.push({ table, rowId, row });
+      tx.writes.push({ table, rowId });
       return {
         id: row.id,
         values: row.values,
@@ -1399,7 +1398,7 @@ export class NativeRuntimeAdapter implements Runtime {
         updatedAtMs: updatedAtMs ?? undefined,
       });
       const row = this.rowStateFromValues(table, rowId, values);
-      tx.writes.push({ table, rowId, row });
+      tx.writes.push({ table, rowId });
       return {
         id: row.id,
         values: row.values,
@@ -1440,10 +1439,8 @@ export class NativeRuntimeAdapter implements Runtime {
     const patch = encodeCellsForPatch(this.table(table), values);
     if (tx) {
       this.assertTransactionWriteIdentity(tx, attribution ? undefined : writeIdentity);
-      // Resolve the synchronous preimage before staging. A rejected merge
-      // (for example an indirect large value) must not leave a native patch
-      // that a caller can accidentally commit after catching the error.
-      const row = this.mergeRowState(table, rowId, values, tx, writeIdentity);
+      // The owner queue resolves the transaction-visible preimage and merges
+      // this patch. A synchronous read here can deadlock on a suspended owner.
       this.db.updateInTransaction(tx.id, table, rowId, patch, {
         head: branchView?.head,
         base: branchView?.base,
@@ -1452,7 +1449,6 @@ export class NativeRuntimeAdapter implements Runtime {
       tx.writes.push({
         table,
         rowId,
-        row,
       });
       return { kind: "staged", openTransactionId: txIdFromContext(writeContext)! };
     }
@@ -1524,29 +1520,14 @@ export class NativeRuntimeAdapter implements Runtime {
     rejectAttributedBranchWrite(attribution, branchView);
     const tx = this.currentTx(writeContext, "Upsert");
     if (tx) this.assertTransactionAttribution(tx, attribution);
-    // Ordinary upserts are queued by Rust, which resolves existence and merges
-    // the patch under the write's identity. A synchronous preflight read here
-    // can wait on a suspended core tick while blocking the host that must
-    // resume it. Only staged transaction bookkeeping needs a local preimage.
-    const existing = branchView
-      ? true
-      : tx
-        ? (this.stagedRowForWriteMerge(tx, table, rowId) ?? this.readRowForWriteMerge(table, rowId))
-        : undefined;
     let cells: Uint8Array;
     try {
-      cells =
-        !tx || branchView || existing
-          ? encodeCellsForPatch(definition, values)
-          : encodeCellsForRow(definition, values, table);
+      cells = encodeCellsForPatch(definition, values);
     } catch (error) {
       throw writeError("Upsert", normalizeWriteSetupMessage(errorMessage(error)));
     }
     if (tx) {
       this.assertTransactionWriteIdentity(tx, attribution ? undefined : writeIdentity);
-      const row = existing
-        ? this.mergeRowState(table, rowId, values, tx, writeIdentity)
-        : this.rowStateFromValues(table, rowId, values);
       this.db.upsertInTransaction(tx.id, table, rowId, cells, {
         head: branchView?.head,
         base: branchView?.base,
@@ -1555,7 +1536,6 @@ export class NativeRuntimeAdapter implements Runtime {
       tx.writes.push({
         table,
         rowId,
-        row,
       });
       return { kind: "staged", openTransactionId: txIdFromContext(writeContext)! };
     }
@@ -2511,24 +2491,6 @@ export class NativeRuntimeAdapter implements Runtime {
     );
   }
 
-  private mergeRowState(
-    table: string,
-    rowId: Uint8Array,
-    patch: Record<string, Value>,
-    tx: PendingTx,
-    _identity?: Uint8Array,
-  ): RowState {
-    const current =
-      this.stagedRowForWriteMerge(tx, table, rowId) ?? this.readRowForWriteMerge(table, rowId);
-    const merged: Record<string, Value> = {};
-    for (const column of this.table(table).columns) {
-      const existing = current?.valuesByColumn?.get(column.name);
-      if (existing !== undefined) merged[column.name] = existing;
-    }
-    Object.assign(merged, patch);
-    return this.rowStateFromValues(table, rowId, merged);
-  }
-
   private async readPlainRows(
     query: PreparedQuery,
     opts: unknown,
@@ -2682,20 +2644,6 @@ export class NativeRuntimeAdapter implements Runtime {
     const session = sessionFromWriteContext(writeContext);
     if (!session) throw new Error("backend attribution requires a valid author");
     return session.identity;
-  }
-
-  private stagedRowForWriteMerge(
-    tx: PendingTx,
-    table: string,
-    rowId: Uint8Array,
-  ): RowState | undefined {
-    const id = formatUuid(rowId);
-    for (let index = tx.writes.length - 1; index >= 0; index -= 1) {
-      const write = tx.writes[index]!;
-      if (write.table !== table || formatUuid(write.rowId) !== id) continue;
-      return write.deleted ? undefined : write.row;
-    }
-    return undefined;
   }
 
   private warnedOnce = new Set<string>();

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
@@ -1358,9 +1358,14 @@ it("keeps session-scoped transaction reads on the client-local native method", a
   expect(transactionReads).toBe(2);
 });
 
-it.each(["mergeable", "exclusive"] as const)(
-  "stages %s patches without synchronously reading a suspended owner's row",
-  (kind) => {
+it.each([
+  ["mergeable", "update"],
+  ["mergeable", "upsert"],
+  ["exclusive", "update"],
+  ["exclusive", "upsert"],
+] as const)(
+  "stages %s %s without synchronously reading a suspended owner's row",
+  (kind, operation) => {
     const update = vi.fn();
     const upsert = vi.fn();
     const forbiddenRead = vi.fn(() => {
@@ -1390,10 +1395,8 @@ it.each(["mergeable", "exclusive"] as const)(
     runtime.beginTransaction(kind, id);
     const context = JSON.stringify({ transaction_id: id });
     const row = "00000000-0000-0000-0000-000000000001";
-    runtime.update("todos", row, { title: { type: "Text", value: "first" } }, context);
-    runtime.upsert("todos", row, { title: { type: "Text", value: "second" } }, context);
-    expect(update).toHaveBeenCalledTimes(1);
-    expect(upsert).toHaveBeenCalledTimes(1);
+    runtime[operation]("todos", row, { title: { type: "Text", value: "patch" } }, context);
+    expect(operation === "update" ? update : upsert).toHaveBeenCalledTimes(1);
     expect(forbiddenRead).not.toHaveBeenCalled();
     runtime.rollbackTransaction(id);
   },

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-transaction-lifecycle.test.ts
@@ -1357,3 +1357,44 @@ it("keeps session-scoped transaction reads on the client-local native method", a
   ]);
   expect(transactionReads).toBe(2);
 });
+
+it.each(["mergeable", "exclusive"] as const)(
+  "stages %s patches without synchronously reading a suspended owner's row",
+  (kind) => {
+    const update = vi.fn();
+    const upsert = vi.fn();
+    const forbiddenRead = vi.fn(() => {
+      throw new Error("synchronous read would wait on the suspended owner");
+    });
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            all: forbiddenRead,
+            localCurrentRow: forbiddenRead,
+            updateInTransaction: update,
+            upsertInTransaction: upsert,
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const id = createOpenTransactionId();
+    runtime.beginTransaction(kind, id);
+    const context = JSON.stringify({ transaction_id: id });
+    const row = "00000000-0000-0000-0000-000000000001";
+    runtime.update("todos", row, { title: { type: "Text", value: "first" } }, context);
+    runtime.upsert("todos", row, { title: { type: "Text", value: "second" } }, context);
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(forbiddenRead).not.toHaveBeenCalled();
+    runtime.rollbackTransaction(id);
+  },
+);

--- a/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
@@ -208,12 +208,25 @@ describe("db exclusive transaction reads browser integration", () => {
     );
   });
 
-  it("rejects partial upserts for missing rows inside transactions", async () => {
+  it("rejects queued partial upserts for missing rows atomically inside transactions", async () => {
+    const { value: existing } = db.insert(app.todos, { title: "Keep original", done: false });
+    expect(await db.all(app.todos)).toEqual([existing]);
     const tx = db.beginExclusiveTransaction();
 
+    // Patch shape is known immediately; row existence is resolved in the queue.
+    expect(() =>
+      // @ts-expect-error Exercise runtime validation of an invalid patch field.
+      tx.upsert(app.todos, existing.id, { done: "invalid boolean" }),
+    ).toThrow();
+    tx.update(app.todos, existing.id, { done: true });
+    tx.insert(app.todos, { title: "Must not publish", done: false });
     expect(() =>
       tx.upsert(app.todos, "00000000-0000-0000-0000-000000000125", { done: true }),
-    ).toThrow("missing required field `title`");
+    ).not.toThrow();
+
+    await expect(async () => tx.commit().wait()).rejects.toThrow("missing required field `title`");
+    // Neither the missing-row upsert nor any earlier operation may publish.
+    expect(await db.all(app.todos)).toEqual([existing]);
   });
 
   describe("db.exclusiveTransaction(cb)", () => {
@@ -484,12 +497,25 @@ describe("db mergeable transaction reads browser integration", () => {
     );
   });
 
-  it("rejects partial upserts for missing rows inside mergeable transactions", async () => {
+  it("rejects queued partial upserts for missing rows atomically inside mergeable transactions", async () => {
+    const { value: existing } = db.insert(app.todos, { title: "Keep original", done: false });
+    expect(await db.all(app.todos)).toEqual([existing]);
     const tx = db.beginTransaction();
 
+    // Patch shape is known immediately; row existence is resolved in the queue.
+    expect(() =>
+      // @ts-expect-error Exercise runtime validation of an invalid patch field.
+      tx.upsert(app.todos, existing.id, { done: "invalid boolean" }),
+    ).toThrow();
+    tx.update(app.todos, existing.id, { done: true });
+    tx.insert(app.todos, { title: "Must not publish", done: false });
     expect(() =>
       tx.upsert(app.todos, "00000000-0000-0000-0000-000000000225", { done: true }),
-    ).toThrow("missing required field `title`");
+    ).not.toThrow();
+
+    await expect(async () => tx.commit().wait()).rejects.toThrow("missing required field `title`");
+    // Neither the missing-row upsert nor any earlier operation may publish.
+    expect(await db.all(app.todos)).toEqual([existing]);
   });
 
   describe("db.transaction(cb)", () => {

--- a/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
@@ -215,9 +215,9 @@ describe("db exclusive transaction reads browser integration", () => {
 
     // Patch shape is known immediately; row existence is resolved in the queue.
     expect(() =>
-      // @ts-expect-error Exercise runtime validation of an invalid patch field.
-      tx.upsert(app.todos, existing.id, { done: "invalid boolean" }),
-    ).toThrow();
+      // @ts-expect-error Exercise runtime validation of null for a required field.
+      tx.upsert(app.todos, existing.id, { done: null }),
+    ).toThrow("Cannot set required field 'done' to null");
     tx.update(app.todos, existing.id, { done: true });
     tx.insert(app.todos, { title: "Must not publish", done: false });
     expect(() =>
@@ -504,9 +504,9 @@ describe("db mergeable transaction reads browser integration", () => {
 
     // Patch shape is known immediately; row existence is resolved in the queue.
     expect(() =>
-      // @ts-expect-error Exercise runtime validation of an invalid patch field.
-      tx.upsert(app.todos, existing.id, { done: "invalid boolean" }),
-    ).toThrow();
+      // @ts-expect-error Exercise runtime validation of null for a required field.
+      tx.upsert(app.todos, existing.id, { done: null }),
+    ).toThrow("Cannot set required field 'done' to null");
     tx.update(app.todos, existing.id, { done: true });
     tx.insert(app.todos, { title: "Must not publish", done: false });
     expect(() =>

--- a/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-staging-scaling.test.ts
@@ -9,7 +9,7 @@ const app = schema.defineApp({
 });
 
 describe("exact local transaction write merging", () => {
-  it("preserves large content after commit rejection and a caught merge-read failure", async () => {
+  it("preserves large content after commit rejection and a caught native staging failure", async () => {
     const db = await createBrowserTestDb({
       appId: "transaction-staging-large-rejection",
       driver: { type: "memory" },
@@ -32,13 +32,13 @@ describe("exact local transaction write merging", () => {
       );
       const tx = db.beginTransaction();
       const { WasmDb } = await loadWasmModule();
-      const exact = vi.spyOn(WasmDb.prototype, "localCurrentRow");
+      const exact = vi.spyOn(WasmDb.prototype, "updateInTransaction");
       exact.mockImplementationOnce(() => {
-        throw new Error("synthetic exact read failure");
+        throw new Error("synthetic staging failure");
       });
       try {
         expect(() => tx.update(app.todos, large.value.id, { done: true })).toThrow(
-          "synthetic exact read failure",
+          "synthetic staging failure",
         );
       } finally {
         exact.mockRestore();
@@ -80,7 +80,7 @@ describe("exact local transaction write merging", () => {
       }
       try {
         tx.update(app.todos, inserted.value.id, { done: true });
-        expect(exact).toHaveBeenCalledTimes(2);
+        expect(exact).not.toHaveBeenCalled();
       } finally {
         exact.mockRestore();
       }
@@ -123,7 +123,7 @@ describe("exact local transaction write merging", () => {
           // A second patch must merge with this transaction's first patch.
           tx.update(app.todos, updates[0].id, { title: "Second patch" });
           expect(all).not.toHaveBeenCalled();
-          expect(exact).toHaveBeenCalledTimes(updates.length);
+          expect(exact).not.toHaveBeenCalled();
         } finally {
           all.mockRestore();
           exact.mockRestore();


### PR DESCRIPTION
🤖 Stacked on #2775; fixes #2777. The exact-row optimization in #2749 exposed a deadlock in a persistent Node-WASM transaction-conflict test: a concurrent queued mutation could retain the node mutex, then JavaScript transaction staging synchronously waited for that mutex while blocking the host that must resume its owner.

Transaction update/upsert do not need that preflight read. Their JavaScript row snapshots only fed subsequent JavaScript snapshot bookkeeping; actual transaction reads, patch merging, and write authorization already run in the core owner queue. Remove those redundant snapshots and send patches directly. Insert/restore return values remain intact, and successful native staging is still required before counting a staged write.

For example, an exclusive transaction reads a todo and its assignee; another write changes the assignee; the transaction then stages a title change. Staging now returns promptly, and commit can report the intended transaction conflict. It cannot spin waiting for a suspended mutation. A second patch to the same row is merged by the core against its staged overlay without a table or exact-row preflight in JavaScript.

Required-field validation for an upsert that becomes an insert moves into the queued core classification, reusing ordinary upsert validation. Existing-row partial patches remain valid; a new row missing required fields fails without publication. Local patch-shape validation remains synchronous; existence-dependent rejection may surface through the queued operation. The existing streamed-large-row commit rejection remains unchanged (#1844); this PR does not claim new large-value support or change storage/wire formats.

Independent correctness/security review passed. Adapter lifecycle tests: 26 passed; native row-codec tests: 27 passed; queued upsert matrix: 1 passed across both transaction kinds, covering required fields, defaults, staged insert/patch, and delete/upsert; existing authorization, conflict and patch canaries: 9 passed. Removing validation independently for either transaction kind makes the new matrix fail. Restoring the old adapter makes four bounded preflight-read canaries fail without hanging.

The browser scaling test now requires zero preflight reads and retains exact final values, repeated-patch behavior and rejected-stage atomicity. Rebuilt-artifact verification passed on the integrated tip: the actual previously stalled Node-WASM test completed, the query-API/adapter run passed 197 tests, and the corrected browser transaction canaries passed 36 tests. Missing-row upsert tests now assert queued rejection and no partial publication; synchronous required-null validation remains covered. The full integrated consumer gate also passed at 6b9f0a2a9c (2,245 SDK Node tests, 326 SDK browser tests, transport/framework/example suites). Fresh CI is still running; this PR remains draft.

This tip also carries the independently reviewed #2769 CI diagnostic amendment: changed suite-log tails are printed periodically, so an outer timeout preserves the last progress instead of relying on a shutdown trap.
