### PR TITLE
perf: attribute native cold load to exclusive node phases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,6 +1526,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "thiserror",
+ "tracing",
  "uuid",
  "web-time",
 ]
@@ -2349,6 +2350,7 @@ dependencies = [
  "rusqlite",
  "serde_json",
  "tempfile",
+ "tracing",
  "uuid",
  "zstd",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,5 @@
 # Author identity is immutable. Only derived encoded-record caches use OnceLock;
 # manual Eq/Hash and stable Debug exclude them. Initializing these caches cannot
 # change an author or any containing query/authorization key.
-ignore-interior-mutability = ["jazz::ids::InternedAuthor"]
+# Preserve Clippy's default immutable Bytes exemption as well.
+ignore-interior-mutability = ["bytes::Bytes", "jazz::ids::InternedAuthor"]

--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2024"
 [features]
 default = []
 test = []
-cold-settle-attribution = []
+cold-settle-attribution = ["dep:tracing"]
 
 [dependencies]
+tracing = { version = "0.1", optional = true }
 internment = { version = "0.8.6", features = ["serde"] }
 bytes = "1"
 blake3 = "1"

--- a/crates/groove/src/db/commit.rs
+++ b/crates/groove/src/db/commit.rs
@@ -110,6 +110,10 @@ impl Database {
     /// persistence. The returned handle owns the pending persistence work and
     /// no longer borrows this database, so resident queries may continue while
     /// storage suspends.
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.storage_apply")
+    )]
     pub async fn apply_batch(&mut self, mut batch: DatabaseBatch) -> Result<AppliedBatch, Error> {
         batch.check_exact_base(self)?;
         self.ensure_not_poisoned()?;

--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -1430,6 +1430,10 @@ impl AppliedBatch {
         self.publication
     }
 
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.storage_persist")
+    )]
     pub async fn persist(&self) -> PersistedBatch {
         assert_eq!(
             self.lifecycle.replace(AppliedBatchLifecycle::Persisting),

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -691,6 +691,10 @@ impl GraphRuntimeView<'_> {
             .retain(|key, _| key.scope != self.scope);
     }
 
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.ivm_hydrate")
+    )]
     pub(super) async fn eval_root(
         &mut self,
         node: NodeId,
@@ -742,6 +746,10 @@ impl TickEvaluator<'_> {
     /// Keeping graph traversal here iterative makes stack use independent of
     /// graph depth, including recursive seed/step scopes which do not use the
     /// outer tick work queue.
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.ivm_update")
+    )]
     pub(super) async fn update_subgraph(
         &mut self,
         root: NodeId,
@@ -2152,6 +2160,10 @@ impl TickEvaluator<'_> {
     /// a root-scope arrangement keyed by the collector input; a collector is
     /// structurally terminal, so it can never become state in a recursive step
     /// or inherit a recursive sub-tick work bound.
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.collect_results")
+    )]
     fn update_collect_by(
         &mut self,
         node: NodeId,

--- a/crates/groove/src/ivm/runtime/record_projection.rs
+++ b/crates/groove/src/ivm/runtime/record_projection.rs
@@ -1415,6 +1415,10 @@ pub(super) fn schema_index_input_descriptor(
     project_descriptor(&catalogue, &fields)
 }
 
+#[cfg_attr(
+    feature = "cold-settle-attribution",
+    tracing::instrument(skip_all, name = "cold.phase.index_projection")
+)]
 pub(super) fn apply_index_by(
     index_by: &IndexByOp,
     input_descriptor: &RecordDescriptor,

--- a/crates/jazz-sim/Cargo.toml
+++ b/crates/jazz-sim/Cargo.toml
@@ -10,9 +10,10 @@ bench-alloc-sites = ["dep:backtrace"]
 profiling = ["dep:pprof"]
 transport-compression-lz4 = ["jazz/transport-compression-lz4"]
 transport-compression-zstd = ["jazz/transport-compression-zstd"]
-cold-settle-attribution = ["jazz/cold-settle-attribution"]
+cold-settle-attribution = ["jazz/cold-settle-attribution", "dep:tracing"]
 
 [dependencies]
+tracing = { version = "0.1", optional = true }
 automerge = "0.10.0"
 backtrace = { version = "0.3", optional = true }
 diamond-types = "1.0.0"

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -305,6 +305,9 @@ const RESOURCE_SPECS: [ResourceSpec; 14] = [
 ];
 
 fn main() {
+    #[cfg(feature = "cold-settle-attribution")]
+    let _phase_subscriber =
+        tracing::subscriber::set_default(jazz_sim::phase_attribution::Collector);
     jazz_benchmark_guard::refuse_contaminated_measurement();
     let config = Config::from_env();
     let schema = schema();
@@ -535,6 +538,7 @@ struct RunSummary {
 /// sender's required sizing work before it can decide whether to chunk.
 #[derive(Clone, Default)]
 struct AttributionSummary {
+    phase_timing: JsonValue,
     core_tick_ns: u64,
     relay_tick_ns: u64,
     client_tick_ns: u64,
@@ -752,6 +756,10 @@ struct CountedDuplex {
 }
 
 impl Transport for DuplexTransport {
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.benchmark_transport")
+    )]
     fn send(&mut self, message: SyncMessage) -> Result<(), TransportError> {
         self.metrics.messages.set(self.metrics.messages.get() + 1);
         if let SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
@@ -1415,6 +1423,7 @@ fn run_connect_and_subscribe(
     alloc_metrics::reset_and_start();
     #[cfg(feature = "cold-settle-attribution")]
     {
+        jazz_sim::phase_attribution::reset();
         jazz::cold_settle_attribution::reset();
         jazz::groove::cold_settle_attribution::reset();
     }
@@ -1488,6 +1497,11 @@ fn run_connect_and_subscribe(
         let core_operators_before = jazz::groove::cold_settle_attribution::snapshot();
         #[cfg(feature = "cold-settle-attribution")]
         let core_tick_start = Instant::now();
+        #[cfg(feature = "cold-settle-attribution")]
+        tracing::trace_span!("cold.phase.core")
+            .in_scope(|| block_on(seeded.core.tick()))
+            .unwrap();
+        #[cfg(not(feature = "cold-settle-attribution"))]
         block_on(seeded.core.tick()).unwrap();
         #[cfg(feature = "cold-settle-attribution")]
         {
@@ -1506,6 +1520,11 @@ fn run_connect_and_subscribe(
         let relay_operators_before = jazz::groove::cold_settle_attribution::snapshot();
         #[cfg(feature = "cold-settle-attribution")]
         let relay_tick_start = Instant::now();
+        #[cfg(feature = "cold-settle-attribution")]
+        tracing::trace_span!("cold.phase.relay")
+            .in_scope(|| block_on(relay.db.tick()))
+            .unwrap();
+        #[cfg(not(feature = "cold-settle-attribution"))]
         block_on(relay.db.tick()).unwrap();
         #[cfg(feature = "cold-settle-attribution")]
         {
@@ -1524,6 +1543,11 @@ fn run_connect_and_subscribe(
         let client_operators_before = jazz::groove::cold_settle_attribution::snapshot();
         #[cfg(feature = "cold-settle-attribution")]
         let client_tick_start = Instant::now();
+        #[cfg(feature = "cold-settle-attribution")]
+        tracing::trace_span!("cold.phase.client")
+            .in_scope(|| block_on(client.db.tick()))
+            .unwrap();
+        #[cfg(not(feature = "cold-settle-attribution"))]
         block_on(client.db.tick()).unwrap();
         #[cfg(feature = "cold-settle-attribution")]
         {
@@ -1550,6 +1574,10 @@ fn run_connect_and_subscribe(
         ticks += 1;
     }
     let settle_ms = settle_start.elapsed().as_millis();
+    #[cfg(feature = "cold-settle-attribution")]
+    {
+        attribution.phase_timing = jazz_sim::phase_attribution::snapshot();
+    }
     if label == "warm" {
         // Warm readiness is relay-local, but the benchmark also asserts that
         // the hot relay declares known state when it reconnects upstream. Drive
@@ -2406,6 +2434,10 @@ fn emit_summary(config: &Config, phase: &str, summary: &RunSummary) {
         ),
     );
     let attribution = &summary.attribution;
+    fields.insert(
+        "settle_phase_timing".to_owned(),
+        attribution.phase_timing.clone(),
+    );
     let operator_json = |operators: &OperatorAttribution| {
         json!({
             "map_project": {

--- a/crates/jazz-sim/src/lib.rs
+++ b/crates/jazz-sim/src/lib.rs
@@ -1424,3 +1424,6 @@ mod tests {
         );
     }
 }
+
+#[cfg(feature = "cold-settle-attribution")]
+pub mod phase_attribution;

--- a/crates/jazz-sim/src/phase_attribution.rs
+++ b/crates/jazz-sim/src/phase_attribution.rs
@@ -1,0 +1,220 @@
+//! Opt-in phase timing for the single-threaded native benchmark driver.
+//!
+//! Async `instrument` spans enter only during polling. Nested time is subtracted
+//! from parents, so exclusive phase times partition each outer node tick. Tick
+//! remainder includes uninstrumented work, executor waiting, and timer overhead.
+//! Snapshots are thread-local: this is not a cross-thread production profiler.
+
+use std::{cell::RefCell, time::Instant};
+use tracing::{
+    Event, Metadata, Subscriber,
+    span::{Attributes, Id, Record},
+};
+
+const PHASES: [&str; 17] = [
+    "core",
+    "relay",
+    "client",
+    "receive_updates",
+    "ingest",
+    "parent_completion",
+    "storage_apply",
+    "storage_persist",
+    "ivm_update",
+    "ivm_hydrate",
+    "collect_results",
+    "index_projection",
+    "publish_supporting_rows",
+    "query_setup",
+    "decode_query_outputs",
+    "deliver_query_outputs",
+    "benchmark_transport",
+];
+const ROLES: [&str; 4] = ["outside_node_ticks", "core", "relay", "client"];
+#[derive(Clone, Copy, Default)]
+struct Timing {
+    inclusive_ns: u64,
+    exclusive_ns: u64,
+    entries: u64,
+}
+struct Frame {
+    phase: usize,
+    role: usize,
+    start: u64,
+    children: u64,
+}
+struct State {
+    epoch: Instant,
+    stack: Vec<Frame>,
+    totals: [[Timing; PHASES.len()]; ROLES.len()],
+}
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            epoch: Instant::now(),
+            stack: Vec::new(),
+            totals: [[Timing::default(); PHASES.len()]; ROLES.len()],
+        }
+    }
+}
+impl State {
+    fn enter(&mut self, phase: usize, now: u64) {
+        let role = if phase < 3 {
+            phase + 1
+        } else {
+            self.stack.last().map_or(0, |f| f.role)
+        };
+        self.stack.push(Frame {
+            phase,
+            role,
+            start: now,
+            children: 0,
+        });
+    }
+    fn exit(&mut self, phase: usize, now: u64) {
+        let frame = self.stack.pop().expect("balanced phase spans");
+        assert_eq!(frame.phase, phase, "phase span exit must match enter");
+        let elapsed = now.saturating_sub(frame.start);
+        assert!(
+            frame.children <= elapsed,
+            "nested phases exceed their parent"
+        );
+        let timing = &mut self.totals[frame.role][phase];
+        timing.inclusive_ns += elapsed;
+        timing.exclusive_ns += elapsed.saturating_sub(frame.children);
+        timing.entries += 1;
+        if let Some(parent) = self.stack.last_mut() {
+            parent.children += elapsed;
+        }
+    }
+}
+thread_local! { static STATE: RefCell<State> = RefCell::new(State::default()); }
+fn phase(metadata: &Metadata<'_>) -> Option<usize> {
+    let name = metadata.name().strip_prefix("cold.phase.")?;
+    PHASES.iter().position(|candidate| *candidate == name)
+}
+/// Minimal subscriber: unrelated spans and events stay disabled.
+pub struct Collector;
+impl Subscriber for Collector {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        phase(metadata).is_some()
+    }
+    fn new_span(&self, attrs: &Attributes<'_>) -> Id {
+        Id::from_u64(phase(attrs.metadata()).expect("known phase") as u64 + 1)
+    }
+    fn record(&self, _: &Id, _: &Record<'_>) {}
+    fn record_follows_from(&self, _: &Id, _: &Id) {}
+    fn event(&self, _: &Event<'_>) {}
+    fn enter(&self, id: &Id) {
+        STATE.with(|s| {
+            let mut s = s.borrow_mut();
+            let now = s.epoch.elapsed().as_nanos() as u64;
+            s.enter(id.into_u64() as usize - 1, now);
+        });
+    }
+    fn exit(&self, id: &Id) {
+        STATE.with(|s| {
+            let mut s = s.borrow_mut();
+            let now = s.epoch.elapsed().as_nanos() as u64;
+            s.exit(id.into_u64() as usize - 1, now);
+        });
+    }
+}
+/// Reset outside any measured span, after seeding and before load setup.
+pub fn reset() {
+    STATE.with(|s| {
+        assert!(s.borrow().stack.is_empty());
+        *s.borrow_mut() = State::default();
+    });
+}
+/// Capture before diagnostic queries. Inclusive times overlap; exclusive times
+/// partition outer ticks. `entries` counts span entries (polls and scoped cleanup), not logical operations.
+pub fn snapshot() -> serde_json::Value {
+    STATE.with(|s| {
+        let s = s.borrow();
+        assert!(s.stack.is_empty());
+        let mut roles = serde_json::Map::new();
+        for (role, name) in ROLES.iter().enumerate() {
+            if role > 0 {
+                assert_eq!(s.totals[role].iter().map(|t| t.exclusive_ns).sum::<u64>(), s.totals[role][role - 1].inclusive_ns, "exclusive phases must partition node ticks");
+            }
+            let mut phases = serde_json::Map::new();
+            for (phase, name) in PHASES.iter().enumerate() {
+                let t = s.totals[role][phase];
+                if t.entries != 0 { phases.insert((*name).into(), serde_json::json!({"inclusive_ns": t.inclusive_ns, "exclusive_ns": t.exclusive_ns, "entries": t.entries})); }
+            }
+            roles.insert((*name).into(), phases.into());
+        }
+        serde_json::json!({"roles":roles, "scope":"setup_and_settle_only", "units":"nanoseconds", "exclusive_times_are_additive":true, "inclusive_times_overlap":true})
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Internal instrumentation invariants need deterministic clock values rather
+    // than flaky sleeps or application query assertions.
+    #[test]
+    fn nested_phases_partition_tick_and_do_not_leak_between_roles() {
+        let mut state = State::default();
+        state.enter(0, 0);
+        state.enter(4, 10);
+        state.enter(6, 20);
+        state.exit(6, 50);
+        state.exit(4, 70);
+        state.exit(0, 100);
+        state.enter(1, 110);
+        state.enter(4, 120);
+        state.exit(4, 140);
+        state.exit(1, 150);
+        assert_eq!(state.totals[1][0].inclusive_ns, 100);
+        assert_eq!(state.totals[1][0].exclusive_ns, 40);
+        assert_eq!(state.totals[1][4].exclusive_ns, 30);
+        assert_eq!(state.totals[1][6].exclusive_ns, 30);
+        assert_eq!(state.totals[2][4].exclusive_ns, 20);
+        assert_eq!(
+            state.totals[1].iter().map(|t| t.exclusive_ns).sum::<u64>(),
+            100
+        );
+    }
+    #[test]
+    fn pending_future_releases_phase_and_resume_uses_current_role() {
+        use std::{
+            future::Future,
+            task::{Context, Poll},
+        };
+        use tracing::Instrument;
+        let _subscriber = tracing::subscriber::set_default(Collector);
+        reset();
+        let mut first = true;
+        let future = std::future::poll_fn(move |_| {
+            if first {
+                first = false;
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
+        })
+        .instrument(tracing::trace_span!("cold.phase.ingest"));
+        let mut future = std::pin::pin!(future);
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(
+            tracing::trace_span!("cold.phase.core")
+                .in_scope(|| future.as_mut().poll(&mut cx))
+                .is_pending()
+        );
+        STATE.with(|s| assert!(s.borrow().stack.is_empty()));
+        assert!(
+            tracing::trace_span!("cold.phase.relay")
+                .in_scope(|| future.as_mut().poll(&mut cx))
+                .is_ready()
+        );
+        STATE.with(|s| {
+            let s = s.borrow();
+            assert!(s.stack.is_empty());
+            assert_eq!(s.totals[1][4].entries, 1);
+            assert_eq!(s.totals[2][4].entries, 1);
+        });
+    }
+}

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -5382,6 +5382,10 @@ fn apply_maintained_membership_update_to_snapshot(
 /// Applies only top-level structured-terminal edits to the producer-owned
 /// subscription snapshot. Descendant edits remain in the returned event for
 /// binding object reducers, which own nested object materialization.
+#[cfg_attr(
+    feature = "cold-settle-attribution",
+    tracing::instrument(skip_all, name = "cold.phase.deliver_query_outputs")
+)]
 fn apply_terminal_operations_to_subscription_snapshot(
     snapshot: &mut RelationSnapshot,
     snapshot_index: &mut RelationSnapshotIndex,

--- a/crates/jazz/src/lib.rs
+++ b/crates/jazz/src/lib.rs
@@ -442,8 +442,6 @@ pub mod account_registry;
 pub mod authorization_scope;
 /// Shared binary row payload contract for the NAPI and WASM bindings.
 pub mod binding_codec;
-/// Opaque immutable chunk staging and retrieval used by Groove large values.
-
 /// Disabled-by-default counters used by the native cold-settle attribution bench.
 #[cfg(feature = "cold-settle-attribution")]
 pub mod cold_settle_attribution;

--- a/crates/jazz/src/node/ingest/commit_bundles.rs
+++ b/crates/jazz/src/node/ingest/commit_bundles.rs
@@ -1109,6 +1109,7 @@ where
         .await
     }
 
+    #[cfg_attr(feature = "cold-settle-attribution", tracing::instrument(skip_all, name = "cold.phase.ingest"))]
     pub(super) async fn ingest_reset_view_bundle_refs_in_bulk(
         &mut self,
         bundles: &[VersionBundleRef<'_>],

--- a/crates/jazz/src/node/ingest/validation.rs
+++ b/crates/jazz/src/node/ingest/validation.rs
@@ -101,6 +101,7 @@ where
                 == coordinate.physical_table_id)
     }
 
+    #[cfg_attr(feature = "cold-settle-attribution", tracing::instrument(skip_all, name = "cold.phase.parent_completion"))]
     async fn complete_parent_versions(
         &mut self,
         tx: &Transaction,

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -485,6 +485,10 @@ impl MaintainedSubscriptionView {
         Ok(transitions)
     }
 
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.decode_query_outputs")
+    )]
     pub(crate) fn apply_multisink_deltas(
         &mut self,
         deltas: MultisinkDeltas,

--- a/crates/jazz/src/node/query_eval.rs
+++ b/crates/jazz/src/node/query_eval.rs
@@ -3709,6 +3709,10 @@ where
         )
     }
 
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.query_setup")
+    )]
     async fn open_seeded_maintained_subscription_view_in_authorization_mode(
         &mut self,
         shape: &ValidatedQuery,

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -887,6 +887,10 @@ where
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.publish_supporting_rows")
+    )]
     pub(crate) async fn view_update_for_maintained_result_members(
         &mut self,
         inputs: MaintainedViewBundleInputs<'_>,
@@ -1507,6 +1511,10 @@ where
         Ok(())
     }
 
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.receive_updates")
+    )]
     pub(crate) async fn apply_view_updates_in_batch(
         &mut self,
         mut updates: Vec<ViewUpdateParts>,

--- a/dev/benchmarks/native-cold-phase-attribution.md
+++ b/dev/benchmarks/native-cold-phase-attribution.md
@@ -1,0 +1,119 @@
+# Native cold-load phase attribution
+
+The opt-in `cold-settle-attribution` feature now produces `settle_phase_timing`
+alongside the existing operator cardinality and transport sizing counters.
+The final measured tree was `fb95c86bd20c0f1529aaba4e3270d97cd199d618`, clean.
+
+Same optimized 39-subscription member fixture: 27,518 expected output rows,
+preseeded Core, initially empty relay and client, RocksDB WalNoSync, semantic
+in-process transport. All expected rows were present. Seeding and final
+one-shot diagnostic queries are outside these phase measurements.
+
+Readiness was **30.037s**, including setup; settling was **29.550s**. The previous
+uninstrumented runs were 29.485s and 29.720s to readiness. These observations put
+instrumentation in the same timing range, but do not isolate its exact overhead.
+The preceding expanded attribution run was 29.894s to readiness.
+
+## Exclusive phase times
+
+These rows are additive. Nested phase time has been removed from its parent.
+
+| Phase                                                   |   Core |  Relay | Client |  Total |
+| ------------------------------------------------------- | -----: | -----: | -----: | -----: |
+| Query operators (including collection/index projection) | 2.522s | 2.710s | 1.444s | 6.676s |
+| Decode query outputs into maintained state              | 2.132s | 1.195s | 1.115s | 4.442s |
+| Build supporting-row updates                            | 2.044s | 1.428s | 0.000s | 3.472s |
+| Receive and ingest, including parent completion         | 0.000s | 3.437s | 2.050s | 5.487s |
+| Apply storage changes, excluding nested operators       | 0.000s | 2.051s | 1.193s | 3.244s |
+| Persist storage changes                                 | 0.000s | 1.206s | 0.695s | 1.901s |
+| Query setup, excluding nested execution/output decoding | 0.525s | 1.064s | 0.000s | 1.589s |
+| Deliver application query outputs                       | 0.000s | 0.000s | 0.419s | 0.419s |
+| Benchmark transport measurement                         | 0.408s | 0.242s | 0.003s | 0.654s |
+| Unclassified / executor wait / timing overhead          | 0.570s | 0.837s | 0.253s | 1.660s |
+
+Node totals: **Core 8.200s, relay 14.170s, client 7.173s**. Their sum differs
+from the outer settling clock by about 7ms of benchmark-loop work. Each node's
+exclusive phases sum exactly to its inclusive tick time; the collector asserts
+this identity when emitting the report. About 94.4% of tick time is assigned to
+named phases beyond the explicit remainder.
+
+`storage_persist` measures the persistence call, not all possible storage costs.
+Storage reads can occur under query execution or setup; synchronous I/O inside
+any instrumented call is included there. These timers do not prove that all
+storage work or all device waiting totals 1.9s.
+
+## What the boundaries mean
+
+- `query_setup`: opening the seeded maintained subscription, excluding its
+  nested query execution and output decoding.
+- `ivm_update` / `ivm_hydrate`: query graph maintenance/evaluation. Collection
+  and index-projection child spans have their own exclusive times, grouped with
+  query operators in the table.
+- `decode_query_outputs`: `apply_multisink_deltas`, turning typed query output
+  batches into the maintained subscription's application/source/witness state.
+- `publish_supporting_rows`: constructing the supporting-row update from
+  maintained result members for downstream delivery.
+- `receive_updates`: applying a received group of view updates, excluding the
+  separately timed bulk ingest and its children.
+- `ingest`: bulk supporting-version ingestion, excluding parent completion,
+  storage apply, persistence and any other nested measured phases.
+- `storage_apply`: resident storage/write preparation, delta processing and
+  related bookkeeping, excluding separately timed query operators.
+- `deliver_query_outputs`: applying terminal changes to the application
+  subscription snapshot.
+- `benchmark_transport`: the in-process transport's message accounting and
+  encoding/compression probes. It is harness work, not simulated network latency.
+
+Parent completion alone is approximately **0.353s** across relay and client.
+Its prominent allocation-stack rank did not imply a correspondingly dominant
+elapsed-time cost. Query-output decoding (~4.44s) and supporting-row publication
+(~3.47s) are larger representation boundaries worth examining closely.
+
+Projection counters recorded **520,896 Core**, **977,810 relay**, and **394,002
+client** input visits: **1,892,708** total. These are operator input visits,
+not unique rows or network transfers. They demonstrate repeated processing
+across operators/queries/nodes, without proving those visits are all avoidable.
+
+## Accounting and limitations
+
+A minimal subscriber accepts only named `cold.phase.*` spans. Async instrumented
+functions enter their spans while polling and during scoped cleanup. They release
+spans on Pending, so suspended work cannot capture another node's execution.
+Nested elapsed time is subtracted from parent exclusive time. Inclusive time is
+also emitted for containment analysis and must not be summed.
+
+The driver brackets each sequential node tick with a role span. The collector
+is thread-local and specifically intended for this native single-thread driver;
+it does not aggregate arbitrary production worker threads. Times are elapsed
+wall time within spans, not OS thread CPU clocks: preemption and synchronous
+blocking remain included. Root remainder includes executor waiting, unmeasured
+code and instrumentation overhead. Span `entries` count polling/cleanup entries,
+not logical operation calls.
+
+The phase snapshot is captured immediately at readiness, before final diagnostic
+queries. `outside_node_ticks` reports instrumented setup work separately; it is
+not a complete timer for all setup. Normal builds contain no phase annotations
+or collector unless the feature is enabled.
+
+## Validation and reproduction
+
+Two deterministic accounting tests pass: nested partition/role isolation and a
+Pending future resumed under another role. Mutating child-time subtraction and
+role attribution makes both tests fail; the mutations were restored and the
+tests passed again. The full fixture passed with exact row counts and runtime
+partition assertions. Feature-enabled and default-feature Clippy checks passed.
+No independent review or full canonical CI result is claimed.
+
+Build with:
+
+```sh
+cargo build -p jazz-sim --bench customer_cold_start --profile perf --features cold-settle-attribution
+```
+
+Run the resulting executable from the repository root with
+`JAZZ_CUSTOMER_IDENTITY=member JAZZ_CUSTOMER_PHASES=cold JAZZ_CUSTOMER_SCALE=1.0
+JAZZ_CUSTOMER_MAX_TICKS=200000`. Keep unrelated builds/tests out of the timed run.
+Read `settle_phase_timing.roles` for nested times and the existing
+`cold_settle_attribution.operator_cardinality` for operator input/output counts.
+Local raw evidence uses the `phase-attribution-final` prefix under
+`jazz-debug-evidence/permissioned-profile/`.


### PR DESCRIPTION
🤖 The native cold-load benchmark previously exposed whole-process CPU samples and allocation sites without a non-overlapping breakdown of the time spent in Core, relay, and client phases. Add opt-in nested timing under the existing `cold-settle-attribution` feature.

For example, a relay receiving a supporting snapshot can perform parent completion, apply storage changes, update query operators, persist writes, and publish another snapshot. The report measures each boundary and subtracts nested time from its parent. Exclusive times therefore partition the relay tick; inclusive times explain containment and must not be summed. Snapshot emission asserts the partition identity.

Async spans enter during polling and scoped cleanup. A suspended ingestion future does not remain the active phase while another node runs. Synchronous storage calls, OS preemption and work inside a poll remain elapsed time in that phase; this is not a hardware CPU-time counter. Root remainder includes uninstrumented work and executor waiting.

The benchmark captures this report at subscription readiness, before final diagnostic queries. Node roles come from its explicit sequential Core/relay/client ticks. The collector is thread-local and intended for this native driver, not a production multi-thread profiler. The benchmark transport's serialization/compression measurement has its own category.

Without the feature, annotations and the collector are disabled. No storage, wire, query or authorization behavior changes. The feature check also repairs an orphan doc comment and preserves Clippy's default immutable `bytes::Bytes` exemption alongside the existing author-cache exemption.

The full optimized 27,518-row fixture now attributes 29.55s of settling to Core 8.20s, relay 14.17s, and client 7.17s. Roughly 94.4% is classified beyond the explicit remainder. Query operators account for ~6.68s, query-output decoding ~4.44s, and supporting-row construction ~3.47s. Parent completion is only ~0.35s despite its allocation-stack prominence. All expected rows were present.

See the [phase table, definitions, and measurement limits](https://github.com/garden-co/jazz/blob/perf/cold-load-phase-attribution/dev/benchmarks/native-cold-phase-attribution.md). Projection counters record 1.89M input visits across the three nodes; these are repeated operator visits, not unique rows.

Validation: deterministic nested timing and pending/resumed future tests pass. Mutating child-time subtraction and role attribution makes the tests fail; restoration passes. The full fixture passes the runtime partition assertions. Feature-enabled and default-feature Clippy pass. Draft; independent review and full canonical CI are not claimed.
