### PR TITLE
perf: prepare projections per field and borrow supported values

### DIFF
--- a/crates/groove/src/ivm/runtime/operator_updates.rs
+++ b/crates/groove/src/ivm/runtime/operator_updates.rs
@@ -601,18 +601,38 @@ impl NodeState {
             .sum::<usize>();
         let mut output = BytesMut::with_capacity(estimated_output_bytes);
         let mut spans = Vec::with_capacity(input.deltas.len());
-        let mut raw_projection_scratch = RawProjectionScratch::default();
         for delta in &input.deltas {
             let span = if let Some(fields) = raw_projection {
-                output_desc
-                    .project_raw_fields_into(
-                        &input.descriptor,
-                        delta.raw(),
-                        fields,
-                        &mut output,
-                        &mut raw_projection_scratch,
-                    )
-                    .map_err(IvmRuntimeError::RecordEncoding)?
+                let start = output.len();
+                let result = output_desc.project_raw_fields_into(
+                    &input.descriptor,
+                    delta.raw(),
+                    fields,
+                    &mut output,
+                    |index, output| {
+                        let value = project_field_value(
+                            &project.expressions[index],
+                            index,
+                            output_desc,
+                            &input.descriptor,
+                            delta.raw(),
+                        )?;
+                        let encoded = encode_projection_field_value(output_desc, index, value)?;
+                        output.extend_from_slice(&encoded);
+                        Ok::<_, IvmRuntimeError>(())
+                    },
+                );
+                match result {
+                    Ok(span) => span,
+                    Err(
+                        IvmRuntimeError::EnumTagProjectionAbsent { .. }
+                        | IvmRuntimeError::EnumProjectionAbsent { .. },
+                    ) if omit_unrepresentable_enum_rows => {
+                        output.truncate(start);
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                }
             } else {
                 let start = output.len();
                 let record = match project_record(

--- a/crates/groove/src/ivm/runtime/record_projection.rs
+++ b/crates/groove/src/ivm/runtime/record_projection.rs
@@ -659,65 +659,86 @@ pub(super) fn project_record(
         )?);
     }
 
-    let input = BorrowedRecord::new(input_record, input_desc);
     let mut values = Vec::with_capacity(expressions.len());
     for (output_idx, expr) in expressions.iter().enumerate() {
-        let resolved = |field: &FieldRef| -> Result<Value, IvmRuntimeError> {
-            let source_idx = resolve_field_ref(input_desc, field)?;
-            input
-                .get_idx(source_idx)
-                .map_err(IvmRuntimeError::RecordEncoding)
-        };
-        values.push(match &expr.expression {
-            ProjectExpr::Field(field) => resolved(field)?,
-            ProjectExpr::RecordField { source, path } => {
-                let mut value = resolved(source)?;
-                for name in path {
-                    let Value::Record(record) = value else {
-                        return Err(IvmRuntimeError::UnsupportedOperator);
-                    };
-                    value = record.get(name)?;
-                }
-                value
-            }
-            ProjectExpr::Literal(value) | ProjectExpr::TypedLiteral { value, .. } => {
-                value.to_value()
-            }
-            ProjectExpr::Null(_) => Value::Nullable(None),
-            ProjectExpr::Nullable(field) => Value::Nullable(Some(Box::new(resolved(field)?))),
-            ProjectExpr::NullableFlat(field) => {
-                let value = resolved(field)?;
-                if matches!(value, Value::Nullable(_)) {
-                    value
-                } else {
-                    Value::Nullable(Some(Box::new(value)))
-                }
-            }
-            ProjectExpr::EnumTagRemap {
-                source: field,
-                tags,
-            } => remap_enum_tag(resolved(field)?, tags)?,
-            ProjectExpr::EnumRemap {
-                source: field,
-                tags,
-            } => remap_enum(resolved(field)?, tags)?,
-            ProjectExpr::RecursiveEnumRemap {
-                source: field,
-                remaps,
-                ..
-            } => {
-                let source_idx = resolve_field_ref(input_desc, field)?;
-                remap_recursive_enum_value(
-                    resolved(field)?,
-                    &input_desc.fields()[source_idx].value_type,
-                    &output_desc.fields()[output_idx].value_type,
-                    remaps,
-                    "root",
-                )?
-            }
-        });
+        values.push(project_field_value(
+            expr,
+            output_idx,
+            output_desc,
+            input_desc,
+            input_record,
+        )?);
     }
     Ok(output_desc.create(&values)?)
+}
+
+#[cfg(test)]
+thread_local! {
+    pub(super) static PROJECT_VALUE_EVALUATIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+pub(super) fn project_field_value(
+    expr: &ProjectionExpr,
+    output_idx: usize,
+    output_desc: RecordDescriptor,
+    input_desc: &RecordDescriptor,
+    input_record: &[u8],
+) -> Result<Value, IvmRuntimeError> {
+    #[cfg(test)]
+    PROJECT_VALUE_EVALUATIONS.with(|count| count.set(count.get() + 1));
+    let input = BorrowedRecord::new(input_record, input_desc);
+    let resolved = |field: &FieldRef| -> Result<Value, IvmRuntimeError> {
+        let source_idx = resolve_field_ref(input_desc, field)?;
+        input
+            .get_idx(source_idx)
+            .map_err(IvmRuntimeError::RecordEncoding)
+    };
+    Ok(match &expr.expression {
+        ProjectExpr::Field(field) => resolved(field)?,
+        ProjectExpr::RecordField { source, path } => {
+            let mut value = resolved(source)?;
+            for name in path {
+                let Value::Record(record) = value else {
+                    return Err(IvmRuntimeError::UnsupportedOperator);
+                };
+                value = record.get(name)?;
+            }
+            value
+        }
+        ProjectExpr::Literal(value) | ProjectExpr::TypedLiteral { value, .. } => value.to_value(),
+        ProjectExpr::Null(_) => Value::Nullable(None),
+        ProjectExpr::Nullable(field) => Value::Nullable(Some(Box::new(resolved(field)?))),
+        ProjectExpr::NullableFlat(field) => {
+            let value = resolved(field)?;
+            if matches!(value, Value::Nullable(_)) {
+                value
+            } else {
+                Value::Nullable(Some(Box::new(value)))
+            }
+        }
+        ProjectExpr::EnumTagRemap {
+            source: field,
+            tags,
+        } => remap_enum_tag(resolved(field)?, tags)?,
+        ProjectExpr::EnumRemap {
+            source: field,
+            tags,
+        } => remap_enum(resolved(field)?, tags)?,
+        ProjectExpr::RecursiveEnumRemap {
+            source: field,
+            remaps,
+            ..
+        } => {
+            let source_idx = resolve_field_ref(input_desc, field)?;
+            remap_recursive_enum_value(
+                resolved(field)?,
+                &input_desc.fields()[source_idx].value_type,
+                &output_desc.fields()[output_idx].value_type,
+                remaps,
+                "root",
+            )?
+        }
+    })
 }
 
 pub(super) fn remap_enum_tag(value: Value, tags: &[Option<u8>]) -> Result<Value, IvmRuntimeError> {
@@ -963,48 +984,112 @@ pub(super) fn raw_projection_fields(
     input_desc: &RecordDescriptor,
     output_desc: RecordDescriptor,
 ) -> Result<Option<Vec<RawProjectionField>>, IvmRuntimeError> {
-    if project.expressions.is_empty() || project.expressions.len() != output_desc.fields().len() {
+    let validate_copy = |source_type: &ValueType, output_idx: usize| {
+        if source_type != &output_desc.fields()[output_idx].value_type {
+            return Err(IvmRuntimeError::RecordEncoding(
+                records::Error::TypeMismatch {
+                    expected: output_desc.fields()[output_idx].value_type.clone(),
+                },
+            ));
+        }
+        Ok(())
+    };
+    if project.expressions.is_empty() {
+        if project.mapping.len() != output_desc.fields().len() {
+            return Ok(None);
+        }
+        let fields = project
+            .mapping
+            .iter()
+            .enumerate()
+            .map(|(output_idx, &(source, source_idx))| {
+                if source != 0 {
+                    return Err(IvmRuntimeError::UnsupportedOperator);
+                }
+                let field = input_desc
+                    .fields()
+                    .get(source_idx)
+                    .ok_or(IvmRuntimeError::GraphFieldIndexOutOfBounds(source_idx))?;
+                validate_copy(&field.value_type, output_idx)?;
+                Ok(RawProjectionField::Copy { source_idx })
+            })
+            .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
+        return Ok(Some(fields));
+    }
+    if project.expressions.len() != output_desc.fields().len() {
         return Ok(None);
     }
-
     let fields = project
         .expressions
         .iter()
         .enumerate()
-        .map(|(output_idx, expr)| match &expr.expression {
-            ProjectExpr::Field(field) => resolve_field_ref(input_desc, field)
-                .ok()
-                .map(|source_idx| RawProjectionField::Copy { source_idx }),
-            ProjectExpr::Nullable(field) => resolve_field_ref(input_desc, field)
-                .ok()
-                .map(|source_idx| RawProjectionField::WrapNullable { source_idx }),
-            ProjectExpr::NullableFlat(field) => resolve_field_ref(input_desc, field)
-                .ok()
-                .map(|source_idx| RawProjectionField::FlattenNullable { source_idx }),
-            ProjectExpr::Null(_) => Some(RawProjectionField::Encoded {
-                bytes: encode_projection_field_value(
-                    output_desc,
-                    output_idx,
-                    Value::Nullable(None),
-                )
-                .ok()?,
-            }),
-            ProjectExpr::Literal(value) | ProjectExpr::TypedLiteral { value, .. } => {
-                Some(RawProjectionField::Encoded {
-                    bytes: encode_projection_field_value(output_desc, output_idx, value.to_value())
-                        .ok()?,
-                })
-            }
-            ProjectExpr::RecordField { .. }
-            | ProjectExpr::EnumTagRemap { .. }
-            | ProjectExpr::EnumRemap { .. }
-            | ProjectExpr::RecursiveEnumRemap { .. } => None,
+        .map(|(output_idx, expr)| {
+            Ok(match &expr.expression {
+                ProjectExpr::Field(field) => {
+                    let source_idx = resolve_field_ref(input_desc, field)?;
+                    validate_copy(&input_desc.fields()[source_idx].value_type, output_idx)?;
+                    RawProjectionField::Copy { source_idx }
+                }
+                ProjectExpr::Nullable(field) | ProjectExpr::NullableFlat(field) => {
+                    let source_idx = resolve_field_ref(input_desc, field)?;
+                    let source_type = &input_desc.fields()[source_idx].value_type;
+                    if matches!(expr.expression, ProjectExpr::NullableFlat(_))
+                        && matches!(source_type, ValueType::Nullable(_))
+                    {
+                        validate_copy(source_type, output_idx)?;
+                        RawProjectionField::Copy { source_idx }
+                    } else {
+                        validate_copy(
+                            &ValueType::Nullable(Box::new(source_type.clone())),
+                            output_idx,
+                        )?;
+                        RawProjectionField::WrapNullable { source_idx }
+                    }
+                }
+                ProjectExpr::RecordField { source, path } => {
+                    let source_idx = resolve_field_ref(input_desc, source)?;
+                    let mut steps = vec![(*input_desc, source_idx)];
+                    let mut value_type = &input_desc.fields()[source_idx].value_type;
+                    for name in path {
+                        let ValueType::Record(descriptor) = value_type else {
+                            return Err(IvmRuntimeError::UnsupportedOperator);
+                        };
+                        let index = descriptor
+                            .field_index(name)
+                            .ok_or(IvmRuntimeError::UnsupportedOperator)?;
+                        steps.push((**descriptor, index));
+                        value_type = &descriptor.fields()[index].value_type;
+                    }
+                    validate_copy(value_type, output_idx)?;
+                    RawProjectionField::Nested { path: steps }
+                }
+                ProjectExpr::Null(_) => {
+                    prepared_constant_field(output_desc, output_idx, Value::Nullable(None))
+                }
+                ProjectExpr::Literal(value) | ProjectExpr::TypedLiteral { value, .. } => {
+                    prepared_constant_field(output_desc, output_idx, value.to_value())
+                }
+                ProjectExpr::EnumTagRemap { .. }
+                | ProjectExpr::EnumRemap { .. }
+                | ProjectExpr::RecursiveEnumRemap { .. } => RawProjectionField::Evaluate,
+            })
         })
-        .collect::<Option<Vec<_>>>();
-    Ok(fields)
+        .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
+    Ok(Some(fields))
 }
 
-fn encode_projection_field_value(
+fn prepared_constant_field(
+    output: RecordDescriptor,
+    index: usize,
+    value: Value,
+) -> RawProjectionField {
+    match records::encode_single_field_value(&value, &output.fields()[index].value_type) {
+        Ok(bytes) => RawProjectionField::Encoded { bytes },
+        Err(error) => RawProjectionField::Error(error),
+    }
+}
+
+pub(super) fn encode_projection_field_value(
     output_desc: RecordDescriptor,
     field_idx: usize,
     value: Value,

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -23,8 +23,8 @@ use super::{
     ArgByDirection, ArrangementUpdateMode, AsOf, EvalContext, GraphRuntimeView, IvmRuntimeError,
     NodeState, RecordDelta, RecordDeltas, ScopeId, StaticScanBounds, SubTick, TableDelta,
     VariantProjection, VariantProjectionKey, arg_by_candidate_replaces, consolidate_deltas,
-    encoded_record_key_part, plan_expr_names, project_binding_source_deltas, scan_bounds,
-    touched_join_keys,
+    encoded_record_key_part, plan_expr_names, project_binding_source_deltas, raw_projection_fields,
+    scan_bounds, touched_join_keys,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -1677,8 +1677,14 @@ impl HydrationEvaluator<'_> {
                 }
                 OpType::MapProject(project) => {
                     let input = self.eval_unary_input(graph_node, node).await?;
-                    let result =
-                        NodeState::update_map_project(project, output_desc, &input, None, false);
+                    let fields = raw_projection_fields(project, &input.descriptor, output_desc)?;
+                    let result = NodeState::update_map_project(
+                        project,
+                        output_desc,
+                        &input,
+                        fields.as_deref(),
+                        false,
+                    );
                     #[cfg(feature = "cold-settle-attribution")]
                     if let Ok(output) = &result {
                         crate::cold_settle_attribution::record_map(

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -2802,3 +2802,270 @@ async fn record_values_canonicalize_delta_identity_and_are_rejected_as_arrangeme
         encoded_record_key_part(descriptor, &changed_record, &[0]).unwrap()
     );
 }
+
+// Internal coverage is needed here because correct output alone cannot detect
+// decoding copied fields, allocating per-row records, or losing batch sharing.
+#[test]
+fn prepared_projection_keeps_mixed_fields_encoded_and_shares_batch_output() {
+    let inner = RecordDescriptor::new([("label", ValueType::String), ("number", ValueType::U64)]);
+    let outer = RecordDescriptor::new([("inner", ValueType::Record(Box::new(inner)))]);
+    let source_enum =
+        ValueType::EnumTag(records::ScalarEnumSchema::new("old", ["a", "b"]).unwrap());
+    let target_enum =
+        ValueType::EnumTag(records::ScalarEnumSchema::new("new", ["b", "a"]).unwrap());
+    let source = RecordDescriptor::new([
+        ("nested", ValueType::Record(Box::new(outer))),
+        ("text", ValueType::String),
+        ("optional", ValueType::Nullable(Box::new(ValueType::String))),
+        ("state", source_enum),
+    ]);
+    let target = RecordDescriptor::new([
+        ("label", ValueType::String),
+        ("number", ValueType::U64),
+        ("copy", ValueType::String),
+        ("wrapped", ValueType::Nullable(Box::new(ValueType::String))),
+        ("flat", ValueType::Nullable(Box::new(ValueType::String))),
+        ("constant", ValueType::String),
+        ("null", ValueType::Nullable(Box::new(ValueType::U64))),
+        ("state", target_enum),
+    ]);
+    let expressions = vec![
+        ProjectExpr::RecordField {
+            source: FieldRef::Resolved(0),
+            path: vec!["inner".into(), "label".into()],
+        },
+        ProjectExpr::RecordField {
+            source: FieldRef::Resolved(0),
+            path: vec!["inner".into(), "number".into()],
+        },
+        ProjectExpr::Field(FieldRef::Resolved(1)),
+        ProjectExpr::Nullable(FieldRef::Resolved(1)),
+        ProjectExpr::NullableFlat(FieldRef::Resolved(2)),
+        ProjectExpr::Literal(LiteralValue::String("constant payload".repeat(100))),
+        ProjectExpr::Null(ValueType::Nullable(Box::new(ValueType::U64))),
+        ProjectExpr::EnumTagRemap {
+            source: FieldRef::Resolved(3),
+            tags: vec![Some(1), Some(0)],
+        },
+    ];
+    let project = MapProjectOp {
+        expressions: expressions
+            .into_iter()
+            .enumerate()
+            .map(|(i, expression)| ProjectionExpr {
+                expression,
+                output_name: Some(format!("out{i}")),
+                output_identity: records::FieldIdentity::Name(format!("out{i}")),
+            })
+            .collect(),
+        mapping: Vec::new(),
+    };
+    let deltas = (0..12)
+        .map(|i| {
+            let nested = OwnedRecord::new(
+                inner
+                    .create(&[Value::String(format!("label-{i}")), Value::U64(i)])
+                    .unwrap(),
+                inner,
+            );
+            let outer_record =
+                OwnedRecord::new(outer.create(&[Value::Record(nested)]).unwrap(), outer);
+            RecordDelta {
+                record: Bytes::from(
+                    source
+                        .create(&[
+                            Value::Record(outer_record),
+                            Value::String("borrow me".repeat(i as usize)),
+                            if i % 2 == 0 {
+                                Value::Nullable(None)
+                            } else {
+                                Value::Nullable(Some(Box::new(Value::String("present".into()))))
+                            },
+                            Value::EnumTag((i % 2) as u8),
+                        ])
+                        .unwrap(),
+                ),
+                weight: if i % 2 == 0 { 1 } else { -1 },
+            }
+        })
+        .collect();
+    let input = RecordDeltas {
+        descriptor: source,
+        deltas,
+    };
+    let expected: Vec<_> = input
+        .deltas
+        .iter()
+        .map(|row| {
+            project_record(
+                &project.expressions,
+                &project.mapping,
+                target,
+                &source,
+                row.raw(),
+            )
+            .unwrap()
+        })
+        .collect();
+    let plan = raw_projection_fields(&project, &source, target)
+        .unwrap()
+        .unwrap();
+    PROJECT_VALUE_EVALUATIONS.with(|count| count.set(0));
+    let output =
+        NodeState::update_map_project(&project, target, &input, Some(&plan), false).unwrap();
+    assert_eq!(
+        PROJECT_VALUE_EVALUATIONS.with(|count| count.get()),
+        input.deltas.len(),
+        "only enum conversion should evaluate an owned Value"
+    );
+    for ((actual, expected), original) in output.deltas.iter().zip(expected).zip(&input.deltas) {
+        assert_eq!(actual.raw(), expected);
+        assert_eq!(actual.weight, original.weight);
+    }
+    for pair in output.deltas.windows(2) {
+        assert_eq!(
+            pair[0].record.as_ptr().wrapping_add(pair[0].record.len()),
+            pair[1].record.as_ptr(),
+            "rows share contiguous batch storage"
+        );
+    }
+    drop(input);
+    assert_eq!(
+        output.deltas[11].borrowed(&target).get_idx(1).unwrap(),
+        Value::U64(11)
+    );
+}
+
+#[test]
+fn prepared_projection_omission_rolls_back_partial_row_and_preserves_following_rows() {
+    let source_enum =
+        ValueType::EnumTag(records::ScalarEnumSchema::new("old", ["keep", "omit"]).unwrap());
+    let target_enum = ValueType::EnumTag(records::ScalarEnumSchema::new("new", ["keep"]).unwrap());
+    // Variable-width recursive conversion runs after a copied variable field,
+    // so omission must roll back both fixed bytes and prior variable payloads.
+    let source_type = ValueType::Array(Box::new(source_enum));
+    let target_type = ValueType::Array(Box::new(target_enum));
+    let source = RecordDescriptor::new([
+        ("id", ValueType::U64),
+        ("text", ValueType::String),
+        ("state", source_type),
+    ]);
+    let target = RecordDescriptor::new([
+        ("id", ValueType::U64),
+        ("text", ValueType::String),
+        ("state", target_type.clone()),
+    ]);
+    let expressions = vec![
+        ProjectExpr::Field(FieldRef::Resolved(0)),
+        ProjectExpr::Field(FieldRef::Resolved(1)),
+        ProjectExpr::RecursiveEnumRemap {
+            source: FieldRef::Resolved(2),
+            target: target_type,
+            remaps: RecursiveEnumRemaps {
+                scalar: BTreeMap::from([("root/array".into(), vec![Some(0), None])]),
+                ..Default::default()
+            },
+            omit_unrepresentable: true,
+        },
+    ];
+    let project = MapProjectOp {
+        expressions: expressions
+            .into_iter()
+            .enumerate()
+            .map(|(i, expression)| ProjectionExpr {
+                expression,
+                output_name: None,
+                output_identity: records::FieldIdentity::Name(format!("out{i}")),
+            })
+            .collect(),
+        mapping: Vec::new(),
+    };
+    let input = RecordDeltas {
+        descriptor: source,
+        deltas: (0..4)
+            .map(|i| RecordDelta {
+                record: Bytes::from(
+                    source
+                        .create(&[
+                            Value::U64(i),
+                            Value::String(format!("text-{i}")),
+                            Value::Array(vec![Value::EnumTag((i % 2) as u8)]),
+                        ])
+                        .unwrap(),
+                ),
+                weight: 1,
+            })
+            .collect(),
+    };
+    let plan = raw_projection_fields(&project, &source, target)
+        .unwrap()
+        .unwrap();
+    let output =
+        NodeState::update_map_project(&project, target, &input, Some(&plan), false).unwrap();
+    assert_eq!(output.deltas.len(), 2);
+    for (row, id) in output.deltas.iter().zip([0, 2]) {
+        assert_eq!(
+            row.borrowed(&target).to_values().unwrap(),
+            vec![
+                Value::U64(id),
+                Value::String(format!("text-{id}")),
+                Value::Array(vec![Value::EnumTag(0)])
+            ]
+        );
+    }
+    assert_eq!(
+        output.deltas[0]
+            .record
+            .as_ptr()
+            .wrapping_add(output.deltas[0].record.len()),
+        output.deltas[1].record.as_ptr()
+    );
+}
+
+#[test]
+fn prepared_projection_rejects_incompatible_copy_before_reading_rows() {
+    let source = RecordDescriptor::new([("value", ValueType::U64)]);
+    let target = RecordDescriptor::new([("value", ValueType::String)]);
+    let project = MapProjectOp {
+        expressions: Vec::new(),
+        mapping: vec![(0, 0)],
+    };
+    assert!(raw_projection_fields(&project, &source, target).is_err());
+}
+
+#[test]
+fn prepared_constant_error_is_evaluated_only_for_present_rows() {
+    let descriptor = RecordDescriptor::new([("value", ValueType::U8)]);
+    let project = MapProjectOp {
+        expressions: vec![ProjectionExpr {
+            expression: ProjectExpr::Literal(LiteralValue::EnumTag(0)),
+            output_name: Some("value".into()),
+            output_identity: records::FieldIdentity::Name("value".into()),
+        }],
+        mapping: Vec::new(),
+    };
+    let plan = raw_projection_fields(&project, &descriptor, descriptor)
+        .unwrap()
+        .unwrap();
+    let mut input = RecordDeltas::empty(descriptor);
+    assert!(
+        NodeState::update_map_project(&project, descriptor, &input, Some(&plan), false)
+            .unwrap()
+            .is_empty()
+    );
+    input.deltas.push(RecordDelta {
+        record: Bytes::from(descriptor.create(&[Value::U8(0)]).unwrap()),
+        weight: 1,
+    });
+    let prepared = NodeState::update_map_project(&project, descriptor, &input, Some(&plan), false)
+        .unwrap_err();
+    let semantic = project_record(
+        &project.expressions,
+        &project.mapping,
+        descriptor,
+        &descriptor,
+        input.deltas[0].raw(),
+    )
+    .unwrap_err();
+    assert_eq!(format!("{prepared:?}"), format!("{semantic:?}"));
+}

--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -664,10 +664,23 @@ pub struct RecordProjector {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum RawProjectionField {
-    Copy { source_idx: usize },
-    WrapNullable { source_idx: usize },
-    FlattenNullable { source_idx: usize },
-    Encoded { bytes: Vec<u8> },
+    Copy {
+        source_idx: usize,
+    },
+    WrapNullable {
+        source_idx: usize,
+    },
+    Nested {
+        path: Vec<(RecordDescriptor, usize)>,
+    },
+    /// Constant preparation failed. Preserve lazy expression semantics:
+    /// an empty input does not evaluate the expression or raise its error.
+    Error(Error),
+    /// Only this field needs semantic evaluation by the caller.
+    Evaluate,
+    Encoded {
+        bytes: Vec<u8>,
+    },
 }
 
 #[derive(Debug, Default)]
@@ -818,79 +831,54 @@ impl RecordProjector {
 }
 
 impl RecordDescriptor {
-    pub(crate) fn project_raw_fields_into(
+    /// Execute a descriptor-checked field plan. Inputs are borrowed; all fields
+    /// append directly into the batch allocation. Only Evaluate calls user logic.
+    pub(crate) fn project_raw_fields_into<E: From<Error>>(
         &self,
         source: &RecordDescriptor,
         source_record: &[u8],
         fields: &[RawProjectionField],
         output: &mut BytesMut,
-        scratch: &mut RawProjectionScratch,
-    ) -> Result<std::ops::Range<usize>, Error> {
-        if self.fields.len() != fields.len() {
-            return Err(Error::ArityMismatch {
-                expected: self.fields.len(),
-                actual: fields.len(),
-            });
-        }
-
-        scratch.variable_fields.clear();
-        scratch.generated.clear();
+        mut evaluate: impl FnMut(usize, &mut BytesMut) -> Result<(), E>,
+    ) -> Result<std::ops::Range<usize>, E> {
         let start = output.len();
         let fixed_size = self.fixed_size();
         let variable_count = self.variable_count();
         let offset_table_size = variable_count.saturating_sub(1) * 4;
-        output.reserve(fixed_size + offset_table_size);
-
+        // Reserve the offset table only once, after the fixed fields. Variable
+        // ends are patched as their bytes arrive: no per-row span/scratch vector.
         for target_idx in &self.layout.logical_by_physical {
-            let layout = self.layout.fields[*target_idx];
-            if matches!(layout, FieldLayout::Variable { .. }) {
-                let bytes = self.raw_projected_field_bytes(
+            if matches!(self.layout.fields[*target_idx], FieldLayout::Static { .. }) {
+                append_projected_field(
                     source,
                     source_record,
+                    &fields[*target_idx],
                     *target_idx,
-                    fields[*target_idx].clone(),
-                    scratch,
+                    output,
+                    &mut evaluate,
                 )?;
-                scratch.variable_fields.push(bytes);
-                continue;
             }
-
-            let bytes = self.raw_projected_field_bytes(
+        }
+        let offset_start = output.len();
+        output.resize(offset_start + offset_table_size, 0);
+        for target_idx in &self.layout.logical_by_physical {
+            let FieldLayout::Variable { variable_idx } = self.layout.fields[*target_idx] else {
+                continue;
+            };
+            append_projected_field(
                 source,
                 source_record,
+                &fields[*target_idx],
                 *target_idx,
-                fields[*target_idx].clone(),
-                scratch,
+                output,
+                &mut evaluate,
             )?;
-            match bytes {
-                RawProjectedBytes::Source(span) => output.extend_from_slice(&source_record[span]),
-                RawProjectedBytes::Generated(span) => {
-                    output.extend_from_slice(&scratch.generated[span])
-                }
+            if variable_idx + 1 < variable_count {
+                let end = usize_to_u32(output.len() - start)?;
+                let offset = start + fixed_size + variable_idx * 4;
+                output[offset..offset + 4].copy_from_slice(&end.to_le_bytes());
             }
         }
-
-        let variable_start = fixed_size + offset_table_size;
-        let mut next_offset = variable_start;
-        for bytes in scratch
-            .variable_fields
-            .iter()
-            .take(scratch.variable_fields.len().saturating_sub(1))
-        {
-            next_offset = checked_add(next_offset, bytes.len())?;
-            output.extend_from_slice(&usize_to_u32(next_offset)?.to_le_bytes());
-        }
-        for bytes in &scratch.variable_fields {
-            match bytes {
-                RawProjectedBytes::Source(span) => {
-                    output.extend_from_slice(&source_record[span.clone()])
-                }
-                RawProjectedBytes::Generated(span) => {
-                    output.extend_from_slice(&scratch.generated[span.clone()])
-                }
-            }
-        }
-
         Ok(start..output.len())
     }
 
@@ -1046,120 +1034,36 @@ impl RecordDescriptor {
 
         Ok(Some(start..output.len()))
     }
+}
 
-    fn raw_projected_field_bytes(
-        &self,
-        source: &RecordDescriptor,
-        source_record: &[u8],
-        target_idx: usize,
-        field: RawProjectionField,
-        scratch: &mut RawProjectionScratch,
-    ) -> Result<RawProjectedBytes, Error> {
-        let target_field = self
-            .fields
-            .get(target_idx)
-            .ok_or(Error::FieldIndexOutOfBounds {
-                index: target_idx,
-                len: self.fields.len(),
-            })?;
-        match field {
-            RawProjectionField::Copy { source_idx } => {
-                let source_field =
-                    source
-                        .fields
-                        .get(source_idx)
-                        .ok_or(Error::FieldIndexOutOfBounds {
-                            index: source_idx,
-                            len: source.fields.len(),
-                        })?;
-                if source_field.value_type != target_field.value_type {
-                    return Err(Error::TypeMismatch {
-                        expected: target_field.value_type.clone(),
-                    });
-                }
-                source
-                    .field_span(source_record, source_idx)
-                    .map(RawProjectedBytes::Source)
-            }
-            RawProjectionField::WrapNullable { source_idx } => self.wrap_nullable_field_bytes(
-                source,
-                source_record,
-                source_idx,
-                target_idx,
-                scratch,
-            ),
-            RawProjectionField::FlattenNullable { source_idx } => {
-                let source_field =
-                    source
-                        .fields
-                        .get(source_idx)
-                        .ok_or(Error::FieldIndexOutOfBounds {
-                            index: source_idx,
-                            len: source.fields.len(),
-                        })?;
-                if source_field.value_type == target_field.value_type
-                    && matches!(source_field.value_type, ValueType::Nullable(_))
-                {
-                    return source
-                        .field_span(source_record, source_idx)
-                        .map(RawProjectedBytes::Source);
-                }
-                self.wrap_nullable_field_bytes(
-                    source,
-                    source_record,
-                    source_idx,
-                    target_idx,
-                    scratch,
-                )
-            }
-            RawProjectionField::Encoded { bytes } => {
-                let start = scratch.generated.len();
-                scratch.generated.extend_from_slice(&bytes);
-                Ok(RawProjectedBytes::Generated(start..scratch.generated.len()))
-            }
+fn append_projected_field<E: From<Error>>(
+    source: &RecordDescriptor,
+    record: &[u8],
+    field: &RawProjectionField,
+    target_idx: usize,
+    output: &mut BytesMut,
+    evaluate: &mut impl FnMut(usize, &mut BytesMut) -> Result<(), E>,
+) -> Result<(), E> {
+    match field {
+        RawProjectionField::Copy { source_idx } => {
+            output.extend_from_slice(&record[source.field_span(record, *source_idx)?]);
         }
-    }
-
-    fn wrap_nullable_field_bytes(
-        &self,
-        source: &RecordDescriptor,
-        source_record: &[u8],
-        source_idx: usize,
-        target_idx: usize,
-        scratch: &mut RawProjectionScratch,
-    ) -> Result<RawProjectedBytes, Error> {
-        let source_field = source
-            .fields
-            .get(source_idx)
-            .ok_or(Error::FieldIndexOutOfBounds {
-                index: source_idx,
-                len: source.fields.len(),
-            })?;
-        let target_field = self
-            .fields
-            .get(target_idx)
-            .ok_or(Error::FieldIndexOutOfBounds {
-                index: target_idx,
-                len: self.fields.len(),
-            })?;
-        let ValueType::Nullable(inner) = &target_field.value_type else {
-            return Err(Error::TypeMismatch {
-                expected: ValueType::Nullable(Box::new(source_field.value_type.clone())),
-            });
-        };
-        if inner.as_ref() != &source_field.value_type {
-            return Err(Error::TypeMismatch {
-                expected: target_field.value_type.clone(),
-            });
+        RawProjectionField::WrapNullable { source_idx } => {
+            output.extend_from_slice(&[1]);
+            output.extend_from_slice(&record[source.field_span(record, *source_idx)?]);
         }
-        let source_span = source.field_span(source_record, source_idx)?;
-        let start = scratch.generated.len();
-        scratch.generated.extend_from_slice(&[1]);
-        scratch
-            .generated
-            .extend_from_slice(&source_record[source_span]);
-        Ok(RawProjectedBytes::Generated(start..scratch.generated.len()))
+        RawProjectionField::Nested { path } => {
+            let mut bytes = record;
+            for (descriptor, index) in path {
+                bytes = &bytes[descriptor.field_span(bytes, *index)?];
+            }
+            output.extend_from_slice(bytes);
+        }
+        RawProjectionField::Encoded { bytes } => output.extend_from_slice(bytes),
+        RawProjectionField::Evaluate => evaluate(target_idx, output)?,
+        RawProjectionField::Error(error) => return Err(error.clone().into()),
     }
+    Ok(())
 }
 
 impl RawProjectedBytes {

--- a/dev/benchmarks/prepared-field-projections.md
+++ b/dev/benchmarks/prepared-field-projections.md
@@ -1,0 +1,108 @@
+# Prepared field projection and the number of projection stages
+
+This slice changes execution of a projection, not query meaning or the wire and
+storage formats. It follows the [permissioned-load profile](permissioned-load-structural-profile.md).
+
+## Execution changes
+
+The existing MapProject output was already one BytesMut batch, frozen into
+shared Bytes slices. The change removes avoidable intermediate work:
+
+- Preparation validates copy/nullable types and resolves nested record paths.
+  The execution loop only finds byte spans; it does not reconstruct descriptors
+  or compare source/target types for those fields.
+- Constants remain borrowed from the prepared plan. Previously cloning a field
+  operation also cloned its constant Vec for every row.
+- Nested record selections walk pre-resolved descriptor/index steps and copy
+  only the selected encoded field, without building owned parent records.
+- Nullable wrapping writes the presence byte and borrowed payload directly.
+  Variable offsets are patched in the output buffer, avoiding the intermediate
+  generated-payload buffer and per-row variable-field scratch.
+- A field needing enum conversion uses the existing semantic conversion only
+  for that field. It no longer sends neighboring copied fields through Values
+  and a temporary encoded row. This is not yet a direct binary implementation
+  of arbitrary recursive enum conversion.
+- Hydration's MapProject path now also prepares and uses the field plan once
+  for its input batch. The normal tick evaluator retains its cached plans.
+- Constant encoding failures are cached during preparation but raised only
+  when a row evaluates the expression. Empty input keeps the previous lazy
+  semantics (covered by the existing typed enum-parameter integration test).
+- When an enum mapping deliberately excludes a row, the batch writer rolls
+  back the entire partially written row before proceeding. Weights and output
+  order remain unchanged.
+
+The internal tests compare encoded output with the existing semantic evaluator,
+count owned field evaluations, verify shared contiguous output ownership, reject
+incompatible plans before processing rows, and exercise omission after a prior
+variable payload has already been written. Internal mechanism checks are needed
+because correct row values alone cannot detect the allocation regression.
+
+## Why there are so many projection stages
+
+The prior per-operator trace counts 2,061,039 input visits during settlement.
+This is neither 2M distinct rows nor one single sequential chain: it includes
+branches for different terminals and repeated evaluation at Core, relay and
+client. Some joined tuples repeat parent data for many children.
+
+Jazz builds its query graph compositionally. Each component publishes a record
+shape for its consumer:
+
+1. Physical/current-row adapters select winning versions, adapt schema fields,
+   and combine global/ahead candidates where that read tier requires it.
+2. Authorization joins attach account claim routes, check policy relations and
+   restore source-shaped rows after the join.
+3. Supporting-row publication restores exact row/version/route identities,
+   attaches immutable version witnesses, and adds event/table/coverage fields.
+4. Application collectors rename fields into a collector namespace and select
+   the user-visible result shape. Closure graphs separately carry root identity
+   and related inputs needed to evaluate or authorize the query.
+
+These stages have real semantics. Materializing every intermediate record is
+not necessarily required to preserve them.
+
+Concrete code paths:
+
+- `query_eval/read_sources.rs::projected_branch_content_source_graph` projects
+  global candidates, ahead candidates and the winner relation, then applies the
+  post-winner projection. Some boundaries protect enum/schema compatibility and
+  must remain logically after winner selection.
+- `query_eval/authorization.rs::compose_policy_filtered_current_source_graph` and its
+  related paths project joined policy data back to the authorized source shape.
+- `lowering/terminals.rs::content_version_witness_graph_from_visible_graph`
+  projects a witness shape, joins it against the exact visible row/version keys,
+  then projects again to restore fields and attach claim routes. The visibility
+  restriction must not disappear in any optimization.
+- `lowering/closure.rs::lower_closure_membership` projects each contributing
+  source back to its source shape plus required routes.
+- `lowering/collect_layout.rs::collect_anchor_graph` adds a collector projection,
+  including full-row field renames.
+
+The important missing optimization is in Groove: `GraphBuilder::project` and
+`project_fields` always construct a Project node, and
+`runtime/compilation.rs::add_dedup_unary_graph` lowers each into MapProject.
+`IvmGraph::dedup_node` shares exactly equal node descriptors, including their
+inputs and output shape. It does not compose adjacent projections or recognize
+that differently named descriptors may describe identical bytes.
+
+The trace illustrates the consequences: the dominant child query has wide
+15-field physical shapes, 20-field witness shapes with literals/nullability,
+23/24-field coverage and collector shapes, and a closure-root copy. On the relay,
+claim-route carriers add further variants. Its 10 x 43,000 and 22 x 23,831 large
+projection visits include both source preparation and terminal branches.
+
+## Next candidates, without changing query semantics
+
+1. Prove byte-layout equivalence once and let identity/rename projections share
+   the input Bytes. The earlier trace found 320,362 identity-shaped input visits,
+   an upper-bound candidate count rather than a verified removable count.
+2. Compose adjacent field projections into one prepared plan, accounting for
+   shared consumers so fusion does not duplicate work. Start with total field
+   selection/renaming/constant operations.
+3. Project directly at join/collector output boundaries where intermediate
+   tuples are immediately discarded; propagate required fields backward while
+   retaining authorization routes and version evidence.
+
+Do not move partial enum conversions across winner selection or filtering:
+error/omission behavior and authored-schema semantics matter. Do not turn
+supporting-row publication into an unrestricted source read. The opportunity is
+fewer representation boundaries, not weaker permission or reconciliation rules.

--- a/dev/benchmarks/prepared-field-projections.md
+++ b/dev/benchmarks/prepared-field-projections.md
@@ -37,6 +37,55 @@ incompatible plans before processing rows, and exercise omission after a prior
 variable payload has already been written. Internal mechanism checks are needed
 because correct row values alone cannot detect the allocation regression.
 
+## Verification and timing
+
+All 738 Groove and 2,002 Jazz library tests pass (2 ignored in each). Forcing
+whole-row semantic evaluation fails the mixed-field test with 96 evaluations
+instead of 12. Removing partial-row rollback also fails. These temporary
+mutations were restored. Full CI, browser acceptance and independent review
+remain outstanding for the draft PR.
+
+The full native fixture preserves all 27,518 expected rows:
+
+| Run                           | Readiness | Settle loop | Harness wall |
+| ----------------------------- | --------: | ----------: | -----------: |
+| Prior inline-probe slice      |  35.863 s |    35.365 s |     37.634 s |
+| Prepared fields, first run    |  35.423 s |    34.930 s |     37.151 s |
+| Prepared fields, final repeat |  35.254 s |    34.757 s |     36.985 s |
+
+These are individual optimized native measurements, not a statistically powered
+comparison. The observed improvement is small (about 1.7% for the comparable
+repeat); this is not evidence of a major end-to-end gain. The first run rebuilt
+its seed cache outside the timed phase; the final repeat and prior run both used
+the cache. The current total remains far above the 5 s goal.
+
+Reclassifying the prior trace by expression kind explains the modest effect:
+
+| Projection expressions                               | Input visits during settle | Share |
+| ---------------------------------------------------- | -------------------------: | ----: |
+| Pure field selection/reordering                      |                  1,457,536 | 70.7% |
+| Constants or nullability, otherwise supported fields |                    600,189 | 29.1% |
+| Nested/enum expressions that disabled the old plan   |                      3,314 | 0.16% |
+
+This categorizes expression eligibility, not time or allocations. The old
+hydration evaluator still used its separate fallback even for otherwise
+eligible expressions. The expanded expression coverage matters for general
+queries, but almost all visits in this fixture were already simple field work.
+
+The complete-run Rust allocator totals move from 485,556,773 requests and
+295,662,073,344 cumulative requested bytes to 483,481,285 requests and
+295,523,063,958 bytes. That saves about 2.08M requests (0.43%) and 139MB (0.047%).
+These are allocation churn, not peak memory, and include final verification and
+diagnostics, not seeding. The new stack sampler uses the original capped
+configuration; use its complete totals here, not capped stack shares. The prior
+uncapped repeat confirmed the baseline totals.
+
+This is a real simplification but not the dominant allocation fix for this
+fixture. The prior profile's schema/descriptor construction, author conversion
+and supporting-version reconstruction remain separate targets. Projection fusion
+addresses redundant passes/copies; it should not be assumed to remove those
+other allocation sources automatically.
+
 ## Why there are so many projection stages
 
 The prior per-operator trace counts 2,061,039 input visits during settlement.


### PR DESCRIPTION
🤖 Make projection execution borrow supported fields independently instead of decoding an entire row when one expression needs conversion.

A projection selecting `title`, `author.account`, a constant, and a remapped enum previously fell back as a whole: it allocated owned values for every field, encoded a temporary row, and copied that row into the batch output. Simple fast-path constants also cloned their encoded Vec for every input row.

The prepared plan now resolves nested descriptor/index paths and checks copied/nullable field types once. Copies and constants borrow encoded spans, nullable wrapping writes a prefix plus the borrowed payload directly, and variable offsets are patched in the shared output buffer. Only the enum-conversion field uses the existing semantic conversion. The hydration evaluator also uses prepared field plans. This does not yet implement arbitrary recursive enum conversion directly over encoded bytes.

The batch remains immutable after publication and each output row owns a shared Bytes slice. Input lifetimes do not escape. Row order, signed weights, exact enum meanings and field identities remain intact. If an enum conversion intentionally omits a row, all bytes already appended for that row are rolled back before the next row. Constant preparation errors are cached but raised only if an input row evaluates the expression, preserving empty-input behavior. No storage or wire encoding changes.

Validation: all 738 Groove and 2,002 Jazz library tests pass (2 ignored in each). The mixed-field regression compares bytes against the existing semantic implementation and observes 12 owned field evaluations for 12 rows instead of 96. It checks output ownership after dropping input. Other checks cover nested fields, constants, nullable values, negative weights, partial-row omission, invalid copy plans and lazy constant errors. Forcing the allocating fallback fails the evaluation-count assertion; disabling rollback fails the shared-batch continuity assertion. The existing enum-parameter empty/populated coverage test caught the eager-error regression during development and now passes.

The full-scale native permissioned fixture still returns all 27,518 rows. Readiness measures 35.423s and 35.254s versus the prior 35.863s observation: a small observed change, not a statistically established speedup. Complete-run allocation requests fall from 485.6M to 483.5M (0.43%); cumulative requested bytes fall from 295.662GB to 295.523GB. This is allocation churn, not peak memory. The prior trace shows 70.7% of projection visits are pure field selection, 29.1% add constants/nullability, and only 0.16% have complex fields that disabled the old plan. This explains why broader fast-path coverage alone does not materially reduce this workload. The accompanying [measurement report and code walk](https://github.com/garden-co/jazz/blob/perf/prepared-field-projections/dev/benchmarks/prepared-field-projections.md) explains the remaining projection-stage count: compositional Jazz lowering plus exact-node deduplication, without projection fusion or byte-preserving rename elimination.

Draft on #2796. Full CI, browser acceptance and independent review are outstanding; this is not a release-ready claim.
