### PR TITLE
perf: probe inline records without decoding their values

### DIFF
--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -2276,6 +2276,7 @@ fn encode_stored_scalar_canonical(
 #[cfg(test)]
 std::thread_local! {
     static STORED_SCALAR_ENCODE_CALLS: Cell<usize> = const { Cell::new(0) };
+    static STORED_SCALAR_DECODE_CALLS: Cell<usize> = const { Cell::new(0) };
     static STORED_SCALAR_CANONICAL_ENCODE_CALLS: Cell<usize> = const { Cell::new(0) };
 }
 
@@ -2294,6 +2295,8 @@ fn stored_scalar_encode_calls() -> usize {
 /// interpreted directly through that schema; indirect values authenticate the
 /// expected kind when their content-addressed nodes are decoded.
 pub fn decode_stored_scalar(kind: LargeValueKind, encoded: &[u8]) -> Result<StoredScalar, Error> {
+    #[cfg(test)]
+    STORED_SCALAR_DECODE_CALLS.with(|calls| calls.set(calls.get() + 1));
     let (tag, payload) =
         crate::records::split_variant_record(encoded).map_err(|_| Error::MalformedScalar)?;
     let decoded = match tag {
@@ -3978,6 +3981,9 @@ pub(crate) fn materialize_record_attempt(
     raw: &[u8],
     inputs: &mut EvaluationInputs,
 ) -> Result<Vec<u8>, IvmRuntimeError> {
+    if !descriptor.fields_contain_indirect_values(raw, 0..descriptor.fields().len())? {
+        return Ok(raw.to_vec());
+    }
     let mut values = descriptor.bind(raw).to_values()?;
     let mut blocked = false;
     let mut changed = false;
@@ -4002,6 +4008,9 @@ pub(crate) fn materialize_record_fields_attempt(
     field_indices: &[usize],
     inputs: &mut EvaluationInputs,
 ) -> Result<Vec<u8>, IvmRuntimeError> {
+    if !descriptor.fields_contain_indirect_values(raw, field_indices.iter().copied())? {
+        return Ok(raw.to_vec());
+    }
     let mut values = descriptor.bind(raw).to_values()?;
     let mut blocked = false;
     let mut changed = false;
@@ -8054,6 +8063,116 @@ mod tests {
         assert!(!std::ptr::eq(bytes, string));
         assert!(!std::ptr::eq(bytes, json));
         assert!(!std::ptr::eq(string, json));
+    }
+
+    #[test]
+    fn materialization_probe_preserves_inline_nested_records_and_resolves_indirect_values() {
+        // Internal receipt: public equality alone cannot prove that inline
+        // values avoided allocation/decoding. Exercise the real materializer
+        // through nullable, array, enum and record boundaries, including retry.
+        for kind in [
+            LargeValueKind::Bytes,
+            LargeValueKind::String,
+            LargeValueKind::Json,
+        ] {
+            let payload = br#"{"value":"nested"}"#;
+            let prepared = prepare_with_locator(kind, payload, deterministic_locator).unwrap();
+            let scalar_type = match kind {
+                LargeValueKind::Bytes => ValueType::Bytes,
+                LargeValueKind::String => ValueType::String,
+                LargeValueKind::Json => physical_storage_value_type(kind),
+            };
+            let inline = match kind {
+                LargeValueKind::Bytes => Value::Bytes(payload.to_vec()),
+                _ => Value::String(String::from_utf8(payload.to_vec()).unwrap()),
+            };
+            let leaf = RecordDescriptor::new([("value", scalar_type)]);
+            let wrapper = RecordDescriptor::new([("leaf", ValueType::Record(Box::new(leaf)))]);
+            let cases = EnumSchema::new(
+                "test.materialization_probe",
+                [EnumCase::new("Value", wrapper)],
+            )
+            .unwrap();
+            let descriptor = RecordDescriptor::new([(
+                "items",
+                ValueType::Array(Box::new(ValueType::Nullable(Box::new(ValueType::Enum(
+                    Box::new(cases),
+                ))))),
+            )]);
+            let encode = |scalar| {
+                let leaf_record =
+                    crate::records::OwnedRecord::new(leaf.create(&[scalar]).unwrap(), leaf);
+                let wrapper_record = crate::records::OwnedRecord::new(
+                    wrapper.create(&[Value::Record(leaf_record)]).unwrap(),
+                    wrapper,
+                );
+                descriptor
+                    .create(&[Value::Array(vec![
+                        Value::Nullable(None),
+                        Value::Nullable(Some(Box::new(Value::Enum(
+                            crate::records::EnumValue::new(0, wrapper_record),
+                        )))),
+                    ])])
+                    .unwrap()
+            };
+            let expected = encode(inline);
+            let mut inputs = EvaluationInputs::default();
+            STORED_SCALAR_DECODE_CALLS.with(|calls| calls.set(0));
+            assert_eq!(
+                materialize_record_attempt(&descriptor, &expected, &mut inputs).unwrap(),
+                expected
+            );
+            assert_eq!(
+                STORED_SCALAR_DECODE_CALLS.with(Cell::get),
+                0,
+                "inline nested scalars must remain encoded"
+            );
+            let indirect = encode(Value::Large(prepared.value_ref.clone()));
+            assert!(matches!(
+                materialize_record_attempt(&descriptor, &indirect, &mut inputs),
+                Err(IvmRuntimeError::EvaluationBlocked)
+            ));
+            assert!(!inputs.take_missing_chunks().is_empty());
+            for chunk in &prepared.staged_chunks {
+                inputs.install_chunk(
+                    ChunkRequest {
+                        object_hash: chunk.node_ref.object_hash.0,
+                        locator: chunk.node_ref.locator,
+                    },
+                    bytes::Bytes::copy_from_slice(&chunk.encoded),
+                );
+            }
+            assert_eq!(
+                materialize_record_attempt(&descriptor, &indirect, &mut inputs).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn materialization_probe_ignores_unselected_indirect_fields() {
+        let prepared =
+            prepare_with_locator(LargeValueKind::Bytes, b"unselected", deterministic_locator)
+                .unwrap();
+        let descriptor = RecordDescriptor::new([
+            ("inline", ValueType::String),
+            ("indirect", ValueType::Bytes),
+        ]);
+        let raw = descriptor
+            .create(&[
+                Value::String("inline".to_owned()),
+                Value::Large(prepared.value_ref),
+            ])
+            .unwrap();
+        let mut inputs = EvaluationInputs::default();
+        STORED_SCALAR_DECODE_CALLS.with(|calls| calls.set(0));
+        assert_eq!(
+            materialize_record_fields_attempt(&descriptor, &raw, &[0], &mut inputs).unwrap(),
+            raw
+        );
+        assert!(inputs.take_missing_chunks().is_empty());
+        assert_eq!(STORED_SCALAR_DECODE_CALLS.with(Cell::get), 0);
+        assert!(materialize_record_fields_attempt(&descriptor, &raw, &[2], &mut inputs).is_err());
     }
 
     #[test]

--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -468,6 +468,26 @@ impl RecordDescriptor {
         record_value_span(record, self, field_idx)
     }
 
+    pub(crate) fn fields_contain_indirect_values(
+        &self,
+        record: &[u8],
+        indices: impl IntoIterator<Item = usize>,
+    ) -> Result<bool, Error> {
+        for index in indices {
+            let field = self.fields.get(index).ok_or(Error::FieldIndexOutOfBounds {
+                index,
+                len: self.fields.len(),
+            })?;
+            if field.value_type.may_contain_stored_scalar() {
+                let span = self.field_span(record, index)?;
+                if values::encoded_contains_indirect_value(&record[span], &field.value_type)? {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+
     pub fn patch_field(
         &self,
         record: &[u8],

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -1213,7 +1213,9 @@ impl ValueType {
     /// on large-value hydration.
     pub(crate) fn may_contain_stored_scalar(&self) -> bool {
         match self {
-            Self::Internal(InternalValueType(InternalValueTypeRepr::StoredScalar(_))) => true,
+            Self::String
+            | Self::Bytes
+            | Self::Internal(InternalValueType(InternalValueTypeRepr::StoredScalar(_))) => true,
             Self::Tuple(members) => members.iter().any(Self::may_contain_stored_scalar),
             Self::Array(inner) | Self::Nullable(inner) => inner.may_contain_stored_scalar(),
             Self::Record(descriptor) => descriptor
@@ -2011,6 +2013,75 @@ fn encode_nullable(
         }
     }
     Ok(())
+}
+
+/// Inspect only framing needed to find an indirect scalar. Admission owns
+/// validity of the record; this is not another canonical decoding pass.
+pub(super) fn encoded_contains_indirect_value(
+    bytes: &[u8],
+    value_type: &ValueType,
+) -> Result<bool, Error> {
+    match value_type {
+        ValueType::String
+        | ValueType::Bytes
+        | ValueType::Internal(InternalValueType(InternalValueTypeRepr::StoredScalar(_))) => {
+            let (tag, _) = super::split_variant_record(bytes)?;
+            match tag {
+                2 => Ok(false),
+                3 => Ok(true),
+                _ => Err(Error::LargeValue(
+                    crate::large_values::Error::MalformedScalar,
+                )),
+            }
+        }
+        ValueType::Nullable(inner) => {
+            let (&flag, payload) = bytes.split_first().ok_or(Error::UnexpectedEof)?;
+            match flag {
+                0 => Ok(false),
+                1 => encoded_contains_indirect_value(payload, inner),
+                flag => Err(Error::InvalidNullFlag(flag)),
+            }
+        }
+        ValueType::Record(descriptor) => {
+            descriptor.fields_contain_indirect_values(bytes, 0..descriptor.fields().len())
+        }
+        ValueType::Enum(schema) => {
+            let (tag, payload) = super::split_variant_record(bytes)?;
+            let descriptor = schema.case(tag)?.payload;
+            descriptor.fields_contain_indirect_values(payload, 0..descriptor.fields().len())
+        }
+        ValueType::Array(inner) if inner.may_contain_stored_scalar() => {
+            // Indirect-capable array elements are variable-width. Bounds-check
+            // the offset table before visiting entries, without allocating it.
+            let count = u32_to_usize(read_u32_at(bytes, 0)?)?;
+            let mut start = checked_add(
+                4,
+                count
+                    .saturating_sub(1)
+                    .checked_mul(4)
+                    .ok_or(Error::InvalidOffset)?,
+            )?;
+            if start > bytes.len() {
+                return Err(Error::UnexpectedEof);
+            }
+            for index in 0..count {
+                let end = if index + 1 == count {
+                    bytes.len()
+                } else {
+                    u32_to_usize(read_u32_at(bytes, 4 + index * 4)?)?
+                };
+                let item = bytes.get(start..end).ok_or(Error::InvalidOffset)?;
+                if encoded_contains_indirect_value(item, inner)? {
+                    return Ok(true);
+                }
+                start = end;
+            }
+            Ok(false)
+        }
+        // Tuples are restricted to fixed-size members and cannot contain an
+        // indirect scalar. Raw engine fields and all other scalars cannot either.
+        _ => Ok(false),
+    }
 }
 
 fn decode_nullable(bytes: &[u8], inner_type: &ValueType) -> Result<Value, Error> {

--- a/dev/benchmarks/permissioned-load-structural-profile.md
+++ b/dev/benchmarks/permissioned-load-structural-profile.md
@@ -1,0 +1,167 @@
+# Permissioned cold load: structural profile and three improvements
+
+This iteration profiles the full-scale, anonymized permissioned resource graph on
+native Core → relay → client, with RocksDB and in-process semantic messages.
+The relay and client start empty; Core uses its populated seed cache. This is
+not a browser timing or a reopen of a populated client. Seed creation is excluded.
+All runs below deliver 27,518 expected rows across 39 subscriptions, including
+23,831 visible children out of 43,000 candidates in the dominant table.
+
+## Measured improvement
+
+| Runtime state                                       | Correct subscription readiness |
+| --------------------------------------------------- | -----------------------------: |
+| Before this iteration (#2793)                       |                       51.914 s |
+| Skip unconstrained completed-parent history (#2794) |                       41.829 s |
+| Skip fresh-occurrence order scans (#2795)           |                       38.718 s |
+| Probe inline values without decoding (#2796)        |                       35.863 s |
+
+These are individual optimized native measurements, not medians. The final
+CPU-sampled repeat reached readiness in 36.351 s. The ordinary final run's
+settle loop took 35.365 s and complete harness wall time was 37.634 s. Final
+one-shot verification and diagnostics extend wall time beyond readiness.
+The three changes save about 31%; the approximately 5 s target remains unmet.
+
+Run a clean optimized timing with:
+
+```sh
+cargo build -p jazz-sim --bench customer_cold_start --profile perf
+JAZZ_CUSTOMER_IDENTITY=member JAZZ_CUSTOMER_PHASES=cold \
+JAZZ_CUSTOMER_SCALE=1.0 JAZZ_CUSTOMER_MAX_TICKS=200000 \
+cargo bench -p jazz-sim --bench customer_cold_start --profile perf
+```
+
+Use the Cargo-reported executable directly for profiling so samples exclude
+Cargo/build work. CPU samples used `perf record --clockid mono -e task-clock
+-F 499 --call-graph dwarf,32768`; a 65528-byte stack capture was also inspected.
+Some libc callers still fail to unwind, so inclusive percentages are incomplete
+and overlapping. Do not add them or treat their differences as exact wall time.
+
+## Why completed parents were expensive
+
+`settle_completed_parent_batch` invalidated transaction caches, then loaded each
+parent's row versions before finding whether any child needed them. A cold
+`query_versions_for_tx` lacked a table hint and probed history indexes across
+unrelated tables. The fixture has a separate seed transaction per row.
+
+The new path scans pending constraints once for the batch and groups only the
+relevant parents. No waiting child means no parent-history reload. Complete
+wrong-coordinate parents still reject pending children; partial/missing parents
+remain inconclusive. The regression includes an unrelated waiting child.
+Restoring the original implementation fails with 32 history reloads instead of
+zero. Existing receiver/reopen cases remain covered.
+
+## What the growing order vector represents
+
+The maintained view stores occurrence records in a map and their collector-defined
+positions in a vector. Distinct occurrences may refer to the same public row.
+An insert can replace an existing occurrence, so its old position must be removed
+before reinsertion. Removing every matching key before every fresh insert was
+unnecessary: 23,831 distinct inserts performed about 284 million comparisons.
+
+The existing occurrence map now determines whether that removal is needed. Fresh
+keys take the direct insertion path; replacement, removal and move behavior remain.
+A 2,000-occurrence test detects both always scanning (1,999,000 comparisons) and
+never removing a replacement (2,001 occurrences instead of 2,000).
+
+## How 27,518 results become 2,061,039 projection inputs
+
+These counters count a record once per projection operator it visits, not once
+per distinct row, storage read, or byte-wire message.
+
+| Node                      | Projection input visits |
+| ------------------------- | ----------------------: |
+| Core                      |                 522,580 |
+| Relay                     |               1,118,743 |
+| Client                    |                 419,716 |
+| Total during settle ticks |               2,061,039 |
+
+A temporary per-operator trace reproduces those totals exactly. The dominant
+child query accounts for 473,715 visits on Core and 979,250 on the relay:
+
+- Core: 11 distinct projection operators each process 43,000 child records,
+  plus 11 × 65 supporting parent records.
+- Relay: 10 distinct operators process 43,000 candidates; 22 distinct operators
+  process 23,831 visible records; smaller parent/access/group relations add work.
+- Client: 14 distinct operators each process a 23,831-record batch, alongside
+  other tables and transaction-key processing.
+
+For these large batches, this is pipeline depth, not repeated invocation of the
+same operator. The projections adapt physical/history fields, expose application
+metadata, attach permission claims and coverage, prepare collector fields, and
+produce supporting-version/membership inputs. For example, a full child record
+is copied into a collector-prefixed layout and another layout adds a closure root.
+The final one-shot verification queries add 137,590 projection visits outside the
+settle ticks; those are not included in the 2,061,039 total.
+
+320,362 visits have identity-shaped field mappings, making them candidates for
+sharing encoded bytes. This is an upper-bound candidate count: type/layout
+compatibility still needs checking before any copy can actually be removed.
+The old dominant-child attribution bucket fails to recognize the lowered graph;
+its zero must not be interpreted as absence of dominant-table work.
+
+## Inline materialization
+
+Previously the materializer decoded every field to allocated Values, recursively
+visited nested values, and returned the original bytes when nothing changed.
+It now inspects descriptor-directed tags and offsets before allocating Values.
+Inline records pass through; real chunk references retain the existing blocking,
+loading and retry path. Selected-field materialization ignores unselected chunks.
+Ordinary String and Bytes are recognized as indirect-capable, matching their codec.
+
+Tests cover bytes, strings and JSON-backed scalars under nullable/array/enum/record
+boundaries, missing chunks, retry, invalid field indexes and unselected references.
+Always-skip and always-decode mutations both fail. The ordinary materialization
+path fell from approximately 5% of initial CPU samples to below 1% afterward.
+No storage or wire encoding changes are involved.
+
+## Allocation profile and remaining thesis
+
+The current workload reports approximately 485.6 million Rust allocation requests
+and 295.7 GB of cumulative requested bytes. A run sampled every 32,768 allocations
+captured 14,818 stacks without reaching the cap; its totals agree with a denser
+run to within a few hundred requests. These are allocation churn, not peak RAM,
+retained data size, actual bytes copied, or C++/RocksDB allocation totals. The
+instrumented allocator includes growth requests and must not define a normal
+wall-time receipt. Counting ends after final verification/storage diagnostics.
+
+Across all 14,818 sampled allocation stacks, 26.7% pass through schema/descriptor
+construction, 17.1% through author conversion, 12.6% through supporting-version
+reconstruction, 8.1% through VersionRecord cloning and 4.7% through join processing.
+These are overlapping allocation-stack shares, not exclusive CPU-time shares.
+Symbols were resolved against the executable's PIE virtual addresses (not ELF
+file offsets), with inline frames included. The first capped sampler's top-stack
+list is not used for these whole-run percentages.
+
+Code walks confirm per-row work that should be schema- or batch-level:
+
+- `update_table_source_from_inputs` calls `record_schema_for_variant` inside its
+  stored-row loop; that rebuilds descriptor field vectors.
+- `VersionRow::from_wire_with_schema_version` constructs a history storage table
+  while preparing individual records.
+- `RowAuthor::value_type`, `to_value`, and `from_value` reconstruct the same nested
+  account/identity descriptor structure repeatedly.
+- `decode_history_owned_record` walks logical table mappings and formats physical
+  table names to reverse-resolve a known physical storage table.
+- Join processing creates temporary encoded keys/buckets, and supporting-version
+  conversion rebuilds records from allocated cells and author metadata.
+
+The next structural direction is to prepare descriptors and physical mappings once
+per schema/batch, then retain encoded records through more of the query pipeline.
+Projection fusion or shared backing bytes may remove entire passes; counters alone
+do not establish which permission stages are redundant. Durability relaxation
+previously showed no measurable improvement and remains a lower-priority lever.
+
+## Verification and limits
+
+#2794: 2,001 Jazz library tests pass, 2 ignored. #2795 and #2796: 2,002 pass,
+2 ignored. #2796 additionally passes 734 Groove library tests, 2 ignored.
+All three changes have mutation-sensitive regressions and successful full-scale
+cold fixture counts. These are library/focused receipts, not CI-equivalent gates
+or browser/device acceptance. The PRs remain drafts in stack #2773.
+
+Broad Cargo tests require the runner's 4 MiB thread stack and sufficient file
+descriptors (`RUST_MIN_STACK=4194304`, `ulimit -n 65536` here). Smaller defaults
+caused a stack abort and RocksDB descriptor-exhaustion failures before clean reruns.
+Diagnostic instrumentation was preserved separately and removed from production
+changes. The existing warm-relay reopen failure remains tracked in #2792.


### PR DESCRIPTION
🤖 Keep inline records encoded when checking whether query evaluation needs external chunks.

The materializer previously decoded every field into allocated Values before discovering that no field needed chunk loading, then copied the original record back out. Nested records repeated that work recursively. This was significant in the permissioned cold-load profile.

An encoded probe now follows the descriptor and the necessary tags/offsets through nullable values, arrays, records and enums. If the selected fields contain only inline values, their bytes pass through without scalar decoding. A chunk reference still enters the existing materializer, including missing-chunk suspension and retry. Unselected fields do not cause hydration. The schema predicate also recognizes ordinary String and Bytes as capable of containing chunk references, matching their existing encoding.

For example, a nested author record containing inline strings needs no allocated string values to prove it is inline. An array containing an indirect string does require hydration; it must wait for the missing chunk and then return the same logical string. No storage or wire encoding changes. The probe assumes admitted record validity; it does not recreate records to establish canonicality.

The full native fixture reaches all 27,518 expected rows in 35.9s, versus 38.7s after #2795 and 51.9s originally. Individual optimized native measurements, not browser timings or medians. Completed CPU and allocation profiles identify repeated schema/descriptor construction and row representation conversion as the next targets. See the [measurement report and code walks](https://github.com/garden-co/jazz/blob/04cd37da76baa805cabe558223ba1612f7b9b677/dev/benchmarks/permissioned-load-structural-profile.md) and [remaining work](https://github.com/garden-co/jazz/issues/2789#issuecomment-5628599506).

Validation: all 734 Groove library tests passed (2 ignored). New nested tests cover bytes, strings and JSON-backed scalars, missing chunks, successful retry, nullable/array/enum/record boundaries, unselected indirect fields and invalid field indexes. Both an always-skip mutation and an always-decode mutation fail. All 2,002 Jazz library tests also pass (2 ignored), with the repository-sized thread stacks and raised descriptor limit. Draft on #2795.
