### PR TITLE
perf: copy encoded witness cells and defer publication descriptors

### DIFF
--- a/crates/jazz-sim/src/phase_attribution.rs
+++ b/crates/jazz-sim/src/phase_attribution.rs
@@ -11,7 +11,7 @@ use tracing::{
     span::{Attributes, Id, Record},
 };
 
-const PHASES: [&str; 17] = [
+const PHASES: [&str; 20] = [
     "core",
     "relay",
     "client",
@@ -29,6 +29,9 @@ const PHASES: [&str; 17] = [
     "decode_query_outputs",
     "deliver_query_outputs",
     "benchmark_transport",
+    "decode_version_witness",
+    "rebind_terminal_output",
+    "canonical_supporting_version",
 ];
 const ROLES: [&str; 4] = ["outside_node_ticks", "core", "relay", "client"];
 #[derive(Clone, Copy, Default)]

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -11,8 +11,8 @@ use groove::records::{
 use super::codec::{
     VersionLayer, VersionRow, VersionRowParts, authored_column_ids_from_value,
     deletion_event_from_value, history_values_from_parts, nullable_value,
-    owned_record_from_storage_values_with_descriptor, register_values_from_parts,
-    runtime_result_identity_bytes, tx_ids_from_value, version_tx_id_from_aliases,
+    register_values_from_parts, runtime_result_identity_bytes, tx_ids_from_value,
+    version_tx_id_from_aliases,
 };
 use super::query_engine::{
     AggregateResultSchema, AppRowCarrier, AppRowSchema, OutputTerminalSchema, ProgramFactKey,
@@ -1547,6 +1547,10 @@ fn covered_input_for_version(
 /// present nullable cell. Nested edits address named collections and stable
 /// keys. An unrelated root field may tighten without changing those edits,
 /// but the addressed collection's complete subtree layout must agree exactly.
+#[cfg_attr(
+    feature = "cold-settle-attribution",
+    tracing::instrument(skip_all, name = "cold.phase.rebind_terminal_output")
+)]
 fn rebind_terminal_operation_to_layout(
     operation: &TerminalOperation,
     layout: &TerminalRootLayout,
@@ -2677,6 +2681,10 @@ fn validate_witness_event_kind(
     }
 }
 
+#[cfg_attr(
+    feature = "cold-settle-attribution",
+    tracing::instrument(skip_all, name = "cold.phase.decode_version_witness")
+)]
 fn decode_typed_version_witness(
     record: BorrowedRecord<'_>,
     schema: &VersionWitnessSchema,
@@ -2729,14 +2737,6 @@ fn decode_typed_version_witness(
         },
         None => BranchKey::default(),
     };
-    let mut cells = BTreeMap::new();
-    if layer == VersionLayer::Content {
-        for column in &table.columns {
-            if let Some(value) = nullable_value(record.get_idx(plan.user_indices[&column.name])?)? {
-                cells.insert(column.name.clone(), value);
-            }
-        }
-    }
     let authored_columns = if layer == VersionLayer::Content {
         nullable_value(record.get_idx(plan.authored_columns_idx)?)?
             .map(authored_column_ids_from_value)
@@ -2776,7 +2776,7 @@ fn decode_typed_version_witness(
                     "maintained witness updated_at_ms exceeds packed HLC range",
                 )
             })?,
-        cells,
+        cells: BTreeMap::new(),
         authored_columns,
         deletion,
     };
@@ -2785,10 +2785,59 @@ fn decode_typed_version_witness(
     } else {
         register_values_from_parts(&parts)?
     };
