### PR TITLE
bench: native local batch profiling and overhead analysis

### DIFF
--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -199,3 +199,8 @@ required-features = ["runtime"]
 [[test]]
 name = "fate_replay"
 required-features = ["testing"]
+
+[[bench]]
+name = "local_batch_phases"
+harness = false
+required-features = ["testing"]

--- a/crates/jazz/benches/README.md
+++ b/crates/jazz/benches/README.md
@@ -78,3 +78,10 @@ measurement intent was ported to `authorization_scope_benchmark`.
 The old `memory_benchmark` file was removed rather than left as a broken
 RuntimeCore path. Reintroduce it after the `Db` facade exposes retained
 memory metrics comparable to the old SyncManager/QueryManager breakdown.
+
+`local_batch_phases` is the native inner-loop equivalent of the synthetic
+browser cold-load/bulk-update receipt. It separates foreground authoring,
+worker ingestion, supporting-row publication, codec work, receiver ingestion,
+and querying, with MemoryStorage/RocksDB and a raw batch baseline. See
+`dev/benchmarks/native-local-batch-profile.md` for commands, profile-clock
+requirements, observed amplification, and fidelity limits.

--- a/crates/jazz/benches/local_batch_phases.rs
+++ b/crates/jazz/benches/local_batch_phases.rs
@@ -1,0 +1,369 @@
+//! Native worker/foreground decomposition of the synthetic browser batch receipt.
+//! Direct nodes intentionally expose phase boundaries that the public Db owner
+//! loop combines. This excludes JS, IndexedDB, scheduling and auth bootstrap.
+use std::{collections::BTreeMap, time::Instant};
+mod schema_fixture;
+mod support;
+use jazz::{
+    block_on,
+    groove::{
+        records::Value,
+        storage::{MemoryStorage, OrderedKvStorage, ReopenableStorage},
+    },
+    ids::{NodeUuid, RowUuid},
+    node::{MergeableCommit, NodeState},
+    peer::PeerState,
+    protocol::{RegisterShapeOptions, ShapeAst, Subscribe, SyncMessage},
+    schema::JazzSchema,
+    tools::{ColumnType, SchemaBuilder, TableSchemaBuilder},
+    tx::DurabilityTier,
+};
+use jazz_storage_rocksdb::{Durability, RocksDbStorage};
+use serde_json::json;
+
+#[cfg(unix)]
+fn clock_ns() -> u64 {
+    let mut time = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    assert_eq!(
+        unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut time) },
+        0
+    );
+    time.tv_sec as u64 * 1_000_000_000 + time.tv_nsec as u64
+}
+#[cfg(not(unix))]
+fn clock_ns() -> u64 {
+    static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+    START.get_or_init(Instant::now).elapsed().as_nanos() as u64
+}
+#[inline(never)]
+fn phase<T>(backend: &str, count: usize, name: &str, f: impl FnOnce() -> T) -> T {
+    let start_ns = clock_ns();
+    let start = Instant::now();
+    let result = f();
+    let elapsed = start.elapsed();
+    let end_ns = clock_ns();
+    println!(
+        "{}",
+        json!({"backend":backend,"rows":count,"phase":name,"wall_us":elapsed.as_micros(),"start_ns":start_ns,"end_ns":end_ns})
+    );
+    result
+}
+fn schema() -> JazzSchema {
+    schema_fixture::compile(
+        SchemaBuilder::new().table(
+            TableSchemaBuilder::new("tasks")
+                .column("title", ColumnType::Text)
+                .column("done", ColumnType::Boolean),
+        ),
+    )
+}
+fn row(i: usize) -> RowUuid {
+    RowUuid::from_bytes((i as u128 + 1).to_be_bytes())
+}
+fn cells(i: usize, done: bool) -> BTreeMap<String, Value> {
+    BTreeMap::from([
+        ("title".into(), Value::String(format!("Task {i}"))),
+        ("done".into(), Value::Bool(done)),
+    ])
+}
+fn open<S: OrderedKvStorage + ReopenableStorage + 'static>(
+    schema: &JazzSchema,
+    storage: S,
+    id: u8,
+) -> NodeState<S> {
+    block_on(NodeState::new_with_shared_test_catalogue(
+        NodeUuid::from_bytes([id; 16]),
+        schema.clone(),
+        storage,
+    ))
+    .unwrap()
+}
+fn publish<S: OrderedKvStorage>(
+    worker: &mut NodeState<S>,
+    peer: &mut PeerState,
+    schema: &JazzSchema,
+    initial: bool,
+) -> SyncMessage {
+    let (shape, binding, mut key) = support::table_subscription(schema, "tasks", peer.identity());
+    let mut opts = RegisterShapeOptions::default();
+    opts.tier = DurabilityTier::Local;
+    key.read_view = opts.read_view_key();
+    peer.set_subscription_policy_binding(key, (peer.identity(), BTreeMap::new()));
+    if initial {
+        block_on(
+            peer.rehydrate_query_for_subscription_with_opts(worker, key, &shape, &binding, opts),
+        )
+        .unwrap()
+        .expect("initial update")
+    } else {
+        block_on(peer.query_update_for_subscription_with_opts(worker, key, &shape, &binding, opts))
+            .unwrap()
+            .expect("updated scope")
+    }
+}
+fn receiver(schema: &JazzSchema, peer: &PeerState) -> NodeState<MemoryStorage> {
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let mut node = open(schema, MemoryStorage::new(&refs).unwrap(), 2);
+    let (shape, _, mut key) = support::table_subscription(schema, "tasks", peer.identity());
+    let mut opts = RegisterShapeOptions::default();
+    opts.tier = DurabilityTier::Local;
+    key.read_view = opts.read_view_key();
+    support::apply_and_settle(
+        &mut node,
+        SyncMessage::RegisterShape {
+            shape_id: shape.shape_id(),
+            ast: ShapeAst::from_validated(&shape),
+            opts,
+        },
+    );
+    support::apply_and_settle(
+        &mut node,
+        SyncMessage::Subscribe(Subscribe {
+            shape_id: shape.shape_id(),
+            subscription: key,
+            values: vec![],
+            known_state: None,
+            delegated_session: Some(jazz::protocol::DelegatedSessionBinding {
+                identity: peer.identity(),
+                claims: BTreeMap::new(),
+            }),
+        }),
+    );
+    node
+}
+fn deliver(
+    backend: &str,
+    count: usize,
+    name: &str,
+    message: SyncMessage,
+    node: &mut NodeState<MemoryStorage>,
+    schema: &JazzSchema,
+    peer: &PeerState,
+    changed: usize,
+) {
+    let bytes = phase(backend, count, &format!("{name}_encode"), || {
+        jazz::wire::encode_sync_message(&message).unwrap()
+    });
+    println!(
+        "{}",
+        json!({"phase":format!("{name}_payload"),"backend":backend,"rows":count,"bytes":bytes.len()})
+    );
+    let message = phase(backend, count, &format!("{name}_decode"), || {
+        jazz::wire::decode_sync_message_trusted(&bytes).unwrap()
+    });
+    node.reset_storage_read_metrics();
+    phase(backend, count, &format!("{name}_receiver_ingest"), || {
+        support::apply_and_settle(node, message)
+    });
+    emit_node_metrics(node, backend, count, &format!("{name}_receiver_metrics"));
+    let (shape, binding, _) = support::table_subscription(schema, "tasks", peer.identity());
+    let rows = phase(backend, count, &format!("{name}_receiver_query"), || {
+        block_on(node.query_rows(&shape, &binding, DurabilityTier::Local)).unwrap()
+    });
+    assert_eq!(rows.len(), count);
+    let actual = rows
+        .iter()
+        .map(|r| r.row_uuid())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(actual, (0..count).map(row).collect());
+    let done_shape = jazz::query::Query::from("tasks")
+        .filter(jazz::query::eq(
+            jazz::query::col("done"),
+            jazz::query::lit(true),
+        ))
+        .validate(schema)
+        .unwrap();
+    let done_binding = done_shape.bind(BTreeMap::new()).unwrap();
+    let done_rows =
+        block_on(node.query_rows(&done_shape, &done_binding, DurabilityTier::Local)).unwrap();
+    let expected = if name == "initial" { 0 } else { changed };
+    assert_eq!(
+        done_rows
+            .iter()
+            .map(|r| r.row_uuid())
+            .collect::<std::collections::BTreeSet<_>>(),
+        (0..expected).map(row).collect()
+    );
+}
+fn run<S: OrderedKvStorage + ReopenableStorage + 'static>(
+    backend: &str,
+    count: usize,
+    percent: usize,
+    mut storage: impl FnMut() -> S,
+) {
+    let schema = schema();
+    let mut worker = open(&schema, storage(), 1);
+    let commits = (0..count)
+        .map(|i| MergeableCommit::new("tasks", row(i), 1000).cells(cells(i, false)))
+        .collect();
+    let publication = phase(backend, count, "seed_author", || {
+        block_on(worker.commit_mergeable_many(commits)).unwrap()
+    });
+    let seed = publication.tx_id();
+    phase(backend, count, "seed_persist", || {
+        support::settle_transaction(&mut worker, publication)
+    });
+    drop(worker);
+    let mut worker = phase(backend, count, "reopen", || open(&schema, storage(), 1));
+    let mut peer = PeerState::new();
+    let mut foreground = receiver(&schema, &peer);
+    worker.reset_storage_read_metrics();
+    let message = phase(backend, count, "initial_publish", || {
+        publish(&mut worker, &mut peer, &schema, true)
+    });
+    emit_node_metrics(&worker, backend, count, "initial_publish_metrics");
+    deliver(
+        backend,
+        count,
+        "initial",
+        message,
+        &mut foreground,
+        &schema,
+        &peer,
+        count,
+    );
+    assert!((1..=100).contains(&percent));
+    let changed = count * percent / 100;
+    foreground.reset_storage_read_metrics();
+    let commits = (0..changed)
+        .map(|i| {
+            MergeableCommit::new("tasks", row(i), 2000)
+                .parents(vec![seed])
+                .cells(cells(i, true))
+        })
+        .collect();
+    let publication = phase(backend, count, "batch_author", || {
+        block_on(foreground.commit_mergeable_many(commits)).unwrap()
+    });
+    let update_tx = publication.tx_id();
+    phase(backend, count, "batch_persist", || {
+        support::settle_transaction(&mut foreground, publication)
+    });
+    emit_node_metrics(&foreground, backend, count, "batch_author_metrics");
+    let unit = phase(backend, count, "batch_upload_build", || {
+        block_on(foreground.commit_unit_for(update_tx)).unwrap()
+    });
+    let bytes = phase(backend, count, "batch_upload_encode", || {
+        jazz::wire::encode_sync_message(&unit).unwrap()
+    });
+    let unit = phase(backend, count, "batch_upload_decode", || {
+        jazz::wire::decode_sync_message(&bytes).unwrap()
+    });
+    let SyncMessage::CommitUnit { tx, versions } = unit else {
+        panic!("commit unit")
+    };
+    worker.reset_storage_read_metrics();
+    phase(backend, count, "batch_worker_ingest", || {
+        block_on(worker.ingest_relay_commit_unit(tx, versions)).unwrap()
+    });
+    emit_node_metrics(&worker, backend, count, "batch_worker_ingest_metrics");
+    worker.reset_storage_read_metrics();
+    let message = phase(backend, count, "batch_publish", || {
+        publish(&mut worker, &mut peer, &schema, false)
+    });
+    emit_node_metrics(&worker, backend, count, "batch_publish_metrics");
+    deliver(
+        backend,
+        count,
+        "batch",
+        message,
+        &mut foreground,
+        &schema,
+        &peer,
+        changed,
+    );
+    drop(foreground);
+    drop(worker);
+    let mut worker = phase(backend, count, "post_reopen", || {
+        open(&schema, storage(), 1)
+    });
+    let mut peer = PeerState::new();
+    let mut foreground = receiver(&schema, &peer);
+    let message = phase(backend, count, "post_publish", || {
+        publish(&mut worker, &mut peer, &schema, true)
+    });
+    deliver(
+        backend,
+        count,
+        "post",
+        message,
+        &mut foreground,
+        &schema,
+        &peer,
+        changed,
+    );
+}
+fn emit_node_metrics<S: OrderedKvStorage>(
+    node: &NodeState<S>,
+    backend: &str,
+    count: usize,
+    name: &str,
+) {
+    let mut fields = support::phase_fields(name, 0);
+    fields.insert("backend".into(), json!(backend));
+    fields.insert("rows".into(), json!(count));
+    support::insert_node_metrics(&mut fields, "node", node);
+    support::emit_json_line("local_batch", fields);
+}
+fn raw_storage<S: OrderedKvStorage>(backend: &str, count: usize, storage: S) {
+    use jazz::groove::storage::OwnedWriteOperation;
+    let ops = (0..count)
+        .map(|i| OwnedWriteOperation::Set {
+            cf: "raw".into(),
+            key: (i as u64).to_be_bytes().to_vec(),
+            value: vec![42; 128],
+        })
+        .collect::<Vec<_>>();
+    phase(backend, count, "raw_batch_write", || {
+        block_on(storage.write_many(ops)).unwrap()
+    });
+    phase(backend, count, "raw_flush", || {
+        block_on(storage.flush_write_boundary()).unwrap()
+    });
+    let rows = phase(backend, count, "raw_scan", || {
+        block_on(storage.prefix("raw".into(), vec![])).unwrap()
+    });
+    assert_eq!(rows.len(), count);
+    assert!(rows.iter().all(|(_, v)| v == &vec![42; 128]));
+}
+fn run_fixture(count: usize, percent: usize) {
+    assert!(
+        (2..=4096).contains(&count),
+        "fixture uses one wire transaction: choose 2..=4096 rows"
+    );
+    raw_storage("memory", count, MemoryStorage::new(&["raw"]).unwrap());
+    let raw_dir = tempfile::tempdir().unwrap();
+    raw_storage(
+        "rocksdb_wal",
+        count,
+        RocksDbStorage::open_with_durability(raw_dir.path(), &["raw"], Durability::WalNoSync)
+            .unwrap(),
+    );
+    let schema = schema();
+    let cfs = schema.column_families();
+    let refs = cfs.iter().map(String::as_str).collect::<Vec<_>>();
+    let memory = MemoryStorage::new(&refs).unwrap();
+    run("memory", count, percent, || memory.clone());
+    let dir = tempfile::tempdir().unwrap();
+    run("rocksdb_wal", count, percent, || {
+        RocksDbStorage::open_with_durability(dir.path(), &refs, Durability::WalNoSync).unwrap()
+    });
+}
+
+/// Internal protocol fixture: phase counters and direct publication are not
+/// exposed by the public Db API. Assertions still check exact visible rows.
+pub(crate) fn correctness_smoke() {
+    run_fixture(10, 50);
+}
+
+fn main() {
+    jazz_benchmark_guard::refuse_contaminated_measurement();
+    let percent = support::env_usize("JAZZ_BATCH_UPDATE_PERCENT", 90);
+    for count in support::csv_usizes("JAZZ_BATCH_ROWS", "1500") {
+        run_fixture(count, percent);
+    }
+}

