### PR TITLE
perf: skip parent history reloads without waiting children

### DIFF
--- a/crates/jazz/src/node/ingest/validation.rs
+++ b/crates/jazz/src/node/ingest/validation.rs
@@ -234,10 +234,9 @@ where
     ) -> Result<(), Error> {
         for parent in complete_parents {
             self.invalidate_tx_version_tables_cache(*parent);
-            self.reject_mismatched_pending_children_for_parent(*parent)
-                .await?;
         }
-        Ok(())
+        self.reject_mismatched_pending_children_for_parents(complete_parents)
+            .await
     }
 
     /// Resolve durable constraints left by children that referenced a parent
@@ -247,74 +246,97 @@ where
         &mut self,
         parent: TxId,
     ) -> Result<(), Error> {
-        let Some(parent_tx) = self.query_transaction(parent).await? else {
-            return Ok(());
-        };
-        if matches!(parent_tx.fate, Fate::Rejected(_)) {
-            return Ok(());
-        }
-        let parent_versions = self.query_versions_for_tx(parent).await?;
-        if parent_versions.is_empty() {
-            return Ok(());
-        }
+        self.reject_mismatched_pending_children_for_parents(&BTreeSet::from([parent]))
+            .await
+    }
 
-        let mut invalid_children = BTreeSet::new();
+    async fn reject_mismatched_pending_children_for_parents(
+        &mut self,
+        parents: &BTreeSet<TxId>,
+    ) -> Result<(), Error> {
+        if parents.is_empty() {
+            return Ok(());
+        }
+        // Discover the constraints once for the entire admitted batch. Most
+        // downloaded transactions have no waiting children; loading their
+        // history first would probe every history table for no useful work.
+        let mut constraints = BTreeMap::<TxId, Vec<(TxId, ParentCoordinate)>>::new();
         for raw in self
             .database
             .primary_key_scan_raw("jazz_pending_edges", &[])
             .await?
         {
             let record = raw.record();
-            let parent_alias = NodeAlias(record.get_u64(
-                PendingEdgeRowRecord::FIELD_PARENT_NODE_ID_IDX,
-            )?);
-            let stored_parent = TxId::new(
+            let parent_alias =
+                NodeAlias(record.get_u64(PendingEdgeRowRecord::FIELD_PARENT_NODE_ID_IDX)?);
+            let parent = TxId::new(
                 TxTime(record.get_u64(PendingEdgeRowRecord::FIELD_PARENT_TIME_IDX)?),
-                self.node_for_alias(parent_alias).ok_or(Error::InvalidStoredValue(
-                    "pending edge parent alias must exist",
-                ))?,
+                self.node_for_alias(parent_alias)
+                    .ok_or(Error::InvalidStoredValue(
+                        "pending edge parent alias must exist",
+                    ))?,
             );
-            if stored_parent != parent {
+            if !parents.contains(&parent) {
                 continue;
             }
-            let coordinate = pending_edge_coordinate_from_record(record)?;
-            let mut exact = false;
-            for candidate in &parent_versions {
-                if self.version_row_matches_parent_coordinate(candidate, &coordinate)? {
-                    exact = true;
-                    break;
-                }
-            }
-            let parent_is_complete = !parent_tx.view_scoped_cardinality
-                && usize::try_from(parent_tx.tx.n_total_writes)
-                    .is_ok_and(|expected| parent_versions.len() >= expected);
-            if !exact && parent_is_complete {
-                let child_alias = NodeAlias(record.get_u64(
-                    PendingEdgeRowRecord::FIELD_CHILD_NODE_ID_IDX,
-                )?);
-                let child = TxId::new(
-                    TxTime(record.get_u64(PendingEdgeRowRecord::FIELD_CHILD_TIME_IDX)?),
-                    self.node_for_alias(child_alias).ok_or(Error::InvalidStoredValue(
+            let child_alias =
+                NodeAlias(record.get_u64(PendingEdgeRowRecord::FIELD_CHILD_NODE_ID_IDX)?);
+            let child = TxId::new(
+                TxTime(record.get_u64(PendingEdgeRowRecord::FIELD_CHILD_TIME_IDX)?),
+                self.node_for_alias(child_alias)
+                    .ok_or(Error::InvalidStoredValue(
                         "pending edge child alias must exist",
                     ))?,
-                );
-                invalid_children.insert(child);
-            }
+            );
+            constraints
+                .entry(parent)
+                .or_default()
+                .push((child, pending_edge_coordinate_from_record(record)?));
         }
 
-        for child in invalid_children {
-            if self
-                .query_transaction(child)
-                .await?
-                .is_some_and(|tx| matches!(tx.fate, Fate::Pending))
-            {
-                Box::pin(self.apply_fate_update(
-                    child,
-                    Fate::Rejected(RejectionReason::CausalityViolation),
-                    None,
-                    None,
-                ))
-                .await?;
+        for (parent, children) in constraints {
+            let mut invalid_children = BTreeSet::new();
+            let Some(parent_tx) = self.query_transaction(parent).await? else {
+                continue;
+            };
+            if matches!(parent_tx.fate, Fate::Rejected(_)) {
+                continue;
+            }
+            let parent_versions = self.query_versions_for_tx(parent).await?;
+            let parent_is_complete = !parent_tx.view_scoped_cardinality
+                && !parent_versions.is_empty()
+                && usize::try_from(parent_tx.tx.n_total_writes)
+                    .is_ok_and(|expected| parent_versions.len() >= expected);
+            if !parent_is_complete {
+                continue;
+            }
+            for (child, coordinate) in children {
+                let mut exact = false;
+                for candidate in &parent_versions {
+                    if self.version_row_matches_parent_coordinate(candidate, &coordinate)? {
+                        exact = true;
+                        break;
+                    }
+                }
+                if !exact {
+                    invalid_children.insert(child);
+                }
+            }
+
+            for child in invalid_children {
+                if self
+                    .query_transaction(child)
+                    .await?
+                    .is_some_and(|tx| matches!(tx.fate, Fate::Pending))
+                {
+                    Box::pin(self.apply_fate_update(
+                        child,
+                        Fate::Rejected(RejectionReason::CausalityViolation),
+                        None,
+                        None,
+                    ))
+                    .await?;
+                }
             }
         }
         Ok(())

--- a/crates/jazz/src/node/tests/branch_views.rs
+++ b/crates/jazz/src/node/tests/branch_views.rs
@@ -2969,3 +2969,29 @@ fn partial_parent_misses_do_not_materialize_retained_siblings() {
         }
     }
 }
+
+#[test]
+fn completed_parents_without_waiting_children_do_not_reload_history() {
+    // Internal mechanism test: visible results cannot expose unnecessary
+    // transaction-wide history probes after a successful batch admission.
+    let (_dir, mut node) = open_node_with_uuid(node(0xb1));
+    let mut parents = BTreeSet::new();
+    for i in 1..=32 {
+        parents.insert(node.commit_mergeable_settled(
+            MergeableCommit::new("todos", RowUuid(uuid::Uuid::from_u128(i)), i as u64)
+                .cells(title_cells("parent without waiting children")),
+        ).unwrap());
+    }
+    let unrelated_child = node.commit_mergeable_settled(
+        MergeableCommit::new("todos", RowUuid(uuid::Uuid::from_u128(99)), 110)
+            .parents(vec![TxId::new(TxTime::from(100), NodeUuid(uuid::Uuid::from_u128(0xb2)))])
+            .cells(title_cells("unrelated waiting child")),
+    ).unwrap();
+    node.reset_storage_read_metrics();
+    super::super::reset_query_versions_for_tx_call_count();
+    node.settle_completed_parent_batch(&parents).resolve().unwrap();
+    assert_eq!(super::super::query_versions_for_tx_call_count(), 0,
+        "completed parents without constraints must not reload their history");
+    assert_eq!(node.storage_read_metrics().history_indexes.reads, 0);
+    assert_eq!(node.transaction_record(unrelated_child).unwrap().fate, Fate::Pending);
+}


### PR DESCRIPTION
🤖 Avoid rereading downloaded transactions that have no waiting children.

When a receiver imported a complete batch, it invalidated the transaction caches and then loaded every transaction's row versions to check for pending children. That lookup probed history indexes across unrelated tables even when no child referred to the transaction. The pending-edge table was also scanned once per parent.

Now settlement scans pending constraints once for the batch, groups relevant constraints by parent, and loads history only for those parents. For example, downloading 30,000 independent rows with no waiting children needs no parent-history reloads. An unrelated waiting child does not change that. If a waiting child references an arriving complete parent at the wrong physical row, branch or layer, the existing causality rejection still applies. Missing or partial parents remain inconclusive, and accepted children are not retroactively rewritten.

The optimized native permissioned fixture delivers all 27,518 expected rows across 39 subscriptions in 41.8 seconds, compared with 51.9 seconds before this change (individual samples, not medians). This is a fresh relay and client against a populated Core using RocksDB and in-process transport; it is not a browser timing. No storage or wire format changes.

Validation: 2,001 Rust library tests passed (2 ignored), including receiver parent/reopen cases. The new mechanism regression passes; restoring the old implementation makes it fail with 32 history reloads instead of zero. The broad run used 4 MiB test-thread stacks and an increased file-descriptor limit; earlier undersized harness runs aborted or hit descriptor exhaustion. This is a draft performance slice on #2793, not a release-ready claim.