+    // Query witnesses already contain encoded nullable user cells. Copy those
+    // fields into the history layout instead of allocating a cells map, cloning
+    // its values, and encoding them again. Metadata still follows the existing
+    // normalization path (in particular author admission and packed timestamps).
+    let raw = plan.descriptor.create_with_encoded_fields::<super::Error>(
+        record.raw().len(),
+        |index, output| {
+            if layer == VersionLayer::Content && index >= 10 && index < 10 + table.columns.len() {
+                let source_index = plan.user_indices[&table.columns[index - 10].name];
+                if record.descriptor().fields()[source_index].value_type
+                    == plan.descriptor.fields()[index].value_type
+                {
+                    let span = record.descriptor().field_span(record.raw(), source_index)?;
+                    output.extend_from_slice(&record.raw()[span]);
+                    return Ok(());
+                }
+                let value = record.get_idx(source_index)?;
+                nullable_value(value.clone())?;
+                plan.descriptor.encode_field_into(index, &value, output)?;
+            } else {
+                plan.descriptor
+                    .encode_field_into(index, &values[index], output)?;
+            }
+            Ok(())
+        },
+    )?;
+    #[cfg(test)]
+    let mut parts = parts;
+    #[cfg(test)]
+    {
+        // Internal byte-equivalence oracle: public query equality would not
+        // detect a change to the immutable history record's exact encoding.
+        let reference_parts = &mut parts;
+        if layer == VersionLayer::Content {
+            for column in &table.columns {
+                if let Some(value) =
+                    nullable_value(record.get_idx(plan.user_indices[&column.name])?)?
+                {
+                    reference_parts.cells.insert(column.name.clone(), value);
+                }
+            }
+        }
+        let reference_values = if layer == VersionLayer::Content {
+            history_values_from_parts(table, reference_parts)?
+        } else {
+            register_values_from_parts(reference_parts)?
+        };
+        assert_eq!(raw, plan.descriptor.create(&reference_values)?);
+    }
     let version = VersionRow {
         table: groove::Intern::new(parts.table),
         branch_key: parts.branch_key,
-        record: owned_record_from_storage_values_with_descriptor(plan.descriptor, values)?,
+        record: OwnedRecord::new(raw, plan.descriptor),
     };
     version.validate_canonical()?;
     Ok(version)

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -2906,6 +2906,10 @@ where
     /// version under its authored schema. This producer-side normalization is
     /// deliberately before serialization; receivers reject non-identical
     /// duplicate row versions rather than repairing them.
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.canonical_supporting_version")
+    )]
     pub(super) async fn canonical_history_version_for_maintained_witness(
         &mut self,
         version: &VersionRow,
@@ -2952,8 +2956,8 @@ where
             .ok_or(Error::InvalidStoredValue(
                 "maintained witness schema version alias must exist",
             ))?;
-        let authored_table = match self.table_in_schema(version.table(), authored_schema) {
-            Ok(table) => table.clone(),
+        match self.table_in_schema(version.table(), authored_schema) {
+            Ok(_) => {}
             Err(Error::TableNotFound(_)) => {
                 // A current-query source may have been projected through a
                 // later schema, so its logical name need not exist under the
@@ -2983,12 +2987,6 @@ where
             }
             Err(error) => return Err(error),
         };
-        let authored_descriptor = if version.layer() == VersionLayer::Deletion {
-            authored_table.register_storage_table().record_schema()
-        } else {
-            authored_table.history_storage_table().record_schema()
-        };
-        let has_authored_layout = version.record.descriptor() == &authored_descriptor;
 
         // A maintained witness is decoded from the current-query graph. Its
         // descriptor can be identical to history storage while selected-out
@@ -3024,6 +3022,15 @@ where
         // their authored descriptor is complete. `authored_columns` lets us
         // distinguish such a row from a query projection whose selected-out
         // authored cells were replaced by typed nulls.
+        // Only synthetic rows need a reconstructed descriptor. Ordinary rows
+        // returned above already carry the immutable store's authored layout.
+        let authored_table = self.table_in_schema(version.table(), authored_schema)?;
+        let authored_descriptor = if version.layer() == VersionLayer::Deletion {
+            authored_table.register_storage_table().record_schema()
+        } else {
+            authored_table.history_storage_table().record_schema()
+        };
+        let has_authored_layout = version.record.descriptor() == &authored_descriptor;
         let has_complete_authored_payload = has_authored_layout
             && (version.layer() == VersionLayer::Deletion
                 || match self.authored_columns_for_version(version)? {

--- a/dev/benchmarks/query-output-boundaries.md
+++ b/dev/benchmarks/query-output-boundaries.md
@@ -1,0 +1,62 @@
+# Encoded query-witness cells and publication preparation
+
+First measured implementation: `6b4aaecd15634f733f49dea75e4d44be9064a878`, clean.
+Parent: #2801. This is a limited representation pass, not a protocol change.
+
+## Mechanism
+
+Witness user fields already have Groove encodings. Previously, each field became
+an owned Value in a column-name map, was cloned into a values vector, then encoded
+again. Matching nullable field types now copy their encoded spans directly into
+the output history record. Differing types use the existing decoded semantics.
+Metadata still uses the existing normalization path; further metadata/plan work
+is possible. Unit-test builds compare every reconstructed witness against the
+old value-based encoder, byte for byte.
+
+Publication previously cloned the authored table and constructed its complete
+history descriptor before attempting the exact stored-version lookup. Most rows
+return from that lookup. Descriptor construction now happens only in the
+synthetic-row fallback, which still verifies authored layout and completeness.
+The lookup itself remains essential: a projected witness can omit cells even
+when its descriptor matches storage.
+
+## Initial optimized measurement
+
+Same 39-subscription native member fixture, 27,518 output rows, preseeded Core,
+empty relay and client, RocksDB WalNoSync, in-process semantic transport. Seed and
+final diagnostic queries are excluded from settling. Both runs include the same
+three additional phase spans. Baseline was parent code plus only those spans
+(dirty instrumentation tree); the after run was the clean implementation above.
+No concurrent build or test ran during either measurement.
+
+| Measure                                         |  Before |   After |
+| ----------------------------------------------- | ------: | ------: |
+| Settling                                        | 30.649s | 28.700s |
+| Dominant subscription ready from scenario start | 31.145s | 29.269s |
+| Witness reconstruction                          |  1.923s |  1.191s |
+| Canonical supporting-version preparation/lookup |  1.600s |  0.615s |
+| Root-layout conversion                          |  0.679s |  0.694s |
+| Other output decoding/bookkeeping               |  2.563s |  2.506s |
+| Other supporting-update construction            |  2.269s |  2.287s |
+
+Phase rows use exclusive times summed across Core, relay and client. They are
+components of settling, not additional time. The targeted phases improve by
+about 1.72s together; total settling improves by 1.95s (6.4%). These are initial
+single-run comparisons, not confidence intervals. Earlier parent measurements
+were closer to 29.55s, so do not interpret the whole difference against an older
+run as a precise isolated effect. All expected rows and timing partitions pass.
+
+## Remaining work
+
+Output bookkeeping still costs about 2.5s, separate from witness decoding.
+The code also clones a root record just to read its UUID, and layout rebinding
+can reconstruct unchanged nested fields. These are follow-up candidates under
+#2789; the current pass does not claim to remove them. The 5s cold-load target
+remains far away.
+
+Validation so far: Jazz library 2,005 passed, 2 ignored; default scoped Clippy and
+formatting pass. All three incremental canaries and the two-seed maintained-vs-one-shot oracle
+(churn depths 10 and 1,000) pass. Flipping one output byte makes the internal
+byte oracle fail in `maintained_local_index_snapshot_is_complete`; restoring
+the exact source makes that test pass. Full canonical CI, browser acceptance, and independent
+review are not claimed.


### PR DESCRIPTION
🤖 Query-output witnesses already contain encoded user cells, but decoding them previously allocated a map of owned values, cloned those values into a second record representation, and encoded them again. Copy fields whose types agree directly into the history record. Metadata keeps its existing normalization, and differing field types retain a decoded fallback.

For example, a nullable text field or a nested record now keeps its encoded bytes while moving from the query witness layout into the history layout. A missing projected cell remains absent; this does not promote a partial query witness into a complete authored version.

Supporting-row publication still resolves the exact stored authored version before sending it. Previously it cloned the table schema and constructed a history descriptor before that lookup. Those operations now happen only if the stored version is absent and the synthesized-row fallback needs to verify completeness. Branch, physical table, schema identity, and authored-column checks remain in place.

No storage or wire format changes. An internal test oracle compares the optimized witness bytes with the previous value-based encoder. The full Jazz library suite passes: 2,005 passed, 2 ignored. All three incremental canaries and the two-seed maintained-vs-one-shot oracle (churn depths 10 and 1,000) pass. Draft, not yet independently reviewed or ready to merge.

Opt-in phase instrumentation further separates witness decoding, root-layout conversion, and canonical supporting-version preparation. A baseline on the full 27,518-row native fixture measured these at approximately 1.92s, 0.68s, and 1.60s respectively. These are nested components of the previous output/publication measurements, not additional time.

Continues #2789, on top of #2801.

Initial optimized comparison with identical phase instrumentation: settling 30.649s → 28.700s, witness reconstruction 1.923s → 1.191s, canonical supporting-version preparation/lookup 1.600s → 0.615s. Both runs produced all 27,518 expected rows. These are single-run observations; the targeted phases explain about 1.72s of the 1.95s total improvement. The 5s target remains far away. See [measurement details](https://github.com/garden-co/jazz/blob/perf/query-output-boundaries/dev/benchmarks/query-output-boundaries.md).

Sensitivity: flipping one reconstructed byte makes the byte-equivalence oracle fail in the maintained local index snapshot test. The exact mutation was restored and the test passes again.
