### PR TITLE
perf: scope merge ancestry lookups to one physical row

### DIFF
--- a/crates/jazz/src/node/ingest/view_updates.rs
+++ b/crates/jazz/src/node/ingest/view_updates.rs
@@ -743,7 +743,7 @@ where
         Ok(())
     }
 
-    async fn content_version_reaches_tx(
+    pub(super) async fn content_version_reaches_tx(
         &mut self,
         table_id: PhysicalTableId,
         branch_key: &BranchKey,
@@ -764,14 +764,36 @@ where
             if !seen.insert(tx_id) {
                 continue;
             }
-            for version in self.query_versions_for_tx(tx_id).await? {
-                if self.physical_table_id_for_version(&version)? == table_id
-                    && version.branch_key() == branch_key
-                    && version.row_uuid() == row_uuid
-                    && version.layer() == VersionLayer::Content
+            // Reachability is row-local. Preserve the transaction-presence and
+            // resident-cache semantics without materializing its sibling rows.
+            let Some(tx) = self.query_transaction(tx_id).await? else {
+                continue;
+            };
+            if self.query.tx_versions_cache.contains_key(&tx_id) {
+                for version in self
+                    .query_versions_for_tx_physical_coordinate(tx_id, table_id, row_uuid)
+                    .await?
                 {
-                    stack.extend(version.parents());
+                    if version.branch_key() == branch_key
+                        && version.layer() == VersionLayer::Content
+                    {
+                        stack.extend(version.parents());
+                    }
                 }
+            } else if let Some(version) = self
+                .query_exact_parent_version(
+                    tx_id,
+                    tx.node_alias,
+                    &ParentCoordinate {
+                        physical_table_id: table_id,
+                        branch_key: branch_key.clone(),
+                        row_uuid,
+                        layer: VersionLayer::Content,
+                    },
+                )
+                .await?
+            {
+                stack.extend(version.parents());
             }
         }
         Ok(false)

--- a/crates/jazz/src/node/tests/merge_heads.rs
+++ b/crates/jazz/src/node/tests/merge_heads.rs
@@ -853,3 +853,45 @@ fn merge_heads_match_history_after_merge_version_application() {
     core.assert_merge_heads_match_history_for_test("todos", row)
         .unwrap();
 }
+
+// Internal because avoiding transaction-wide materialization is not observable
+// through query results; the reachability answers pin the semantic boundary too.
+#[test]
+fn ancestry_lookup_avoids_transaction_wide_reads_resident_and_cold() {
+    let schema = two_column_schema();
+    let (dir, mut writer) = open_node_with_schema(node(0xe1), schema.clone());
+    let row_uuid = row(0xe2);
+    let (parent, _) = writer.commit_mergeable_unit_settled(
+        MergeableCommit::new("todos", row_uuid, 10)
+            .cells(BTreeMap::from([("title".to_owned(), "first".to_owned())])),
+    ).unwrap();
+    let (child, _) = writer.commit_mergeable_unit_settled(
+        MergeableCommit::new("todos", row_uuid, 11).parents(vec![parent])
+            .cells(BTreeMap::from([("title".to_owned(), "second".to_owned())])),
+    ).unwrap();
+    let table_id = writer.physical_table_id_for_schema(
+        writer.catalogue.current_write_schema.schema, "todos",
+    ).unwrap();
+    // Force the resident branch, then repeat against cold persisted history.
+    let versions = writer.query_versions_for_tx(child).unwrap();
+    writer.cache_tx_versions(child, versions);
+    for cold in [false, true] {
+        if cold {
+            drop(writer);
+            writer = reopen_node_at(&dir, node(0xe1), schema.clone());
+            writer.query.tx_versions_cache.clear();
+        }
+        reset_query_versions_for_tx_call_count();
+        assert!(writer.content_version_reaches_tx(
+            table_id, &BranchKey::default(), row_uuid, child, parent,
+        ).unwrap());
+        assert!(!writer.content_version_reaches_tx(
+            table_id, &BranchKey::default(), row(0xe3), child, parent,
+        ).unwrap());
+        assert!(!writer.content_version_reaches_tx(
+            table_id, &BranchKey::default(), row_uuid, parent, child,
+        ).unwrap());
+        assert_eq!(query_versions_for_tx_call_count(), 0,
+            "row ancestry must never materialize a whole transaction (cold={cold})");
+    }
+}

--- a/crates/jazz/tests/wire_fixtures.rs
+++ b/crates/jazz/tests/wire_fixtures.rs
@@ -1027,7 +1027,7 @@ fn wire_message_frame_fixtures_decode_to_expected_messages() {
     }
 }
 
-/// Snapshots have only exact native row references; duplicate references are malformed.
+/// Untrusted admission rejects malformed references; the trusted encoder does not validate.
 #[test]
 fn supporting_snapshots_reject_duplicate_rows_and_invalid_native_table() {
     let (_, _, message) = wire_fixture_messages()
@@ -1038,13 +1038,11 @@ fn supporting_snapshots_reject_duplicate_rows_and_invalid_native_table() {
         unreachable!()
     };
     view.supporting_rows.push(view.supporting_rows[0].clone());
-    assert!(encode_sync_message(&SyncMessage::ViewUpdate(view.clone())).is_err());
-    let bytes = postcard::to_allocvec(&SyncMessage::ViewUpdate(view.clone())).unwrap();
+    let bytes = encode_sync_message(&SyncMessage::ViewUpdate(view.clone())).unwrap();
     assert!(decode_sync_message(&bytes).is_err());
     view.supporting_rows.pop();
     view.supporting_rows[0].version_table = String::new().into();
-    assert!(encode_sync_message(&SyncMessage::ViewUpdate(view.clone())).is_err());
-    let bytes = postcard::to_allocvec(&SyncMessage::ViewUpdate(view)).unwrap();
+    let bytes = encode_sync_message(&SyncMessage::ViewUpdate(view)).unwrap();
     assert!(decode_sync_message(&bytes).is_err());
 }
 


### PR DESCRIPTION
🤖 A row ancestry check currently loads every row version in each visited transaction, sorts them, and then discards all but the requested physical row. For a transaction updating 1,350 different rows, repeating that lookup for each row amplifies shallow ancestry into approximately quadratic work. Profiles attributed 6.38 seconds of the batch and 5.25 seconds of its reload to this walk.

This change keeps the ancestry algorithm and merge semantics, but retrieves only the requested row. Resident transactions use the existing row-addressable cache. Cold transactions use the immutable history primary key: physical table, branch, row, transaction time and node alias. The transaction-presence check remains, and a resident cache remains authoritative rather than silently falling back to stored history. Authored-schema decoding preserves table identity across renames.

For example, after A -> B -> C for one row, receiving older B must not introduce a false concurrent head alongside C. Conversely, two children B and C of A must remain concurrent until merged. Both cases still follow that row's parent links; other rows written by the same transaction do not participate. Missing history retains the existing reachability behavior. Transaction-wide completeness checks and full commit reads are unchanged.

No wire or storage format changes. Broader caller audit: #2784. Separately deferred authoring collapse invariant: #2783.

Validation so far: a resident/cold regression test proves ancestry answers and zero transaction-wide helper calls. Restoring the previous walker fails with 3 calls versus 0; mutation restored. This test is internal because unnecessary materialization is not observable in query results. Full Jazz library: 1,995 passed, 2 ignored. Wire fixture integration suite: 10 passed. CI exposed an old outgoing-encoder rejection expectation from the preceding trusted-decoding slice; this PR also moves that assertion to untrusted decode. Routing it through trusted decode fails as expected; mutation restored.

Same optimized persistent-browser workload, 1,500 rows / 1,350 updates:

| Operation | Before this PR | After |
|---|---:|---:|
| Initial runtime-reopen read | 976.41 ms | 965.07 ms |
| Batch commit + local durability | 7,491.53 ms | 1,166.78 ms |
| Post-batch runtime-reopen read | 6,094.77 ms | 1,010.54 ms |

Four-size sweep passed. Batch times at 150/300/750/1,500 rows: 118.50 / 216.20 / 531.19 / 1,166.78 ms, replacing the prior approximately quadratic growth with approximately linear growth over this range. The harness asserts updated row values, subscription delivery and values after reopen. Single-run measurements on synthetic data, no concurrent local builds/tests, not cold-browser startup or latency percentiles.

Separate passing CPU-profile run: ancestry falls from 6,379 ms to 9.02 ms in the worker batch and from 5,252 ms to 7.87 ms in the foreground reload. Remaining costs include version ingestion/current-index maintenance and supporting-view publication; ancestry is no longer dominant. Inclusive profile totals overlap and must not be added.

Draft, coordinator-only implementation and self-review under the user's single-track instruction. No independent review or merge approval claimed.
