### PR TITLE
perf: compile current-result payload projection per batch

### DIFF
--- a/crates/jazz/src/node/descriptor_roles.rs
+++ b/crates/jazz/src/node/descriptor_roles.rs
@@ -316,78 +316,98 @@ fn current_role_schema(
     )?)
 }
 
+/// One compiled field mapping per source descriptor and publication schema.
+/// The caller scopes reuse to a single terminal's delta batch.
+pub(super) struct CurrentPayloadEncodePlan {
+    projector: records::RecordProjector,
+    descriptor: Vec<u8>,
+}
+
+impl CurrentPayloadEncodePlan {
+    pub(super) fn new(
+        descriptor: RecordDescriptor,
+        schema: &super::query_engine::ResultMembershipSchema,
+    ) -> Result<Self, Error> {
+        let selected = std::iter::once(schema.row_field.as_str())
+            .chain(
+                schema
+                    .payload_fields
+                    .iter()
+                    .filter(|field| field.name != schema.row_field)
+                    .map(|field| field.name.as_str()),
+            )
+            .chain(
+                schema
+                    .occurrence_id_fields
+                    .iter()
+                    .skip(1)
+                    .map(String::as_str),
+            )
+            .chain(
+                schema
+                    .occurrence_union_arm_fields
+                    .values()
+                    .map(String::as_str),
+            );
+        let mut mapping = Vec::new();
+        let mut runtime_fields = Vec::new();
+        for name in selected {
+            let index = descriptor
+                .fields()
+                .iter()
+                .position(|field| field.name.as_deref() == Some(name))
+                .ok_or(Error::InvalidStoredValue(
+                    "result payload is missing its declared carrier",
+                ))?;
+            if descriptor.fields()[index + 1..]
+                .iter()
+                .any(|field| field.name.as_deref() == Some(name))
+            {
+                return Err(Error::InvalidStoredValue(
+                    "result payload carrier binding is ambiguous",
+                ));
+            }
+            mapping.push((index, mapping.len()));
+            runtime_fields.push(descriptor.fields()[index].clone());
+        }
+        let runtime = RecordDescriptor::new_with_fields(runtime_fields);
+        let canonical = current_role_schema(schema)?;
+        // A complete named/type tree comparison precedes any byte-layout reuse.
+        for (source, target) in runtime.fields().iter().zip(canonical.fields()) {
+            let source_type = RecordDescriptor::new([("value", source.value_type.clone())]);
+            let target_type = RecordDescriptor::new([("value", target.value_type.clone())]);
+            if records::encode_persisted_record_descriptor(&source_type)?
+                != records::encode_persisted_record_descriptor(&target_type)?
+            {
+                return Err(Error::InvalidStoredValue(
+                    "result payload type differs from its publication schema",
+                ));
+            }
+        }
+        let projector =
+            records::RecordProjector::new_registry_rebound(descriptor, canonical, mapping)?;
+        Ok(Self {
+            projector,
+            descriptor: encode_result_descriptor(ResultDescriptorRole::Current, &canonical)?,
+        })
+    }
+
+    pub(super) fn encode(&self, record: BorrowedRecord<'_>) -> Result<(Vec<u8>, Vec<u8>), Error> {
+        // Both descriptors are trusted compiled schemas. Copy the selected
+        // encoded fields; do not decode and re-encode our own encoder's output.
+        Ok((
+            self.descriptor.clone(),
+            self.projector.project(record)?.into_raw(),
+        ))
+    }
+}
+
+#[cfg(test)]
 pub(super) fn encode_current_payload_record(
     record: BorrowedRecord<'_>,
     schema: &super::query_engine::ResultMembershipSchema,
 ) -> Result<(Vec<u8>, Vec<u8>), Error> {
-    let descriptor = record.descriptor();
-    let selected = std::iter::once(schema.row_field.as_str())
-        .chain(
-            schema
-                .payload_fields
-                .iter()
-                .filter(|field| field.name != schema.row_field)
-                .map(|field| field.name.as_str()),
-        )
-        .chain(
-            schema
-                .occurrence_id_fields
-                .iter()
-                .skip(1)
-                .map(String::as_str),
-        )
-        .chain(
-            schema
-                .occurrence_union_arm_fields
-                .values()
-                .map(String::as_str),
-        );
-    let mut values = Vec::new();
-    let mut runtime_fields = Vec::new();
-    for name in selected {
-        let index = descriptor
-            .fields()
-            .iter()
-            .position(|field| field.name.as_deref() == Some(name))
-            .ok_or(Error::InvalidStoredValue(
-                "result payload is missing its declared carrier",
-            ))?;
-        if descriptor.fields()[index + 1..]
-            .iter()
-            .any(|field| field.name.as_deref() == Some(name))
-        {
-            return Err(Error::InvalidStoredValue(
-                "result payload carrier binding is ambiguous",
-            ));
-        }
-        values.push(record.get_idx(index)?);
-        runtime_fields.push(descriptor.fields()[index].clone());
-    }
-    let runtime = RecordDescriptor::new_with_fields(runtime_fields);
-    let raw = runtime.create(&values)?;
-    let canonical = current_role_schema(schema)?;
-    // A complete named/type tree comparison precedes any byte-layout reuse.
-    for (source, target) in runtime.fields().iter().zip(canonical.fields()) {
-        let source_type = RecordDescriptor::new([("value", source.value_type.clone())]);
-        let target_type = RecordDescriptor::new([("value", target.value_type.clone())]);
-        if records::encode_persisted_record_descriptor(&source_type)?
-            != records::encode_persisted_record_descriptor(&target_type)?
-        {
-            return Err(Error::InvalidStoredValue(
-                "result payload type differs from its publication schema",
-            ));
-        }
-    }
-    let values = canonical.bind(&raw).to_values()?;
-    if canonical.create(&values)? != raw {
-        return Err(Error::InvalidStoredValue(
-            "result payload row is not canonical",
-        ));
-    }
-    Ok((
-        encode_result_descriptor(ResultDescriptorRole::Current, &canonical)?,
-        raw,
-    ))
+    CurrentPayloadEncodePlan::new(record.descriptor(), schema)?.encode(record)
 }
 
 pub(super) fn decode_current_payload_record(
@@ -582,6 +602,83 @@ mod tests {
             settle_position_field: None,
             routing_param_fields: BTreeSet::new(),
         }
+    }
+
+    // Internal byte-compatibility test: the public API exposes values, not
+    // runtime publication bytes or descriptor rebinding. Compare projection
+    // against independently encoding the selected fields, including nested
+    // enum payloads, nullable values, arrays and reordered source fields.
+    #[test]
+    fn current_payload_plan_preserves_encoded_fields_across_reuse() {
+        use groove::records::{EnumCase, EnumSchema, EnumValue};
+        let child = RecordDescriptor::new([("code", ValueType::U64), ("label", ValueType::String)]);
+        let event = EnumSchema::new("event", [EnumCase::new("value", child)])
+            .unwrap()
+            .with_registry_id(987);
+        let nested = RecordDescriptor::new([
+            ("words", ValueType::Array(Box::new(ValueType::String))),
+            (
+                "event",
+                ValueType::Nullable(Box::new(ValueType::Enum(Box::new(event)))),
+            ),
+        ]);
+        let ty = ValueType::Record(Box::new(nested));
+        let mut schema = current_schema(1, "payload");
+        schema.payload_fields[0].ty = ty.clone();
+        let source = RecordDescriptor::new([
+            ("ignored", ty.clone()),
+            ("payload", ty.clone()),
+            ("row_uuid", ValueType::Uuid),
+        ]);
+        let selected = RecordDescriptor::new([("row_uuid", ValueType::Uuid), ("payload", ty)]);
+        let plan = CurrentPayloadEncodePlan::new(source, &schema).unwrap();
+        let canonical = current_role_schema(&schema).unwrap();
+        for i in 0..32 {
+            let value = Value::Record(OwnedRecord::new(
+                nested
+                    .create(&[
+                        Value::Array(vec![
+                            Value::String(format!("row-{i}")),
+                            Value::String("longer value".repeat(i)),
+                        ]),
+                        Value::Nullable(if i % 2 == 0 {
+                            Some(Box::new(Value::Enum(
+                                EnumValue::create(
+                                    0,
+                                    child,
+                                    &[Value::U64(i as u64), Value::String("nested".to_owned())],
+                                )
+                                .unwrap(),
+                            )))
+                        } else {
+                            None
+                        }),
+                    ])
+                    .unwrap(),
+                nested,
+            ));
+            let ignored = Value::Record(OwnedRecord::new(
+                nested
+                    .create(&[Value::Array(vec![]), Value::Nullable(None)])
+                    .unwrap(),
+                nested,
+            ));
+            let id = Value::Uuid(uuid::Uuid::from_u128(i as u128 + 1));
+            let raw = source
+                .create(&[ignored, value.clone(), id.clone()])
+                .unwrap();
+            let (descriptor, projected) = plan.encode(source.bind(&raw)).unwrap();
+            assert_eq!(projected, selected.create(&[id, value]).unwrap());
+            assert_eq!(
+                descriptor,
+                encode_result_descriptor(ResultDescriptorRole::Current, &canonical).unwrap()
+            );
+        }
+        let wrong_source = RecordDescriptor::new([
+            ("row_uuid", ValueType::Uuid),
+            ("payload", ValueType::String),
+        ]);
+        assert!(plan.encode(wrong_source.bind(&[])).is_err());
     }
 
     // Malformed member/schema pairings cannot be authored through the public

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -456,6 +456,7 @@ impl MaintainedSubscriptionView {
         let requires_authoritative_membership_reconcile =
             !deltas.is_empty() && kind.requires_authoritative_membership_reconcile();
         let mut decode_plan_cache = VersionDecodePlanCache::new();
+        let mut payload_plans = std::collections::HashMap::new();
         let decoded = deltas
             .iter()
             .map(|(record, weight)| {
@@ -465,6 +466,7 @@ impl MaintainedSubscriptionView {
                     tables,
                     node_aliases,
                     &mut decode_plan_cache,
+                    &mut payload_plans,
                     self.read_view,
                 )
                 .map(|event| (event, weight))
@@ -2049,6 +2051,10 @@ fn decode_typed_terminal_record(
     tables: &TableSchemas,
     node_aliases: &BTreeMap<NodeUuid, NodeAlias>,
     decode_plan_cache: &mut VersionDecodePlanCache,
+    payload_plans: &mut std::collections::HashMap<
+        RecordDescriptor,
+        super::descriptor_roles::CurrentPayloadEncodePlan,
+    >,
     read_view: crate::protocol::ReadViewKey,
 ) -> Result<DecodedMaintainedEvent, super::Error> {
     match kind {
@@ -2187,8 +2193,16 @@ fn decode_typed_terminal_record(
                 None => member,
             }
             .into();
-            let (descriptor, row_bytes) =
-                super::descriptor_roles::encode_current_payload_record(record, schema)?;
+            let plan = match payload_plans.entry(record.descriptor()) {
+                std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(super::descriptor_roles::CurrentPayloadEncodePlan::new(
+                        record.descriptor(),
+                        schema,
+                    )?)
+                }
+            };
+            let (descriptor, row_bytes) = plan.encode(record)?;
             let payload = ResultMemberPayloadEntry {
                 member: member.clone(),
                 descriptor,

--- a/dev/benchmarks/partial-parent-and-payload-profile.md
+++ b/dev/benchmarks/partial-parent-and-payload-profile.md
@@ -95,3 +95,30 @@ The inner loop required no WASM build. The first new byte test used a tuple
 with variable-width members, which Groove correctly rejects; its final fixture
 uses a nested record. Native timing and profile collection ran after builds
 and tests completed.
+
+## Second target for this iteration: permissioned graph loads
+
+Alongside `local_batch_phases`, track `jazz-sim`'s `customer_cold_start` at
+`JAZZ_CUSTOMER_SCALE=1.0`: the anonymized large-load
+workload historically described as approximately 20.5k rows with recursive group membership, resource access edges and inherited
+child permissions. The fixture subscribes across 39 tables. Use the emitted
+`expected_rows`/`rows_materialized` for exact counts rather than treating the
+historical headline size as a fixed assertion.
+
+Track member `cold` and `warm` separately. Cold starts with an empty relay;
+warm primes, closes and reopens its RocksDB state, then connects a fresh
+client. Warm therefore measures persisted relay reuse, not a retained browser
+foreground. Keep admin cold and unauthorized (`spy`) cold as permission
+controls. Preserve exact visibility assertions and compare phase, per-table
+readiness, transport and memory metrics alongside total time.
+
+Build the native benchmark once under `--profile perf`, then invoke its
+executable directly with `JAZZ_CUSTOMER_IDENTITY=member`,
+`JAZZ_CUSTOMER_PHASES=cold,warm`, `JAZZ_CUSTOMER_SCALE=1.0` and
+`JAZZ_CUSTOMER_MAX_TICKS=200000`. The existing `repro-customer.sh` identifies the
+historical matrix, but its output pipeline suppresses command failures; use
+direct commands and inspect exit status for new receipts. Do not reuse old
+seed databases across storage revisions without checking their compatibility.
+
+This section selects the additional workload; a current-tip timing baseline
+has not yet been collected.

--- a/dev/benchmarks/partial-parent-and-payload-profile.md
+++ b/dev/benchmarks/partial-parent-and-payload-profile.md
@@ -1,0 +1,97 @@
+# Partial-parent lookup and compiled payload projection
+
+Follow-up to [the native baseline](native-local-batch-profile.md), using the
+same synthetic fixture, optimized profile, clock-aligned Rust sampling and
+MemoryStorage/RocksDB backends. These are native core phase measurements,
+not browser results or complete app startup latency.
+
+## Partial-parent misses
+
+PR #2790 (`74b6f8e463`) avoids loading retained siblings when an exact parent
+coordinate is missing from a known partial transaction. Such siblings cannot
+establish invalidity; the existing pending coordinate constraint is retained.
+Exact parent reads and complete-transaction rejection retain their semantics.
+
+| Fresh foreground ingestion after reopening |   Before |  After |
+| ------------------------------------------ | -------: | -----: |
+| 1,500 rows, 50% updated, memory            | 2,151 ms | 120 ms |
+| 1,500 rows, 90% updated, memory            |   887 ms | 130 ms |
+| 1,500 rows, 100% updated, memory           |   135 ms | 134 ms |
+| 3,000 rows, 90% updated, memory            | 3,376 ms | 275 ms |
+
+The 50% case drops from 2,259,793 counted storage reads/index entries to
+8,293. History-index entries drop from 1,126,500 to 1,500. These counters
+include in-memory probes and index entries, not disk I/O. At 90%, the count
+falls from 822,793 to 10,093. Doubling the input now approximately doubles
+this phase, instead of roughly quadrupling it.
+
+The regression covers cold and resident caches at two transaction widths.
+Restoring the old implementation makes 32 misses perform 64 whole-transaction
+loads and fails the assertion. All 1,999 active library tests passed.
+
+## Compiled current-result payload projection
+
+The next profile showed repeated descriptor construction and value conversion.
+The current-result encoder rebuilt its schema for each row, materialized selected
+values, encoded them, rebound and decoded the result, then encoded it again to
+check its own output. It also serialized type descriptors for every row.
+
+The replacement compiles a field mapping once per source descriptor in a single
+terminal delta batch. Groove's existing registry-rebinding projector copies
+encoded field spans and reconstructs framing. Compatibility is checked when
+compiling the plan. Descriptor interning handles are cache keys, never ordered
+or serialized identities. The cache cannot outlive or cross its terminal schema.
+No storage or wire format changes. Publication descriptor bytes still accompany
+the runtime payload; this slice does not redesign that representation.
+
+After timings are medians of three uninstrumented runs, compared with the
+immediately preceding partial-parent-only run, at 1,500 rows/1,350 updates:
+
+| Publication phase | Parent fix only | Plus compiled projection |
+| ----------------- | --------------: | -----------------------: |
+| Initial, memory   |        215.8 ms |                 194.9 ms |
+| Updated, memory   |        162.6 ms |                 135.5 ms |
+| Initial, RocksDB  |        224.0 ms |                 206.4 ms |
+| Updated, RocksDB  |        167.1 ms |                 136.8 ms |
+
+Across five separately profiled runs, memory batch publication has 830 samples
+before and 691 after. Samples containing the payload encoder/plan fall from
+113 to 3. This agrees with the phase improvement, rather than relying only on
+small timing differences. Some outer async frames remain unresolved/truncated.
+
+All 2,000 active library tests passed (2 ignored). An internal byte-compatibility
+test compares projected bytes with independently encoded selected fields across
+32 rows, reordered inputs, nested enum registry rebinding, arrays and nulls.
+Deliberately selecting an unrelated payload field makes that test fail; the
+mutation was restored. The optimized harness also verifies exact row IDs and
+updated-row sets on both backends.
+
+## Remaining bottlenecks and interpretation
+
+Memory worker ingestion remains approximately 229 ms for 1,350 updates;
+this publication change does not improve that phase. In its final profile:
+
+- 364/1,161 samples contain a record encode/decode or descriptor construction
+  frame (union of those frames, counted once per sample).
+- 189 contain `BorrowedRecord::to_values`; 160 contain `decode_value`.
+- 285 contain an IVM `update_one_node` frame. This overlaps conversion work.
+- 206 have memory copy as the leaf frame.
+
+These figures overlap and must not be summed. They support eliminating repeated
+representations, not merely tuning a serializer's primitive encoding speed.
+`VersionRow::from_wire_with_schema_version` reconstructs storage tables,
+materializes row values, then constructs and encodes a storage record per row.
+The next candidate is a per-table conversion plan that retains encoded payloads
+where wire/storage layouts permit it and encodes only changing metadata.
+
+Within IVM, `materialize_record_attempt` expands all values even when it
+ultimately returns the original bytes because nothing was indirect. A compiled
+layout-aware fast path is another candidate. Known receipt ingestion still
+reconstructs stored versions for conflict comparison. These remaining paths
+are tracked in #2789; publication projection is only the first slice.
+
+Tooling: optimized native core rebuilds took about 1m30–1m40 with warm caches.
+The inner loop required no WASM build. The first new byte test used a tuple
+with variable-width members, which Groove correctly rejects; its final fixture
+uses a nested record. Native timing and profile collection ran after builds
+and tests completed.


### PR DESCRIPTION
🤖 Compile current-result payload projection once per terminal delta batch, then copy encoded fields instead of repeatedly decoding and encoding every row.

For a 1,350-row update, the old publisher rebuilt the same role descriptor and field-type comparison for every row, materialized values, encoded the selected fields, decoded that output, and re-encoded it to check itself. The new plan validates the compiled source/target schemas once per source descriptor and uses Groove's existing byte-copy projector. For example, when the input carries an unrelated field before the requested payload and row ID, the mapping selects only the correct fields and rebuilds their framing. Nested enum registry rebinding, nulls, arrays, join occurrence identities and reordered fields retain their encoded meaning.

The cache belongs to one terminal's delta batch, so it cannot reuse a plan against another query schema. It uses interned source descriptor handles for lookup, never for durable identity. No storage or wire format changes; this does not remove the runtime descriptor attached to each publication payload or change the protocol's supporting-row semantics.

With the quadratic parent fix already applied, native batch publication improves from 163 ms to 136 ms in memory and 167 ms to 137 ms with RocksDB. Initial publication improves from 216 ms to 195 ms in memory. The encoder accounts for 113 samples before and 3 after across five runs. These are synthetic native phase measurements, not browser timing predictions. The accompanying report includes the parent fix's results, methodology, limitations and remaining ingestion/IVM conversion bottlenecks.

Validation: 2,000 active library tests pass, 2 ignored. The new byte-equivalence test covers 32 reused rows, reordered fields, nested enum registry rebinding, arrays and nulls. A temporary wrong-field mapping makes it fail; restored. Existing publication role/occurrence tests pass. Optimized memory/RocksDB acceptance and fresh Rust profiles completed. Draft pending broader integration and independent review.

Builds on #2790. First slice of #2789.
