### PR TITLE
bench: restore permissioned graph loads and record current baseline

### DIFF
--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -284,7 +284,7 @@ const CHILD_TABLES: usize = 6;
 const DOMINANT_CHILD_TABLE: &str = "res_l_child_3";
 const DOMINANT_CHILD_VISIBLE_PARENTS: usize = 36;
 const DOMINANT_CHILD_TOTAL_PARENTS: usize = 65;
-const SEED_CACHE_VERSION: &str = "customer-cold-start-seed-v5";
+const SEED_CACHE_VERSION: &str = "customer-cold-start-seed-v7";
 const SEED_CACHE_READY: &str = ".jazz_customer_seed_ready";
 
 const RESOURCE_SPECS: [ResourceSpec; 14] = [
@@ -963,7 +963,7 @@ fn resource_policy(access_table: &str) -> PolicyExpr {
         &[("administrator", PublicValue::Boolean(false))],
         GROUP_ACCESS,
         "user_id",
-        &["user"],
+        &["user", "account"],
         "group_id",
     )
 }
@@ -1871,13 +1871,16 @@ fn subscription_tables() -> Vec<String> {
 fn seed_db(core: &Node<RocksDbStorage>, table: &str, row: RowUuid, cells: BTreeMap<String, Value>) {
     let node = core.node();
     let mut node = block_on(node.lock());
-    jazz_sim::fixture::commit_mergeable_unit_settled(
+    let (tx_id, _) = jazz_sim::fixture::commit_mergeable_unit_settled(
         &mut node,
         MergeableCommit::new(table, row, next_seed_time())
             .made_by(AuthorSubject::SYSTEM)
             .cells(cells),
     )
     .unwrap();
+    // Core seed rows must be accepted, not merely persisted local writes.
+    let outcome = block_on(node.finalize_local_mergeable_commit(tx_id)).unwrap();
+    jazz_sim::fixture::settle_outcome(&mut node, outcome).unwrap();
 }
 
 fn open_db_node(
@@ -1968,7 +1971,15 @@ fn group_cells(org: RowUuid, i: usize) -> BTreeMap<String, Value> {
 fn group_access_cells(group: RowUuid, user: RowUuid, i: usize) -> BTreeMap<String, Value> {
     BTreeMap::from([
         ("group_id".to_owned(), Value::Uuid(group.0)),
-        ("user_id".to_owned(), Value::Uuid(user.0)),
+        (
+            "user_id".to_owned(),
+            Value::Uuid(
+                AuthorSubject::for_test_uuid(user.0)
+                    .account_id()
+                    .expect("fixture identity has an account")
+                    .0,
+            ),
+        ),
         ("role".to_owned(), Value::EnumTag((i % 3) as u8)),
     ])
 }

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -1219,19 +1219,10 @@ where
     /// logical table-prefix scan.
     pub async fn encoded_storage_bytes_for_test(&self) -> Result<u64, Error> {
         let mut total = 0_u64;
-        for class_cf in [
-            "__groove_class_history",
-            "__groove_class_register",
-            "__groove_class_global_current",
-            "__groove_class_ahead_current",
-            "__groove_class_changes",
-            "__groove_class_indices",
-            "__groove_class_content",
-            "__groove_class_meta",
-        ] {
+        for class_cf in self.try_current_schema()?.physical_column_families() {
             total += self
                 .database
-                .approximate_class_bytes(class_cf)
+                .approximate_class_bytes(&class_cf)
                 .await
                 .map_err(Error::Groove)?
                 .unwrap_or_default();

--- a/dev/benchmarks/partial-parent-and-payload-profile.md
+++ b/dev/benchmarks/partial-parent-and-payload-profile.md
@@ -120,5 +120,5 @@ historical matrix, but its output pipeline suppresses command failures; use
 direct commands and inspect exit status for new receipts. Do not reuse old
 seed databases across storage revisions without checking their compatibility.
 
-This section selects the additional workload; a current-tip timing baseline
-has not yet been collected.
+The first current-tip cold receipt and the warm reopen blocker are recorded in
+[permissioned-load-current.md](permissioned-load-current.md).

--- a/dev/benchmarks/permissioned-load-current.md
+++ b/dev/benchmarks/permissioned-load-current.md
@@ -32,6 +32,20 @@ after materialization. These are therefore harness timings, not a clean
 production end-to-end latency estimate. Allocation/RSS metrics emitted as zero
 in this build are unavailable and must not be interpreted as zero memory use.
 
+## Iteration targets
+
+The working target is approximately **5 seconds** to correct cold subscription
+readiness; the stretch target is **under 1 second**. Against this 51.9-second
+baseline, those require approximately 10x and 52x improvements respectively.
+Track the final one-shot materialization and diagnostic overhead separately.
+The historical harness's `target_ms=1000` remains the stretch-target marker;
+its existing `under_target` field uses total harness wall time, not readiness.
+Use the readiness metric above for this iteration's product target.
+
+Profile core, relay and client work separately, including recursive permission
+and inherited-child evaluation, publication, ingestion and local materialization.
+Measure codec probes separately before attributing their work to the runtime.
+
 ## Warm failure
 
 Warm priming passes its row-count checks, but reopening the newly created relay

--- a/dev/benchmarks/permissioned-load-current.md
+++ b/dev/benchmarks/permissioned-load-current.md
@@ -71,3 +71,31 @@ No production query, permission, sync or storage-format behavior is changed.
 The benchmark's visibility assertions are preserved. The original account and
 seed implementations failed those assertions/execution; the repaired cold
 phase reaches exact expected counts. The remaining reopen failure is separate.
+
+## Client durability experiment
+
+The benchmark uses RocksDB `WalNoSync`; the client configures a durability
+boundary every 512 initial-sync writes, followed by a final flush. Test whether
+periodic client fsync explains the load time by setting
+`JAZZ_CUSTOMER_INITIAL_SYNC_FLUSH_CADENCE=1000000000` (effectively final-only
+for this workload). Core and relay settings stay unchanged.
+
+| Configuration                           | Subscription readiness | Harness wall |
+| --------------------------------------- | ---------------------: | -----------: |
+| Current 512-write cadence               |               51.914 s |     53.772 s |
+| Effectively unlimited cadence           |               51.963 s |     53.858 s |
+| Unlimited, activated before bulk ingest |               52.875 s |     54.760 s |
+
+Each run reaches exactly 27,518 rows. These are individual runs, not confidence
+intervals; none shows a useful improvement. The third run temporarily moves
+`begin_initial_sync_flush_cadence` ahead of
+`ingest_reset_view_bundle_refs_in_bulk`, after the existing outer admission
+checks, because the current code activates it after that bulk work. The
+experiment was reverted and is not part of the PR's production runtime changes.
+
+This does not test disabling the WAL, bypassing persistence, or relaxing
+IndexedDB transactions. It specifically finds no benefit from reducing periodic
+client flushes here. Retain the CPU-profile plan to separate Jazz/Groove
+representation and permission work from storage indexing/WAL work. Future
+cache-durability experiments must keep recoverable row data and sync progress
+consistent, while preserving durability of user-authored pending writes.

--- a/dev/benchmarks/permissioned-load-current.md
+++ b/dev/benchmarks/permissioned-load-current.md
@@ -1,0 +1,59 @@
+# Current permissioned graph load receipt
+
+Measured with the production runtime at `d51c965f0a` (PR #2791) plus the
+benchmark compatibility/diagnostic repairs described below. Native optimized
+`perf` build; full-scale `customer_cold_start`, member identity, 39 subscriptions.
+This is one successful cold-load phase, not a repeated-run median. The combined
+cold/warm process exits unsuccessfully later during warm relay reopen.
+
+| Cold phase                                                   |      Time |
+| ------------------------------------------------------------ | --------: |
+| Connection setup                                             |     <1 ms |
+| Subscription setup                                           |    502 ms |
+| Drive synchronization to expected subscription counts        | 51,418 ms |
+| Last subscription reaches its expected row count, from start | 51,914 ms |
+| Final one-shot query materialization/count checks            |  1,550 ms |
+| Total reported wall, including diagnostics                   | 53,772 ms |
+
+Expected and observed visible rows both equal **27,518**. The dominant child
+table contributes **23,831**. Per-table checks pass across all 39 subscriptions.
+Only three outer settle-loop iterations were needed; this is substantial work
+within ticks, not a long sequence of empty network polling iterations.
+
+Cold means an empty relay and fresh client connected to a populated core.
+Warm first primes a separate relay, closes it, reopens its RocksDB state and
+connects a fresh client. These are in-process native core/relay/client links,
+without network RTT, browser/WASM startup or UI rendering. Fixture seeding is
+outside the timed load (352 ms using this invocation's accepted seed cache).
+
+The existing harness performs extra codec comparisons during transport; these
+remain included. Its `wall_ms` also includes storage/runtime diagnostic work
+after materialization. These are therefore harness timings, not a clean
+production end-to-end latency estimate. Allocation/RSS metrics emitted as zero
+in this build are unavailable and must not be interpreted as zero memory use.
+
+## Warm failure
+
+Warm priming passes its row-count checks, but reopening the newly created relay
+fails with `scalar enum registry case provenance disagrees with authority
+identities`. The failure also reproduces at 1% scale. No warm timing exists.
+Tracked in #2792; do not bypass that validation or report the failed run as a
+performance success.
+
+## Compatibility repairs needed to run this historical fixture
+
+- Compare the UUID membership column with `user.account`, not structured `user`;
+  seed the account UUID derived by the fixture identity helper. The old form
+  fails with `value does not match type Uuid`.
+- Finalize core seed writes as accepted after persisting them. The old seed
+  leaves every downstream table empty and times out. This follows the existing
+  `s3_permissions` core seed path. The seed cache version changes to keep the
+  old generated datasets separate.
+- Derive test-only byte-meter column families from the current schema. The
+  hard-coded removed `__groove_class_content` family previously crashed the
+  diagnostics after successful loading.
+
+No production query, permission, sync or storage-format behavior is changed.
+The benchmark's visibility assertions are preserved. The original account and
+seed implementations failed those assertions/execution; the repaired cold
+phase reaches exact expected counts. The remaining reopen failure is separate.


### PR DESCRIPTION
🤖 Restore the historical permissioned graph benchmark on the current account and storage APIs, and record its first current cold-load baseline.

The fixture now compares UUID memberships against `user.account` and seeds matching fixture account IDs. Core seed writes are finalized as accepted after persistence, following the maintained `s3_permissions` fixture; previously all downstream tables stayed empty. A new seed-cache version keeps older generated stores separate. The test-only storage byte meter now derives column families from the current schema instead of querying a removed hard-coded family.

The full-scale member cold phase reaches exactly 27,518 rows across 39 subscriptions, including 23,831 rows in the dominant child table. Subscription readiness takes 51.9 seconds; final one-shot queries take 1.55 seconds; harness wall time is 53.8 seconds. This is one completed cold phase, not a repeated median or browser measurement. Diagnostic codec probes remain included. Our iteration target is approximately 5 seconds to correct cold readiness, ideally under 1 second.

Warm priming passes, but reopening that fresh relay fails scalar-enum provenance validation. This also reproduces at 1% scale and is tracked separately in #2792. No warm timing is claimed, and the combined process exits unsuccessfully at that point. No assertions were weakened to produce the cold receipt.

Validation: optimized benchmark build, successful full-scale cold visibility/materialization checks, reproductions of the original fixture failures and reduced-size warm reopen failure; commit Clippy/format/sensitive-data checks passed. The report documents exact measurement boundaries and remaining blocker. Production query/sync/permission behavior and storage formats are unchanged. Draft pending the warm blocker and further profiling; builds on #2791.
