### PR TITLE
perf: batch immutable history ingestion with ensure_exact

### DIFF
--- a/crates/groove/SPEC/2_storage_model.md
+++ b/crates/groove/SPEC/2_storage_model.md
@@ -836,3 +836,35 @@ The former hybrid columnar-base proposal is rejected and is not part of Groove's
 - 🔶 [#1775](https://github.com/garden-co/jazz/issues/1775) — Current-base selection, compaction handoff, scan exclusion, and compaction-quality receipts.
 - 🔶 [#1774](https://github.com/garden-co/jazz/issues/1774) — Portable storage guarantees, reopen normativity, async persistence, serverless backends, row encoding, and compression policy.
 - 🔶 [#1776](https://github.com/garden-co/jazz/issues/1776) — Explicit index declarations and stale-index behavior.
+
+### Batch-scoped immutable record insertion
+
+`DatabaseBatch::ensure_exact(database, table, key, record)` resolves an immutable
+record against the resident database and preceding operations in that batch.
+It returns `Inserted`, `AlreadyIdentical`, or `Conflict`. `Inserted` stages the
+record but does not publish or persist it. `AlreadyIdentical` adds no physical
+write or query delta. `Conflict` invalidates the whole batch; attempting to
+apply it must fail before publishing any of its writes, without poisoning the
+database. Later operations must not contradict an ensured record.
+
+Equality compares the same locally encoded record representation, including
+its variant discriminator. It does not decode and reconstruct logical fields.
+The operation retains its absence decision for delta computation, avoiding a
+second storage read for inserted records. Repeated keys observe earlier staged
+writes. An empty duplicate-only history batch may still accompany mutable
+transaction/fate updates supplied by the higher layer.
+
+These decisions are scoped to one database owner and resident publication
+revision. Applying them to another database or after a resident publication
+fails with `StaleImmutableBatch`; callers rebuild instead of reusing stale
+outcomes. As with ordinary Groove index/IVM batches, the database owner must
+serialize mutations to its managed tables. This API is not a cross-owner
+compare-and-swap transaction and must not be used to coordinate independently
+mutating database instances over the same tables.
+
+The storage seam's `compare_value` is a side-effect-free read returning absent,
+identical or different. It does not reserve a key. Implementations may compare
+borrowed memory, pinned storage values or B-tree leaf/overflow bytes without
+returning an owned old value. The staged/resident overlays must participate in
+this lookup. Backends retain their existing atomic `write_many` persistence
+boundary. No new durable record or wire encoding is introduced.

--- a/crates/groove/src/db/batch.rs
+++ b/crates/groove/src/db/batch.rs
@@ -46,6 +46,10 @@ impl StagedDatabaseBatch<'_> {
 #[derive(Clone, Debug, Default)]
 pub struct DatabaseBatch {
     pub(super) operations: Vec<BatchOperation>,
+    pub(super) exact_base: Option<(usize, u64)>,
+    pub(super) exact_conflict: bool,
+    pub(super) exact_owner: Option<Rc<()>>,
+    pub(super) exact_keys: BTreeMap<(String, Vec<u8>), Vec<u8>>,
     pub(super) txn_operations: RefCell<StagedWriteState>,
     pub(super) txn_indexed_operations: Cell<usize>,
     pub(super) notification_timing: NotificationTiming,
@@ -54,7 +58,10 @@ pub struct DatabaseBatch {
 
 impl PartialEq for DatabaseBatch {
     fn eq(&self, other: &Self) -> bool {
-        self.operations == other.operations
+        self.exact_base == other.exact_base
+            && self.exact_conflict == other.exact_conflict
+            && self.exact_keys == other.exact_keys
+            && self.operations == other.operations
             && self.notification_timing == other.notification_timing
             && self.accepted_large_values == other.accepted_large_values
     }
@@ -72,7 +79,79 @@ pub enum NotificationTiming {
     AfterPersistence,
 }
 
+/// Outcome of a batch-scoped immutable-record insertion.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EnsureExactOutcome {
+    Inserted,
+    AlreadyIdentical,
+    Conflict,
+}
+
 impl DatabaseBatch {
+    /// Stage an immutable record, or accept its identical existing bytes.
+    /// A conflict poisons this batch, never the database. Outcomes cannot be
+    /// applied to a different database or after another resident publication.
+    pub async fn ensure_exact(
+        &mut self,
+        database: &Database,
+        table: impl Into<String>,
+        key: PrimaryKeyValue,
+        record: impl Into<RawRecordInput>,
+    ) -> Result<EnsureExactOutcome, Error> {
+        database.ensure_not_poisoned()?;
+        self.check_exact_base(database)?;
+        self.exact_base = Some((
+            Rc::as_ptr(&database.immutable_batch_owner) as usize,
+            database.next_publication_id,
+        ));
+        self.exact_owner = Some(Rc::clone(&database.immutable_batch_owner));
+        let table = table.into();
+        let record = record.into();
+        let operation = BatchOperation::InsertRawFresh {
+            table: table.clone(),
+            key,
+            record,
+        };
+        let pending = database.pending_write_from_operation(&operation)?;
+        let expected = pending.stored_record().expect("immutable insert has bytes");
+        database.ensure_batch_storage_txn(self)?;
+        let resident = database.resident_storage();
+        let overlay = StagedWriteOverlay::new(&resident, &self.txn_operations);
+        let coordinate = (table.clone(), pending.key().to_vec());
+        let comparison = overlay
+            .compare_value(table, pending.key().to_vec(), expected.clone())
+            .await?;
+        if comparison != crate::storage::ValueComparison::Different {
+            self.exact_keys.insert(coordinate, expected);
+        }
+        match comparison {
+            crate::storage::ValueComparison::Absent => {
+                self.push_operation(operation);
+                Ok(EnsureExactOutcome::Inserted)
+            }
+            crate::storage::ValueComparison::Identical => Ok(EnsureExactOutcome::AlreadyIdentical),
+            crate::storage::ValueComparison::Different => {
+                self.exact_conflict = true;
+                Ok(EnsureExactOutcome::Conflict)
+            }
+        }
+    }
+
+    pub(super) fn check_exact_base(&self, database: &Database) -> Result<(), Error> {
+        if self.exact_conflict {
+            return Err(Error::ImmutableBatchConflict);
+        }
+        if self.exact_base.is_some_and(|base| {
+            base != (
+                Rc::as_ptr(&database.immutable_batch_owner) as usize,
+                database.next_publication_id,
+            )
+        }) {
+            return Err(Error::StaleImmutableBatch);
+        }
+        Ok(())
+    }
+
     pub fn deliver_notifications(&mut self, timing: NotificationTiming) {
         self.notification_timing = timing;
     }

--- a/crates/groove/src/db/batch.rs
+++ b/crates/groove/src/db/batch.rs
@@ -118,7 +118,8 @@ impl DatabaseBatch {
         let resident = database.resident_storage();
         let overlay = StagedWriteOverlay::new(&resident, &self.txn_operations);
         let coordinate = (table.clone(), pending.key().to_vec());
-        let comparison = overlay
+        let storage = MeteredStorage::new(&overlay, &database.storage_read_metrics);
+        let comparison = storage
             .compare_value(table, pending.key().to_vec(), expected.clone())
             .await?;
         if comparison != crate::storage::ValueComparison::Different {

--- a/crates/groove/src/db/commit.rs
+++ b/crates/groove/src/db/commit.rs
@@ -110,14 +110,14 @@ impl Database {
     /// persistence. The returned handle owns the pending persistence work and
     /// no longer borrows this database, so resident queries may continue while
     /// storage suspends.
-    pub async fn apply_batch(&mut self, batch: DatabaseBatch) -> Result<AppliedBatch, Error> {
+    pub async fn apply_batch(&mut self, mut batch: DatabaseBatch) -> Result<AppliedBatch, Error> {
         batch.check_exact_base(self)?;
         self.ensure_not_poisoned()?;
         let accepted_large_values = batch.accepted_large_values.clone();
         let defer_notifications_until_durable =
             batch.notification_timing == NotificationTiming::AfterPersistence;
         // Later ordinary writes must not invalidate an ensure_exact result.
-        let exact_keys = batch.exact_keys.clone();
+        let exact_keys = std::mem::take(&mut batch.exact_keys);
         let pending_writes = self.pending_writes_from_batch(batch)?;
         for write in &pending_writes {
             if let Some(expected) =

--- a/crates/groove/src/db/commit.rs
+++ b/crates/groove/src/db/commit.rs
@@ -111,11 +111,22 @@ impl Database {
     /// no longer borrows this database, so resident queries may continue while
     /// storage suspends.
     pub async fn apply_batch(&mut self, batch: DatabaseBatch) -> Result<AppliedBatch, Error> {
+        batch.check_exact_base(self)?;
         self.ensure_not_poisoned()?;
         let accepted_large_values = batch.accepted_large_values.clone();
         let defer_notifications_until_durable =
             batch.notification_timing == NotificationTiming::AfterPersistence;
+        // Later ordinary writes must not invalidate an ensure_exact result.
+        let exact_keys = batch.exact_keys.clone();
         let pending_writes = self.pending_writes_from_batch(batch)?;
+        for write in &pending_writes {
+            if let Some(expected) =
+                exact_keys.get(&(write.table().to_owned(), write.key().to_vec()))
+                && write.stored_record().as_ref() != Some(expected)
+            {
+                return Err(Error::ImmutableBatchConflict);
+            }
+        }
         let mut accepted_staging = Vec::new();
         for staged_id in &accepted_large_values {
             let key = staged_large_value_key(*staged_id);

--- a/crates/groove/src/db/facade.rs
+++ b/crates/groove/src/db/facade.rs
@@ -377,6 +377,7 @@ impl Database {
             storage_read_metrics: Rc::new(RefCell::new(StorageReadMetrics::default())),
             stored_record_descriptors: RefCell::new(BTreeMap::new()),
             next_publication_id: 1,
+            immutable_batch_owner: Rc::new(()),
             durable_publication_frontier: None,
             resident_publications: BTreeMap::new(),
             persisted_publications: BTreeSet::new(),

--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -1360,6 +1360,7 @@ pub struct Database {
     /// re-hash the same logical field list once per stored row.
     stored_record_descriptors: RefCell<BTreeMap<String, BTreeMap<u32, RecordDescriptor>>>,
     next_publication_id: u64,
+    immutable_batch_owner: Rc<()>,
     durable_publication_frontier: Option<PublicationId>,
     resident_publications: BTreeMap<PublicationId, Rc<RefCell<StagedWriteState>>>,
     persisted_publications: BTreeSet<PublicationId>,
@@ -1665,6 +1666,10 @@ pub use storage_helpers::{
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("immutable record conflict invalidated the batch")]
+    ImmutableBatchConflict,
+    #[error("immutable batch must be rebuilt against the current database state")]
+    StaleImmutableBatch,
     #[error("database instance is poisoned after a failed atomic commit")]
     DatabasePoisoned,
     #[error("publication does not belong to this database: {0:?}")]

--- a/crates/groove/src/db/storage_helpers.rs
+++ b/crates/groove/src/db/storage_helpers.rs
@@ -530,6 +530,19 @@ where
         self.storage.column_family_names()
     }
 
+    fn compare_value(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> crate::storage::StorageFuture<
+        '_,
+        Result<crate::storage::ValueComparison, crate::storage::Error>,
+    > {
+        self.metrics.borrow_mut().record_point(&cf, &key);
+        self.storage.compare_value(cf, key, expected)
+    }
+
     fn get(
         &self,
         cf: String,

--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -5603,3 +5603,167 @@ async fn persistence_receipts_cannot_settle_another_database() {
         [(vec![Value::U64(2), Value::String("second".to_owned())], 1)]
     );
 }
+
+#[futures_test::test]
+async fn immutable_batch_is_idempotent_and_conflicts_abort_every_write() {
+    let schema = albums_schema();
+    let storage = MemoryStorage::new(&schema.column_families()).unwrap();
+    let mut db = Database::new(schema, storage).await.unwrap();
+    let descriptor = RecordDescriptor::new([("id", ValueType::U64), ("title", ValueType::String)]);
+    let record = |id, title: &str| {
+        descriptor
+            .create(&[Value::U64(id), Value::String(title.into())])
+            .unwrap()
+    };
+    let mut batch = db.open_batch();
+    assert_eq!(
+        batch
+            .ensure_exact(&db, "albums", PrimaryKeyValue::U64(1), record(1, "one"))
+            .await
+            .unwrap(),
+        EnsureExactOutcome::Inserted
+    );
+    assert_eq!(
+        batch
+            .ensure_exact(&db, "albums", PrimaryKeyValue::U64(1), record(1, "one"))
+            .await
+            .unwrap(),
+        EnsureExactOutcome::AlreadyIdentical
+    );
+    db.commit_batch(batch).await.unwrap();
+    let mut replay = db.open_batch();
+    assert_eq!(
+        replay
+            .ensure_exact(&db, "albums", PrimaryKeyValue::U64(1), record(1, "one"))
+            .await
+            .unwrap(),
+        EnsureExactOutcome::AlreadyIdentical
+    );
+    assert!(
+        replay.operations.is_empty(),
+        "identical history emits no writes or deltas"
+    );
+    db.commit_batch(replay).await.unwrap();
+    let mut conflict = db.open_batch();
+    assert_eq!(
+        conflict
+            .ensure_exact(&db, "albums", PrimaryKeyValue::U64(2), record(2, "two"))
+            .await
+            .unwrap(),
+        EnsureExactOutcome::Inserted
+    );
+    assert_eq!(
+        conflict
+            .ensure_exact(
+                &db,
+                "albums",
+                PrimaryKeyValue::U64(1),
+                record(1, "different")
+            )
+            .await
+            .unwrap(),
+        EnsureExactOutcome::Conflict
+    );
+    assert!(matches!(
+        db.commit_batch(conflict).await,
+        Err(Error::ImmutableBatchConflict)
+    ));
+    assert!(
+        db.primary_key_get_raw("albums", &[Value::U64(2)])
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        db.primary_key_get_raw("albums", &[Value::U64(1)])
+            .await
+            .unwrap()
+            .unwrap()
+            .raw(),
+        record(1, "one")
+    );
+    let mut usable = db.open_batch();
+    usable.insert(
+        "albums",
+        vec![Value::U64(3), Value::String("still usable".into())],
+    );
+    db.commit_batch(usable).await.unwrap();
+}
+
+#[futures_test::test]
+async fn immutable_batch_rejects_stale_resident_proofs() {
+    let schema = albums_schema();
+    let storage = MemoryStorage::new(&schema.column_families()).unwrap();
+    let mut db = Database::new(schema, storage).await.unwrap();
+    let descriptor = RecordDescriptor::new([("id", ValueType::U64), ("title", ValueType::String)]);
+    let mut old = db.open_batch();
+    old.ensure_exact(
+        &db,
+        "albums",
+        PrimaryKeyValue::U64(1),
+        descriptor
+            .create(&[Value::U64(1), Value::String("old".into())])
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+    let mut newer = db.open_batch();
+    newer.insert("albums", vec![Value::U64(1), Value::String("new".into())]);
+    let applied = db.apply_batch(newer).await.unwrap();
+    assert!(matches!(
+        db.apply_batch(old).await,
+        Err(Error::StaleImmutableBatch)
+    ));
+    db.finish_persistence(applied.persist().await).unwrap();
+    assert_eq!(
+        db.primary_key_get_raw("albums", &[Value::U64(1)])
+            .await
+            .unwrap()
+            .unwrap()
+            .record()
+            .get_str(1)
+            .unwrap(),
+        "new"
+    );
+}
+
+#[futures_test::test]
+async fn immutable_batch_rejects_later_overwrite_and_other_database() {
+    let schema = albums_schema();
+    let storage = MemoryStorage::new(&schema.column_families()).unwrap();
+    let mut db = Database::new(schema.clone(), storage).await.unwrap();
+    let descriptor = RecordDescriptor::new([("id", ValueType::U64), ("title", ValueType::String)]);
+    let bytes = descriptor
+        .create(&[Value::U64(1), Value::String("original".into())])
+        .unwrap();
+    let mut batch = db.open_batch();
+    batch
+        .ensure_exact(&db, "albums", PrimaryKeyValue::U64(1), bytes.clone())
+        .await
+        .unwrap();
+    batch.update(
+        "albums",
+        vec![Value::U64(1), Value::String("overwrite".into())],
+    );
+    assert!(matches!(
+        db.commit_batch(batch).await,
+        Err(Error::ImmutableBatchConflict)
+    ));
+    assert!(
+        db.primary_key_get_raw("albums", &[Value::U64(1)])
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let mut batch = db.open_batch();
+    batch
+        .ensure_exact(&db, "albums", PrimaryKeyValue::U64(1), bytes)
+        .await
+        .unwrap();
+    let storage = MemoryStorage::new(&schema.column_families()).unwrap();
+    let mut other = Database::new(schema, storage).await.unwrap();
+    assert!(matches!(
+        other.commit_batch(batch).await,
+        Err(Error::StaleImmutableBatch)
+    ));
+}

--- a/crates/groove/src/storage/idb.rs
+++ b/crates/groove/src/storage/idb.rs
@@ -230,6 +230,28 @@ impl<S> OrderedKvStorage for IdbStorage<S>
 where
     S: PageStore + Clone + 'static,
 {
+    fn compare_value(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> StorageFuture<'_, Result<super::ValueComparison, Error>> {
+        Box::pin(async move {
+            let key = self.encoded_key(&cf, &key)?;
+            let result = self
+                .read_resident(|tree| {
+                    let (key, expected) = (key.clone(), expected.clone());
+                    async move { tree.value_equals(&key, &expected).await }
+                })
+                .await?;
+            Ok(match result {
+                None => super::ValueComparison::Absent,
+                Some(true) => super::ValueComparison::Identical,
+                Some(false) => super::ValueComparison::Different,
+            })
+        })
+    }
+
     fn get(&self, cf: String, key: Vec<u8>) -> StorageFuture<'_, Result<Option<Value>, Error>> {
         Box::pin(async move {
             let key = self.encoded_key(&cf, &key)?;

--- a/crates/groove/src/storage/memory.rs
+++ b/crates/groove/src/storage/memory.rs
@@ -351,6 +351,21 @@ impl MemoryStorage {
 }
 
 impl OrderedKvStorage for MemoryStorage {
+    fn compare_value(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> super::StorageFuture<'_, Result<super::ValueComparison, Error>> {
+        Box::pin(async move {
+            self.with_cf(&cf, |values| match values.get(&key) {
+                None => super::ValueComparison::Absent,
+                Some(value) if value == &expected => super::ValueComparison::Identical,
+                Some(_) => super::ValueComparison::Different,
+            })
+        })
+    }
+
     fn permits_eager_read_retry(&self) -> bool {
         true
     }

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -330,6 +330,14 @@ pub type ScanVisitor<'visitor> =
 /// absences. Successful writes through the same storage instance must be
 /// reflected by those resident reads. A backend may evict retained data; after
 /// eviction, a later read may become pending again.
+/// Result of comparing an encoded value without returning its body.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ValueComparison {
+    Absent,
+    Identical,
+    Different,
+}
+
 pub trait OrderedKvStorage {
     /// Whether a read that yields once may be immediately re-polled by the
     /// caller without turning an external storage wait into a synchronous
@@ -354,6 +362,23 @@ pub trait OrderedKvStorage {
     }
 
     fn get(&self, cf: String, key: Vec<u8>) -> StorageFuture<'_, Result<Option<Value>, Error>>;
+    /// Compare at the storage boundary. Backends can avoid cloning resident values.
+    /// This is a read, not a conditional mutation or a cross-writer reservation.
+    fn compare_value(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> StorageFuture<'_, Result<ValueComparison, Error>> {
+        Box::pin(async move {
+            Ok(match self.get(cf, key).await? {
+                None => ValueComparison::Absent,
+                Some(value) if value == expected => ValueComparison::Identical,
+                Some(_) => ValueComparison::Different,
+            })
+        })
+    }
+
     /// Atomically install `value` only when `key` is absent. Returns the
     /// pre-existing value when another writer already installed one.
     fn put_if_absent(
@@ -503,6 +528,15 @@ impl<S> OrderedKvStorage for Rc<S>
 where
     S: OrderedKvStorage,
 {
+    fn compare_value(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> StorageFuture<'_, Result<ValueComparison, Error>> {
+        self.as_ref().compare_value(cf, key, expected)
+    }
+
     fn permits_eager_read_retry(&self) -> bool {
         self.as_ref().permits_eager_read_retry()
     }
@@ -597,6 +631,15 @@ impl<S> OrderedKvStorage for &S
 where
     S: OrderedKvStorage,
 {
+    fn compare_value(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> StorageFuture<'_, Result<ValueComparison, Error>> {
+        S::compare_value(*self, cf, key, expected)
+    }
+
     fn permits_eager_read_retry(&self) -> bool {
         S::permits_eager_read_retry(*self)
     }
@@ -977,6 +1020,18 @@ impl LayoutStorage {
 }
 
 impl OrderedKvStorage for LayoutStorage {
+    fn compare_value(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> StorageFuture<'_, Result<ValueComparison, Error>> {
+        Box::pin(async move {
+            let (cf, key) = self.physical_key(&cf, &key)?;
+            self.inner.compare_value(cf, key, expected).await
+        })
+    }
+
     fn get(&self, cf: String, key: Vec<u8>) -> StorageFuture<'_, Result<Option<Value>, Error>> {
         Box::pin(async move {
             let (physical_cf, physical_key) = self.physical_key(&cf, &key)?;
@@ -1207,6 +1262,15 @@ impl BoxedStorage {
 }
 
 impl OrderedKvStorage for BoxedStorage {
+    fn compare_value(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> StorageFuture<'_, Result<ValueComparison, Error>> {
+        self.inner.compare_value(cf, key, expected)
+    }
+
     fn scan(&self, request: ScanRequest) -> StorageFuture<'_, Result<StorageScan<'_>, Error>> {
         self.inner.scan(request)
     }
@@ -1900,6 +1964,29 @@ impl<S: ?Sized> OrderedKvStorage for StagedWriteOverlay<'_, S>
 where
     S: OrderedKvStorage,
 {
+    fn compare_value(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> StorageFuture<'_, Result<ValueComparison, Error>> {
+        Box::pin(async move {
+            {
+                let mut staged = self.staged_writes.borrow_mut();
+                if let Some(index) = staged.latest_index(&cf, &key) {
+                    return Ok(match &staged.operations[index] {
+                        OwnedWriteOperation::Delete { .. } => ValueComparison::Absent,
+                        OwnedWriteOperation::Set { value, .. } if value == &expected => {
+                            ValueComparison::Identical
+                        }
+                        _ => ValueComparison::Different,
+                    });
+                }
+            }
+            self.base.compare_value(cf, key, expected).await
+        })
+    }
+
     fn permits_eager_read_retry(&self) -> bool {
         self.base.permits_eager_read_retry()
     }
@@ -2085,6 +2172,37 @@ pub mod conformance {
     where
         S: OrderedKvStorage,
     {
+        let key = b"comparison-only".to_vec();
+        assert_eq!(
+            storage
+                .compare_value("records".into(), key.clone(), b"first".to_vec())
+                .await
+                .unwrap(),
+            ValueComparison::Absent
+        );
+        storage
+            .set("records".into(), key.clone(), b"first".to_vec())
+            .await
+            .unwrap();
+        assert_eq!(
+            storage
+                .compare_value("records".into(), key.clone(), b"first".to_vec())
+                .await
+                .unwrap(),
+            ValueComparison::Identical
+        );
+        assert_eq!(
+            storage
+                .compare_value("records".into(), key.clone(), b"other".to_vec())
+                .await
+                .unwrap(),
+            ValueComparison::Different
+        );
+        assert_eq!(
+            storage.get("records".into(), key.clone()).await.unwrap(),
+            Some(b"first".to_vec())
+        );
+        storage.delete("records".into(), key).await.unwrap();
         storage
             .set("records".into(), b"user:2".to_vec(), b"two".to_vec())
             .await

--- a/crates/idb-tree/src/lib.rs
+++ b/crates/idb-tree/src/lib.rs
@@ -198,6 +198,18 @@ impl<S: PageStore + Clone> IdbTree<S> {
         self.inner.borrow().dirty.len()
     }
 
+    /// Compare an existing value in place; None denotes an absent key.
+    pub async fn value_equals(&self, key: &[u8], expected: &[u8]) -> Result<Option<bool>, Error> {
+        loop {
+            self.ensure_live()?;
+            let attempt = self.inner.borrow().try_value_equals(key, expected)?;
+            match attempt {
+                Attempt::Ready(value) => return Ok(value),
+                Attempt::Missing(page_id) => self.hydrate(page_id).await?,
+            }
+        }
+    }
+
     pub async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         loop {
             self.ensure_live()?;
@@ -447,6 +459,54 @@ impl<S: PageStore> TreeCore<S> {
             tree.metadata.root_page_id = Some(root);
         }
         Ok(tree)
+    }
+
+    fn try_value_equals(
+        &self,
+        key: &[u8],
+        expected: &[u8],
+    ) -> Result<Attempt<Option<bool>>, Error> {
+        let Some((_, entries, _, mut visited)) = self.resident_descent(key)? else {
+            return Ok(Attempt::Missing(self.missing_page_for_key(key)?));
+        };
+        let Ok(index) = entries.binary_search_by(|(candidate, _)| candidate.as_slice().cmp(key))
+        else {
+            return Ok(Attempt::Ready(None));
+        };
+        match &entries[index].1 {
+            ValueCell::Inline(value) => Ok(Attempt::Ready(Some(value.as_slice() == expected))),
+            ValueCell::Overflow { head, len } => {
+                if u64::try_from(expected.len()).ok() != Some(*len) {
+                    return Ok(Attempt::Ready(Some(false)));
+                }
+                let mut current = Some(*head);
+                let mut offset = 0usize;
+                while let Some(page_id) = current {
+                    if !visited.insert(page_id) {
+                        return Err(Error::InvalidPage(
+                            "tree graph contains a cycle or shared page".to_owned(),
+                        ));
+                    }
+                    let Some(page) = self.pages.get(&page_id) else {
+                        return Ok(Attempt::Missing(page_id));
+                    };
+                    let Page::Overflow { next, bytes } = page else {
+                        return Err(Error::InvalidPage(
+                            "value references a non-overflow page".to_owned(),
+                        ));
+                    };
+                    let end = offset.checked_add(bytes.len()).ok_or_else(|| {
+                        Error::InvalidPage("overflow value length overflow".to_owned())
+                    })?;
+                    if expected.get(offset..end) != Some(bytes.as_slice()) {
+                        return Ok(Attempt::Ready(Some(false)));
+                    }
+                    offset = end;
+                    current = *next;
+                }
+                Ok(Attempt::Ready(Some(offset == expected.len())))
+            }
+        }
     }
 
     fn try_get(&self, key: &[u8]) -> Result<Attempt<Option<Vec<u8>>>, Error> {
@@ -1152,6 +1212,47 @@ mod tests {
     // These are intentionally engine-level contract tests: page splitting,
     // reopen, and residency are not observably attributable through Jazz's
     // public query API, while every backend must preserve them.
+    #[test]
+    fn exact_value_comparison_handles_inline_overflow_and_cold_reopen() {
+        futures::executor::block_on(async {
+            let store = MemoryPageStore::default();
+            let options = Options { page_size: 1024 };
+            let tree = IdbTree::open(store.clone(), options.clone()).await.unwrap();
+            tree.put(b"small".to_vec(), b"hello".to_vec())
+                .await
+                .unwrap();
+            let large = vec![7; 10000];
+            tree.put(b"large".to_vec(), large.clone()).await.unwrap();
+            tree.flush().await.unwrap();
+            drop(tree);
+            let tree = IdbTree::open(store, options).await.unwrap();
+            assert_eq!(tree.value_equals(b"missing", b"hello").await.unwrap(), None);
+            assert_eq!(
+                tree.value_equals(b"small", b"hello").await.unwrap(),
+                Some(true)
+            );
+            assert_eq!(
+                tree.value_equals(b"small", b"world").await.unwrap(),
+                Some(false)
+            );
+            assert_eq!(
+                tree.value_equals(b"large", &large).await.unwrap(),
+                Some(true)
+            );
+            let mut changed = large.clone();
+            changed[9999] = 8;
+            assert_eq!(
+                tree.value_equals(b"large", &changed).await.unwrap(),
+                Some(false)
+            );
+            assert_eq!(
+                tree.value_equals(b"large", &large[..9999]).await.unwrap(),
+                Some(false)
+            );
+            assert_eq!(tree.get(b"large").await.unwrap(), Some(large));
+        });
+    }
+
     #[test]
     fn inserts_split_reopen_and_scan_in_key_order() {
         futures::executor::block_on(async {

--- a/crates/jazz-storage-rocksdb/src/lib.rs
+++ b/crates/jazz-storage-rocksdb/src/lib.rs
@@ -717,6 +717,30 @@ impl ReopenableStorage for RocksDbStorage {
 }
 
 impl OrderedKvStorage for RocksDbStorage {
+    fn compare_value(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> StorageFuture<'_, Result<groove::storage::ValueComparison, Error>> {
+        Box::pin(async move {
+            let value = if cf == "default" {
+                self.db.get_pinned(&key).storage()?
+            } else {
+                self.db
+                    .get_pinned_cf(self.cf_handle(&cf)?, &key)
+                    .storage()?
+            };
+            Ok(match value {
+                None => groove::storage::ValueComparison::Absent,
+                Some(value) if value.as_ref() == expected.as_slice() => {
+                    groove::storage::ValueComparison::Identical
+                }
+                Some(_) => groove::storage::ValueComparison::Different,
+            })
+        })
+    }
+
     fn get(&self, cf: String, key: Vec<u8>) -> StorageFuture<'_, Result<Option<Value>, Error>> {
         Box::pin(async move {
             let value = if cf == "default" {

--- a/crates/jazz-storage-sqlite/src/lib.rs
+++ b/crates/jazz-storage-sqlite/src/lib.rs
@@ -566,6 +566,30 @@ impl ReopenableStorage for SqliteStorage {
 }
 
 impl OrderedKvStorage for SqliteStorage {
+    fn compare_value(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> StorageFuture<'_, Result<groove::storage::ValueComparison, Error>> {
+        Box::pin(async move {
+            let cf = self.cf_id(&cf)?;
+            self.with_connection(|connection| {
+                let equal: Option<bool> = connection
+                    .prepare_cached("SELECT v = ?3 FROM kv WHERE cf = ?1 AND k = ?2")
+                    .map_err(backend)?
+                    .query_row(params![cf, key, expected], |row| row.get(0))
+                    .optional()
+                    .map_err(backend)?;
+                Ok(match equal {
+                    None => groove::storage::ValueComparison::Absent,
+                    Some(true) => groove::storage::ValueComparison::Identical,
+                    Some(false) => groove::storage::ValueComparison::Different,
+                })
+            })
+        })
+    }
+
     fn get(&self, cf: String, key: Vec<u8>) -> StorageFuture<'_, Result<Option<Value>, Error>> {
         Box::pin(async move {
             let cf = self.cf_id(&cf)?;

--- a/crates/jazz/SPEC/18_representation_ownership.md
+++ b/crates/jazz/SPEC/18_representation_ownership.md
@@ -206,3 +206,18 @@ encoders.
 This map intentionally defines ownership, not a second source of query or
 protocol semantics. The numbered chapters and invariant registries remain
 authoritative.
+
+### Immutable history admission batches
+
+Jazz resolves wire identities to its local physical history representation
+before calling Groove's batch-scoped `ensure_exact`. History equality is over
+that storage representation, not between wire bytes and a storage envelope.
+Known-transaction admission compares only incoming coordinates; it must not
+reconstruct every stored row and linearly search them for each incoming row.
+
+Jazz still owns transaction identity, authorization, parent constraints,
+partial cardinality, fate/durability transitions and current-row visibility.
+An identical history version does not imply a transaction-status no-op. The
+history insertions, transaction metadata and derived current/index effects
+share the existing database batch/publication boundary. Alias allocation for
+a multi-transaction publication precedes immutable-row batch decisions.

--- a/crates/jazz/src/node/ingest/authority_publications.rs
+++ b/crates/jazz/src/node/ingest/authority_publications.rs
@@ -228,6 +228,17 @@ where
             .iter()
             .map(|unit| (unit.tx.tx_id, unit.versions.clone()))
             .collect::<Vec<_>>();
+        // Alias allocation is a separate monotone publication. Complete it for
+        // the whole input before any immutable-row decisions bind the batch.
+        for unit in &publication.commits {
+            self.ensure_node_alias(unit.tx.tx_id.node).await?;
+            for version in &unit.versions {
+                self.ensure_schema_version_alias(version.schema_version()).await?;
+                for parent in version.parents() {
+                    self.ensure_node_alias(parent.node).await?;
+                }
+            }
+        }
         let mut batch = self.database.open_batch();
         self.preflight_complete_parent_batch(&mut batch, &complete_parents)
             .await?;

--- a/crates/jazz/src/node/ingest/commit_bundles.rs
+++ b/crates/jazz/src/node/ingest/commit_bundles.rs
@@ -1007,28 +1007,29 @@ where
         let versions = canonical_versions(versions);
         self.prepare_authored_schema_variants_for_commit(&versions).await?;
         if let Some(existing) = self.query_transaction(tx.tx_id).await? {
-            let mut existing_versions = self
-                .query_versions_for_tx(tx.tx_id).await?
-                .into_iter()
-                .map(|stored| self.version_record_from_row(&stored))
-                .collect::<Result<Vec<_>, Error>>()?;
-            existing_versions.sort();
             if !(known_transaction_payload_matches_redacted_permission_subject(&existing.tx, &tx)
                 || existing.view_scoped_cardinality
                     && known_transaction_payload_matches_redacted_cardinality(&existing.tx, &tx))
             {
                 return Err(Error::ConflictingCommitUnit(tx.tx_id));
             }
+            // Normalize aliases before establishing the batch's resident base.
+            for schema in versions.iter().map(VersionRecord::schema_version).collect::<BTreeSet<_>>() {
+                self.ensure_schema_version_alias(schema).await?;
+            }
+            for parent in versions.iter().flat_map(VersionRecord::parents) {
+                self.ensure_node_alias(parent.node).await?;
+            }
+            let mut batch = self.database.open_batch();
             let mut version_bundles = Vec::new();
             for version in versions {
-                match existing_versions.iter().find(|existing| {
-                    view_version_key_for_ingest(existing) == view_version_key_for_ingest(&version)
-                }) {
-                    Some(existing) if existing != &version => {
-                        return Err(Error::ConflictingCommitUnit(tx.tx_id));
-                    }
-                    Some(_) => {}
-                    None => version_bundles.push(version),
+                let stored = self.prepare_exact_history_version(existing.node_alias, tx.tx_id.time, &version).await?;
+                let (table, record) = self.version_storage_write_binding(&stored)?;
+                let key = self.version_storage_primary_key(&stored)?;
+                match batch.ensure_exact(&self.database, table.as_ref(), key, record).await? {
+                    groove::db::EnsureExactOutcome::Inserted => version_bundles.push(version),
+                    groove::db::EnsureExactOutcome::AlreadyIdentical => {},
+                    groove::db::EnsureExactOutcome::Conflict => return Err(Error::ConflictingCommitUnit(tx.tx_id)),
                 }
             }
             if version_bundles.is_empty() && !existing.view_scoped_cardinality {
@@ -1036,12 +1037,15 @@ where
                     .await?;
                 return Ok(());
             }
-            return self.ingest_transaction_and_versions(
+            return self.ingest_transaction_and_versions_with_current_indexes_in_batch(
+                batch,
                 tx,
                 version_bundles,
                 fate,
                 global_time,
                 durability,
+                true,
+                false,
             ).await;
         }
         self.ingest_transaction_and_versions(tx, versions, fate, global_time, durability)

--- a/crates/jazz/src/node/ingest/validation.rs
+++ b/crates/jazz/src/node/ingest/validation.rs
@@ -410,8 +410,39 @@ where
         Ok(PublishedTransaction { tx_id, persistence })
     }
 
+    async fn prepare_exact_history_version(
+        &mut self, tx_node_alias: NodeAlias, tx_time: TxTime, version: &VersionRecord,
+    ) -> Result<VersionRow, Error> {
+        let author_schema = version.schema_version();
+        let table = self.table_in_schema(version.table(), author_schema)?;
+        let schema_alias = self.ensure_schema_version_alias(author_schema).await?;
+        let authored = self.authored_column_ids_for_names(author_schema, version.table(), version.authored_columns())?;
+        VersionRow::from_wire_with_schema_version(
+            &table, version, authored, tx_node_alias, schema_alias, tx_time,
+            (author_schema != self.catalogue.current_schema_version_id).then_some(author_schema),
+        )
+    }
+
     async fn ingest_transaction_and_versions_with_current_indexes(
         &mut self,
+        tx: Transaction,
+        versions: Vec<VersionRecord>,
+        fate: Fate,
+        global_time: Option<GlobalTime>,
+        durability: DurabilityTier,
+        update_current_indexes: bool,
+        view_scoped_cardinality: bool,
+    ) -> Result<(), Error> {
+        let batch = self.database.open_batch();
+        self.ingest_transaction_and_versions_with_current_indexes_in_batch(
+            batch, tx, versions, fate, global_time, durability, update_current_indexes,
+            view_scoped_cardinality,
+        ).await
+    }
+
+    async fn ingest_transaction_and_versions_with_current_indexes_in_batch(
+        &mut self,
+        mut batch: DatabaseBatch,
         tx: Transaction,
         versions: Vec<VersionRecord>,
         fate: Fate,
@@ -426,7 +457,6 @@ where
         } else {
             self.complete_parent_versions(&tx, &versions).await?
         };
-        let mut batch = self.database.open_batch();
         if let Some(complete_parent_versions) = complete_parent_versions.as_deref() {
             self.preflight_complete_parent_constraints(
                 &mut batch,
@@ -504,6 +534,9 @@ where
             .collect::<BTreeSet<_>>();
         for parent_node in parent_nodes {
             self.ensure_node_alias(parent_node).await?;
+        }
+        for schema in versions.iter().map(VersionRecord::schema_version).collect::<BTreeSet<_>>() {
+            self.ensure_schema_version_alias(schema).await?;
         }
         let stored_tx = self.query_transaction(tx.tx_id).await?;
         let tx_already_known = stored_tx.is_some();
@@ -651,28 +684,10 @@ where
             }
             let (history_table, groove_record) = self.version_storage_write_binding(&stored)?;
             let storage_key = self.version_storage_primary_key(&stored)?;
-            if tx_already_known {
-                let existing = self.database.primary_key_get_raw_in_batch(
-                    batch,
-                    history_table.as_ref(),
-                    &self.version_storage_primary_key_values(&stored)?,
-                )
-                .await?;
-                if let Some(existing) = existing {
-                    if existing.record().raw() != groove_record.record().raw() {
-                        return Err(Error::ConflictingCommitUnit(tx.tx_id));
-                    }
-                } else {
-                    batch.insert_raw(history_table.as_ref(), storage_key, groove_record);
-                }
-            } else {
-                // SAFETY: transaction metadata and immutable history rows persist atomically, so
-                // an unknown transaction id proves that this history key is absent from storage.
-                // The bulk-ingest path also deduplicates transaction ids before staging, proving
-                // there is no earlier operation for this key in the same batch.
-                unsafe {
-                    batch.insert_raw_fresh(history_table.as_ref(), storage_key, groove_record);
-                }
+            if batch.ensure_exact(&self.database, history_table.as_ref(), storage_key, groove_record).await?
+                == groove::db::EnsureExactOutcome::Conflict
+            {
+                return Err(Error::ConflictingCommitUnit(tx.tx_id));
             }
             if update_current_indexes && !matches!(fate, Fate::Rejected(_)) && global_time.is_none()
             {

--- a/crates/jazz/src/node/physical/storage.rs
+++ b/crates/jazz/src/node/physical/storage.rs
@@ -393,28 +393,6 @@ where
         Ok(history_primary_key(version))
     }
 
-    pub(super) fn version_storage_primary_key_values(
-        &self,
-        version: &VersionRow,
-    ) -> Result<Vec<Value>, Error> {
-        if version.layer() == VersionLayer::Deletion {
-            let table_id = self.physical_table_id_for_version(version)?;
-            return Ok(vec![
-                Value::Bytes(version.branch_key().canonical_bytes()),
-                Value::U64(table_id.0),
-                Value::Uuid(version.row_uuid().0),
-                Value::U64(version.tx_time().0),
-                Value::U64(version.tx_node_alias().0),
-            ]);
-        }
-        Ok(vec![
-            Value::Bytes(version.branch_key().canonical_bytes()),
-            Value::Uuid(version.row_uuid().0),
-            Value::U64(version.tx_time().0),
-            Value::U64(version.tx_node_alias().0),
-        ])
-    }
-
     /// Re-encode every enum occurrence in a logical storage record before it
     /// crosses into a physical table.  History, settled-current and
     /// ahead-current writes share this boundary; allowing one of those paths

--- a/crates/jazz/src/node/tests/merge_heads.rs
+++ b/crates/jazz/src/node/tests/merge_heads.rs
@@ -895,3 +895,22 @@ fn ancestry_lookup_avoids_transaction_wide_reads_resident_and_cold() {
             "row ancestry must never materialize a whole transaction (cold={cold})");
     }
 }
+
+// Internal work-count receipt: transaction fate handling may read the full
+// unit once; exact row matching must not add another transaction-wide read.
+#[test]
+fn known_transaction_matching_probes_only_incoming_history_keys() {
+    let schema = two_column_schema();
+    let (_dir, mut writer) = open_node_with_schema(node(0xf1), schema);
+    let tx_id = writer.commit_mergeable_many_settled((0..32).map(|i| {
+        MergeableCommit::new("todos", row(i + 1), 10)
+            .cells(BTreeMap::from([("title".to_owned(), "same".to_owned())]))
+    }).collect()).unwrap();
+    let SyncMessage::CommitUnit { tx, versions } = writer.commit_unit_for(tx_id).unwrap() else { panic!("commit unit"); };
+    let state = writer.query_transaction(tx_id).unwrap().unwrap();
+    writer.query.tx_versions_cache.clear();
+    reset_query_versions_for_tx_call_count();
+    writer.ingest_known_transaction(tx, versions, state.fate.clone(), state.global_time, state.durability).unwrap();
+    assert_eq!(query_versions_for_tx_call_count(), 1, "only fate processing needs a whole-transaction read");
+    assert_eq!(writer.query_versions_for_tx(tx_id).unwrap().len(), 32);
+}

--- a/crates/jazz/src/node/tests/sync/receiver_batches.rs
+++ b/crates/jazz/src/node/tests/sync/receiver_batches.rs
@@ -2024,3 +2024,166 @@ fn view_scoped_cardinality_survives_reopen_and_upgrades_to_complete_payload() {
     assert_eq!(stored.tx.n_total_writes, 2);
     assert!(!stored.view_scoped_cardinality);
 }
+
+
+#[test]
+fn receiver_batch_prepares_all_author_aliases_before_exact_ingestion() {
+    let (_writer_dir, mut writer) = open_node_with_uuid(node(1));
+    let (_core_dir, mut core) = open_node_with_uuid(node(2));
+    let (_reader_dir, mut reader) = open_node_with_uuid(node(3));
+    let (_second_dir, mut second_writer) = open_node_with_uuid(node(4));
+    register_whole_table_receiver(&mut reader, "todos");
+
+    commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("todos", row(1), 10).cells(title_cells("one")),
+    );
+    commit_mergeable_global(
+        &mut second_writer,
+        &mut core,
+        MergeableCommit::new("todos", row(2), 11).cells(title_cells("two")),
+    );
+
+    let update = core.view_update_for_current_rows("todos").unwrap();
+    let mut version_bundles = version_bundles_for_update(&update);
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+        subscription,
+        settled_through,
+        peer_payload_inventory,
+        supporting_rows: program_fact_adds,
+        ..
+    }) = update
+    else {
+        panic!("expected view update");
+    };
+    assert_eq!(version_bundles.len(), 2);
+    for bundle in &mut version_bundles {
+        bundle.scope = crate::protocol::VersionBundleScope::ViewScoped;
+    }
+    version_bundles.reverse();
+    // Both entries are complete sets; exact native payloads ingest only once.
+
+    reader
+        .apply_view_updates_in_batch(vec![
+            todos_receiver_reset(subscription),
+            ViewUpdateParts {
+                wire_rows: Some(program_fact_adds),
+                subscription,
+                settled_through,
+                defer_settlement: false,
+                reset_input_set: true,
+                version_carriers: crate::protocol::build_version_carriers_from_singletons(
+                    version_bundles,
+                )
+                .unwrap(),
+                peer_complete_tx_payload_refs: peer_payload_inventory.complete_tx_payloads,
+                authorization_progress: None,
+                opening_pending: false,
+                result_member_adds: Vec::new(),
+                result_member_removes: Vec::new(),
+                program_fact_adds: Vec::new(),
+                program_fact_removes: Vec::new(),
+            },
+        ])
+        .unwrap();
+
+    let version_rows = reader.query_all_versions().unwrap();
+    assert_eq!(version_rows.len(), 2);
+    assert!(
+        version_rows
+            .iter()
+            .any(|version| version.table() == "todos" && version.row_uuid() == row(1))
+    );
+    assert!(
+        version_rows
+            .iter()
+            .any(|version| version.table() == "todos" && version.row_uuid() == row(2))
+    );
+    assert_eq!(reader.sync_metrics().receiver_bulk_ingest_commits, 1);
+    assert_eq!(reader.sync_metrics().receiver_bulk_bundle_ingests, 2);
+    assert_eq!(reader.sync_metrics().receiver_per_bundle_ingests, 0);
+}
+
+#[test]
+fn receiver_batch_defers_known_transaction_publication_until_new_rows_commit() {
+    let (_writer_dir, mut writer) = open_node_with_uuid(node(1));
+    let (_core_dir, mut core) = open_node_with_uuid(node(2));
+    let (_reader_dir, mut reader) = open_node_with_uuid(node(3));
+    let (_second_dir, mut second_writer) = open_node_with_uuid(node(4));
+    register_whole_table_receiver(&mut reader, "todos");
+
+    commit_mergeable_global(
+        &mut writer,
+        &mut core,
+        MergeableCommit::new("todos", row(1), 10).cells(title_cells("one")),
+    );
+    commit_mergeable_global(
+        &mut second_writer,
+        &mut core,
+        MergeableCommit::new("todos", row(2), 11).cells(title_cells("two")),
+    );
+
+    let update = core.view_update_for_current_rows("todos").unwrap();
+    let mut version_bundles = version_bundles_for_update(&update);
+    let SyncMessage::ViewUpdate(crate::protocol::ViewUpdatePayload {
+        subscription,
+        settled_through,
+        peer_payload_inventory,
+        supporting_rows: program_fact_adds,
+        ..
+    }) = update
+    else {
+        panic!("expected view update");
+    };
+    assert_eq!(version_bundles.len(), 2);
+    for bundle in &mut version_bundles {
+        bundle.global_time = None;
+        bundle.durability = DurabilityTier::Local;
+    }
+    let known = version_bundles.iter().find(|bundle| bundle.tx.tx_id.node == node(4)).unwrap();
+    let known_tx_id = known.tx.tx_id;
+    reader.ingest_known_transaction(known.tx.clone(), known.versions.clone(), Fate::Pending, known.global_time, known.durability).unwrap();
+    version_bundles.reverse();
+    // Both entries are complete sets; exact native payloads ingest only once.
+
+    reader
+        .apply_view_updates_in_batch(vec![
+            todos_receiver_reset(subscription),
+            ViewUpdateParts {
+                wire_rows: Some(program_fact_adds),
+                subscription,
+                settled_through,
+                defer_settlement: false,
+                reset_input_set: false,
+                version_carriers: crate::protocol::build_version_carriers_from_singletons(
+                    version_bundles,
+                )
+                .unwrap(),
+                peer_complete_tx_payload_refs: peer_payload_inventory.complete_tx_payloads,
+                authorization_progress: None,
+                opening_pending: false,
+                result_member_adds: Vec::new(),
+                result_member_removes: Vec::new(),
+                program_fact_adds: Vec::new(),
+                program_fact_removes: Vec::new(),
+            },
+        ])
+        .unwrap();
+
+    assert_eq!(reader.query_transaction(known_tx_id).unwrap().unwrap().fate, Fate::Accepted);
+    let version_rows = reader.query_all_versions().unwrap();
+    assert_eq!(version_rows.len(), 2);
+    assert!(
+        version_rows
+            .iter()
+            .any(|version| version.table() == "todos" && version.row_uuid() == row(1))
+    );
+    assert!(
+        version_rows
+            .iter()
+            .any(|version| version.table() == "todos" && version.row_uuid() == row(2))
+    );
+    assert_eq!(reader.sync_metrics().receiver_bulk_ingest_commits, 1);
+    assert_eq!(reader.sync_metrics().receiver_bulk_bundle_ingests, 1);
+}

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -1627,6 +1627,7 @@ where
         let mut receiver_batch_global_times = Vec::new();
         let mut receiver_batch_content_versions = Vec::new();
         let mut receiver_batch_bundle_count = 0u64;
+        let mut deferred_bundles = Vec::new();
         for bundle in receiver_candidates.values() {
             let staged = self
                 .stage_view_bundle(
@@ -1639,6 +1640,8 @@ where
                 .await?;
             if staged {
                 receiver_batch_bundle_count += 1;
+            } else {
+                deferred_bundles.push(bundle.clone());
             }
         }
         self.write_merge_heads_for_bulk_content_versions(
@@ -1667,6 +1670,14 @@ where
         }
         let mut preloaded_tx_ids = bulk_loaded_tx_ids;
         preloaded_tx_ids.extend(receiver_batch_tx_ids);
+        // Supplying preloaded IDs bypasses per-update bundle ingestion below,
+        // so deferred known transactions must explicitly apply their new fate.
+        for bundle in deferred_bundles {
+            let tx_id = bundle.tx.tx_id;
+            self.sync_metrics.receiver_per_bundle_ingests += 1;
+            self.ingest_view_bundle(bundle).await?;
+            preloaded_tx_ids.insert(tx_id);
+        }
         // Cross-subscription ordering within one receiver tick carries no
         // protocol semantics beyond per-link FIFO. Table writes are coalesced
         // above; per-subscription settled-state mutations still apply in

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -1610,6 +1610,18 @@ where
         for tx_id in &bulk_loaded_tx_ids {
             receiver_candidates.remove(tx_id);
         }
+        // Alias registration publishes metadata. Resolve every author, parent
+        // and schema before preparing any immutable row in this shared batch.
+        for bundle in receiver_candidates.values() {
+            self.ensure_node_alias(bundle.tx.tx_id.node).await?;
+            for version in &bundle.versions {
+                self.ensure_schema_version_alias(version.schema_version())
+                    .await?;
+                for parent in version.parents() {
+                    self.ensure_node_alias(parent.node).await?;
+                }
+            }
+        }
         let mut receiver_batch = self.database.open_batch();
         let mut receiver_batch_tx_ids = BTreeSet::new();
         let mut receiver_batch_global_times = Vec::new();
@@ -2635,14 +2647,17 @@ where
             .await?;
             return Ok(true);
         }
+        // Known complete transactions take the fate/update path below, after
+        // this batch commits. That path may publish independently and must not
+        // invalidate exact-match preparation for preceding new transactions.
+        if self.query_transaction(bundle.tx.tx_id).await?.is_some() {
+            return Ok(false);
+        }
         if bundle.tx.kind == TxKind::Exclusive {
             let complete_len = usize::try_from(bundle.tx.n_total_writes).map_err(|_| {
                 Error::InvalidStoredValue("exclusive transaction write count does not fit usize")
             })?;
             if bundle.versions.len() != complete_len {
-                return Ok(false);
-            }
-            if self.query_transaction(bundle.tx.tx_id).await?.is_some() {
                 return Ok(false);
             }
         }

--- a/dev/benchmarks/post-ancestry-profile.md
+++ b/dev/benchmarks/post-ancestry-profile.md
@@ -67,4 +67,46 @@ transaction becoming accepted. Removing the deferral reproduces the stale-batch
 failure; the fixed path preserves both rows and the accepted fate.
 
 The failed intermediate browser run is not a valid performance measurement.
-The final optimized build and fresh timing/profile round are pending.
+The corrected optimized build passed the fresh timing/profile round below.
+
+### Final measurements
+
+Implementation revision: `e05e400dd5`; measurement checkout: `64de44ea7e`.
+All changed Rust files were byte-identical. Hosted CI passed on the implementation
+revision. Local Jazz library tests: 1,998 passed, 2 ignored; Groove: 732 passed,
+2 ignored. Backend comparison tests and the mutation checks described above pass.
+
+Same optimized WASM and persistent-browser harness as the previous slice:
+
+| Operation, 1,500 rows                          | Previous slice | This slice, two quiet runs |
+| ---------------------------------------------- | -------------: | -------------------------: |
+| First read after runtime reopen                |         965 ms |                 778–808 ms |
+| 1,350 updates, commit through local durability |       1,167 ms |             1,116–1,181 ms |
+| First read after post-update runtime reopen    |       1,011 ms |                 856–865 ms |
+
+These are runtime reopens in a loaded Chromium session, not browser-process cold
+starts. The first-read improvement is roughly 16–19%, and post-update read improvement
+is 14–15%; bulk-write latency is effectively
+unchanged in this small sample. The four-size batch sweep measured 119, 226, 541,
+and 1,181 ms at 150, 300, 750, and 1,500 rows respectively. Browser correctness:
+four-size sweep 4 passed, single-size repeat 1 passed, profiling run 1 passed.
+
+Rust-function CPU profiles show the intended path improved substantially:
+foreground `ingest_known_transaction` fell from 224 to 43 ms on initial read,
+223 to 46 ms during the batch, and 183 to 39 ms on post-update reopen. Whole-unit
+fate handling still legitimately reads transaction history; immutable matching
+no longer adds a second full-transaction read.
+
+The next bottlenecks are outside exact matching. During the batch, the worker
+profile attributes about 340 ms to supporting-row update construction, 132 ms
+to record field-byte access, 153 ms to Groove batch application and 116 ms to page
+encoding. Allocation/deallocation account for about 191 ms of self time across
+these operations. Worker `ensure_exact` is about 7 ms, including about 2 ms in
+backend comparison. These are overlapping inclusive categories except the stated
+allocator self time; do not add them together or add foreground and worker totals.
+
+The next thesis is to carry shared batch records through current-index maintenance
+and publication instead of repeatedly extracting fields and reconstructing records
+and descriptors. Further tuning of the exact comparison alone cannot deliver the
+requested order-of-magnitude end-to-end gains. No further optimization is included
+in this slice.

--- a/dev/benchmarks/post-ancestry-profile.md
+++ b/dev/benchmarks/post-ancestry-profile.md
@@ -51,3 +51,20 @@ Other candidates for subsequent slices:
   ingestion costs and should not lead the next slice.
 
 This note records the baseline; no new performance improvement is claimed until remeasurement.
+
+### Receiver batching boundary found during browser acceptance
+
+The first optimized browser run rejected a post-update reopen: two authoring
+nodes appeared in one received snapshot, and registration of the second node's
+alias published metadata after the first row's exact-match preparation. A native
+multi-author receiver test reproduces this failure. Receiver batching now resolves
+all author, parent and schema aliases before preparing rows.
+
+Known complete transactions can also publish through their fate-update path.
+They are handled after the prepared receiver batch commits, rather than publishing
+inside it. A regression covers a new row alongside a previously pending known
+transaction becoming accepted. Removing the deferral reproduces the stale-batch
+failure; the fixed path preserves both rows and the accepted fate.
+
+The failed intermediate browser run is not a valid performance measurement.
+The final optimized build and fresh timing/profile round are pending.

--- a/dev/benchmarks/post-ancestry-profile.md
+++ b/dev/benchmarks/post-ancestry-profile.md
@@ -26,12 +26,14 @@ of a transaction can therefore perform quadratic comparisons. Unlike ancestry,
 this operation does need the whole relevant transaction; it does not need a
 repeated search through it.
 
-Next implementation hypothesis: build a coordinate index once, compute each
-incoming key once, and preserve exact byte comparison for matches, conflict
-rejection, missing-version ingestion, partial cardinality and fate updates.
-Keep this separate from storage and protocol changes. Pin work scaling with a
-deterministic regression and confirm sensitivity before repeating measurements.
-The full 224 ms is an inclusive upper bound, not a promised saving.
+Implementation: use Groove's batch-scoped `ensure_exact` on each incoming
+physical history record. Storage compares encoded values without returning old
+row bodies; Groove stages only missing records and retains the lookup result
+for delta computation. Exact duplicates add no history writes. The batch is
+bound to its database/resident revision and a conflict invalidates it. Jazz
+retains transaction identity, partial cardinality, fate and visibility rules.
+This removes the repeated search rather than indexing all stored rows. No
+storage or wire encoding changes. Updated timings are pending.
 
 Other candidates for subsequent slices:
 
@@ -48,4 +50,4 @@ Other candidates for subsequent slices:
   time in the batch profile. These are smaller than current publication and
   ingestion costs and should not lead the next slice.
 
-No runtime change or measured improvement beyond #2785 is claimed by this note.
+This note records the baseline; no new performance improvement is claimed until remeasurement.

--- a/dev/benchmarks/post-ancestry-profile.md
+++ b/dev/benchmarks/post-ancestry-profile.md
@@ -1,0 +1,51 @@
+# Next performance slice: known-transaction row matching
+
+Investigation baseline: ancestry runtime ebf279ce49 (PR #2785), measured as
+3bfdd6d264 in an isolated checkout with identical runtime files. Optimized WASM,
+synthetic persistent-browser workload: 1,500 two-field rows, 1,350 updates,
+active subscription, local durability. Runtime reopen in an already loaded
+browser; not browser startup, forced disk-cache eviction or percentile data.
+Unprofiled batch 1,166.78 ms; initial reopen read 965.07 ms; post-batch reopen
+read 1,010.54 ms. Separate sampled CPU runs include profiling overhead.
+
+## Findings
+
+Inclusive times overlap; do not sum parent and child totals or page and worker.
+
+| Path                                         | Initial read |  Batch | Post-batch read |
+| -------------------------------------------- | -----------: | -----: | --------------: |
+| Worker supporting-view construction          |       343 ms | 342 ms |          308 ms |
+| Page known-transaction ingestion             |       224 ms | 223 ms |          183 ms |
+| Worker transaction ingestion/current indexes |            — | 455 ms |               — |
+
+Known-transaction ingestion in `crates/jazz/src/node/ingest/commit_bundles.rs`
+loads stored versions and then performs a linear `find` for every incoming
+version. `view_version_key_for_ingest` reconstructs owned table/branch keys and
+reads row identity and deletion state for comparisons. Matching two wide copies
+of a transaction can therefore perform quadratic comparisons. Unlike ancestry,
+this operation does need the whole relevant transaction; it does not need a
+repeated search through it.
+
+Next implementation hypothesis: build a coordinate index once, compute each
+incoming key once, and preserve exact byte comparison for matches, conflict
+rejection, missing-version ingestion, partial cardinality and fate updates.
+Keep this separate from storage and protocol changes. Pin work scaling with a
+deterministic regression and confirm sensitivity before repeating measurements.
+The full 224 ms is an inclusive upper bound, not a promised saving.
+
+Other candidates for subsequent slices:
+
+- Record field access: `BorrowedRecord::field_bytes` accounts for 123 ms in the
+  initial-read worker and 124 ms in the batch worker. Inspect repeated access
+  and layout lookup rather than assuming every bounds check is unnecessary.
+- Descriptor construction: `from_logical_fields` accounts for 47–89 ms per
+  measured runtime/phase; structured author type construction contributes
+  27–48 ms within those totals. Inspect reuse of immutable descriptors.
+- Page `VersionRecord::deletion` costs 81 ms on initial read and 96 ms in the
+  batch, including children. It is used by repeated row-key construction, so
+  measure again after removing that repetition before optimizing the accessor.
+- Worker page encoding and internal-shape validation have 60 ms and 31 ms self
+  time in the batch profile. These are smaller than current publication and
+  ingestion costs and should not lead the next slice.
+
+No runtime change or measured improvement beyond #2785 is claimed by this note.


### PR DESCRIPTION
🤖 This changes transaction ingestion from loading and comparing every stored row in a known transaction to checking only the incoming immutable row versions, through a batch-scoped `ensure_exact` operation.

### Behavior, with examples

Suppose a transaction contains 1,500 rows and a peer sends 10 of them again. Previously, known-transaction matching loaded the transaction's stored versions and searched that collection for each incoming row. Now each of those 10 coordinates is compared directly with its stored bytes:

- Missing coordinate: stage its insertion and the corresponding derived-state changes.
- Identical bytes: accept the replay without inserting the row or emitting another insertion delta.
- Different bytes at the same immutable coordinate: reject the commit unit. Other insertions prepared in that batch are not published.

Repeated coordinates within the same batch observe earlier staged writes. The batch is tied to one Database and its resident publication revision: intervening publication or applying it to another Database rejects the stale preparation. This preserves the existing serialized Database ownership contract; it is not a cross-writer storage compare-and-swap.

Jazz still owns transaction identity, authorization, partial-transaction cardinality, fate, visibility and persistence. Groove owns staged exact-match insertion and atomic application. Existing fate processing may still read a whole transaction; this change removes that read specifically from immutable-version matching.

### Storage implementation

`compare_value` reports absent / identical / different without requiring an owned copy of the existing value. Memory compares borrowed bytes, RocksDB uses pinned values, IndexedDB's tree compares inline bytes or overflow chunks while hydrating pages as needed, and SQLite compares the blob inside its query. Wrappers preserve backend dispatch. Other implementations have a correct `get`-based fallback.

There is no wire or persisted-format change. Alias allocation occurs before batch preparation, including multi-transaction authority publications and receiver snapshots containing several authors. Known complete transactions that need independent fate updates are explicitly ingested after the prepared receiver batch commits. For example, a snapshot can insert one new row while changing another known transaction from pending to accepted, without invalidating the batch or losing the fate update.

### Validation and measurement

Tests cover identical replay, conflicting replay, atomic rejection, stale preparation, cross-Database use, later overwrites, and cold inline/overflow comparisons. A Jazz regression checks that known-transaction matching no longer adds a whole-transaction history read. The final Jazz library suite passes (1,998 passed, 2 ignored). Memory/SQLite/RocksDB/IndexedDB comparison tests and mutation checks passed. [Hosted CI passed](https://github.com/garden-co/jazz/actions/runs/34539216641) on implementation revision `e05e400dd5`. The quiet Groove suite passed 732 tests (2 ignored). The optimized browser four-size sweep, repeat and Rust-function profiling run also passed.

### Measured outcome

Same optimized WASM harness, 1,500 rows and 1,350 updates:

| Operation | Before | After, two quiet runs |
| --- | ---: | ---: |
| First read after runtime reopen | 965 ms | 778–808 ms |
| Batch commit through local durability | 1,167 ms | 1,116–1,181 ms |
| First read after post-update reopen | 1,011 ms | 856–865 ms |

This improves the first read by roughly 16–19% and the post-update read by 14–15%; bulk writes are effectively unchanged in this sample. These are runtime reopens in a loaded Chromium session, not browser-process cold starts.

The targeted foreground matching path improved about 5× (224 → 43 ms on initial read; 223 → 46 ms during the batch). Worker exact insertion/comparison now accounts for about 7 ms during the batch. Remaining costs include supporting-row publication, repeated record-field access/descriptor construction and page encoding; these need separate work to reach the larger end-to-end target. Detailed measurements and the next performance thesis are in `dev/benchmarks/post-ancestry-profile.md`.
