### PR TITLE
perf: borrow authors and encoded fields during row ingestion

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+# Author identity is immutable. Only derived encoded-record caches use OnceLock;
+# manual Eq/Hash and stable Debug exclude them. Initializing these caches cannot
+# change an author or any containing query/authorization key.
+ignore-interior-mutability = ["jazz::ids::InternedAuthor"]

--- a/crates/groove/src/db/commit.rs
+++ b/crates/groove/src/db/commit.rs
@@ -151,12 +151,8 @@ impl Database {
                 else {
                     continue;
                 };
-                for value in descriptor.bind(record).to_values()? {
-                    if value_contains_large_ref(&value, &staged.value_ref) {
-                        found = true;
-                        break;
-                    }
-                }
+                found = descriptor
+                    .visit_large_value_refs(record, |reference| reference == &staged.value_ref)?;
                 if found {
                     break;
                 }
@@ -189,9 +185,14 @@ impl Database {
         let mut durable_root_deltas = BTreeMap::<crate::large_values::NodeRef, i64>::new();
         for table_delta in &table_deltas {
             for delta in &table_delta.deltas {
-                for value in table_delta.descriptor.bind(&delta.record).to_values()? {
-                    collect_large_root_deltas(&value, delta.weight, &mut durable_root_deltas);
-                }
+                table_delta
+                    .descriptor
+                    .visit_large_value_refs(&delta.record, |reference| {
+                        *durable_root_deltas
+                            .entry(reference.root.clone())
+                            .or_default() += delta.weight;
+                        false
+                    })?;
             }
         }
         let mut staged_operations = pending_writes
@@ -748,59 +749,5 @@ impl Database {
         } else {
             Ok(())
         }
-    }
-}
-
-fn value_contains_large_ref(value: &Value, expected: &crate::large_values::LargeValueRef) -> bool {
-    match value {
-        Value::Large(value_ref) => value_ref == expected,
-        Value::Tuple(values) | Value::Array(values) => values
-            .iter()
-            .any(|value| value_contains_large_ref(value, expected)),
-        Value::Nullable(Some(value)) => value_contains_large_ref(value, expected),
-        Value::Record(record) => record.to_values().is_ok_and(|values| {
-            values
-                .iter()
-                .any(|value| value_contains_large_ref(value, expected))
-        }),
-        Value::Enum(value) => value.record().to_values().is_ok_and(|values| {
-            values
-                .iter()
-                .any(|value| value_contains_large_ref(value, expected))
-        }),
-        _ => false,
-    }
-}
-
-fn collect_large_root_deltas(
-    value: &Value,
-    weight: i64,
-    deltas: &mut BTreeMap<crate::large_values::NodeRef, i64>,
-) {
-    match value {
-        Value::Large(value_ref) => {
-            *deltas.entry(value_ref.root.clone()).or_default() += weight;
-        }
-        Value::Tuple(values) | Value::Array(values) => {
-            for value in values {
-                collect_large_root_deltas(value, weight, deltas);
-            }
-        }
-        Value::Nullable(Some(value)) => collect_large_root_deltas(value, weight, deltas),
-        Value::Record(record) => {
-            if let Ok(values) = record.to_values() {
-                for value in values {
-                    collect_large_root_deltas(&value, weight, deltas);
-                }
-            }
-        }
-        Value::Enum(value) => {
-            if let Ok(values) = value.record().to_values() {
-                for value in values {
-                    collect_large_root_deltas(&value, weight, deltas);
-                }
-            }
-        }
-        _ => {}
     }
 }

