### PR TITLE
perf: avoid quadratic partial-parent miss scans

### DIFF
--- a/crates/jazz/src/node/ingest/validation.rs
+++ b/crates/jazz/src/node/ingest/validation.rs
@@ -36,6 +36,15 @@ where
             }
             return Ok(ParentCoordinateValidation::Exact);
         }
+        // A missing exact witness in a partial transaction cannot establish
+        // an invalid parent. Other retained rows provide no evidence about
+        // this coordinate. Avoid loading that fragment for every missing
+        // parent; retain the pending coordinate constraint instead.
+        if parent_tx.view_scoped_cardinality
+            && !self.query.tx_versions_cache.contains_key(&parent)
+        {
+            return Ok(ParentCoordinateValidation::Inconclusive);
+        }
         let coordinate_versions = self
             .query_versions_for_tx_physical_coordinate(
                 parent,
@@ -47,6 +56,9 @@ where
             if self.version_row_matches_parent_coordinate(candidate, coordinate)? {
                 return Ok(ParentCoordinateValidation::Exact);
             }
+        }
+        if parent_tx.view_scoped_cardinality {
+            return Ok(ParentCoordinateValidation::Inconclusive);
         }
         let parent_versions = self.query_versions_for_tx(parent).await?;
         if parent_versions.is_empty() {

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -2923,3 +2923,49 @@ fn cold_parent_coordinate_lookup_decodes_one_witness_from_large_transactions() {
         }
     }
 }
+
+#[test]
+fn partial_parent_misses_do_not_materialize_retained_siblings() {
+    // Internal test: public results cannot reveal repeated sibling scans.
+    // Exercise real authored and view-scoped records, then meter both cold
+    // and resident lookup paths. Complete-parent rejection is covered above.
+    use super::super::ingest::ParentCoordinateValidation;
+    for width in [1_u128, 150] {
+        let (_writer_dir, mut writer) = open_node_with_uuid(node(0xa1));
+        let (_reader_dir, mut reader) = open_node_with_uuid(node(0xa2));
+        let parent = writer.commit_mergeable_many_settled(
+            (1..=width + 1).map(|i| {
+                MergeableCommit::new("todos", RowUuid(uuid::Uuid::from_u128(i)), 10)
+                    .cells(title_cells("parent"))
+            }).collect(),
+        ).unwrap();
+        let SyncMessage::CommitUnit { mut tx, mut versions } = writer.commit_unit_for(parent).unwrap() else {
+            panic!("commit unit");
+        };
+        versions.retain(|version| version.row_uuid() != RowUuid(uuid::Uuid::from_u128(width + 1)));
+        tx.n_total_writes = versions.len() as u32;
+        reader.ingest_view_scoped_transaction_with_current_indexes(
+            tx, versions, Fate::Pending, None, DurabilityTier::Local,
+        ).unwrap();
+        let present = ParentCoordinate {
+            physical_table_id: reader.physical_table_id_for_schema(reader.catalogue.current_schema_version_id, "todos").unwrap(),
+            branch_key: BranchKey::default(),
+            row_uuid: RowUuid(uuid::Uuid::from_u128(1)),
+            layer: VersionLayer::Content,
+        };
+        let retained = reader.query_versions_for_tx(parent).unwrap();
+        for resident in [false, true] {
+            reader.invalidate_tx_version_tables_cache(parent);
+            if resident { reader.cache_tx_versions(parent, retained.clone()); }
+            assert_eq!(reader.validate_known_parent_coordinate(parent, &present).resolve().unwrap(), ParentCoordinateValidation::Exact);
+            reader.reset_storage_read_metrics();
+            super::super::reset_query_versions_for_tx_call_count();
+            for i in width + 1..=width + 32 {
+                let missing = ParentCoordinate { row_uuid: RowUuid(uuid::Uuid::from_u128(i)), ..present.clone() };
+                assert_eq!(reader.validate_known_parent_coordinate(parent, &missing).resolve().unwrap(), ParentCoordinateValidation::Inconclusive);
+            }
+            assert_eq!(super::super::query_versions_for_tx_call_count(), 0, "missing partial parents must not load sibling bodies (width={width}, resident={resident})");
+            assert_eq!(reader.storage_read_metrics().history_indexes.reads, 0, "no by_tx index scans for partial misses");
+        }
+    }
+}


### PR DESCRIPTION
🤖 Stop repeatedly loading every retained sibling when an exact parent is absent from a partial transaction.

For example, after reopening a 1,500-row collection with half its rows updated, the receiver retains 750 old row versions and receives 750 new versions whose exact parents are absent. Previously each missing-parent check loaded all 750 retained siblings twice, although a partial transaction cannot prove that the missing coordinate is invalid. Now the exact lookup remains, and a partial miss immediately retains the existing pending coordinate constraint. Resident exact-parent lookup and complete-transaction wrong-coordinate rejection are unchanged, including branch, table and deletion-layer boundaries.

Native optimized measurements: reopened ingestion at 50% updated falls from 2,151 ms to 120 ms; at 90%, from 887 ms to 130 ms. The 50% case falls from 2,259,793 counted reads/index entries to 8,293. At 3,000 rows/90% updated, 3,376 ms becomes 275 ms. These are synthetic native core measurements, not browser timing predictions. Storage and wire formats do not change.

Validation: 1,999 library tests passed, 2 ignored. The new cold/resident partial-parent regression asserts zero whole-transaction loads and zero history-index reads for missing coordinates. Removing the optimization makes it fail with 64 whole-transaction calls for 32 misses. Existing complete-parent and durable pending-constraint tests passed. Optimized MemoryStorage/RocksDB scenarios and fresh Rust-symbol profiles completed. Draft pending broader integration/review.

Part of #2784; builds on #2788.
