### PR TITLE
perf: compose field projections and share identical record bytes

### DIFF
--- a/crates/groove/src/ivm/runtime/compilation.rs
+++ b/crates/groove/src/ivm/runtime/compilation.rs
@@ -744,32 +744,71 @@ impl IvmRuntime {
             GraphBuilder::Project { input, fields } => {
                 let compiled_input =
                     self.add_dedup_graph_cached(input, output_memo, compiled_memo)?;
-                let input_node = compiled_input.node;
+                let mut input_node = compiled_input.node;
                 let input_output = compiled_input.output;
                 let output = inferred_output;
-                let mapping = fields
+                let mut expressions = fields
                     .iter()
-                    .filter_map(|field| {
-                        field.source().map(|source| {
-                            resolve_field_ref(&input_output, source).map(|idx| (0, idx))
+                    .map(|field| {
+                        project_field_expr(&input_output, field).map(|expression| ProjectionExpr {
+                            expression,
+                            output_name: Some(field.output_name.clone()),
+                            output_identity: field.output_identity.clone(),
                         })
                     })
-                    .collect::<Result<Vec<_>, _>>()?;
+                    .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
+                // Compose only total field selections. Dropping an unselected
+                // enum conversion or constant expression could change whether
+                // a row is omitted or an error is raised. Never cross those,
+                // filters, joins, winner selection or other semantic operators.
+                while expressions
+                    .iter()
+                    .all(|expr| matches!(expr.expression, ProjectExpr::Field(_)))
+                {
+                    let parent = self
+                        .graph
+                        .node(input_node)
+                        .ok_or(IvmRuntimeError::GraphNodeNotFound(input_node))?;
+                    let OpType::MapProject(parent_project) = &parent.descriptor.operator else {
+                        break;
+                    };
+                    if parent_project.expressions.is_empty()
+                        || !parent_project
+                            .expressions
+                            .iter()
+                            .all(|expr| matches!(expr.expression, ProjectExpr::Field(_)))
+                    {
+                        break;
+                    }
+                    for expr in &mut expressions {
+                        let ProjectExpr::Field(field) = &expr.expression else {
+                            unreachable!();
+                        };
+                        let index = resolve_field_ref(&parent.descriptor.output.records(), field)?;
+                        expr.expression = parent_project.expressions[index].expression.clone();
+                    }
+                    input_node = parent.descriptor.inputs[0];
+                }
+                let source_output = self
+                    .graph
+                    .node(input_node)
+                    .ok_or(IvmRuntimeError::GraphNodeNotFound(input_node))?
+                    .descriptor
+                    .output
+                    .records();
+                let mapping = expressions
+                    .iter()
+                    .filter_map(|expr| match &expr.expression {
+                        ProjectExpr::Field(field) => {
+                            Some(resolve_field_ref(&source_output, field).map(|idx| (0, idx)))
+                        }
+                        _ => None,
+                    })
+                    .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
                 let node = self.graph.dedup_node(
                     NodeDescriptor::new(
                         OpType::MapProject(MapProjectOp {
-                            expressions: fields
-                                .iter()
-                                .map(|field| {
-                                    project_field_expr(&input_output, field).map(|expression| {
-                                        ProjectionExpr {
-                                            expression,
-                                            output_name: Some(field.output_name.clone()),
-                                            output_identity: field.output_identity.clone(),
-                                        }
-                                    })
-                                })
-                                .collect::<Result<Vec<_>, IvmRuntimeError>>()?,
+                            expressions,
                             mapping,
                         }),
                         [input_node],

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -1597,7 +1597,7 @@ impl TickEvaluator<'_> {
         project: &MapProjectOp,
         input_desc: &RecordDescriptor,
         output_desc: RecordDescriptor,
-    ) -> Result<Option<Arc<[RawProjectionField]>>, IvmRuntimeError> {
+    ) -> Result<Option<Arc<PreparedProjection>>, IvmRuntimeError> {
         if let Some(cached) = self
             .node_meta
             .get(&node)

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -38,8 +38,9 @@ use crate::ivm::{
     ValueComparison, VariantProjectOp, VariantProjectionTarget,
 };
 use crate::records::{
-    self, BorrowedRecord, EnumSchema, EnumValue, OwnedRecord, RawProjectionField,
-    RawProjectionScratch, RecordDescriptor, Value, ValueType, collect_by_ordered_scalar,
+    self, BorrowedRecord, EnumSchema, EnumValue, OwnedRecord, PreparedProjection,
+    RawProjectionField, RawProjectionScratch, RecordDescriptor, Value, ValueType,
+    collect_by_ordered_scalar,
 };
 use crate::schema::{DatabaseSchema, IndexSchema, TableSchema};
 use crate::storage::{OrderedKvStorage, RecordStore, ScanBounds, ScanDirection, ScanRequest};
@@ -89,7 +90,7 @@ enum VariantProjectionCase {
     Project {
         source: RecordDescriptor,
         project: MapProjectOp,
-        raw_projection: Option<Arc<[RawProjectionField]>>,
+        raw_projection: Option<Arc<PreparedProjection>>,
         /// A Jazz schema-read boundary may exclude rows containing a case the
         /// target schema cannot represent. This is deliberately narrower than
         /// a general projection error: malformed values still fail loudly.
@@ -103,7 +104,7 @@ enum VariantProjectionCase {
         tag: u32,
         payload: RecordDescriptor,
         project: MapProjectOp,
-        raw_projection: Option<Arc<[RawProjectionField]>>,
+        raw_projection: Option<Arc<PreparedProjection>>,
     },
 }
 

--- a/crates/groove/src/ivm/runtime/operator_updates.rs
+++ b/crates/groove/src/ivm/runtime/operator_updates.rs
@@ -9,7 +9,7 @@ pub(super) struct NodeRuntimeMeta {
     pub(super) depends_on_context: Option<bool>,
     pub(super) input_signature: Option<Arc<NodeInputSignature>>,
     pub(super) input_generation: u64,
-    pub(super) raw_projection_fields: Option<Option<Arc<[RawProjectionField]>>>,
+    pub(super) raw_projection_fields: Option<Option<Arc<PreparedProjection>>>,
     pub(super) join_left_fields: Option<Arc<[String]>>,
     pub(super) join_right_fields: Option<Arc<[String]>>,
     pub(super) join_output_mapping: Option<Arc<[(usize, usize)]>>,
@@ -581,9 +581,15 @@ impl NodeState {
         project: &MapProjectOp,
         output_desc: RecordDescriptor,
         input: &RecordDeltas,
-        raw_projection: Option<&[RawProjectionField]>,
+        raw_projection: Option<&PreparedProjection>,
         omit_unrepresentable_enum_rows: bool,
     ) -> Result<RecordDeltas, IvmRuntimeError> {
+        if raw_projection.is_some_and(|plan| plan.reuses_input) {
+            return Ok(RecordDeltas {
+                descriptor: output_desc,
+                deltas: input.deltas.clone(),
+            });
+        }
         let omit_unrepresentable_enum_rows = omit_unrepresentable_enum_rows
             || project.expressions.iter().any(|expression| {
                 matches!(
@@ -607,7 +613,7 @@ impl NodeState {
                 let result = output_desc.project_raw_fields_into(
                     &input.descriptor,
                     delta.raw(),
-                    fields,
+                    &fields.fields,
                     &mut output,
                     |index, output| {
                         let value = project_field_value(
@@ -674,7 +680,7 @@ impl NodeState {
         project: &MapProjectOp,
         output_desc: RecordDescriptor,
         input: &RecordDeltas,
-        raw_projection: Option<&[RawProjectionField]>,
+        raw_projection: Option<&PreparedProjection>,
     ) -> Result<RecordDeltas, IvmRuntimeError> {
         let payloads =
             Self::update_map_project(project, payload_desc, input, raw_projection, false)?;

--- a/crates/groove/src/ivm/runtime/record_projection.rs
+++ b/crates/groove/src/ivm/runtime/record_projection.rs
@@ -983,7 +983,7 @@ pub(super) fn raw_projection_fields(
     project: &MapProjectOp,
     input_desc: &RecordDescriptor,
     output_desc: RecordDescriptor,
-) -> Result<Option<Vec<RawProjectionField>>, IvmRuntimeError> {
+) -> Result<Option<PreparedProjection>, IvmRuntimeError> {
     let validate_copy = |source_type: &ValueType, output_idx: usize| {
         if source_type != &output_desc.fields()[output_idx].value_type {
             return Err(IvmRuntimeError::RecordEncoding(
@@ -1014,7 +1014,11 @@ pub(super) fn raw_projection_fields(
                 Ok(RawProjectionField::Copy { source_idx })
             })
             .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
-        return Ok(Some(fields));
+        return Ok(Some(PreparedProjection::new(
+            *input_desc,
+            output_desc,
+            fields,
+        )));
     }
     if project.expressions.len() != output_desc.fields().len() {
         return Ok(None);
@@ -1075,7 +1079,11 @@ pub(super) fn raw_projection_fields(
             })
         })
         .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
-    Ok(Some(fields))
+    Ok(Some(PreparedProjection::new(
+        *input_desc,
+        output_desc,
+        fields,
+    )))
 }
 
 fn prepared_constant_field(

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -1682,7 +1682,7 @@ impl HydrationEvaluator<'_> {
                         project,
                         output_desc,
                         &input,
-                        fields.as_deref(),
+                        fields.as_ref(),
                         false,
                     );
                     #[cfg(feature = "cold-settle-attribution")]

--- a/crates/groove/src/ivm/runtime/schema.rs
+++ b/crates/groove/src/ivm/runtime/schema.rs
@@ -436,8 +436,7 @@ impl IvmRuntime {
                 .collect::<Result<Vec<_>, IvmRuntimeError>>()?,
             mapping,
         };
-        let raw_projection = raw_projection_fields(&project, &source, payload)?
-            .map(Arc::<[RawProjectionField]>::from);
+        let raw_projection = raw_projection_fields(&project, &source, payload)?.map(Arc::new);
         let case = VariantProjectionCase::Enum {
             source,
             tag,
@@ -632,8 +631,8 @@ impl IvmRuntime {
                     .collect::<Result<Vec<_>, IvmRuntimeError>>()?,
                 mapping,
             };
-            let raw_projection = raw_projection_fields(&project, &source, projection.output)?
-                .map(Arc::<[RawProjectionField]>::from);
+            let raw_projection =
+                raw_projection_fields(&project, &source, projection.output)?.map(Arc::new);
             VariantProjectionCase::Project {
                 source,
                 project,

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -3069,3 +3069,128 @@ fn prepared_constant_error_is_evaluated_only_for_present_rows() {
     .unwrap_err();
     assert_eq!(format!("{prepared:?}"), format!("{semantic:?}"));
 }
+
+// Internal pointer/graph checks are needed: public values alone cannot reveal
+// redundant copying or a projection node still executing between two aliases.
+#[test]
+fn projection_reuse_checks_physical_slots_not_names_or_logical_order() {
+    let source = RecordDescriptor::new([
+        ("text", ValueType::String),
+        ("n", ValueType::U64),
+        ("other", ValueType::String),
+    ]);
+    let target = RecordDescriptor::new([
+        ("renamed_n", ValueType::U64),
+        ("renamed_text", ValueType::String),
+        ("renamed_other", ValueType::String),
+    ]);
+    let project = MapProjectOp {
+        expressions: Vec::new(),
+        mapping: vec![(0, 1), (0, 0), (0, 2)],
+    };
+    let plan = raw_projection_fields(&project, &source, target)
+        .unwrap()
+        .unwrap();
+    let input = RecordDeltas {
+        descriptor: source,
+        deltas: vec![RecordDelta {
+            record: Bytes::from(
+                source
+                    .create(&[
+                        Value::String("first".into()),
+                        Value::U64(42),
+                        Value::String("second".into()),
+                    ])
+                    .unwrap(),
+            ),
+            weight: -2,
+        }],
+    };
+    let output =
+        NodeState::update_map_project(&project, target, &input, Some(&plan), false).unwrap();
+    assert_eq!(
+        output.deltas[0].record.as_ptr(),
+        input.deltas[0].record.as_ptr()
+    );
+    assert_eq!(output.deltas[0].weight, -2);
+    assert_eq!(
+        output.deltas[0].borrowed(&target).to_values().unwrap(),
+        vec![
+            Value::U64(42),
+            Value::String("first".into()),
+            Value::String("second".into())
+        ]
+    );
+    let swapped = MapProjectOp {
+        expressions: Vec::new(),
+        mapping: vec![(0, 1), (0, 2), (0, 0)],
+    };
+    let plan = raw_projection_fields(&swapped, &source, target)
+        .unwrap()
+        .unwrap();
+    let output =
+        NodeState::update_map_project(&swapped, target, &input, Some(&plan), false).unwrap();
+    assert_ne!(
+        output.deltas[0].record.as_ptr(),
+        input.deltas[0].record.as_ptr()
+    );
+    assert_eq!(
+        output.deltas[0].borrowed(&target).get_idx(1).unwrap(),
+        Value::String("second".into())
+    );
+}
+
+#[test]
+fn projection_composition_skips_only_adjacent_total_selections() {
+    let mut runtime = IvmRuntime::new(albums_schema()).unwrap();
+    let source = GraphBuilder::table("albums");
+    let alias = source.clone().project_fields([
+        ProjectField::renamed("id", "key"),
+        ProjectField::renamed("title", "label"),
+    ]);
+    let inner = runtime.add_dedup_graph(&alias).unwrap();
+    let outer = runtime
+        .add_dedup_graph(&alias.project_fields([ProjectField::renamed("label", "name")]))
+        .unwrap();
+    let base = runtime.add_dedup_graph(&source).unwrap();
+    assert_eq!(
+        runtime.graph.node(outer.node).unwrap().descriptor.inputs,
+        vec![base.node]
+    );
+    assert_ne!(inner.node, outer.node); // The independently used inner alias survives.
+    let OpType::MapProject(op) = &runtime.graph.node(outer.node).unwrap().descriptor.operator
+    else {
+        panic!("projection expected")
+    };
+    let descriptor = base.output;
+    let raw = descriptor
+        .create(&[Value::U64(1), Value::String("album".into())])
+        .unwrap();
+    let output = project_record(
+        &op.expressions,
+        &op.mapping,
+        outer.output,
+        &descriptor,
+        &raw,
+    )
+    .unwrap();
+    assert_eq!(
+        outer.output.bind(&output).get_idx(0).unwrap(),
+        Value::String("album".into())
+    );
+    let partial = source.project_fields([
+        ProjectField::named("id"),
+        ProjectField::literal_typed(
+            "bad",
+            LiteralValue::String("not a number".into()),
+            ValueType::U64,
+        ),
+    ]);
+    let partial_node = runtime.add_dedup_graph(&partial).unwrap();
+    let narrowed = runtime.add_dedup_graph(&partial.project(["id"])).unwrap();
+    assert_eq!(
+        runtime.graph.node(narrowed.node).unwrap().descriptor.inputs,
+        vec![partial_node.node],
+        "discarding an output must not discard its fallible computation"
+    );
+}

--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -683,6 +683,40 @@ pub(crate) enum RawProjectionField {
     },
 }
 
+/// Field plan with a once-proven byte-preserving case. Names and logical
+/// identities may differ; every physical field must occupy the same slot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PreparedProjection {
+    pub(crate) fields: Vec<RawProjectionField>,
+    pub(crate) reuses_input: bool,
+}
+
+impl PreparedProjection {
+    pub(crate) fn new(
+        source: RecordDescriptor,
+        target: RecordDescriptor,
+        fields: Vec<RawProjectionField>,
+    ) -> Self {
+        let reuses_input = source.fields.len() == target.fields.len()
+            && fields.len() == target.fields.len()
+            && source.fixed_size() == target.fixed_size()
+            && source.variable_count() == target.variable_count()
+            && fields.iter().enumerate().all(|(target_idx, field)| {
+                let RawProjectionField::Copy { source_idx } = field else {
+                    return false;
+                };
+                source.fields.get(*source_idx).is_some_and(|source_field| {
+                    source_field.value_type == target.fields[target_idx].value_type
+                        && source.layout.fields[*source_idx] == target.layout.fields[target_idx]
+                })
+            });
+        Self {
+            fields,
+            reuses_input,
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct RawProjectionScratch {
     variable_fields: Vec<RawProjectedBytes>,


### PR DESCRIPTION
🤖 Avoid copying byte-identical projections and compose adjacent field-only selections/renames.

A projection may change logical names or declaration order without changing the physical encoded layout. Its prepared plan now proves matching source/target types, fixed/variable counts and exact physical slots once. If all slots match, output rows share the input Bytes while retaining the new descriptor, ordering and signed weights. Swapping variable payload slots still takes the copying path. This shares immutable ownership rather than borrowing beyond input lifetime.

The compiler also follows adjacent MapProject nodes containing only ordinary field selections and composes their mappings directly onto the underlying source. For example `title -> label -> name` becomes one projection from `title` to `name`. A separately used `label` output remains available. This does not cross constants, enum conversions, filters, joins, winner selection or other semantic operators: an unselected expression can still be fallible or omit a row, so discarding it would change behavior.

Validation: all 740 Groove and 2,002 Jazz library tests pass (2 ignored in each). New internal checks verify physical-layout byte sharing, logical-order changes, incompatible variable-slot swaps, composed output values, shared inner nodes and preservation of an unselected fallible expression. Mechanism checks are internal because correct public row values alone cannot reveal redundant copies or redundant executing nodes. Disabling byte reuse fails the pointer-sharing test; disabling composition fails the graph-dependency test. Both mutations were restored. The full permissioned native load returned all 27,518 expected rows in 35.320 s versus 35.254 s on #2797: no measurable end-to-end gain from this small slice in these individual runs.

No storage or wire format change. Draft on #2797; full CI, browser acceptance and independent review remain outstanding.
