### PR TITLE
perf: index supporting row witness selection

### DIFF
--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -69,18 +69,6 @@ fn maintained_view_tx_versions_contain_winner(
     })
 }
 
-fn maintained_view_find_content_witness<'a>(
-    tx_versions: &'a [VersionRow],
-    entry_table: &str,
-    row_uuid: RowUuid,
-) -> Option<&'a VersionRow> {
-    tx_versions.iter().find(|version| {
-        version.table() == entry_table
-            && version.row_uuid() == row_uuid
-            && version.deletion().is_none()
-    })
-}
-
 fn merge_receiver_version_bundle_ref(
     bundles: &mut BTreeMap<TxId, VersionBundle>,
     bundle: VersionBundleRef<'_>,
@@ -1123,22 +1111,35 @@ where
             let tx_versions = tx_versions_cache
                 .entry(*tx_id)
                 .or_insert_with(|| maintained_facts.versions_by_tx(*tx_id));
+            // These checks only need content-witness presence, not a selected
+            // version. Index once rather than decoding row identities while
+            // scanning the transaction twice for every requested row. Keep
+            // the original version vector intact (including ordering and
+            // multiple versions/layers for a coordinate).
+            let mut content_coordinates = tx_versions
+                .iter()
+                .filter(|version| version.deletion().is_none())
+                .map(|version| (version.table().to_owned(), version.row_uuid()))
+                .collect::<BTreeSet<_>>();
             let mut needs_storage_fallback = false;
             for (entry_table, row_uuid) in wanted_rows {
-                if maintained_view_find_content_witness(tx_versions, entry_table, *row_uuid)
-                    .is_none()
-                {
-                    let (content_winner, _) =
-                        maintained_facts.replacement_for(entry_table, *row_uuid);
-                    if let Some(content_winner) = content_winner {
-                        if self.version_tx_id(&content_winner)? == *tx_id {
-                            tx_versions.push(content_winner);
+                let coordinate = (entry_table.clone(), *row_uuid);
+                if content_coordinates.contains(&coordinate) {
+                    continue;
+                }
+                let (content_winner, _) = maintained_facts.replacement_for(entry_table, *row_uuid);
+                if let Some(content_winner) = content_winner {
+                    if self.version_tx_id(&content_winner)? == *tx_id {
+                        if content_winner.deletion().is_none() {
+                            content_coordinates.insert((
+                                content_winner.table().to_owned(),
+                                content_winner.row_uuid(),
+                            ));
                         }
+                        tx_versions.push(content_winner);
                     }
                 }
-                if maintained_view_find_content_witness(tx_versions, entry_table, *row_uuid)
-                    .is_none()
-                {
+                if !content_coordinates.contains(&coordinate) {
                     needs_storage_fallback = true;
                 }
             }


### PR DESCRIPTION
🤖 Supporting-row publication searched a transaction's retained versions twice for every requested row. For a transaction containing 1,500 requested content rows, that can require about 2.25 million candidate comparisons, repeatedly decoding record identities.

This change builds a content-coordinate presence index once per transaction. For example, publishing all rows from a large insert now checks each requested coordinate in the index instead of scanning the transaction again. A missing coordinate still consults the maintained replacement winner; a matching-transaction replacement is appended as before and its content coordinate enters the index. If no content witness is found, the existing storage fallback still runs.

The index only answers whether a content witness exists. It does not select, reorder, or deduplicate the retained version vector. Content and deletion/restore versions remain distinct, and complete exclusive payload handling, permissions, storage, and wire formats are unchanged.

Validation: full Jazz library suite passed (1,998 passed, 2 ignored), Clippy and formatting passed. The suite needs a 4 MiB test-thread stack and a raised file-descriptor limit in this shell; initial attempts hit those environment limits. This is a draft, not yet independently reviewed.

Stacked on #2786; this PR isolates the indexed selection change from the previous ingestion work.

Optimized Chromium receipt (1,500 synthetic rows; 1,350 updates in one transaction, including local durability): two runs measured initial reopen/read at 603.0/603.3 ms (previous slice 778.4/808.2 ms), bulk update at 1062.0/1089.2 ms (previous 1181.2/1115.7 ms), and post-update reopen/read at 685.7/696.6 ms (previous 864.6/855.6 ms). Both browser runs passed. These are fresh runtimes inside a warm browser, not a cold browser-process launch; timings are two-run observations, not confidence intervals. The measured Rust source differs from committed a7c85d2e7b only by rustfmt line wrapping.
