### PR TITLE
Avoid rereading locally acknowledged transaction history on every tick

### DIFF
--- a/.changeset/skip-settled-local-ack-probes.md
+++ b/.changeset/skip-settled-local-ack-probes.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Avoid repeatedly reading transaction status for writes already acknowledged locally while waiting for server confirmation, improving offline bulk-write performance.

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -1800,7 +1800,19 @@ async fn queue_local_acknowledgements<S>(routes: &LocalFateRoutes, node: &Shared
 where
     S: OrderedKvStorage,
 {
-    let tx_ids = routes.borrow().keys().copied().collect::<Vec<_>>();
+    // Acknowledged routes remain registered for later global/rejection fates,
+    // but no longer need a local durability probe. A new queue on the same
+    // transaction still gets its own acknowledgement; dead queues need none.
+    let tx_ids = routes
+        .borrow()
+        .iter()
+        .filter(|(_, pending)| {
+            pending
+                .iter()
+                .any(|route| !route.local_acknowledged && route.queue.strong_count() > 0)
+        })
+        .map(|(tx_id, _)| *tx_id)
+        .collect::<Vec<_>>();
     let mut durable = BTreeSet::new();
     let mut node = node.lock().await;
     for tx_id in tx_ids {

--- a/crates/jazz/src/db/tests/node_runtime.rs
+++ b/crates/jazz/src/db/tests/node_runtime.rs
@@ -3522,3 +3522,129 @@ fn cold_browser_relay_restore_yields_to_storage() {
         cold_pending_restore_yields_and_recovers(true);
     }
 }
+
+#[test]
+fn local_acknowledgements_do_not_reprobe_retained_history() {
+    // Internal topology is necessary to count storage probes at the local
+    // acknowledgement boundary independently of unrelated query/persistence
+    // work. Writes and durability still use the ordinary Db API.
+    let schema = schema();
+    let author = AuthorSubject::for_test_bytes([0xce; 16]);
+    let families = schema.column_families();
+    let refs = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let (storage, control) = TestStorage::controlled(&refs);
+    let db = block_on(Db::open(DbConfig {
+        schema,
+        storage,
+        identity: DbIdentity {
+            node: NodeUuid::from_bytes([0xce; 16]),
+            author,
+        },
+        id_source: Some(Box::new(SeededRowIdSource::new(0xce))),
+    }))
+    .unwrap();
+    let routes: LocalFateRoutes = Rc::new(RefCell::new(BTreeMap::new()));
+    let queue: PendingDownstreamFates = Rc::new(RefCell::new(Vec::new()));
+    let mut samples = Vec::new();
+    for i in 0..1500 {
+        let write = db
+            .insert(
+                "todos",
+                cells("retained local route", false, author),
+                Default::default(),
+            )
+            .unwrap();
+        db.tick().unwrap();
+        let tx_id = write.mergeable_tx_id();
+        register_local_fate_observer(&routes, tx_id, &queue);
+        if i == 149 || i == 1499 {
+            let before = control.point_read_count();
+            block_on(queue_local_acknowledgements(&routes, &db.node.node));
+            let reads = control.point_read_count() - before;
+            eprintln!("retained_routes={} status_storage_reads={reads}", i + 1);
+            samples.push(reads);
+        }
+    }
+    assert_eq!(
+        samples,
+        [0, 0],
+        "already acknowledged routes must not reread transaction history"
+    );
+    assert_eq!(
+        routes.borrow().len(),
+        1500,
+        "routes remain for terminal fates"
+    );
+    assert!(
+        queue.borrow().is_empty(),
+        "no duplicate local acknowledgements"
+    );
+    let tx_id = *routes.borrow().keys().next().unwrap();
+    let newcomer: PendingDownstreamFates = Rc::new(RefCell::new(Vec::new()));
+    register_local_fate_route(&routes, tx_id, &newcomer);
+    let before = control.point_read_count();
+    block_on(queue_local_acknowledgements(&routes, &db.node.node));
+    assert_eq!(
+        control.point_read_count() - before,
+        1,
+        "only the new queue needs a probe"
+    );
+    assert!(
+        matches!(newcomer.borrow().as_slice(), [SyncMessage::FateUpdate {
+        tx_id: received, fate: Fate::Pending, durability: Some(DurabilityTier::Local), ..
+    }] if *received == tx_id)
+    );
+    assert!(queue.borrow().is_empty());
+    let before = control.point_read_count();
+    block_on(queue_local_acknowledgements(&routes, &db.node.node));
+    assert_eq!(control.point_read_count(), before);
+    assert_eq!(newcomer.borrow().len(), 1, "acknowledge each queue once");
+
+    // A cancelled waiter must be pruned without reopening stored history.
+    let cancelled: PendingDownstreamFates = Rc::new(RefCell::new(Vec::new()));
+    register_local_fate_route(&routes, tx_id, &cancelled);
+    drop(cancelled);
+    block_on(queue_local_acknowledgements(&routes, &db.node.node));
+    assert_eq!(control.point_read_count(), before);
+    assert_eq!(routes.borrow()[&tx_id].len(), 2);
+
+    // Local acknowledgement must not consume either terminal fate route.
+    let global = SyncMessage::FateUpdate {
+        tx_id,
+        fate: Fate::Accepted,
+        global_time: Some(GlobalTime(1)),
+        durability: Some(DurabilityTier::Global),
+    };
+    route_local_fate(&routes, tx_id, &global);
+    assert!(matches!(
+        queue.borrow().last(),
+        Some(SyncMessage::FateUpdate {
+            durability: Some(DurabilityTier::Global),
+            ..
+        })
+    ));
+    assert!(matches!(
+        newcomer.borrow().last(),
+        Some(SyncMessage::FateUpdate {
+            durability: Some(DurabilityTier::Global),
+            ..
+        })
+    ));
+    assert!(!routes.borrow().contains_key(&tx_id));
+    let rejected_id = *routes.borrow().keys().next().unwrap();
+    let rejected = SyncMessage::FateUpdate {
+        tx_id: rejected_id,
+        fate: Fate::Rejected(RejectionReason::AuthorizationDenied),
+        global_time: None,
+        durability: Some(DurabilityTier::Edge),
+    };
+    route_local_fate(&routes, rejected_id, &rejected);
+    assert!(matches!(
+        queue.borrow().last(),
+        Some(SyncMessage::FateUpdate {
+            fate: Fate::Rejected(_),
+            ..
+        })
+    ));
+    assert!(!routes.borrow().contains_key(&rejected_id));
+}

--- a/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
+++ b/packages/jazz-tools/tests/browser/db.transaction-reads.test.ts
@@ -513,7 +513,9 @@ describe("db mergeable transaction reads browser integration", () => {
       tx.upsert(app.todos, "00000000-0000-0000-0000-000000000225", { done: true }),
     ).not.toThrow();
 
-    await expect(async () => tx.commit().wait()).rejects.toThrow("missing required field `title`");
+    await expect(async () => tx.commit().wait({ tier: "local" })).rejects.toThrow(
+      "missing required field `title`",
+    );
     // Neither the missing-row upsert nor any earlier operation may publish.
     expect(await db.all(app.todos)).toEqual([existing]);
   });


### PR DESCRIPTION
🤖 Stacked on #2778. Removes repeated transaction-status storage reads after a downstream listener has already received its local durability acknowledgment.

When an offline browser writes 1,500 rows, its relay retains routes for those writes so it can later forward server confirmation or rejection. Previously, every peer tick reread the status of every retained transaction, even when all listeners had already received local acknowledgment. As writes accumulated, each new write triggered increasingly many reads of old transaction history. A counter reproducer measured exactly 150 and 1,500 storage reads in one pass over 150 and 1,500 already-acknowledged transactions.

The acknowledgment pass now reads status only when a transaction has at least one live listener still awaiting local acknowledgment. The same counter reports zero reads for both retained-history sizes. For example, a second listener subscribing to an old transaction still gets its own acknowledgment: that transaction is read once, while the previously acknowledged listener receives no duplicate. Dropped listeners are pruned without a read. All live routes remain registered for eventual global acceptance or rejection and are removed by the existing terminal-fate path.

This does not cache transaction status, change durability meaning, or alter storage/wire formats. The cheap scan of retained routes remains; the expensive repeated storage probes are removed. A clean optimized browser run at 23595340dd measured 49.112s for 1,350 ordinary updates with a local-durability wait after each row, versus 50.751s previously. This small single-run difference is not a substantial end-to-end speedup claim. Exact completed/untouched rows and reopen checks passed; reopen first-all was 1.424s and subscription-first 0.686s. Further attribution of serialized durability waits and batched-write behavior continues.

Validation: the focused counter and new-listener/dead-listener/global/rejection boundaries pass; the old implementation fails the count assertion with [150, 1500] instead of [0, 0]. Independent correctness/security review passed with nine focused tests covering the counter, new observers, bounded fate retries, authority-epoch handling, cancellation, blocked durability and global/remote waiters. Its independent restoration of the old all-keys loop failed with exactly [150, 1500]; restoring the fix passed. The coordinator independently reran the counter successfully. The full integrated TypeScript consumer run passed at 6b9f0a2a9c: all 28 Node build/test tasks, 2,245 SDK Node tests, 326 SDK browser tests, five transport checks, framework suites, and BandChat/WorkOS/RecordPlayer examples. Ten browser tests remain explicitly skipped as before. Fresh CI is still running; this remains draft pending the complete gate result.
