### PR TITLE
perf: remove discarded primary-key descriptor preparation

### DIFF
--- a/crates/groove/src/db/commit.rs
+++ b/crates/groove/src/db/commit.rs
@@ -176,13 +176,7 @@ impl Database {
         let stores = pending_writes
             .iter()
             .zip(&descriptors)
-            .map(|(write, descriptor)| {
-                let key_descriptor = self
-                    .table(write.table())
-                    .ok()
-                    .and_then(|table| table.primary_key.as_ref().map(primary_key_descriptor));
-                record_store_for_table(&overlay, write.table(), key_descriptor, descriptor)
-            })
+            .map(|(write, descriptor)| RecordStore::new(&overlay, write.table(), descriptor))
             .collect::<Vec<_>>();
         let table_deltas =
             compute_table_deltas(&pending_writes, &stores, self.ivm_runtime.schema()).await?;

--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -31,7 +31,7 @@ use crate::records::{
     encode_variant_record, split_variant_record,
 };
 use crate::schema::{
-    ColumnType, DatabaseSchema, DirectRecordStoreSchema, IndexSchema, IntegerKeyType, PrimaryKey,
+    ColumnType, DatabaseSchema, DirectRecordStoreSchema, IndexSchema, IntegerKeyType,
     PrimaryKeyColumn, PrimaryKeyType, TableSchema, TableVariant,
 };
 use crate::storage::{

--- a/crates/groove/src/db/primary_storage.rs
+++ b/crates/groove/src/db/primary_storage.rs
@@ -292,8 +292,7 @@ impl Database {
         if !staged_contains_key {
             let resident = self.resident_storage();
             let storage = MeteredStorage::new(&resident, &self.storage_read_metrics);
-            let key_descriptor = primary_key_descriptor(primary_key);
-            let store = record_store_for_table(&storage, table, Some(key_descriptor), &descriptor);
+            let store = RecordStore::new(&storage, table, &descriptor);
             return store
                 .get_raw(&encoded_key)
                 .await?
@@ -304,8 +303,7 @@ impl Database {
         let resident = self.resident_storage();
         let overlay = StagedWriteOverlay::new(&resident, &batch.txn_operations);
         let storage = MeteredStorage::new(&overlay, &self.storage_read_metrics);
-        let key_descriptor = primary_key_descriptor(primary_key);
-        let store = record_store_for_table(&storage, table, Some(key_descriptor), &descriptor);
+        let store = RecordStore::new(&storage, table, &descriptor);
         store
             .get_raw(&encoded_key)
             .await?
@@ -340,8 +338,7 @@ impl Database {
             ensure_primary_key_value_type(table_schema, column, value)?;
             encode_primary_key_part(&mut encoded_key, value)?;
         }
-        let key_descriptor = primary_key_descriptor(primary_key);
-        let store = record_store_for_table(storage, table, Some(key_descriptor), &descriptor);
+        let store = RecordStore::new(storage, table, &descriptor);
         store
             .get_raw(&encoded_key)
             .await?
@@ -376,8 +373,7 @@ impl Database {
             ensure_primary_key_value_type(table_schema, column, value)?;
             encode_primary_key_part(&mut key_prefix, value)?;
         }
-        let key_descriptor = primary_key_descriptor(primary_key);
-        let store = record_store_for_table(storage, table, Some(key_descriptor), &descriptor);
+        let store = RecordStore::new(storage, table, &descriptor);
         store
             .prefix(&key_prefix)
             .await?
@@ -413,8 +409,7 @@ impl Database {
             ensure_primary_key_value_type(table_schema, column, value)?;
             encode_primary_key_part(&mut key_prefix, value)?;
         }
-        let key_descriptor = primary_key_descriptor(primary_key);
-        let store = record_store_for_table(storage, table, Some(key_descriptor), &descriptor);
+        let store = RecordStore::new(storage, table, &descriptor);
         store
             .last_with_prefix(&key_prefix)
             .await?
@@ -464,8 +459,7 @@ impl Database {
         }
         let resident = self.resident_storage();
         let storage = MeteredStorage::new(&resident, &self.storage_read_metrics);
-        let key_descriptor = primary_key_descriptor(primary_key);
-        let store = record_store_for_table(&storage, table, Some(key_descriptor), &descriptor);
+        let store = RecordStore::new(&storage, table, &descriptor);
         store
             .range(&start_key, &end_key)
             .await?
@@ -555,8 +549,7 @@ impl Database {
         }
         let resident = self.resident_storage();
         let storage = MeteredStorage::new(&resident, &self.storage_read_metrics);
-        let key_descriptor = primary_key_descriptor(primary_key);
-        let store = record_store_for_table(&storage, table, Some(key_descriptor), &descriptor);
+        let store = RecordStore::new(&storage, table, &descriptor);
         store
             .last_with_prefix_before_or_at(&key_prefix, &upper_key)
             .await?
@@ -736,11 +729,7 @@ impl Database {
     {
         let table_schema = self.table(table)?;
         let storage_descriptor = self.table_storage_descriptor(table)?;
-        let key_descriptor = table_schema
-            .primary_key
-            .as_ref()
-            .map(primary_key_descriptor);
-        let store = record_store_for_table(storage, table, key_descriptor, &storage_descriptor);
+        let store = RecordStore::new(storage, table, &storage_descriptor);
         let index_descriptor = index_record_descriptor();
         let mut records = Vec::new();
         for (storage_key, persisted_record) in raw_entries {

--- a/crates/groove/src/db/storage_helpers.rs
+++ b/crates/groove/src/db/storage_helpers.rs
@@ -1004,25 +1004,3 @@ where
         })
         .collect())
 }
-
-pub(super) fn record_store_for_table<'a, S>(
-    storage: &'a S,
-    table: &'a str,
-    key_descriptor: Option<RecordDescriptor>,
-    descriptor: &'a RecordDescriptor,
-) -> RecordStore<'a, S>
-where
-    S: OrderedKvStorage,
-{
-    let _ = key_descriptor;
-    RecordStore::new(storage, table, descriptor)
-}
-
-pub(super) fn primary_key_descriptor(primary_key: &PrimaryKey) -> RecordDescriptor {
-    RecordDescriptor::new(
-        primary_key
-            .columns
-            .iter()
-            .map(|column| (column.column.clone(), column.key_type.column_type().clone())),
-    )
-}

--- a/dev/benchmarks/unused-key-descriptors.md
+++ b/dev/benchmarks/unused-key-descriptors.md
@@ -1,0 +1,40 @@
+# Removing discarded key-descriptor preparation
+
+Implementation: `9795973039`, on top of #2802. Groove's old
+`record_store_for_table` helper discarded its key-descriptor argument. Reads and
+every pending physical write nevertheless constructed one. Direct RecordStore
+construction removes that work and 39 net lines, with no cache or format change.
+
+Initial optimized measurements (same native fixtures and options as the prior
+reports; no concurrent builds/tests during timing):
+
+| Measure                                                   |    #2802 | This pass |
+| --------------------------------------------------------- | -------: | --------: |
+| Permissioned fixture settle, 27,518 outputs               |  28.700s |   28.181s |
+| Todo initial publication + ingest + query, RocksDB worker | 231.65ms |  218.15ms |
+| Todo author + persist, 1,350 updates                      |  58.66ms |   50.61ms |
+| Todo full measured update roundtrip                       | 425.03ms |  411.87ms |
+| Todo fresh post-update foreground ingest                  |  80.25ms |   74.41ms |
+
+The large-fixture gain is only about 2%; the todo roundtrip gain about 3%.
+These are single-run observations. Retain this change because it deletes
+obsolete work and code rather than adding complexity. It is not a major step
+toward the 5s permissioned cold-load target.
+
+The todo fixture runs 1,500 rows and updates 90% in one transaction. Roundtrip
+sums the measured author, persist, upload build/codec, worker ingest, updated
+publication, returned codec/ingest, and foreground-query phases. It excludes
+application staging, JS, browser IndexedDB, external authentication and network
+latency. Exact row-ID and completed-row sets are asserted. Compared with the
+older #2787 receipt, fresh post-update foreground ingestion has fallen from
+about 886ms to 74ms; that comparison includes all intervening improvements.
+
+Validation: Groove library 743 passed, 2 ignored; scoped Clippy passes. Three
+incremental canaries and a two-seed maintained-vs-one-shot oracle pass. No new
+behavioral tests were needed for removal of a discarded argument. Full canonical
+CI, browser acceptance and independent review remain outstanding.
+
+Next investigation under #2789: physical history/current writes still reconstruct
+whole records and repeatedly prepare enum remapping despite the existing
+per-schema write plan. Keep authored enum identities and catalogue invalidation
+semantics while moving preparation out of per-row work.


### PR DESCRIPTION
🤖 Groove built primary-key record descriptors for each pending write and for primary-key/index reads, then passed them to `record_store_for_table`, which immediately discarded the argument. Remove the obsolete helper and descriptor construction; construct the same RecordStore directly.

For example, a batch of 1,500 rows previously rebuilt a key descriptor once per pending physical write, despite the store receiving already encoded keys. Reads likewise paid this preparation after their keys had already been encoded and validated. The key values, key encoding, value descriptor, storage operations, validation, and IVM deltas are unchanged.

This is a net code deletion, not a new cache. No storage, wire, authorization, or query semantics change.

Validation: Groove library 743 passed, 2 ignored. All three incremental canaries and the two-seed maintained-vs-one-shot oracle pass. Initial optimized settling is 28.700s → 28.181s; the 1,500-todo native roundtrip is 425ms → 412ms. These are small, single-run gains; the change is worth retaining as a code deletion. Draft, not independently reviewed or ready to merge.

Continues the representation/allocation work in #2789, on top of #2802.

[Measurement details and todo progress](https://github.com/garden-co/jazz/blob/perf/remove-unused-key-descriptors/dev/benchmarks/unused-key-descriptors.md).
