### PR TITLE
perf: reuse record metadata and owned version buffers

### DIFF
--- a/crates/groove/src/ivm/runtime/operator_updates.rs
+++ b/crates/groove/src/ivm/runtime/operator_updates.rs
@@ -137,6 +137,41 @@ impl NodeState {
         )
     }
 
+    // Resolve each variant layout once for the batch, before projecting rows.
+    // A descriptor is interned, but constructing its fields is not free.
+    pub(super) fn group_source_rows<'a>(
+        table: &crate::schema::TableSchema,
+        rows: impl IntoIterator<Item = &'a [u8]>,
+    ) -> Result<Vec<TableDelta>, IvmRuntimeError> {
+        let mut grouped = HashMap::<u32, TableDelta>::default();
+        for stored in rows {
+            let (variant_tag, payload) = crate::records::split_variant_record(stored)?;
+            let group = match grouped.entry(variant_tag) {
+                std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    let descriptor =
+                        table
+                            .record_schema_for_variant(variant_tag)
+                            .ok_or_else(|| IvmRuntimeError::UnknownTableVariant {
+                                table: table.name.clone(),
+                                version: u64::from(variant_tag),
+                            })?;
+                    entry.insert(TableDelta {
+                        table: table.name.clone(),
+                        variant_tag,
+                        descriptor,
+                        deltas: Vec::new(),
+                    })
+                }
+            };
+            group.deltas.push(RecordDelta {
+                record: Bytes::copy_from_slice(payload),
+                weight: 1,
+            });
+        }
+        Ok(grouped.into_values().collect())
+    }
+
     pub(super) fn update_table_source_from_inputs(
         input: &TableSourceOp,
         schema: &DatabaseSchema,
@@ -150,32 +185,13 @@ impl NodeState {
         let table_schema = schema
             .table(&input.table)
             .ok_or_else(|| IvmRuntimeError::TableNotFound(input.table.clone()))?;
-        let mut grouped = HashMap::<(u32, RecordDescriptor), Vec<RecordDelta>>::default();
-        for (_, stored) in inputs.rows(request)? {
-            let (variant_tag, payload) = crate::records::split_variant_record(stored)?;
-            let descriptor = table_schema
-                .record_schema_for_variant(variant_tag)
-                .ok_or_else(|| IvmRuntimeError::UnknownTableVariant {
-                    table: input.table.clone(),
-                    version: u64::from(variant_tag),
-                })?;
-            grouped
-                .entry((variant_tag, descriptor))
-                .or_default()
-                .push(RecordDelta {
-                    record: Bytes::copy_from_slice(payload),
-                    weight: 1,
-                });
-        }
-        let table_deltas = grouped
-            .into_iter()
-            .map(|((variant_tag, descriptor), deltas)| TableDelta {
-                table: input.table.clone(),
-                variant_tag,
-                descriptor,
-                deltas,
-            })
-            .collect::<Vec<_>>();
+        let table_deltas = Self::group_source_rows(
+            table_schema,
+            inputs
+                .rows(request)?
+                .iter()
+                .map(|(_, stored)| stored.as_slice()),
+        )?;
         Self::update_table_source(
             input,
             schema,
@@ -200,32 +216,10 @@ impl NodeState {
             let table_schema = schema
                 .table(&input.table)
                 .ok_or_else(|| IvmRuntimeError::TableNotFound(input.table.clone()))?;
-            let mut grouped = HashMap::<(u32, RecordDescriptor), Vec<RecordDelta>>::default();
-            for (_, stored) in rows {
-                let (variant_tag, payload) = crate::records::split_variant_record(stored)?;
-                let descriptor = table_schema
-                    .record_schema_for_variant(variant_tag)
-                    .ok_or_else(|| IvmRuntimeError::UnknownTableVariant {
-                        table: input.table.clone(),
-                        version: u64::from(variant_tag),
-                    })?;
-                grouped
-                    .entry((variant_tag, descriptor))
-                    .or_default()
-                    .push(RecordDelta {
-                        record: Bytes::copy_from_slice(payload),
-                        weight: 1,
-                    });
-            }
-            let table_deltas = grouped
-                .into_iter()
-                .map(|((variant_tag, descriptor), deltas)| TableDelta {
-                    table: input.table.clone(),
-                    variant_tag,
-                    descriptor,
-                    deltas,
-                })
-                .collect::<Vec<_>>();
+            let table_deltas = Self::group_source_rows(
+                table_schema,
+                rows.iter().map(|(_, stored)| stored.as_slice()),
+            )?;
             return Self::update_table_source(
                 &TableSourceOp {
                     table: input.table.clone(),

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -3194,3 +3194,55 @@ fn projection_composition_skips_only_adjacent_total_selections() {
         "discarding an output must not discard its fallible computation"
     );
 }
+
+// Internal because row equality cannot prove batch-amortized descriptor setup.
+#[test]
+fn source_batch_prepares_one_descriptor_per_variant() {
+    let table = crate::schema::TableSchema::new(
+        "source_batch",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("label", ColumnType::String),
+        ],
+    )
+    .with_variant(1, ["id"])
+    .with_variant(2, ["id", "label"]);
+    let a = table.record_schema_for_variant(1).unwrap();
+    let b = table.record_schema_for_variant(2).unwrap();
+    let mut rows = Vec::new();
+    for id in 0..1000 {
+        let (tag, payload) = if id % 2 == 0 {
+            (1, a.create(&[Value::U64(id)]).unwrap())
+        } else {
+            (
+                2,
+                b.create(&[Value::U64(id), Value::String("value".into())])
+                    .unwrap(),
+            )
+        };
+        rows.push(crate::records::encode_variant_record(tag, &payload));
+    }
+    crate::schema::VARIANT_DESCRIPTOR_BUILDS.with(|count| count.set(0));
+    let groups = NodeState::group_source_rows(&table, rows.iter().map(Vec::as_slice)).unwrap();
+    assert_eq!(
+        crate::schema::VARIANT_DESCRIPTOR_BUILDS.with(|count| count.get()),
+        2
+    );
+    assert_eq!(groups.len(), 2);
+    for group in groups {
+        assert_eq!(group.deltas.len(), 500);
+        assert_eq!(group.descriptor, if group.variant_tag == 1 { a } else { b });
+        for (index, delta) in group.deltas.iter().enumerate() {
+            assert_eq!(delta.weight, 1);
+            assert_eq!(
+                group.descriptor.bind(&delta.record).get_u64(0).unwrap(),
+                index as u64 * 2 + u64::from(group.variant_tag - 1)
+            );
+        }
+    }
+    let unknown = crate::records::encode_variant_record(3, &[]);
+    assert!(matches!(
+        NodeState::group_source_rows(&table, [unknown.as_slice()]),
+        Err(IvmRuntimeError::UnknownTableVariant { version: 3, .. })
+    ));
+}

--- a/crates/groove/src/schema.rs
+++ b/crates/groove/src/schema.rs
@@ -235,6 +235,11 @@ pub struct TableSchema {
     pub variants: Vec<TableVariant>,
 }
 
+#[cfg(test)]
+thread_local! {
+    pub(crate) static VARIANT_DESCRIPTOR_BUILDS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 impl TableSchema {
     pub fn new(name: impl Into<String>, columns: impl IntoIterator<Item = ColumnSchema>) -> Self {
         Self::new_inner(name, columns, false)
@@ -380,6 +385,8 @@ impl TableSchema {
 
     /// Build the dense descriptor registered for one whole-row enum case.
     pub fn record_schema_for_variant(&self, tag: u32) -> Option<RecordDescriptor> {
+        #[cfg(test)]
+        VARIANT_DESCRIPTOR_BUILDS.with(|count| count.set(count.get() + 1));
         if self.variants.is_empty() {
             return Some(self.record_schema());
         }

--- a/crates/jazz/src/ids.rs
+++ b/crates/jazz/src/ids.rs
@@ -251,6 +251,17 @@ pub enum AuthorSubjectError {
     InvalidSystemOrigin,
 }
 
+fn author_identity_descriptor() -> crate::groove::records::RecordDescriptor {
+    use crate::groove::records::{RecordDescriptor, ValueType};
+    static DESCRIPTOR: std::sync::OnceLock<RecordDescriptor> = std::sync::OnceLock::new();
+    *DESCRIPTOR.get_or_init(|| {
+        RecordDescriptor::new([
+            ("issuer", ValueType::String),
+            ("subject", ValueType::String),
+        ])
+    })
+}
+
 impl RowAuthor {
     /// Create durable system attribution for work originating at `node`.
     pub fn system_at(node: NodeUuid) -> Self {
@@ -352,59 +363,58 @@ impl RowAuthor {
 
     /// Native record type exposed for persisted row and transaction metadata.
     pub fn value_type() -> crate::groove::records::ValueType {
+        crate::groove::records::ValueType::Record(Box::new(Self::record_descriptor()))
+    }
+
+    fn record_descriptor() -> crate::groove::records::RecordDescriptor {
         use crate::groove::records::{RecordDescriptor, ValueType};
-        ValueType::Record(Box::new(RecordDescriptor::new([
-            ("account", ValueType::Uuid),
-            (
-                "identity",
-                ValueType::Record(Box::new(RecordDescriptor::new([
-                    ("issuer", ValueType::String),
-                    ("subject", ValueType::String),
-                ]))),
-            ),
-        ])))
+        static DESCRIPTOR: std::sync::OnceLock<RecordDescriptor> = std::sync::OnceLock::new();
+        *DESCRIPTOR.get_or_init(|| {
+            RecordDescriptor::new([
+                ("account", ValueType::Uuid),
+                (
+                    "identity",
+                    ValueType::Record(Box::new(author_identity_descriptor())),
+                ),
+            ])
+        })
     }
 
     /// Structured durable attribution value.
     pub fn to_value(self) -> crate::groove::records::Value {
-        use crate::groove::records::{OwnedRecord, RecordDescriptor, Value, ValueType};
+        use crate::groove::records::{OwnedRecord, Value};
         let (issuer, subject) = self.principal_parts();
-        let identity = RecordDescriptor::new([
-            ("issuer", ValueType::String),
-            ("subject", ValueType::String),
-        ]);
+        let identity = author_identity_descriptor();
         let raw = identity
             .create(&[Value::String(issuer), Value::String(subject)])
             .expect("row author identity record");
         let identity = Value::Record(OwnedRecord::new(raw, identity));
-        let ValueType::Record(descriptor) = Self::value_type() else {
-            unreachable!()
-        };
+        let descriptor = Self::record_descriptor();
         let raw = descriptor
             .create(&[Value::Uuid(self.account_id().0), identity])
             .expect("row author record");
-        Value::Record(OwnedRecord::new(raw, *descriptor))
+        Value::Record(OwnedRecord::new(raw, descriptor))
     }
 
     /// Decode durable metadata without granting the system capability.
     pub fn from_value(value: crate::groove::records::Value) -> Result<Self, AuthorSubjectError> {
-        use crate::groove::records::{Value, ValueType};
+        use crate::groove::records::Value;
         let bad = || AuthorSubjectError::InvalidCanonical("invalid row author record".into());
         let Value::Record(record) = value else {
             return Err(bad());
         };
-        let ValueType::Record(expected) = Self::value_type() else {
-            unreachable!()
-        };
-        if record.descriptor() != expected.as_ref() {
+        let expected = Self::record_descriptor();
+        if record.descriptor() != &expected {
             return Err(bad());
         }
         let borrowed = record.borrowed();
         let account = crate::account_registry::AccountId(borrowed.get_uuid(0).map_err(|_| bad())?);
-        let Value::Record(identity) = borrowed.get_idx(1).map_err(|_| bad())? else {
-            return Err(bad());
-        };
-        let identity = identity.borrowed();
+        let span = record
+            .descriptor()
+            .field_span(record.raw(), 1)
+            .map_err(|_| bad())?;
+        let identity_descriptor = author_identity_descriptor();
+        let identity = identity_descriptor.bind(&record.raw()[span]);
         let issuer = identity.get_str(0).map_err(|_| bad())?;
         let subject = identity.get_str(1).map_err(|_| bad())?;
         if !principal_is_nonempty(issuer) {
@@ -594,17 +604,21 @@ impl AuthorSubject {
 
     /// Native record type exposed for structured author metadata.
     pub fn value_type() -> crate::groove::records::ValueType {
+        crate::groove::records::ValueType::Record(Box::new(Self::record_descriptor()))
+    }
+
+    fn record_descriptor() -> crate::groove::records::RecordDescriptor {
         use crate::groove::records::{RecordDescriptor, ValueType};
-        ValueType::Record(Box::new(RecordDescriptor::new([
-            ("account", ValueType::Nullable(Box::new(ValueType::Uuid))),
-            (
-                "identity",
-                ValueType::Record(Box::new(RecordDescriptor::new([
-                    ("issuer", ValueType::String),
-                    ("subject", ValueType::String),
-                ]))),
-            ),
-        ])))
+        static DESCRIPTOR: std::sync::OnceLock<RecordDescriptor> = std::sync::OnceLock::new();
+        *DESCRIPTOR.get_or_init(|| {
+            RecordDescriptor::new([
+                ("account", ValueType::Nullable(Box::new(ValueType::Uuid))),
+                (
+                    "identity",
+                    ValueType::Record(Box::new(author_identity_descriptor())),
+                ),
+            ])
+        })
     }
 
     /// Valid nested author metadata paths. Field names are never interpreted
@@ -644,19 +658,14 @@ impl AuthorSubject {
 
     /// Structured native author value; intern handles are never serialized.
     pub fn to_value(self) -> crate::groove::records::Value {
-        use crate::groove::records::{OwnedRecord, RecordDescriptor, Value, ValueType};
+        use crate::groove::records::{OwnedRecord, Value};
         let (issuer, subject) = self.principal_parts();
-        let identity = RecordDescriptor::new([
-            ("issuer", ValueType::String),
-            ("subject", ValueType::String),
-        ]);
+        let identity = author_identity_descriptor();
         let raw = identity
             .create(&[Value::String(issuer), Value::String(subject)])
             .expect("author identity record");
         let identity = Value::Record(OwnedRecord::new(raw, identity));
-        let ValueType::Record(descriptor) = Self::value_type() else {
-            unreachable!()
-        };
+        let descriptor = Self::record_descriptor();
         let account = Value::Nullable(
             self.account_id()
                 .map(|account| Box::new(Value::Uuid(account.0))),
@@ -664,24 +673,20 @@ impl AuthorSubject {
         let raw = descriptor
             .create(&[account, identity])
             .expect("author record");
-        Value::Record(OwnedRecord::new(raw, *descriptor))
+        Value::Record(OwnedRecord::new(raw, descriptor))
     }
 
     /// Decode structured provenance using its exact native descriptor.
     pub fn from_value(value: crate::groove::records::Value) -> Result<Self, AuthorSubjectError> {
-        use crate::groove::records::{Value, ValueType};
+        use crate::groove::records::Value;
         let bad = || AuthorSubjectError::InvalidCanonical("invalid author record".into());
         let Value::Record(record) = value else {
             return Err(bad());
         };
-        let ValueType::Record(session_descriptor) = Self::value_type() else {
-            unreachable!()
-        };
-        let ValueType::Record(row_descriptor) = RowAuthor::value_type() else {
-            unreachable!()
-        };
-        let row_author = record.descriptor() == row_descriptor.as_ref();
-        if !row_author && record.descriptor() != session_descriptor.as_ref() {
+        let session_descriptor = Self::record_descriptor();
+        let row_descriptor = RowAuthor::record_descriptor();
+        let row_author = record.descriptor() == &row_descriptor;
+        if !row_author && record.descriptor() != &session_descriptor {
             return Err(bad());
         }
         let borrowed = record.borrowed();
@@ -690,10 +695,12 @@ impl AuthorSubject {
         } else {
             borrowed.get_nullable_uuid(0).map_err(|_| bad())?
         };
-        let Value::Record(identity) = borrowed.get_idx(1).map_err(|_| bad())? else {
-            return Err(bad());
-        };
-        let identity = identity.borrowed();
+        let span = record
+            .descriptor()
+            .field_span(record.raw(), 1)
+            .map_err(|_| bad())?;
+        let identity_descriptor = author_identity_descriptor();
+        let identity = identity_descriptor.bind(&record.raw()[span]);
         let issuer = identity.get_str(0).map_err(|_| bad())?;
         let subject = identity.get_str(1).map_err(|_| bad())?;
         if issuer == Self::SYSTEM_ISSUER {

--- a/crates/jazz/src/node/codec.rs
+++ b/crates/jazz/src/node/codec.rs
@@ -2149,7 +2149,7 @@ fn history_record_descriptor(table: &TableSchema) -> records::RecordDescriptor {
     })
 }
 
-fn register_record_descriptor(table: &TableSchema) -> records::RecordDescriptor {
+pub(super) fn register_record_descriptor(table: &TableSchema) -> records::RecordDescriptor {
     // Every table uses the same fixed deletion-register record fields.
     static DESCRIPTOR: std::sync::OnceLock<records::RecordDescriptor> = std::sync::OnceLock::new();
     *DESCRIPTOR.get_or_init(|| table.register_storage_table().record_schema())
@@ -5128,6 +5128,33 @@ mod authority_storage_codec_tests {
             history_record_descriptor(&text),
             text.authored_history_storage_table().record_schema()
         );
+    }
+
+    // Internal: these names are engine-owned lookup keys, not an application API.
+    #[test]
+    fn physical_version_name_resolution_preserves_exact_constructor_spelling() {
+        for id in [0, 1, 10, 1000, u64::MAX] {
+            let id = PhysicalTableId(id);
+            for (name, deletion) in [
+                (physical_history_table_name(id), false),
+                (physical_register_table_name(id), true),
+            ] {
+                assert_eq!(physical_version_table_id(&name, deletion), Some(id));
+                assert_eq!(physical_version_table_id(&name, !deletion), None);
+            }
+        }
+        for name in [
+            "jazz_physical__history",
+            "jazz_physical_01_history",
+            "jazz_physical_+1_history",
+            "jazz_physical_-1_history",
+            "jazz_physical_18446744073709551616_history",
+            "jazz_physical_1_history_extra",
+            "jazz_physical_1a_history",
+            "jazz_deletion_history",
+        ] {
+            assert_eq!(physical_version_table_id(name, false), None, "{name}");
+        }
     }
 
     fn tx(time: u64, node: u8) -> TxId {

--- a/crates/jazz/src/node/codec.rs
+++ b/crates/jazz/src/node/codec.rs
@@ -2081,6 +2081,80 @@ pub(super) struct VersionRowParts {
     pub(super) deletion: Option<DeletionEvent>,
 }
 
+// Record layout depends on the table name (enum registry binding) and ordered
+// physical column shape, not defaults, indices, or policies. Compare the shape
+// itself: schema objects are mutable and a table name alone is insufficient.
+struct HistoryDescriptorCacheEntry {
+    table_name: String,
+    columns: Vec<(
+        String,
+        groove::schema::ColumnType,
+        crate::schema::LargeValueSemanticKind,
+    )>,
+    descriptor: records::RecordDescriptor,
+}
+
+#[cfg(test)]
+thread_local! {
+    static HISTORY_DESCRIPTOR_BUILDS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+fn history_record_descriptor(table: &TableSchema) -> records::RecordDescriptor {
+    thread_local! {
+        static CACHE: std::cell::RefCell<Vec<HistoryDescriptorCacheEntry>> = const {
+            std::cell::RefCell::new(Vec::new())
+        };
+    }
+    CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(entry) = cache.iter().find(|entry| {
+            entry.table_name == table.name
+                && entry.columns.len() == table.columns.len()
+                && entry
+                    .columns
+                    .iter()
+                    .zip(&table.columns)
+                    .all(|((name, ty, kind), column)| {
+                        name == &column.name
+                            && ty == &column.column_type
+                            && kind == &column.large_value_kind
+                    })
+        }) {
+            return entry.descriptor;
+        }
+        #[cfg(test)]
+        HISTORY_DESCRIPTOR_BUILDS.with(|count| count.set(count.get() + 1));
+        let descriptor = table.authored_history_storage_table().record_schema();
+        // Bound retained preparation data even for applications with continual
+        // schema changes. Eviction affects preparation cost only, never bytes.
+        if cache.len() == 128 {
+            cache.remove(0);
+        }
+        cache.push(HistoryDescriptorCacheEntry {
+            table_name: table.name.clone(),
+            columns: table
+                .columns
+                .iter()
+                .map(|column| {
+                    (
+                        column.name.clone(),
+                        column.column_type.clone(),
+                        column.large_value_kind,
+                    )
+                })
+                .collect(),
+            descriptor,
+        });
+        descriptor
+    })
+}
+
+fn register_record_descriptor(table: &TableSchema) -> records::RecordDescriptor {
+    // Every table uses the same fixed deletion-register record fields.
+    static DESCRIPTOR: std::sync::OnceLock<records::RecordDescriptor> = std::sync::OnceLock::new();
+    *DESCRIPTOR.get_or_init(|| table.register_storage_table().record_schema())
+}
+
 impl VersionRow {
     pub(super) fn from_parts_with_schema_version(
         table: &TableSchema,
@@ -2095,14 +2169,17 @@ impl VersionRow {
             history_values_from_parts(table, &parts)?
         };
         let record = if is_deletion {
-            owned_record_from_storage_values(&table.register_storage_table(), values)?
+            owned_record_from_storage_values_with_descriptor(
+                register_record_descriptor(table),
+                values,
+            )?
         } else {
             match history_descriptor {
                 Some(descriptor) => {
                     owned_record_from_storage_values_with_descriptor(descriptor, values)?
                 }
-                None => owned_record_from_storage_values(
-                    &table.authored_history_storage_table(),
+                None => owned_record_from_storage_values_with_descriptor(
+                    history_record_descriptor(table),
                     values,
                 )?,
             }
@@ -2133,9 +2210,9 @@ impl VersionRow {
                 "row version parents must be sorted and unique",
             ));
         }
-        let (storage_table, values) = if let Some(deletion) = version.deletion() {
+        let (descriptor, values) = if let Some(deletion) = version.deletion() {
             (
-                table.register_storage_table(),
+                register_record_descriptor(table),
                 register_values_from_wire(
                     version,
                     tx_node_alias,
@@ -2146,7 +2223,7 @@ impl VersionRow {
             )
         } else {
             (
-                table.authored_history_storage_table(),
+                history_record_descriptor(table),
                 history_values_from_wire(
                     table,
                     version,
@@ -2160,7 +2237,7 @@ impl VersionRow {
         Ok(Self {
             table: groove::Intern::new(version.table().to_owned()),
             branch_key: version.branch_key().clone(),
-            record: owned_record_from_storage_values(&storage_table, values)?,
+            record: owned_record_from_storage_values_with_descriptor(descriptor, values)?,
         })
     }
 
@@ -4991,6 +5068,67 @@ pub(super) fn version_layer_string(layer: VersionLayer) -> String {
 #[cfg(test)]
 mod authority_storage_codec_tests {
     use super::*;
+
+    // Internal because application values cannot reveal descriptor construction
+    // frequency or accidental reuse of a different physical enum registry.
+    #[test]
+    fn version_descriptor_preparation_tracks_exact_schema_shape() {
+        use crate::tools::{ColumnType, SchemaBuilder, TableSchemaBuilder};
+        let table = |name: &str, ty: ColumnType| {
+            JazzSchema::new(
+                &SchemaBuilder::new()
+                    .table(TableSchemaBuilder::new(name).column("payload", ty))
+                    .build(),
+            )
+            .unwrap()
+            .tables()[0]
+                .clone()
+        };
+        let text = table("descriptor_cache_test", ColumnType::Text);
+        let json = table("descriptor_cache_test", ColumnType::Json { schema: None });
+        let integer = table("descriptor_cache_test", ColumnType::Integer);
+        let enum_type = || ColumnType::ScalarEnum {
+            name: "state".into(),
+            variants: vec!["a".into(), "b".into()],
+        };
+        let enum_a = table("descriptor_cache_enum_a", enum_type());
+        let enum_b = table("descriptor_cache_enum_b", enum_type());
+        HISTORY_DESCRIPTOR_BUILDS.with(|count| count.set(0));
+        for table in [&text, &json, &integer, &enum_a, &enum_b] {
+            let expected = table.authored_history_storage_table().record_schema();
+            for _ in 0..100 {
+                assert_eq!(history_record_descriptor(table), expected);
+                assert_eq!(
+                    register_record_descriptor(table),
+                    table.register_storage_table().record_schema()
+                );
+            }
+        }
+        assert_eq!(HISTORY_DESCRIPTOR_BUILDS.with(|count| count.get()), 5);
+        assert_ne!(
+            history_record_descriptor(&text),
+            history_record_descriptor(&json)
+        );
+        assert_ne!(
+            history_record_descriptor(&enum_a),
+            history_record_descriptor(&enum_b)
+        );
+        // Eviction must change only cost, not the selected record layout.
+        for index in 0..140 {
+            let other = table(
+                &format!("descriptor_cache_eviction_{index}"),
+                ColumnType::Text,
+            );
+            assert_eq!(
+                history_record_descriptor(&other),
+                other.authored_history_storage_table().record_schema()
+            );
+        }
+        assert_eq!(
+            history_record_descriptor(&text),
+            text.authored_history_storage_table().record_schema()
+        );
+    }
 
     fn tx(time: u64, node: u8) -> TxId {
         TxId::new(TxTime(time), NodeUuid::from_bytes([node; 16]))

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -833,7 +833,10 @@ where
                 stored_table.clone()
             } else {
                 let requested_schema = if self
-                    .table_in_schema(requested_table, self.catalogue.current_write_schema.schema)
+                    .table_in_schema_ref(
+                        requested_table,
+                        self.catalogue.current_write_schema.schema,
+                    )
                     .is_ok()
                 {
                     self.catalogue.current_write_schema.schema
@@ -846,10 +849,10 @@ where
                         "shared deletion row escaped requested physical-table prefix",
                     ))?
             };
-            let logical_table = self.table_in_schema(&stored_table, schema_version)?;
-            let descriptor = logical_table.register_storage_table().record_schema();
+            let logical_table = self.table_in_schema_ref(&stored_table, schema_version)?;
+            let descriptor = register_record_descriptor(logical_table);
             let branch_key = RuntimeSchema::decode_persisted_branch_key(
-                &logical_table,
+                logical_table,
                 record
                     .borrowed()
                     .get_bytes(SharedDeletionHistoryRowRecord::FIELD_BRANCH_KEY_IDX)?,
@@ -882,29 +885,27 @@ where
         let table = if !storage_table.starts_with("jazz_physical_") {
             requested_table.to_owned()
         } else {
+            let table_id = physical_version_table_id(storage_table, is_deletion).ok_or(
+                Error::InvalidStoredValue("physical version storage logical table mapping missing"),
+            )?;
             self.catalogue
                 .physical_mappings
                 .get(&schema_version)
                 .and_then(|mapping| {
                     mapping.tables.iter().find_map(|(logical_table, mapping)| {
-                        let root = if is_deletion {
-                            physical_register_table_name(mapping.table_id)
-                        } else {
-                            physical_history_table_name(mapping.table_id)
-                        };
-                        (root == storage_table).then(|| logical_table.clone())
+                        (mapping.table_id == table_id).then(|| logical_table.clone())
                     })
                 })
                 .ok_or(Error::InvalidStoredValue(
                     "physical version storage logical table mapping missing",
                 ))?
         };
-        let table_schema = self.table_in_schema(&table, schema_version)?;
-        let record = record.borrowed();
+        let table_schema = self.table_in_schema_ref(&table, schema_version)?;
+        let record_view = record.borrowed();
         let tx_node_alias = if is_deletion {
-            NodeAlias(record.get_u64(RegisterRowRecord::FIELD_TX_NODE_ID_IDX)?)
+            NodeAlias(record_view.get_u64(RegisterRowRecord::FIELD_TX_NODE_ID_IDX)?)
         } else {
-            NodeAlias(record.get_u64(HistoryRowRecord::FIELD_TX_NODE_ID_IDX)?)
+            NodeAlias(record_view.get_u64(HistoryRowRecord::FIELD_TX_NODE_ID_IDX)?)
         };
         let tx_node = self
             .node_aliases
@@ -914,23 +915,23 @@ where
                 "history tx node alias must exist",
             ))?;
         let tx_time = if is_deletion {
-            TxTime(record.get_u64(RegisterRowRecord::FIELD_TX_TIME_IDX)?)
+            TxTime(record_view.get_u64(RegisterRowRecord::FIELD_TX_TIME_IDX)?)
         } else {
-            TxTime(record.get_u64(HistoryRowRecord::FIELD_TX_TIME_IDX)?)
+            TxTime(record_view.get_u64(HistoryRowRecord::FIELD_TX_TIME_IDX)?)
         };
         let _ = TxId::new(tx_time, tx_node);
         let version = VersionRow {
             table: groove::Intern::new(table),
             branch_key: RuntimeSchema::decode_persisted_branch_key(
-                &table_schema,
-                record.get_bytes(if is_deletion {
+                table_schema,
+                record_view.get_bytes(if is_deletion {
                     RegisterRowRecord::FIELD_BRANCH_KEY_IDX
                 } else {
                     HistoryRowRecord::FIELD_BRANCH_KEY_IDX
                 })?,
             )
             .map_err(|_| Error::InvalidStoredValue("invalid stored branch key"))?,
-            record: OwnedRecord::new(record.raw().to_vec(), record.descriptor()),
+            record,
         };
         version.validate_canonical()?;
         Ok(version)

--- a/crates/jazz/src/node/physical/catalogue.rs
+++ b/crates/jazz/src/node/physical/catalogue.rs
@@ -542,6 +542,20 @@ pub(super) fn physical_register_table_name(table_id: PhysicalTableId) -> String 
     format!("jazz_physical_{}_register", table_id.0)
 }
 
+/// Inverse of the physical history/register name constructors. Resolve the id
+/// once instead of allocating a formatted name for every catalogue candidate.
+pub(super) fn physical_version_table_id(name: &str, is_deletion: bool) -> Option<PhysicalTableId> {
+    let suffix = if is_deletion { "_register" } else { "_history" };
+    let digits = name.strip_prefix("jazz_physical_")?.strip_suffix(suffix)?;
+    // Keep the exact spelling accepted by comparing with the constructors:
+    // unsigned decimal, no sign, no padding, including the single digit zero.
+    if digits.is_empty() || !digits.as_bytes()[0].is_ascii_digit()
+        || (digits.len() > 1 && digits.starts_with('0')) {
+        return None;
+    }
+    digits.parse().ok().map(PhysicalTableId)
+}
+
 /// Fixed sparse deletion history shared by every physical content lineage.
 ///
 /// Unlike `physical_register_table_name`, this is not a per-lineage table;

--- a/crates/jazz/src/node/state/read_payload.rs
+++ b/crates/jazz/src/node/state/read_payload.rs
@@ -27,6 +27,14 @@ where
         table: &str,
         schema_version: SchemaVersionId,
     ) -> Result<TableSchema, Error> {
+        self.table_in_schema_ref(table, schema_version).cloned()
+    }
+
+    pub(super) fn table_in_schema_ref(
+        &self,
+        table: &str,
+        schema_version: SchemaVersionId,
+    ) -> Result<&TableSchema, Error> {
         self.catalogue
             .catalogue_schemas
             .get(&schema_version)
@@ -36,11 +44,10 @@ where
                     .tables
                     .iter()
                     .find(|candidate| candidate.name == table)
-                    .cloned()
             })
             .or_else(|| {
                 (schema_version == self.catalogue.current_schema_version_id)
-                    .then(|| self.table(table).ok().cloned())
+                    .then(|| self.table(table).ok())
                     .flatten()
             })
             .ok_or_else(|| Error::TableNotFound(table.to_owned()))

--- a/dev/benchmarks/projection-composition-metadata-preparation.md
+++ b/dev/benchmarks/projection-composition-metadata-preparation.md
@@ -1,0 +1,128 @@
+# Projection composition and metadata preparation
+
+This continues [prepared field projections](prepared-field-projections.md).
+The two review slices are [#2798](https://github.com/garden-co/jazz/pull/2798)
+and [#2799](https://github.com/garden-co/jazz/pull/2799).
+
+## Scope and timings
+
+The optimized native permissioned fixture has a seeded Core and empty relay and
+client, 39 subscriptions and 27,518 expected result rows. Its dominant child
+query returns 23,831 rows from 43,000 candidates. It uses RocksDB WalNoSync and
+in-process semantic messages. Seeding is excluded. This is neither a populated
+browser reopen nor a measurement of the separate 1,500-row write fixture.
+
+| Code                                                   | All subscriptions ready |   Settle | Full measured wall |
+| ------------------------------------------------------ | ----------------------: | -------: | -----------------: |
+| #2797, `1f7eb2884f`                                    |                35.254 s | 34.757 s |           36.985 s |
+| Projection composition/reuse, `f1f72e96f8`             |                35.320 s | 34.831 s |           37.098 s |
+| Descriptor preparation, `33712f26aa`                   |                32.504 s | 32.036 s |           33.999 s |
+| Plus borrowed schema/owned version reuse, `c1d58fc30c` |                32.415 s | 31.946 s |           33.956 s |
+
+All runs returned the expected rows. These are individual observations, not a
+statistical speedup claim. Clean timing runs had no concurrent builds or tests.
+The projection slice has no measurable end-to-end win here; the combined pass
+improves readiness by about 8%. The extra version ownership cleanup primarily
+removes allocation work, without a distinguishable timing gain in these runs.
+We remain well above the 5-second target.
+
+Allocation totals come from separate instrumented runs. They cover the measured
+load and final verification/diagnostic reads, excluding seeding; they do not
+isolate just the readiness interval.
+
+| Code                   | Allocation requests | Cumulative requested bytes |
+| ---------------------- | ------------------: | -------------------------: |
+| #2797                  |         483,481,285 |            295,523,063,958 |
+| Descriptor preparation |         391,198,694 |            289,941,226,709 |
+| Final metadata slice   |         383,877,574 |            289,350,646,379 |
+
+The combined pass removes 20.6% of allocation requests but only 2.1% of requested
+bytes. Requested bytes are allocation churn, **not peak resident memory**.
+There is no separate allocation baseline for the projection-only commit.
+
+## Changes and boundaries
+
+Projection plans prove physical slot/type identity once. A projection that only
+renames or reorders logical fields while keeping identical physical slots shares
+its immutable input bytes. Rearranging variable payload slots still copies.
+Adjacent pure field selections compose directly onto their underlying source;
+shared inner projections remain available. Composition does not cross fallible
+expressions, enum conversions, filters, joins or other semantic operators.
+
+Table and index source readers resolve each stored variant descriptor once per
+batch rather than once per row. The mechanism canary proves two preparations for
+1,000 rows across two variants. Unknown variants still fail.
+
+The fixed identity, durable row-author and nullable session-author descriptors
+are prepared once. Nested identity decoding borrows the encoded field instead
+of creating an intermediate owned record. Durable authors still cannot restore
+the in-process SYSTEM capability; validation and exact provenance are preserved.
+
+Version encoding uses prepared history descriptors and the fixed deletion
+register descriptor directly, avoiding complete storage-table/index construction
+per version. The history cache retains at most 128 shapes per thread and matches
+table name, ordered field names/types and large-value semantic kinds. Table names
+matter for native enum registry binding; JSON and text can have different
+physical representations. Eviction affects only preparation cost.
+
+Version decoding resolves the physical table ID without formatting a name for
+every catalogue candidate, borrows its schema, and keeps the incoming owned
+record buffer. The inverse name parser accepts exactly the constructor's
+unsigned decimal spelling and distinguishes history from register names.
+There are no storage or wire encoding changes.
+
+## Verification
+
+On final code: 741 Groove library tests and 2,004 Jazz library tests passed,
+with two ignored in each. All three incremental-delivery canaries passed,
+including scale-independent relation updates and writes and the linear snapshot
+receiver bound. The maintained/one-shot differential oracle passed with two
+seeds and churn depths 10 and 1,000.
+
+Mutation checks deliberately disabled reuse/composition, restored per-row
+variant preparation, disabled history caching, or accepted padded physical
+names. The relevant tests failed: pointer/dependency assertions; 1,000 builds
+instead of two; 500 builds instead of five; and acceptance of `01` instead of
+only `1`. All mutations were restored before final verification.
+
+These are draft PRs. Full canonical CI, browser acceptance and independent review
+are still outstanding. No subagents were used for this single-track pass.
+
+## Interpretation and next investigation
+
+A fresh full-process CPU profile still shows substantial allocator and copy self
+cost: `_int_malloc` about 8.6%, `memmove` 6.4%, and `_int_free` 5.6%, with other
+allocation/free routines adding further cost. This was a 99-Hz DWARF userspace
+profile; 46 samples were lost and kernel symbols were unavailable. It is
+indicative, not a phase-specific exact accounting.
+
+The new allocation trace and code walk point to remaining repeated work:
+
+- `Database::apply_batch` reconstructs primary-key descriptors for pending writes
+  and decodes complete delta rows into `Value`s to collect large-value roots.
+- `resolve_owned_record_input` / `encode_record` still assemble records from
+  owned values during ingestion.
+- `canonical_history_version_for_maintained_witness` still constructs a history
+  storage table to obtain its descriptor, outside the new VersionRow cache.
+- Whole author/value reconstruction and other schema/version clones remain.
+
+The stack sampler caps at 50,000 samples, so these are concrete candidates, not
+full-run allocation-share rankings. Full allocation totals remain valid. The
+next investigation should concentrate on eliminating whole-record/value
+round-trips and moving remaining table metadata preparation to batch/plan scope,
+rather than continuing with projection-only micro-optimizations. Follow-up is
+tracked in [#2789](https://github.com/garden-co/jazz/issues/2789).
+
+## Reproduction and iteration notes
+
+Build the native fixture with `cargo build -p jazz-sim --bench customer_cold_start
+--profile perf`, then run its emitted executable from the worktree root with
+`JAZZ_CUSTOMER_IDENTITY=member JAZZ_CUSTOMER_PHASES=cold JAZZ_CUSTOMER_SCALE=1.0
+JAZZ_CUSTOMER_MAX_TICKS=200000`. Build separately with `--features bench-alloc-sites`
+for allocation totals. Do not compare instrumented wall time with clean timings.
+
+For the bounded oracle, use `JAZZ_SEED_COUNT=2
+JAZZ_DIFFERENTIAL_CHURN_DEPTHS=10,1000 dev/t --exact
+node::tests::harness::m3_maintained_one_shot_differential_oracle -- --ignored`.
+A seed limit alone does not bound its separate aggregate-churn prelude: an initial
+run was stopped after encountering the default 100,000-depth workload.


### PR DESCRIPTION
🤖 Prepare record metadata once per shape/batch instead of reconstructing it for each row version.

A cold permissioned load repeatedly constructs the same descriptor fields even though the resulting descriptors are interned. For example, reading 1,000 stored rows with two physical variants used to construct 1,000 variant descriptors. Table and index source loading now group by variant and construct two. Payload bytes and signed row semantics are unchanged; an unknown variant still fails the read.

The fixed account/identity descriptors are initialized once. Durable non-null row authors remain distinct from nullable session/capability authors. Decoding borrows the nested identity bytes rather than allocating an intermediate owned record, while preserving issuer, subject, reserved-account and SYSTEM-origin checks. This does not let persisted authorship rehydrate the in-process SYSTEM capability.

Version encoding uses a prepared history descriptor or the fixed deletion-register descriptor directly, avoiding construction of a full storage table and its indices for every version. The history cache is bounded to 128 shapes per thread and compares table name, ordered column names/types and large-value semantic kinds. A changed type, JSON/text distinction or enum binding cannot reuse a stale layout. Eviction changes preparation cost only. Caller-supplied history descriptors retain precedence.

Version decoding now resolves the physical table ID once rather than formatting a name for every catalogue candidate. It borrows the matched schema and retains its incoming owned record buffer. Physical table lookup still distinguishes history from register names and rejects noncanonical names exactly as before.

No storage or wire encoding changes. This is preparation/ownership work; other row payload copies, canonical author interning, transaction/version object construction and remaining schema clones are not eliminated.

Validation: all 741 Groove and 2,004 Jazz library tests pass (two ignored in each), plus the differential oracle at two seeds and churn depths 10/1,000. Mutation checks fail when variant descriptors rebuild per row (1,000 versus 2), history preparation bypasses its cache (500 versus 5), or padded physical names are accepted. Mutations are restored. All three incremental-delivery canaries pass. The 27,518-row permissioned native fixture improves from 35.254 s before these two PRs to 32.415 s (individual clean runs, about 8%). Allocation requests fall from 483,481,285 to 383,877,574 (20.6%); cumulative requested bytes fall only 2.1%, so larger record/value copying remains. See [the benchmark report](https://github.com/garden-co/jazz/blob/perf/prepared-metadata-descriptors/dev/benchmarks/projection-composition-metadata-preparation.md) for scope, intermediate measurements and remaining hotspots. Draft on #2798; independent review, full CI and browser acceptance remain outstanding.