--- a/crates/jazz/tests/legacy_benchmark_smoke.rs
+++ b/crates/jazz/tests/legacy_benchmark_smoke.rs
@@ -41,3 +41,12 @@ fn relation_include_delivery_correctness_smoke() {
 fn route_subscription_curve_correctness_smoke() {
     route_subscription_curve::correctness_smoke();
 }
+
+#[allow(dead_code)]
+#[path = "../benches/local_batch_phases.rs"]
+mod local_batch_phases;
+
+#[test]
+fn local_batch_phases_correctness_smoke() {
+    local_batch_phases::correctness_smoke();
+}

--- a/dev/benchmarks/native-local-batch-profile.md
+++ b/dev/benchmarks/native-local-batch-profile.md
@@ -1,0 +1,201 @@
+# Native local batch: phase and CPU attribution
+
+Measured on the indexed-selection implementation `a7c85d2e7b` (PR #2787).
+This is a diagnostic receipt, not a timing gate or a predicted browser result.
+No production runtime code was changed for this investigation.
+
+## Workload and boundaries
+
+`crates/jazz/benches/local_batch_phases.rs` creates a synthetic `tasks` table
+with `title` and `done`. It seeds one transaction, drops/reopens the worker,
+sends a Local query snapshot to a fresh in-memory foreground, updates 90% of
+rows in one foreground transaction, uploads the commit to the worker, returns
+the updated supporting rows, then drops/reopens both runtimes and repeats the
+read. Exact row-ID sets and the exact set of completed rows are asserted.
+A deterministic small version is in `legacy_benchmark_smoke`.
+
+The worker backend is either shared MemoryStorage or RocksDB `WalNoSync`;
+the foreground is MemoryStorage. Both use real Jazz/Groove code, wire codecs,
+Local relay ingestion, and maintained peer publication. Seeding directly on the
+worker is fixture setup. The test excludes JS bindings, browser scheduling,
+IndexedDB page storage, external authentication, network latency, remote fate
+assignment, and the facade's open-transaction staging. It provides complete
+replacement cells and explicit parent IDs to the low-level authoring call.
+RocksDB closes/reopens here; this does not evict OS disk caches. Raw storage
+measurements include an explicit durability flush and 128-byte values, but
+exclude construction of the input vector. They are a substrate baseline, not
+semantically equivalent Jazz operations.
+
+The initial attempt at a 10,000-row single transaction exceeded the existing
+4,096-version wire limit; that is not a valid timing result. The harness now
+rejects that size up front. Larger logical workloads require multiple batches.
+
+## Reproduce
+
+```sh
+cargo build -p jazz --bench local_batch_phases --profile perf \
+  --features testing,transport-compression-zstd
+# Cargo prints the executable path; use that exact binary below.
+JAZZ_BATCH_ROWS=150,750,1500,3000 target/perf/deps/local_batch_phases-<hash>
+JAZZ_BATCH_ROWS=1500 JAZZ_BATCH_UPDATE_PERCENT=50 \
+  target/perf/deps/local_batch_phases-<hash>
+dev/t --test legacy_benchmark_smoke local_batch_phases_correctness_smoke
+```
+
+Build once, run repeatedly. The first native dependency build is a cold cost;
+subsequent harness-only optimized builds took about 29 seconds. No WASM build
+is needed. Use fully optimized browser builds at checkpoints, not an
+unoptimized WASM proxy for release performance.
+
+On Linux, collect attribution separately from ordinary timings:
+
+```sh
+perf record --clockid mono -e task-clock -F 999 \
+  --call-graph dwarf,16384 -o /tmp/local-batch.perf -- \
+  env JAZZ_BATCH_ROWS=1500 target/perf/deps/local_batch_phases-<hash>
+perf script --no-inline --ns -i /tmp/local-batch.perf \
+  -F comm,pid,tid,time,event,ip,sym,dso
+```
+
+The JSONL phase start/end timestamps use CLOCK_MONOTONIC on Unix. Explicitly
+select that clock in perf before assigning samples to phases. The first
+capture used perf's default clock and was discarded for phase attribution.
+The valid capture contains five runs at 1,500 rows. Kernel symbols are not
+available; some outer async stacks are truncated. Inclusive function sample
+fractions overlap and must not be summed. `--no-inline` avoids slow system
+library addr2line expansion; Rust function symbols remain available.
+
+## Uninstrumented timing
+
+Representative sweep, milliseconds at 1,500 rows / 1,350 updates:
+
+| Phase                                                     | Memory worker | RocksDB worker |
+| --------------------------------------------------------- | ------------: | -------------: |
+| Raw 1,500-value batch                                     |          0.34 |           0.49 |
+| Raw durability flush                                      |         <0.01 |           0.89 |
+| Raw scan                                                  |          0.13 |           0.25 |
+| Initial supporting-row publication                        |         209.4 |          229.5 |
+| Initial foreground ingestion                              |         124.3 |          126.8 |
+| Initial foreground query                                  |          33.3 |           34.8 |
+| Foreground authoring                                      |          86.7 |           85.7 |
+| Foreground persistence                                    |           5.4 |            5.6 |
+| Build upload payload                                      |          17.9 |           18.5 |
+| Worker ingestion, persistence and maintained-query update |         247.1 |          261.4 |
+| Updated supporting-row publication                        |         174.7 |          180.1 |
+| Already-authoring foreground ingestion                    |         113.8 |          120.5 |
+| Foreground query after update                             |          41.6 |           44.0 |
+| Fresh foreground ingestion after reopen                   |         886.6 |          886.1 |
+
+Wire encoding/decoding usually takes a few milliseconds per message; checked
+upload decoding took about 11–12 ms. These costs are recorded separately.
+Another uninstrumented 90%-update run showed the same ordering (fresh receiver
+870 ms with memory worker, 859 ms with RocksDB worker). These are observations,
+not confidence intervals. Native authoring/persistence alone is roughly 15k
+row updates/s; the full roundtrip is much slower because of subsequent work.
+
+## Finding 1: partial-parent misses repeatedly read siblings
+
+Memory-worker fresh foreground ingestion scales as follows at 90% updated:
+
+|  Rows | Time (ms) |
+| ----: | --------: |
+|   150 |      22.3 |
+|   750 |     256.4 |
+| 1,500 |     886.6 |
+| 3,000 |   3,376.4 |
+
+`validate_known_parent_coordinate` represents 3,584 of 4,449 sampled stacks
+in the 1,500-row post-update receiver phase (~81%).
+`query_versions_for_tx` appears in 3,506 (~79%). These overlap.
+
+Mechanics: the fresh scope includes 150 unchanged rows from transaction A and
+1,350 current rows from transaction B, each naming a parent in A. A is therefore
+known but partial. An exact parent lookup misses for a B row. Validation calls
+`query_versions_for_tx_physical_coordinate`, whose cold fallback reads A's
+entire retained fragment. It then calls `query_versions_for_tx` again to assess
+completeness. The cold read caches table names, not the materialized versions,
+so the same sibling fragment is repeatedly read, decoded and sorted.
+
+Varying only the updated percentage at 1,500 rows confirms the cross-product:
+
+| Updated | Fresh receiver ms | Total read counter |
+| ------: | ----------------: | -----------------: |
+|     10% |             844.4 |            816,793 |
+|     50% |           2,151.1 |          2,259,793 |
+|     90% |             869.9 |            822,793 |
+|    100% |             134.7 |             13,530 |
+
+At 50%, history-index reads alone are 1,126,500: approximately two scans of
+750 siblings for each of 750 missing parents, plus ordinary work. Read counters
+include point probes and returned index/row entries; these are not disk I/Os.
+At 100%, A is wholly absent, so the missing-transaction branch returns without
+loading siblings. A smaller update can therefore be dramatically slower.
+
+Next design target: batch parent-coordinate evidence and completeness metadata.
+An incomplete parent transaction must remain inconclusive when the exact
+witness is unavailable; a complete transaction with a wrong coordinate must
+still be rejected. Do not retrieve old parent bodies merely to improve timing.
+This is the cold-fallback case already tracked in #2784.
+
+## Finding 2: trusted internal rows still get round-trip validation
+
+`node/descriptor_roles.rs::encode_current_payload_record` builds a new row,
+serializes per-field type descriptors to compare their trees, decodes the row,
+re-encodes it to compare bytes, and emits a result descriptor. This is local
+trusted output, not untrusted wire admission. Its inclusive stack fraction is
+151/842 (~18%) of memory-worker batch publication samples.
+
+`maintained_subscription_view::decode_typed_terminal_record` covers 318/842
+(~38%) of that phase. These overlap: result-payload encoding is one of its
+children. `decode_typed_version_witness` separately decodes cells and authors
+into values, reconstructs history values, and creates another version record.
+Schema-level checks and plans should be shared; trusted records should not
+make repeated encode/decode validation round trips.
+
+## Finding 3: conversion and work amplification remain after batching
+
+For 1,350 updates, both foreground authoring and worker ingestion each emit
+8,102 physical writes (~six per row plus transaction metadata), about 1.70 MB.
+The authoring phase records 8,100 point/range operations; the worker ingest
+records 9,467 ranges/point probes and 12,165 returned/probed entries. Its last
+IVM tick encodes about 1.02 MB of notifications. These metrics describe that
+commit/tick, not every operation over the entire scenario.
+
+The raw substrate remains fast while Jazz timings are similar with either
+backend. Multiple logical records have semantic purposes, but batching storage
+writes does not yet make the surrounding per-row transformations cheap.
+
+CPU evidence and corresponding code paths:
+
+- Worker ingest: IVM evaluator update frames occur in ~36% of samples;
+  `BorrowedRecord::to_values` in ~28%. Large-value materialization appears in
+  ~14%, despite this fixture containing only small inline values. It decodes
+  a whole row to inspect values and returns a copied byte vector when nothing
+  changes (`groove/large_values.rs::materialize_record_attempt`).
+- Batch publication: deletion-winner fallback occupies ~21%, predominantly
+  per-row query work. This is separate from result-terminal conversion.
+- Known foreground receipt: `preflight_view_bundle_conflicts` occupies ~37%,
+  with stored-row to wire-record reconstruction underneath. The later
+  `ingest_known_transaction` occupies ~32%; the earlier ensure_exact change
+  did not remove this preflight's full stored-version reconstruction.
+- Even the plain receiver query rebuilds public row representations:
+  `CurrentRow::project` appears in ~50% of initial receiver-query samples.
+  `normalize_public_current_rows` invokes projection for every result row,
+  rebuilding fields, values and metadata even for this simple all-rows query.
+- Allocation/free routines plus byte-copy routines account for at least
+  33–39% of self samples in the major measured phases. This is disjoint leaf
+  attribution, not the sum of overlapping inclusive frames.
+
+## Performance thesis
+
+The next gains should come from reducing work above storage, not switching
+backends or only making the next tiny helper faster. First remove the
+partial-parent cross-product. Then remove trusted round-trip checks and move
+schema/descriptor work out of row loops. Finally retain owned immutable row
+bytes plus typed identity/provenance across query maintenance and publication,
+so unchanged rows and known receipts do not repeatedly become value trees and
+new encoded records. Preserve permission selection and authored-row fidelity;
+those semantics do not require every current implementation conversion.
+
+This investigation proposes those changes; it does not implement them or
+claim that 100k semantic end-to-end writes/s is already achievable.

--- a/dev/benchmarks/native-local-batch-profile.md
+++ b/dev/benchmarks/native-local-batch-profile.md
@@ -35,7 +35,7 @@ rejects that size up front. Larger logical workloads require multiple batches.
 ```sh
 cargo build -p jazz --bench local_batch_phases --profile perf \
   --features testing,transport-compression-zstd
-# Cargo prints the executable path; use that exact binary below.
+# Use the executable (not the .d/.o files) under target/perf/deps below.
 JAZZ_BATCH_ROWS=150,750,1500,3000 target/perf/deps/local_batch_phases-<hash>
 JAZZ_BATCH_ROWS=1500 JAZZ_BATCH_UPDATE_PERCENT=50 \
   target/perf/deps/local_batch_phases-<hash>


### PR DESCRIPTION
🤖 Add a native counterpart to the synthetic 1,500-row browser performance receipt so profiling iterations do not require a WASM build.

The fixture sends a Local supporting-row snapshot from a persistent worker to an in-memory foreground, authors 1,350 updates in the foreground, uploads them to the worker, delivers the updated scope, and repeats the read after reopening. It runs against memory and RocksDB, reports separate phase times and storage/IVM metrics, and asserts exact row-ID and completed-row sets. A raw 128-byte storage baseline provides context, not an equivalent database operation.

The report traces native profiles back to code. The largest finding is a quadratic cold parent-miss path: at 50% updated, a 1,500-row snapshot causes about 2.26 million read/index entries and takes 2.15 seconds to ingest. At 100% updated it takes 135 ms. It also identifies trusted internal encode/decode/re-encode validation and repeated descriptor/row reconstruction.

No production runtime or storage/wire behavior changes. This is a research/benchmark PR on #2787. It excludes JS, IndexedDB, external auth, remote fate assignment and facade transaction staging; native timings are not predictions of browser timing. The report documents those boundaries and profiling methodology.

Validation: focused benchmark compile and deterministic protocol smoke passed. A temporary mutation that kept updated rows incomplete made the exact completed-row assertion fail; it was restored. Optimized native scaling and percentage sweeps passed within the existing 4,096-version transaction limit. Final optimized smoke also passed.
