### PR TITLE
Reuse the complete subscription closure during publication bookkeeping

### DIFF
--- a/.changeset/reuse-publication-source-closure.md
+++ b/.changeset/reuse-publication-source-closure.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reuse the complete supporting-row set during subscription publication bookkeeping instead of reconstructing it again.

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -831,6 +831,8 @@ impl MaintainedSubscriptionView {
     /// This intentionally exposes neither rendered result rows nor internal
     /// proof/relationship facts.
     pub(crate) fn active_peer_source_closure_facts(&self) -> BTreeSet<ProgramFactEntry> {
+        #[cfg(test)]
+        SOURCE_CLOSURE_TRAVERSALS.with(|count| count.set(count.get() + 1));
         self.source_fact_weights
             .iter()
             .filter(|(fact, weights)| {
@@ -4909,4 +4911,9 @@ mod terminal_role_hash_tests {
         );
         assert_ne!(first.id, terminal_root_layout(&changed_name).id);
     }
+}
+
+#[cfg(test)]
+std::thread_local! {
+    pub(crate) static SOURCE_CLOSURE_TRAVERSALS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }

--- a/crates/jazz/src/peer/publication.rs
+++ b/crates/jazz/src/peer/publication.rs
@@ -1219,9 +1219,7 @@ impl PeerState {
             .map(|view| view.maintained.active_peer_source_closure_facts())
             .ok_or(Error::InvalidStoredValue(
                 "maintained subscription view is missing source closure state",
-            ))?
-            .into_iter()
-            .collect::<BTreeSet<_>>();
+            ))?;
         let (program_fact_adds, program_fact_removes) = if initial_snapshot_completed {
             // A reopened evaluator can finish hydration after the opening
             // call returned, with the previous publication closure retained.
@@ -1340,7 +1338,17 @@ impl PeerState {
         }
         self.metrics.maintained_subscription_view.hits_out += 1;
         self.refresh_maintained_subscription_view_footprint(subscription);
-        self.record_outgoing_view_update(&update);
+        // The maintained view was only borrowed while constructing this
+        // update. Reuse its already-computed complete successor closure for
+        // predecessor bookkeeping; no second traversal or cache lifetime is
+        // needed, and the complete wire manifest is constructed unchanged.
+        self.record_outgoing_view_update_metadata(&update);
+        if let SyncMessage::ViewUpdate(view) = &update {
+            self.publication_states
+                .entry(view.subscription)
+                .or_default()
+                .program_fact_set = current_program_fact_set;
+        }
         Ok(Some(MaintainedCanonicalUpdate {
                 changed: true,            update,
             allow_storage_witness_fallback,

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -6120,3 +6120,37 @@ fn duplicate_usage_reopens_stale_canonical_query_before_cloning() {
 fn apply_test_result_delta(peer: &mut PeerState, update: &(SubscriptionKey, bool, Vec<ResultMemberEntry>, Vec<ResultMemberEntry>)) {
     peer.apply_outgoing_view_delta(update.0, update.1, &update.2, &update.3, &[], &[]);
 }
+
+#[test]
+fn maintained_publication_reuses_complete_successor_closure() {
+    // The traversal bound is internal bookkeeping, not a wire delta promise.
+    // Assert full supporting-row manifests as well as the cost boundary.
+    use crate::node::maintained_subscription_view::SOURCE_CLOSURE_TRAVERSALS;
+    let (_dir, mut core) = open_node_with_uuid(node(0x93));
+    let mut expected = BTreeSet::new();
+    for index in 0..150 {
+        let id = row_from_u64(index);
+        let tx = core.commit_mergeable_settled(
+            MergeableCommit::new("todos", id, 1_000 + index).cells(title_cells("initial")),
+        ).unwrap();
+        accept_global(&mut core, tx, index + 1);
+        expected.insert(id);
+    }
+    let shape = Query::from("todos").validate(&schema()).unwrap();
+    let binding = shape.bind(BTreeMap::new()).unwrap();
+    let subscription = subscription_key(&shape, &binding);
+    let mut peer = PeerState::new();
+    peer.rehydrate_query(&mut core, &shape, &binding).unwrap();
+    let tx = core.commit_mergeable_settled(
+        MergeableCommit::new("todos", row_from_u64(0), 2_000).cells(title_cells("updated")),
+    ).unwrap();
+    accept_global(&mut core, tx, 151);
+    SOURCE_CLOSURE_TRAVERSALS.with(|count| count.set(0));
+    let update = peer.query_update(&mut core, &shape, &binding).unwrap();
+    let traversals = SOURCE_CLOSURE_TRAVERSALS.with(|count| count.get());
+    assert_eq!(traversals, 2, "one closure for canonical transition and one for the complete wire manifest; bookkeeping must reuse the former");
+    let SyncMessage::ViewUpdate(view) = update else { panic!("expected complete manifest") };
+    assert_eq!(view.supporting_rows.iter().map(|row| row.row).collect::<BTreeSet<_>>(), expected);
+    let state = &peer.publication_states[&subscription];
+    assert_eq!(state.program_fact_set, state.maintained_subscription_view.as_ref().unwrap().maintained.active_peer_source_closure_facts());
+}

--- a/crates/jazz/src/peer/tests.rs
+++ b/crates/jazz/src/peer/tests.rs
@@ -6151,6 +6151,8 @@ fn maintained_publication_reuses_complete_successor_closure() {
     assert_eq!(traversals, 2, "one closure for canonical transition and one for the complete wire manifest; bookkeeping must reuse the former");
     let SyncMessage::ViewUpdate(view) = update else { panic!("expected complete manifest") };
     assert_eq!(view.supporting_rows.iter().map(|row| row.row).collect::<BTreeSet<_>>(), expected);
+    assert_eq!(view.supporting_rows.len(), 150, "complete manifest has no duplicate rows");
+    assert_eq!(view.supporting_rows.iter().find(|row| row.row == row_from_u64(0)).unwrap().version.tx, tx, "changed row carries its current exact version");
     let state = &peer.publication_states[&subscription];
     assert_eq!(state.program_fact_set, state.maintained_subscription_view.as_ref().unwrap().maintained.active_peer_source_closure_facts());
 }


### PR DESCRIPTION
🤖 Stacked on #2779 as a separate performance follow-up. Publishing a one-row change in a large subscription already computes the complete current supporting-row set. Previously the hot path unnecessarily rebuilt that BTreeSet, then traversed the maintained view again to reconstruct the same set for predecessor bookkeeping.

Reuse the existing complete set for bookkeeping after successful update construction. For example, updating one of 150 subscribed tasks still sends all 150 supporting-row identities, including the updated task’s exact new version. Only the duplicate internal traversal disappears. The wire builder still constructs the complete manifest in the same way; resets, negative evidence and authorization behavior remain unchanged. No storage or wire format changes.

The captured set is stable: update construction receives only a shared borrow of the maintained view, and bookkeeping advances at the same successful point as before. Failure or cancellation does not advance the predecessor. Other publication paths retain their existing helper.

Independent correctness/security review passed 12 focused tests covering resets, transient changes, self-joins, permission grant/revocation, cancellation and stale-closure repair. Restoring the old bookkeeping helper makes the new traversal canary fail with three traversals instead of two. The coordinator reran the canary; additional assertions pin complete cardinality and the changed row’s exact transaction version.

This remains draft: the final amended canary passed, while integrated artifact acceptance and optimized browser measurement are pending. The already-green stack through #2779 remains independently reviewable; no end-to-end speedup is claimed for this follow-up yet.