--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -473,6 +473,30 @@ impl RecordDescriptor {
         record: &[u8],
         indices: impl IntoIterator<Item = usize>,
     ) -> Result<bool, Error> {
+        self.visit_encoded_indirect_fields(record, indices, &mut |_, _| Ok(true))
+    }
+
+    /// Visit stored indirect references without materializing inline contents or
+    /// unrelated fields. Return true from the visitor to stop early.
+    pub(crate) fn visit_large_value_refs(
+        &self,
+        record: &[u8],
+        mut visitor: impl FnMut(&crate::large_values::LargeValueRef) -> bool,
+    ) -> Result<bool, Error> {
+        self.visit_encoded_indirect_fields(record, 0..self.fields.len(), &mut |bytes, ty| {
+            let Value::Large(reference) = values::decode_value(bytes, ty)? else {
+                unreachable!("indirect traversal visits only the indirect scalar arm")
+            };
+            Ok(visitor(&reference))
+        })
+    }
+
+    fn visit_encoded_indirect_fields(
+        &self,
+        record: &[u8],
+        indices: impl IntoIterator<Item = usize>,
+        visitor: &mut impl FnMut(&[u8], &ValueType) -> Result<bool, Error>,
+    ) -> Result<bool, Error> {
         for index in indices {
             let field = self.fields.get(index).ok_or(Error::FieldIndexOutOfBounds {
                 index,
@@ -480,12 +504,66 @@ impl RecordDescriptor {
             })?;
             if field.value_type.may_contain_stored_scalar() {
                 let span = self.field_span(record, index)?;
-                if values::encoded_contains_indirect_value(&record[span], &field.value_type)? {
+                if values::visit_encoded_indirect_values(&record[span], &field.value_type, visitor)?
+                {
                     return Ok(true);
                 }
             }
         }
         Ok(false)
+    }
+
+    /// Assemble a record in one output allocation. The callback must append the
+    /// exact field encoding for this descriptor; offsets are owned by this method.
+    pub fn create_with_encoded_fields<E: From<Error>>(
+        &self,
+        capacity: usize,
+        mut append: impl FnMut(usize, &mut Vec<u8>) -> Result<(), E>,
+    ) -> Result<Vec<u8>, E> {
+        let mut output = Vec::with_capacity(capacity);
+        for &index in &self.layout.logical_by_physical {
+            if matches!(self.layout.fields[index], FieldLayout::Static { .. }) {
+                append(index, &mut output)?;
+            }
+        }
+        let fixed_size = self.fixed_size();
+        let variable_count = self.variable_count();
+        output.resize(
+            checked_add(fixed_size, variable_count.saturating_sub(1) * 4)?,
+            0,
+        );
+        for &index in &self.layout.logical_by_physical {
+            let FieldLayout::Variable { variable_idx } = self.layout.fields[index] else {
+                continue;
+            };
+            append(index, &mut output)?;
+            if variable_idx + 1 < variable_count {
+                let end = usize_to_u32(output.len())?;
+                let offset = fixed_size + variable_idx * 4;
+                output[offset..offset + 4].copy_from_slice(&end.to_le_bytes());
+            }
+        }
+        Ok(output)
+    }
+
+    /// Append a generated field alongside fields copied from encoded records.
+    pub fn encode_field_into(
+        &self,
+        index: usize,
+        value: &Value,
+        output: &mut Vec<u8>,
+    ) -> Result<(), Error> {
+        let field = self.fields.get(index).ok_or(Error::FieldIndexOutOfBounds {
+            index,
+            len: self.fields.len(),
+        })?;
+        ensure_value_type(value, &field.value_type)?;
+        if field.value_type.is_fixed_size() {
+            encode_fixed_value(output, value, &field.value_type)
+        } else {
+            output.extend_from_slice(&encode_value(value, &field.value_type)?);
+            Ok(())
+        }
     }
 
     pub fn patch_field(
@@ -1159,6 +1237,28 @@ impl<'a> BorrowedRecord<'a> {
 
     pub fn get_idx(&self, field_idx: usize) -> Result<Value, Error> {
         self.descriptor.get_idx(self.raw, field_idx)
+    }
+
+    /// Borrow a nested record directly from its encoded field.
+    pub fn get_record(&self, field_idx: usize) -> Result<BorrowedRecord<'a>, Error> {
+        let field =
+            self.descriptor
+                .fields()
+                .get(field_idx)
+                .ok_or(Error::FieldIndexOutOfBounds {
+                    index: field_idx,
+                    len: self.descriptor.fields().len(),
+                })?;
+        let ValueType::Record(descriptor) = &field.value_type else {
+            return Err(Error::TypeMismatch {
+                expected: field.value_type.clone(),
+            });
+        };
+        let span = self.descriptor.field_span(self.raw, field_idx)?;
+        Ok(BorrowedRecord {
+            raw: &self.raw[span],
+            descriptor: **descriptor,
+        })
     }
 
     pub fn to_values(&self) -> Result<Vec<Value>, Error> {

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -2547,3 +2547,100 @@ fn nested_record_read_does_not_reencode_descendants() {
     assert_eq!(record.get_idx(0).unwrap(), Value::Record(leaf_record));
     assert_eq!(RECORD_ENCODE_COUNT.with(|count| count.get()), 0);
 }
+
+// Internal representation tests: byte identity and borrowed storage cannot be
+// observed through a database query, which deliberately hides record layouts.
+#[test]
+fn encoded_field_assembly_matches_value_encoder_and_borrows_nested_record() {
+    let nested = descriptor([ValueType::String, ValueType::U64]);
+    let child = OwnedRecord::new(
+        nested
+            .create(&[Value::String("nested".into()), Value::U64(19)])
+            .unwrap(),
+        nested,
+    );
+    let d = descriptor([
+        ValueType::String,
+        ValueType::U64,
+        ValueType::Record(Box::new(nested)),
+        ValueType::Nullable(Box::new(ValueType::U64)),
+        ValueType::Bytes,
+    ]);
+    let values = [
+        Value::String("first".into()),
+        Value::U64(7),
+        Value::Record(child),
+        Value::Nullable(None),
+        Value::Bytes(vec![1, 2, 3]),
+    ];
+    let expected = d.create(&values).unwrap();
+    let actual = d
+        .create_with_encoded_fields::<Error>(expected.len(), |index, out| {
+            if index == 1 {
+                d.encode_field_into(index, &values[index], out)
+            } else {
+                out.extend_from_slice(&expected[d.field_span(&expected, index)?]);
+                Ok(())
+            }
+        })
+        .unwrap();
+    assert_eq!(actual, expected);
+    let borrowed = d.bind(&actual).get_record(2).unwrap();
+    assert_eq!(borrowed.get_str(0).unwrap(), "nested");
+    assert_eq!(borrowed.get_u64(1).unwrap(), 19);
+    assert_eq!(
+        borrowed.raw().as_ptr(),
+        actual[d.field_span(&actual, 2).unwrap()].as_ptr()
+    );
+    assert!(d.bind(&actual).get_record(0).is_err());
+    assert!(d.bind(&actual).get_record(99).is_err());
+}
+
+#[test]
+fn indirect_reference_visitor_preserves_nested_multiplicity_and_early_stop() {
+    use crate::large_values::{LargeValueKind, prepare};
+    let reference = prepare(LargeValueKind::String, b"indirect contents")
+        .unwrap()
+        .value_ref;
+    let nested = descriptor([ValueType::String]);
+    let child = OwnedRecord::new(
+        nested.create(&[Value::Large(reference.clone())]).unwrap(),
+        nested,
+    );
+    let d = descriptor([
+        ValueType::String,
+        ValueType::Array(Box::new(ValueType::Nullable(Box::new(ValueType::String)))),
+        ValueType::Record(Box::new(nested)),
+    ]);
+    let raw = d
+        .create(&[
+            Value::String("inline contents".repeat(100)),
+            Value::Array(vec![
+                Value::Nullable(None),
+                Value::Nullable(Some(Box::new(Value::Large(reference.clone())))),
+                Value::Nullable(Some(Box::new(Value::String("inline".into())))),
+                Value::Nullable(Some(Box::new(Value::Large(reference.clone())))),
+            ]),
+            Value::Record(child),
+        ])
+        .unwrap();
+    let mut seen = Vec::new();
+    assert!(
+        !d.visit_large_value_refs(&raw, |r| {
+            seen.push(r.clone());
+            false
+        })
+        .unwrap()
+    );
+    assert_eq!(seen, vec![reference.clone(); 3]);
+    let mut count = 0;
+    assert!(
+        d.visit_large_value_refs(&raw, |r| {
+            assert_eq!(r, &reference);
+            count += 1;
+            true
+        })
+        .unwrap()
+    );
+    assert_eq!(count, 1);
+}

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -2017,9 +2017,10 @@ fn encode_nullable(
 
 /// Inspect only framing needed to find an indirect scalar. Admission owns
 /// validity of the record; this is not another canonical decoding pass.
-pub(super) fn encoded_contains_indirect_value(
+pub(super) fn visit_encoded_indirect_values(
     bytes: &[u8],
     value_type: &ValueType,
+    visitor: &mut impl FnMut(&[u8], &ValueType) -> Result<bool, Error>,
 ) -> Result<bool, Error> {
     match value_type {
         ValueType::String
@@ -2028,7 +2029,7 @@ pub(super) fn encoded_contains_indirect_value(
             let (tag, _) = super::split_variant_record(bytes)?;
             match tag {
                 2 => Ok(false),
-                3 => Ok(true),
+                3 => visitor(bytes, value_type),
                 _ => Err(Error::LargeValue(
                     crate::large_values::Error::MalformedScalar,
                 )),
@@ -2038,17 +2039,17 @@ pub(super) fn encoded_contains_indirect_value(
             let (&flag, payload) = bytes.split_first().ok_or(Error::UnexpectedEof)?;
             match flag {
                 0 => Ok(false),
-                1 => encoded_contains_indirect_value(payload, inner),
+                1 => visit_encoded_indirect_values(payload, inner, visitor),
                 flag => Err(Error::InvalidNullFlag(flag)),
             }
         }
         ValueType::Record(descriptor) => {
-            descriptor.fields_contain_indirect_values(bytes, 0..descriptor.fields().len())
+            descriptor.visit_encoded_indirect_fields(bytes, 0..descriptor.fields().len(), visitor)
         }
         ValueType::Enum(schema) => {
             let (tag, payload) = super::split_variant_record(bytes)?;
             let descriptor = schema.case(tag)?.payload;
-            descriptor.fields_contain_indirect_values(payload, 0..descriptor.fields().len())
+            descriptor.visit_encoded_indirect_fields(payload, 0..descriptor.fields().len(), visitor)
         }
         ValueType::Array(inner) if inner.may_contain_stored_scalar() => {
             // Indirect-capable array elements are variable-width. Bounds-check
@@ -2071,7 +2072,7 @@ pub(super) fn encoded_contains_indirect_value(
                     u32_to_usize(read_u32_at(bytes, 4 + index * 4)?)?
                 };
                 let item = bytes.get(start..end).ok_or(Error::InvalidOffset)?;
-                if encoded_contains_indirect_value(item, inner)? {
+                if visit_encoded_indirect_values(item, inner, visitor)? {
                     return Ok(true);
                 }
                 start = end;

--- a/crates/jazz/src/ids.rs
+++ b/crates/jazz/src/ids.rs
@@ -179,12 +179,94 @@ impl RowUuid {
 
 /// Whole-structure interned author identity. The cached portable spelling is
 /// derived once; equality and field access never repeatedly parse JSON.
-#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct InternedAuthor {
     account: Option<crate::account_registry::AccountId>,
     issuer: String,
     subject: String,
     canonical: String,
+    row_record: std::sync::OnceLock<crate::groove::records::OwnedRecord>,
+    session_record: std::sync::OnceLock<crate::groove::records::OwnedRecord>,
+}
+
+// Derived caches must not change diagnostic identity as they initialize.
+impl std::fmt::Debug for InternedAuthor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InternedAuthor")
+            .field("account", &self.account)
+            .field("issuer", &self.issuer)
+            .field("subject", &self.subject)
+            .field("canonical", &self.canonical)
+            .finish()
+    }
+}
+
+// Borrowed composite lookup uses the existing intern pool. Derived encodings
+// do not participate in identity; construct them only after a lookup misses.
+trait AuthorIdentity {
+    fn identity(&self) -> (Option<crate::account_registry::AccountId>, &str, &str);
+}
+impl AuthorIdentity for InternedAuthor {
+    fn identity(&self) -> (Option<crate::account_registry::AccountId>, &str, &str) {
+        (self.account, &self.issuer, &self.subject)
+    }
+}
+impl PartialEq for InternedAuthor {
+    fn eq(&self, other: &Self) -> bool {
+        self.identity() == other.identity()
+    }
+}
+impl Eq for InternedAuthor {}
+impl std::hash::Hash for InternedAuthor {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(&self.identity(), state);
+    }
+}
+impl PartialEq for dyn AuthorIdentity + '_ {
+    fn eq(&self, other: &Self) -> bool {
+        self.identity() == other.identity()
+    }
+}
+impl Eq for dyn AuthorIdentity + '_ {}
+impl std::hash::Hash for dyn AuthorIdentity + '_ {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(&self.identity(), state);
+    }
+}
+impl<'a> std::borrow::Borrow<dyn AuthorIdentity + 'a> for InternedAuthor {
+    fn borrow(&self) -> &(dyn AuthorIdentity + 'a) {
+        self
+    }
+}
+impl<'a> From<&(dyn AuthorIdentity + 'a)> for InternedAuthor {
+    fn from(value: &(dyn AuthorIdentity + 'a)) -> Self {
+        let (account, issuer, subject) = value.identity();
+        let canonical = match account {
+            Some(account) => serde_json::to_string(&(account.0.to_string(), issuer, subject)),
+            None => serde_json::to_string(&(issuer, subject)),
+        }
+        .expect("author components have a canonical JSON spelling");
+        Self {
+            account,
+            issuer: issuer.to_owned(),
+            subject: subject.to_owned(),
+            canonical,
+            row_record: std::sync::OnceLock::new(),
+            session_record: std::sync::OnceLock::new(),
+        }
+    }
+}
+struct BorrowedAuthor<'a>(Option<crate::account_registry::AccountId>, &'a str, &'a str);
+impl AuthorIdentity for BorrowedAuthor<'_> {
+    fn identity(&self) -> (Option<crate::account_registry::AccountId>, &str, &str) {
+        (self.0, self.1, self.2)
+    }
+}
+fn intern_author(
+    account: Option<crate::account_registry::AccountId>,
+    issuer: &str,
+    subject: &str,
+) -> internment::Intern<InternedAuthor> {
+    internment::Intern::from_ref(&BorrowedAuthor(account, issuer, subject) as &dyn AuthorIdentity)
 }
 
 /// Authenticated subject recorded on transactions and row provenance.
@@ -382,6 +464,17 @@ impl RowAuthor {
 
     /// Structured durable attribution value.
     pub fn to_value(self) -> crate::groove::records::Value {
+        crate::groove::records::Value::Record(self.encoded_record().clone())
+    }
+
+    pub(crate) fn encoded_record(self) -> &'static crate::groove::records::OwnedRecord {
+        let author = match self.0 {
+            RowAuthorKind::SystemAt(author) | RowAuthorKind::Account(author) => author.as_ref(),
+        };
+        author.row_record.get_or_init(|| self.build_record())
+    }
+
+    fn build_record(self) -> crate::groove::records::OwnedRecord {
         use crate::groove::records::{OwnedRecord, Value};
         let (issuer, subject) = self.principal_parts();
         let identity = author_identity_descriptor();
@@ -393,7 +486,7 @@ impl RowAuthor {
         let raw = descriptor
             .create(&[Value::Uuid(self.account_id().0), identity])
             .expect("row author record");
-        Value::Record(OwnedRecord::new(raw, descriptor))
+        OwnedRecord::new(raw, descriptor)
     }
 
     /// Decode durable metadata without granting the system capability.
@@ -403,11 +496,18 @@ impl RowAuthor {
         let Value::Record(record) = value else {
             return Err(bad());
         };
+        Self::from_record(record.borrowed())
+    }
+
+    pub(crate) fn from_record(
+        record: crate::groove::records::BorrowedRecord<'_>,
+    ) -> Result<Self, AuthorSubjectError> {
+        let bad = || AuthorSubjectError::InvalidCanonical("invalid row author record".into());
         let expected = Self::record_descriptor();
-        if record.descriptor() != &expected {
+        if record.descriptor() != expected {
             return Err(bad());
         }
-        let borrowed = record.borrowed();
+        let borrowed = record;
         let account = crate::account_registry::AccountId(borrowed.get_uuid(0).map_err(|_| bad())?);
         let span = record
             .descriptor()
@@ -430,23 +530,27 @@ impl RowAuthor {
             let node = uuid::Uuid::parse_str(subject)
                 .map(NodeUuid)
                 .map_err(|_| AuthorSubjectError::InvalidSystemOrigin)?;
-            if node.0.to_string() != subject {
+            if &*node
+                .0
+                .hyphenated()
+                .encode_lower(&mut uuid::Uuid::encode_buffer())
+                != subject
+            {
                 return Err(AuthorSubjectError::InvalidSystemOrigin);
             }
-            return Ok(Self::system_at(node));
+            return Ok(Self(RowAuthorKind::SystemAt(intern_author(
+                Some(account),
+                issuer,
+                subject,
+            ))));
         }
         if account.is_system() {
             return Err(AuthorSubjectError::ReservedAccount);
         }
-        let canonical =
-            serde_json::to_string(&(account.0.to_string(), issuer, subject)).map_err(|_| bad())?;
-        Ok(Self(RowAuthorKind::Account(internment::Intern::new(
-            InternedAuthor {
-                account: Some(account),
-                issuer: issuer.to_owned(),
-                subject: subject.to_owned(),
-                canonical,
-            },
+        Ok(Self(RowAuthorKind::Account(intern_author(
+            Some(account),
+            issuer,
+            subject,
         ))))
     }
 
@@ -503,30 +607,16 @@ impl AuthorSubject {
     }
 
     fn intern(issuer: &str, subject: &str) -> Self {
-        let canonical = serde_json::to_string(&(issuer, subject))
-            .expect("two strings always have a canonical JSON encoding");
-        Self::Authenticated(internment::Intern::new(InternedAuthor {
-            account: None,
-            issuer: issuer.to_owned(),
-            subject: subject.to_owned(),
-            canonical,
-        }))
+        Self::Authenticated(intern_author(None, issuer, subject))
     }
 
-    /// Attribute a durable system write to its originating node without
-    /// manufacturing the internal `System` capability.
+    /// Attribute a durable system write to its originating node.
     pub fn system_at(node: NodeUuid) -> Self {
-        let account = crate::account_registry::SYSTEM_ACCOUNT_ID;
-        let issuer = Self::SYSTEM_ISSUER.to_owned();
-        let subject = node.0.to_string();
-        let canonical = serde_json::to_string(&(account.0.to_string(), &issuer, &subject))
-            .expect("system author is serializable");
-        Self::SystemAt(internment::Intern::new(InternedAuthor {
-            account: Some(account),
-            issuer,
-            subject,
-            canonical,
-        }))
+        Self::SystemAt(intern_author(
+            Some(crate::account_registry::SYSTEM_ACCOUNT_ID),
+            Self::SYSTEM_ISSUER,
+            &node.0.to_string(),
+        ))
     }
 
     fn is_reserved_issuer(issuer: &str) -> bool {
@@ -573,15 +663,14 @@ impl AuthorSubject {
             "system is not an account principal"
         );
         assert!(!account.is_system(), "system account is not user-owned");
-        let (issuer, subject) = self.principal_parts();
-        let canonical = serde_json::to_string(&(account.0.to_string(), &issuer, &subject))
-            .expect("account author is serializable");
-        Self::Authenticated(internment::Intern::new(InternedAuthor {
-            account: Some(account),
-            issuer,
-            subject,
-            canonical,
-        }))
+        let Self::Authenticated(author) = self else {
+            unreachable!()
+        };
+        Self::Authenticated(intern_author(
+            Some(account),
+            &author.issuer,
+            &author.subject,
+        ))
     }
 
     /// Exact authenticating principal, independent of account ownership.
@@ -658,6 +747,24 @@ impl AuthorSubject {
 
     /// Structured native author value; intern handles are never serialized.
     pub fn to_value(self) -> crate::groove::records::Value {
+        crate::groove::records::Value::Record(self.encoded_record().clone())
+    }
+
+    pub(crate) fn encoded_record(self) -> &'static crate::groove::records::OwnedRecord {
+        match self {
+            Self::System => {
+                static RECORD: std::sync::OnceLock<crate::groove::records::OwnedRecord> =
+                    std::sync::OnceLock::new();
+                RECORD.get_or_init(|| self.build_record())
+            }
+            Self::SystemAt(author) | Self::Authenticated(author) => author
+                .as_ref()
+                .session_record
+                .get_or_init(|| self.build_record()),
+        }
+    }
+
+    fn build_record(self) -> crate::groove::records::OwnedRecord {
         use crate::groove::records::{OwnedRecord, Value};
         let (issuer, subject) = self.principal_parts();
         let identity = author_identity_descriptor();
@@ -673,7 +780,7 @@ impl AuthorSubject {
         let raw = descriptor
             .create(&[account, identity])
             .expect("author record");
-        Value::Record(OwnedRecord::new(raw, descriptor))
+        OwnedRecord::new(raw, descriptor)
     }
 
     /// Decode structured provenance using its exact native descriptor.
@@ -720,18 +827,34 @@ impl AuthorSubject {
             let node = uuid::Uuid::parse_str(subject)
                 .map(NodeUuid)
                 .map_err(|_| AuthorSubjectError::InvalidSystemOrigin)?;
-            if node.0.to_string() != subject {
+            if &*node
+                .0
+                .hyphenated()
+                .encode_lower(&mut uuid::Uuid::encode_buffer())
+                != subject
+            {
                 return Err(AuthorSubjectError::InvalidSystemOrigin);
             }
-            return Ok(Self::system_at(node));
+            return Ok(Self::SystemAt(intern_author(
+                Some(crate::account_registry::AccountId(account)),
+                issuer,
+                subject,
+            )));
         }
-        let canonical = if let Some(account) = account {
-            serde_json::to_string(&(account.to_string(), issuer, subject))
-        } else {
-            serde_json::to_string(&(issuer, subject))
+        if account.is_some_and(|account| account == crate::account_registry::SYSTEM_ACCOUNT_ID.0) {
+            return Err(AuthorSubjectError::ReservedAccount);
         }
-        .map_err(|_| bad())?;
-        Self::from_canonical(&canonical)
+        if !principal_is_nonempty(issuer) {
+            return Err(AuthorSubjectError::MissingIssuer);
+        }
+        if !principal_is_nonempty(subject) {
+            return Err(AuthorSubjectError::MissingSubject);
+        }
+        Ok(Self::Authenticated(intern_author(
+            account.map(crate::account_registry::AccountId),
+            issuer,
+            subject,
+        )))
     }
 
     /// Ownership value exposed by account policies and row owner metadata.
@@ -776,7 +899,12 @@ impl AuthorSubject {
             let node = uuid::Uuid::parse_str(&subject)
                 .map(NodeUuid)
                 .map_err(|_| AuthorSubjectError::InvalidSystemOrigin)?;
-            if node.0.to_string() != subject {
+            if &*node
+                .0
+                .hyphenated()
+                .encode_lower(&mut uuid::Uuid::encode_buffer())
+                != subject.as_str()
+            {
                 return Err(AuthorSubjectError::InvalidSystemOrigin);
             }
             let author = Self::system_at(node);
@@ -980,6 +1108,29 @@ mod tests {
             AuthorSubject::SYSTEM,
         ] {
             assert_eq!(AuthorSubject::from_value(value.to_value()).unwrap(), value);
+        }
+    }
+
+    // Internal: allocation reuse is a process-local representation property.
+    #[test]
+    fn author_encoded_records_are_reused_without_changing_identity_or_bytes() {
+        let principal = AuthorSubject::authenticated("https://cache.example", "subject").unwrap();
+        let account = crate::account_registry::AccountId(uuid::Uuid::from_bytes([47; 16]));
+        let subject = principal.with_account(account);
+        let row = RowAuthor::from_persisted_subject(subject).unwrap();
+        let session_record = subject.encoded_record();
+        let row_record = row.encoded_record();
+        assert_eq!(session_record, &subject.build_record());
+        assert_eq!(row_record, &row.build_record());
+        for _ in 0..10 {
+            let same = AuthorSubject::authenticated("https://cache.example", "subject")
+                .unwrap()
+                .with_account(account);
+            assert_eq!(same, subject);
+            assert!(std::ptr::eq(same.encoded_record(), session_record));
+            let decoded = RowAuthor::from_record(row_record.borrowed()).unwrap();
+            assert_eq!(decoded, row);
+            assert!(std::ptr::eq(decoded.encoded_record(), row_record));
         }
     }
 

--- a/crates/jazz/src/node/codec.rs
+++ b/crates/jazz/src/node/codec.rs
@@ -202,14 +202,18 @@ impl records::RecordField for AuthorSubject {
 
 impl records::RecordField for RowAuthor {
     fn read_raw(bytes: &[u8], value_type: &records::ValueType) -> Result<Self, records::Error> {
-        RowAuthor::from_value(<Value as records::RecordField>::read_raw(
-            bytes, value_type,
-        )?)
-        .map_err(|_| records::Error::NonCanonicalRecord)
+        let records::ValueType::Record(descriptor) = value_type else {
+            return Err(records::Error::TypeMismatch {
+                expected: value_type.clone(),
+            });
+        };
+        RowAuthor::from_record(descriptor.bind(bytes))
+            .map_err(|_| records::Error::NonCanonicalRecord)
     }
 
     fn read(record: &records::BorrowedRecord<'_>, idx: usize) -> Result<Self, records::Error> {
-        RowAuthor::from_value(record.get_idx(idx)?).map_err(|_| records::Error::NonCanonicalRecord)
+        RowAuthor::from_record(record.get_record(idx)?)
+            .map_err(|_| records::Error::NonCanonicalRecord)
     }
 
     fn to_value(&self) -> Value {
@@ -2210,34 +2214,115 @@ impl VersionRow {
                 "row version parents must be sorted and unique",
             ));
         }
-        let (descriptor, values) = if let Some(deletion) = version.deletion() {
-            (
-                register_record_descriptor(table),
+        let deletion = version.deletion();
+        let descriptor = if deletion.is_some() {
+            register_record_descriptor(table)
+        } else {
+            history_record_descriptor(table)
+        };
+        let source = version.record().borrowed();
+        let source_descriptor = source.descriptor();
+        // Admission still requires an account-bearing row author, including the
+        // reserved SYSTEM identity. Preserve that check without rebuilding Values.
+        RowAuthor::from_persisted_subject(version.created_by())
+            .map_err(|_| Error::UnadmittedWriteAuthor)?;
+        RowAuthor::from_persisted_subject(version.updated_by())
+            .map_err(|_| Error::UnadmittedWriteAuthor)?;
+        let created_at = TxTime::from_physical_ms(version.created_at_ms())
+            .map_err(|_| Error::InvalidStoredValue("wire created_at_ms exceeds packed HLC range"))?
+            .0;
+        let updated_at = TxTime::from_physical_ms(version.updated_at_ms())
+            .map_err(|_| Error::InvalidStoredValue("wire updated_at_ms exceeds packed HLC range"))?
+            .0;
+        let raw = descriptor.create_with_encoded_fields::<Error>(
+            source.raw().len() + 128,
+            |index, output| {
+                let source_index = match index {
+                    1 => Some(0),
+                    5 => Some(1),
+                    6 => Some(2),
+                    8 => Some(4),
+                    i if deletion.is_none() && i >= 10 && i < 10 + table.columns.len() => {
+                        Some(i - 10 + 7)
+                    }
+                    _ => None,
+                };
+                if let Some(source_index) = source_index {
+                    if source_descriptor
+                        .fields()
+                        .get(source_index)
+                        .is_some_and(|field| {
+                            field.value_type == descriptor.fields()[index].value_type
+                        })
+                    {
+                        let span = source_descriptor.field_span(source.raw(), source_index)?;
+                        output.extend_from_slice(&source.raw()[span]);
+                        return Ok(());
+                    }
+                }
+                let value = match index {
+                    0 => Value::Bytes(version.branch_key().canonical_bytes()),
+                    1 => Value::Uuid(version.row_uuid().0),
+                    2 => Value::U64(tx_time.0),
+                    3 => Value::U64(tx_node_alias.0),
+                    4 => Value::U64(schema_version_alias.0),
+                    5 => Value::Array(
+                        version
+                            .parents()
+                            .iter()
+                            .map(|parent| tx_id_value(*parent))
+                            .collect(),
+                    ),
+                    6 => row_author_value(version.created_by())?,
+                    7 => Value::U64(created_at),
+                    8 => row_author_value(version.updated_by())?,
+                    9 => Value::U64(updated_at),
+                    _ if deletion.is_some() => deletion_event_value(deletion.unwrap()),
+                    i if i < 10 + table.columns.len() => {
+                        let value = version.optional_cell_at(i - 10);
+                        if let Some(value) = value.as_ref() {
+                            validate_cell_value(&table.columns[i - 10], value)?;
+                        }
+                        Value::Nullable(value.map(Box::new))
+                    }
+                    _ => authored_column_ids_value(authored_columns.as_ref()),
+                };
+                descriptor.encode_field_into(index, &value, output)?;
+                Ok(())
+            },
+        )?;
+        #[cfg(test)]
+        {
+            // Compare the optimized representation boundary with the previous
+            // Value-based encoder across every ingress fixture in the unit suite.
+            let values = if let Some(deletion) = deletion {
                 register_values_from_wire(
                     version,
                     tx_node_alias,
                     schema_version_alias,
                     tx_time,
                     deletion,
-                )?,
-            )
-        } else {
-            (
-                history_record_descriptor(table),
+                )?
+            } else {
                 history_values_from_wire(
                     table,
                     version,
-                    authored_columns,
+                    authored_columns.clone(),
                     tx_node_alias,
                     schema_version_alias,
                     tx_time,
-                )?,
-            )
-        };
+                )?
+            };
+            assert_eq!(
+                raw,
+                descriptor.create(&values)?,
+                "borrowed wire ingest changed storage bytes"
+            );
+        }
         Ok(Self {
             table: groove::Intern::new(version.table().to_owned()),
             branch_key: version.branch_key().clone(),
-            record: owned_record_from_storage_values_with_descriptor(descriptor, values)?,
+            record: OwnedRecord::new(raw, descriptor),
         })
     }
 
@@ -2310,10 +2395,10 @@ impl VersionRow {
         } else {
             HistoryRowRecord::FIELD_CREATED_BY_IDX
         };
-        RowAuthor::from_value(
+        RowAuthor::from_record(
             self.record
                 .borrowed()
-                .get_idx(idx)
+                .get_record(idx)
                 .expect("valid created_by"),
         )
         .expect("canonical created_by")
@@ -2340,10 +2425,10 @@ impl VersionRow {
         } else {
             HistoryRowRecord::FIELD_UPDATED_BY_IDX
         };
-        RowAuthor::from_value(
+        RowAuthor::from_record(
             self.record
                 .borrowed()
-                .get_idx(idx)
+                .get_record(idx)
                 .expect("valid updated_by"),
         )
         .expect("canonical updated_by")
@@ -4140,6 +4225,7 @@ pub(super) fn history_values_from_parts(
     Ok(values)
 }
 
+#[cfg(test)]
 fn history_values_from_wire(
     table: &TableSchema,
     version: &VersionRecord,
@@ -4211,6 +4297,7 @@ pub(super) fn register_values_from_parts(version: &VersionRowParts) -> Result<Ve
     ])
 }
 
+#[cfg(test)]
 fn register_values_from_wire(
     version: &VersionRecord,
     tx_node_alias: NodeAlias,

--- a/crates/jazz/src/node/currency.rs
+++ b/crates/jazz/src/node/currency.rs
@@ -1120,8 +1120,8 @@ where
                 record.get_enum(TransactionRowRecord::FIELD_KIND_IDX)?,
             )?,
             n_total_writes: record.get_u32(TransactionRowRecord::FIELD_N_TOTAL_WRITES_IDX)?,
-            made_by: RowAuthor::from_value(
-                record.get_idx(TransactionRowRecord::FIELD_MADE_BY_IDX)?,
+            made_by: RowAuthor::from_record(
+                record.get_record(TransactionRowRecord::FIELD_MADE_BY_IDX)?,
             )
             .map_err(|_| groove::records::Error::NonCanonicalRecord)?
             .as_author_subject(),

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -2751,7 +2751,7 @@ fn decode_typed_version_witness(
         )?),
         tx_time,
         parents: tx_ids_from_value(record.get_idx(plan.parents_idx)?)?,
-        created_by: RowAuthor::from_value(record.get_idx(plan.created_by_idx)?)
+        created_by: RowAuthor::from_record(record.get_record(plan.created_by_idx)?)
             .map_err(|_| groove::records::Error::NonCanonicalRecord)?
             .as_author_subject(),
         // Current-row provenance is public Unix milliseconds. Witness state
@@ -2763,7 +2763,7 @@ fn decode_typed_version_witness(
                     "maintained witness created_at_ms exceeds packed HLC range",
                 )
             })?,
-        updated_by: RowAuthor::from_value(record.get_idx(plan.updated_by_idx)?)
+        updated_by: RowAuthor::from_record(record.get_record(plan.updated_by_idx)?)
             .map_err(|_| groove::records::Error::NonCanonicalRecord)?
             .as_author_subject(),
         updated_at: TxTime::from_physical_ms(record_u64_idx(record, plan.updated_at_idx)?)

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -1896,7 +1896,7 @@ impl CurrentRow {
         };
         let record = self.record.borrowed();
         Ok(Some(match column {
-            "$createdBy" | "$updatedBy" => RowAuthor::from_value(record.get_idx(index)?)
+            "$createdBy" | "$updatedBy" => RowAuthor::from_record(record.get_record(index)?)
                 .map_err(|_| groove::records::Error::NonCanonicalRecord)?
                 .to_value(),
             "$createdAt" | "$updatedAt" => Value::U64(record.get_u64(index)?),
@@ -1921,11 +1921,11 @@ impl CurrentRow {
             return Ok(None);
         };
         Ok(Some(RowProvenance {
-            created_by: RowAuthor::from_value(borrowed.get_idx(created_by_idx)?)
+            created_by: RowAuthor::from_record(borrowed.get_record(created_by_idx)?)
                 .map_err(|_| groove::records::Error::NonCanonicalRecord)?
                 .as_author_subject(),
             created_at: borrowed.get_u64(created_at_idx)?,
-            updated_by: RowAuthor::from_value(borrowed.get_idx(updated_by_idx)?)
+            updated_by: RowAuthor::from_record(borrowed.get_record(updated_by_idx)?)
                 .map_err(|_| groove::records::Error::NonCanonicalRecord)?
                 .as_author_subject(),
             updated_at: borrowed.get_u64(updated_at_idx)?,

--- a/crates/jazz/src/node/state/durable.rs
+++ b/crates/jazz/src/node/state/durable.rs
@@ -542,8 +542,8 @@ where
         {
             let record = raw.record();
             let fate = record.get_enum(TransactionRowRecord::FIELD_FATE_IDX)?;
-            let made_by = RowAuthor::from_value(
-                record.get_idx(TransactionRowRecord::FIELD_MADE_BY_IDX)?,
+            let made_by = RowAuthor::from_record(
+                record.get_record(TransactionRowRecord::FIELD_MADE_BY_IDX)?,
             )
             .map_err(|_| groove::records::Error::NonCanonicalRecord)?
             .as_author_subject();
@@ -611,8 +611,8 @@ where
             scan.records_visited += 1;
             let record = raw.record();
             if NodeAlias(record.get_u64(TransactionRowRecord::FIELD_NODE_ID_IDX)?) != node_alias
-                || RowAuthor::from_value(
-                    record.get_idx(TransactionRowRecord::FIELD_MADE_BY_IDX)?,
+                || RowAuthor::from_record(
+                    record.get_record(TransactionRowRecord::FIELD_MADE_BY_IDX)?,
                 )
                 .map_err(|_| groove::records::Error::NonCanonicalRecord)?
                 .as_author_subject()

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -1248,7 +1248,7 @@ impl VersionRecord {
             WireRowRecord::FIELD_CREATED_BY_IDX,
             WireRowRecord::FIELD_UPDATED_BY_IDX,
         ] {
-            RowAuthor::from_value(borrowed.get_idx(index).map_err(|_| malformed())?)
+            RowAuthor::from_record(borrowed.get_record(index).map_err(|_| malformed())?)
                 .map_err(|_| malformed())?;
         }
         borrowed
@@ -1464,10 +1464,10 @@ impl VersionRecord {
 
     /// Original author for this logical row.
     pub fn created_by(&self) -> AuthorSubject {
-        RowAuthor::from_value(
+        RowAuthor::from_record(
             self.record
                 .borrowed()
-                .get_idx(WireRowRecord::FIELD_CREATED_BY_IDX)
+                .get_record(WireRowRecord::FIELD_CREATED_BY_IDX)
                 .expect("valid wire created_by"),
         )
         .expect("canonical wire created_by")
@@ -1484,10 +1484,10 @@ impl VersionRecord {
 
     /// Author of this row version.
     pub fn updated_by(&self) -> AuthorSubject {
-        RowAuthor::from_value(
+        RowAuthor::from_record(
             self.record
                 .borrowed()
-                .get_idx(WireRowRecord::FIELD_UPDATED_BY_IDX)
+                .get_record(WireRowRecord::FIELD_UPDATED_BY_IDX)
                 .expect("valid wire updated_by"),
         )
         .expect("canonical wire updated_by")

--- a/crates/jazz/src/tx.rs
+++ b/crates/jazz/src/tx.rs
@@ -736,10 +736,10 @@ impl RejectedTransaction {
 
     /// Author that made the transaction.
     pub fn made_by(&self) -> AuthorSubject {
-        RowAuthor::from_value(
+        RowAuthor::from_record(
             self.record
                 .borrowed()
-                .get_idx(RejectedTransactionRowRecord::FIELD_MADE_BY_IDX)
+                .get_record(RejectedTransactionRowRecord::FIELD_MADE_BY_IDX)
                 .expect("valid rejected author"),
         )
         .expect("canonical rejected row author")

--- a/dev/benchmarks/borrowed-author-version-values.md
+++ b/dev/benchmarks/borrowed-author-version-values.md
@@ -33,7 +33,9 @@ browser reopen or the 1,500-todo bulk-write benchmark.
 | Allocation requests               |     383,877,574 |     318,503,788 |
 | Cumulative allocated bytes        | 289,350,646,379 | 275,184,546,230 |
 
-The clean timing run improves readiness by 9.0%. These are individual runs,
+A second clean run after restoration and rebuild reached all-ready at 29,720 ms
+(settle 29,249 ms; full wall 31,188 ms), with all 27,518 expected rows. The two
+clean runs improve readiness by 8.3–9.0%. These are individual runs,
 not statistically established confidence intervals. Allocation totals come from
 separate instrumented runs and include final diagnostic queries. They decrease
 17.0% in requests and 4.9% in bytes; cumulative bytes are not peak RAM.

--- a/dev/benchmarks/borrowed-author-version-values.md
+++ b/dev/benchmarks/borrowed-author-version-values.md
@@ -1,0 +1,110 @@
+# Borrowed author and version values
+
+This pass follows the projection/metadata preparation measurements in
+[the preceding report](projection-composition-metadata-preparation.md).
+
+## What changed
+
+- Author lookup borrows `(account, issuer, subject)` and uses the existing intern
+  pool. Canonical JSON spelling and native author records are built once per
+  identity. Record readers borrow nested authors instead of copying their
+  records and reconstructing JSON. SYSTEM provenance cannot become authority.
+- Incoming versions copy compatible encoded fields directly into one output
+  record. Storage aliases and converted timestamps are generated alongside them.
+  Differing types retain conversion; author admission and canonical parent
+  ordering are still checked. This is not a new storage or wire format.
+- Groove large-value reference accounting walks encoded containers and decodes
+  only indirect references. Inline strings and unrelated fields are not rebuilt
+  as owned `Value` trees. Reference multiplicity is preserved.
+
+## Measurements
+
+Same optimized native member fixture: preseeded Core, empty relay and client,
+39 subscriptions, 27,518 expected output rows, RocksDB WalNoSync, semantic
+in-process transport. The dominant child subscription has 23,831 visible rows
+from 43,000 candidates. Seeding is outside the measured load. This is not a
+browser reopen or the 1,500-todo bulk-write benchmark.
+
+| Metric                            |    Previous tip |       This pass |
+| --------------------------------- | --------------: | --------------: |
+| All subscriptions ready           |       32,415 ms |       29,485 ms |
+| Settle                            |       31,946 ms |       29,013 ms |
+| Full load plus diagnostic queries |       33,956 ms |       30,924 ms |
+| Allocation requests               |     383,877,574 |     318,503,788 |
+| Cumulative allocated bytes        | 289,350,646,379 | 275,184,546,230 |
+
+The clean timing run improves readiness by 9.0%. These are individual runs,
+not statistically established confidence intervals. Allocation totals come from
+separate instrumented runs and include final diagnostic queries. They decrease
+17.0% in requests and 4.9% in bytes; cumulative bytes are not peak RAM.
+The 5-second cold-load target remains unmet.
+
+## New profile and interpretation
+
+A fresh 99-Hz DWARF CPU profile still shows allocation/copy self costs:
+`_int_malloc` 8.31%, `memmove` 6.96%, `_int_free` 5.10%, `malloc` 4.09%,
+and `String::clone` 2.15%. These cover the complete benchmark process and
+are not additive to inclusive caller costs. Kernel symbols are unavailable;
+async/unresolved stacks limit inclusive attribution. The self-cost report had
+zero lost samples. Disabling inline expansion makes an exploratory inclusive
+report fast, but its incomplete stack attribution must not be treated as a
+complete phase breakdown.
+
+Allocation stack samples plus code inspection identify remaining ownership and
+representation work:
+
+1. `complete_parent_versions` in `node/ingest/validation.rs` constructs a map
+   and clones incoming `VersionRecord`s, including their owned payloads, before
+   returning a new vector. This is still active during bulk reset ingestion.
+2. `Database::apply_batch` constructs primary-key descriptors per write;
+   `canonical_history_version_for_maintained_witness` reconstructs a history
+   table to obtain its record descriptor. These are preparation costs in row
+   loops, separate from the descriptor paths fixed in the preceding PR.
+3. Other storage writes still enter `resolve_owned_record_input` as
+   `RecordInput::Values` and go through `encode_record`/`RecordDescriptor::create`.
+   Current-row carriers also reconstruct parents, cells and metadata as values.
+4. Staged writes and physical storage-operation translation copy owned
+   operations and keys. `IndexBy` and terminal collection remain visible too.
+
+The allocation sampler stops collecting candidate stacks at 50,000 samples
+(one per 4,096 requests), so its ranks identify early hot callers rather than
+whole-run percentage shares. Full allocation counters remain valid.
+
+The next hypothesis is to preserve encoded ownership through remaining
+transaction/current-row/storage staging boundaries, and prepare descriptors
+outside row loops. The evidence does not justify assuming another scalar
+encoding micro-optimization will supply the remaining roughly 6x improvement.
+Avoiding repeated payload copies and reducing total row visits need separate
+measurement; these are related but distinct costs.
+
+## Validation
+
+- Final Groove library suite: 743 passed, 2 ignored, including two added
+  byte/reference tests. The focused record subset also passed (83 tests).
+- Final Jazz library suite: 2,005 passed, 2 ignored. Test builds compare each
+  incoming-version encoding with the previous Value-based encoder byte for byte.
+- Three incremental delivery canaries passed: relation changes, complete
+  supporting snapshots, and batched writes.
+- Two-seed differential oracle with churn depths 10 and 1,000 passed.
+- The first Jazz full run had one deletion-coverage failure. The exact same
+  binary passed that case alone, and the subsequent full suite passed. This
+  intermittent result is recorded rather than counted as an initial clean pass.
+- Record mutation checks: corrupting offset assembly and stopping reference
+  traversal after its first reference each fail their corresponding new test.
+  Mutations were restored. Disabling author-record reuse also fails the new
+  cache-reuse test; its mutation was restored.
+- Clippy passes with a narrow `InternedAuthor` interior-mutability exception:
+  derived caches are excluded from manual Eq/Hash and stable Debug; identity
+  never mutates.
+
+Independent review, full canonical CI and browser acceptance are not claimed.
+
+## Reproduction
+
+Build `cargo build -p jazz-sim --bench customer_cold_start --profile perf` and
+run the executable from the repository root with `JAZZ_CUSTOMER_IDENTITY=member`,
+`JAZZ_CUSTOMER_PHASES=cold`, `JAZZ_CUSTOMER_SCALE=1.0`, and
+`JAZZ_CUSTOMER_MAX_TICKS=200000`. Build separately with `--features bench-alloc-sites`
+for allocation counts. Keep clean timing runs separate from builds and tests.
+Local raw evidence is under `jazz-debug-evidence/permissioned-profile/` with the
+`borrowed-values` prefix (timing, allocation trace and CPU profile).


### PR DESCRIPTION
🤖
Incoming row versions and storage commit bookkeeping repeatedly reconstructed owned record values even when the encoded data was already available. This change borrows those representations and allocates the final output instead.

For example, an incoming row with text, nullable fields and structured authors previously decoded its parents, author records and cells into owned values, validated cells by encoding them again, and then encoded the storage row. Compatible fields now copy their encoded spans into one record buffer; storage-only aliases and converted timestamps are generated directly. Differing field types retain the conversion path. Author admission and sorted-parent checks remain in place.

Author lookup now hashes borrowed `(account, issuer, subject)` components in the existing intern pool. Canonical spelling and native row/session encodings are built once per identity. Reading authors from records borrows the nested record and strings. SYSTEM row provenance remains distinct from the SYSTEM authority capability.

Storage commit accounting now traverses encoded containers to find indirect large-value references. Inline strings and unrelated fields are not decoded into values. Repeated references still count separately, including references inside arrays, nullable values, nested records and enum payloads.

Storage and wire bytes are unchanged. Test builds compare the direct incoming-version encoder against the previous Value-based encoder throughout the unit ingress corpus. Focused record tests cover byte identity, borrowed nested records, reference multiplicity and early stopping.

Measured on the same optimized native 39-subscription/27,518-row permissioned cold-load fixture: all-ready time fell from 32.415s to 29.485s (9.0%), allocation requests from 383.9M to 318.5M (17.0%), and cumulative allocated bytes from 289.4GB to 275.2GB (4.9%). A second clean run was 29.720s, confirming an 8.3–9.0% readiness gain across these two runs. These are individual clean timing runs and separate allocation runs, not browser results or peak RAM. The 5s goal remains unmet.

The new profile still shows substantial allocator/copy work. Remaining sampled callers include complete-parent version cloning, per-write primary-key descriptor creation, witness history descriptor reconstruction, and other Value-based storage encoders. See the [measurement and profile report](https://github.com/garden-co/jazz/blob/perf/borrowed-author-version-values/dev/benchmarks/borrowed-author-version-values.md).

Validation: Jazz library suite 2,005 passed/2 ignored and Groove 743 passed/2 ignored; record tests, all three incremental delivery canaries, and the two-seed differential oracle passed. Test mutations that corrupt offsets, stop indirect-reference traversal early, or disable author-record reuse each fail the corresponding new test and were restored. An initial deletion-coverage test failure passed alone on the same binary and in the full rerun; the report records it. Clippy passed, including a narrow immutable-identity exemption for derived author caches.

Draft: independent review, full canonical CI and browser acceptance remain outstanding.
