### PR TITLE
perf: prepare physical row encoders and reuse encoded fields

### DIFF
--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -1908,6 +1908,24 @@ impl VariantRecord {
 }
 
 impl ValidatedVariantRecord {
+    /// Assemble a variant with a trusted field encoder. As with
+    /// [`RecordDescriptor::create_with_encoded_fields`], the callback must emit
+    /// exactly the target field encoding. The descriptor owns offset assembly;
+    /// commit need not decode the newly produced bytes to validate them again.
+    /// This is an encoder API, not admission of arbitrary network bytes.
+    pub fn create_with_encoded_fields<E: From<Error>>(
+        variant_tag: u32,
+        descriptor: RecordDescriptor,
+        capacity: usize,
+        append: impl FnMut(usize, &mut Vec<u8>) -> Result<(), E>,
+    ) -> Result<Self, E> {
+        let raw = descriptor.create_with_encoded_fields(capacity, append)?;
+        Ok(Self(VariantRecord::new(
+            variant_tag,
+            OwnedRecord::new(raw, descriptor),
+        )))
+    }
+
     pub fn create(
         variant_tag: u32,
         descriptor: RecordDescriptor,

--- a/crates/jazz/src/node/codec.rs
+++ b/crates/jazz/src/node/codec.rs
@@ -4385,6 +4385,7 @@ fn stored_version_prefix_values(version: &VersionRow) -> Result<Vec<Value>, Erro
     ])
 }
 
+#[cfg(test)]
 pub(super) fn global_current_values(
     table: &TableSchema,
     version: &VersionRow,

--- a/crates/jazz/src/node/ingest/view_updates.rs
+++ b/crates/jazz/src/node/ingest/view_updates.rs
@@ -1283,30 +1283,14 @@ where
                     version.table(),
                     PhysicalWriteTarget::GlobalCurrent,
                 )?;
-                let mut values = self.public_current_values(
-                    &plan.source_table,
-                    version,
-                    Some(global_time),
-                )?;
-                self.remap_authored_enum_cells_for_physical(
-                    &mut values,
-                    &plan.source_table,
-                    &plan.source_mapping,
-                    &plan.physical_table,
-                    GlobalCurrentRowRecord::USER_CELLS,
-                )?;
-                let physical = OwnedRecord::new(
-                    plan.physical_descriptor.create(&values)?,
-                    plan.physical_descriptor,
-                );
+                // Validate node-local authored column aliases before deriving
+                // the current carrier; encoding itself retains trusted bytes.
+                let _ = self.authored_columns_for_version(version)?;
+                let physical = self.encode_physical_version_record(&plan, version, Some(global_time))?;
                 batch.update_raw(
                     plan.storage_table.clone(),
                     global_current_primary_key(version.branch_key(), version.row_uuid()),
-                    groove::records::VariantRecord::new(
-                        u32::try_from(version.schema_version_alias().0)
-                            .expect("schema aliases are allocated in Groove's variant-tag space"),
-                        physical,
-                    ),
+                    physical,
                 );
             }
             VersionLayer::Deletion => batch.update_raw(
@@ -1370,27 +1354,12 @@ where
                     version.table(),
                     PhysicalWriteTarget::AheadCurrent,
                 )?;
-                let mut values =
-                    self.public_current_values(&plan.source_table, version, None)?;
-                self.remap_authored_enum_cells_for_physical(
-                    &mut values,
-                    &plan.source_table,
-                    &plan.source_mapping,
-                    &plan.physical_table,
-                    GlobalCurrentRowRecord::USER_CELLS,
-                )?;
-                let physical = OwnedRecord::new(
-                    plan.physical_descriptor.create(&values)?,
-                    plan.physical_descriptor,
-                );
+                let _ = self.authored_columns_for_version(version)?;
+                let physical = self.encode_physical_version_record(&plan, version, None)?;
                 batch.insert_raw(
                     plan.storage_table.clone(),
                     history_primary_key(version),
-                    groove::records::VariantRecord::new(
-                        u32::try_from(version.schema_version_alias().0)
-                            .expect("schema aliases are allocated in Groove's variant-tag space"),
-                        physical,
-                    ),
+                    physical,
                 );
             }
             VersionLayer::Deletion => batch.insert_raw(
@@ -1421,6 +1390,7 @@ where
     }
 
     /// Build the physical current-source carrier consumed by Groove terminals.
+    #[cfg(test)]
     fn public_current_values(
         &mut self,
         table: &TableSchema,

--- a/crates/jazz/src/node/physical.rs
+++ b/crates/jazz/src/node/physical.rs
@@ -20,10 +20,25 @@ pub(super) enum PhysicalWriteTarget {
 pub(super) struct PreparedPhysicalWritePlan {
     pub(super) storage_table: String,
     pub(super) source_table: Arc<TableSchema>,
+    #[cfg(test)]
     pub(super) source_mapping: Arc<TablePhysicalMapping>,
+    #[cfg(test)]
     pub(super) physical_table: Arc<GrooveTableSchema>,
     pub(super) logical_descriptor: records::RecordDescriptor,
     pub(super) physical_descriptor: records::RecordDescriptor,
+    history_descriptor: records::RecordDescriptor,
+    write_fields: Vec<PhysicalWriteField>,
+    enum_remaps: Vec<EnumOccurrenceRemaps>,
+}
+
+#[derive(Debug)]
+enum PhysicalWriteField {
+    Copy(usize),
+    Decode(usize),
+    Enum { source: usize, column: usize },
+    CreatedAtMillis,
+    UpdatedAtMillis,
+    GlobalTime,
 }
 
 include!("physical/catalogue.rs");

--- a/crates/jazz/src/node/physical/storage.rs
+++ b/crates/jazz/src/node/physical/storage.rs
@@ -336,18 +336,66 @@ where
                 physical_current_field_names(&source_table, &source_mapping)?
             }
         };
-        let physical_descriptor = physical_write_descriptor(
-            &logical_descriptor,
-            &physical_names,
-            &physical_table,
-        )?;
+        let physical_descriptor =
+            physical_write_descriptor(&logical_descriptor, &physical_names, &physical_table)?;
+        let history_descriptor = source_table.history_storage_table().record_schema();
+        let enum_remaps =
+            self.prepare_authored_enum_cells_for_physical(&source_table, &source_mapping)?;
+        let current = target != PhysicalWriteTarget::History;
+        let user_cells = if current {
+            GlobalCurrentRowRecord::USER_CELLS
+        } else {
+            HistoryRowRecord::USER_CELLS
+        };
+        let write_fields = physical_descriptor
+            .fields()
+            .iter()
+            .enumerate()
+            .map(|(index, field)| {
+                if current {
+                    match index {
+                        GlobalCurrentRowRecord::FIELD_CREATED_AT_IDX => {
+                            return PhysicalWriteField::CreatedAtMillis;
+                        }
+                        GlobalCurrentRowRecord::FIELD_UPDATED_AT_IDX => {
+                            return PhysicalWriteField::UpdatedAtMillis;
+                        }
+                        GlobalCurrentRowRecord::FIELD_GLOBAL_TIME_IDX => {
+                            return PhysicalWriteField::GlobalTime;
+                        }
+                        _ => {}
+                    }
+                }
+                let source = if current && index > GlobalCurrentRowRecord::FIELD_GLOBAL_TIME_IDX {
+                    index - 1
+                } else {
+                    index
+                };
+                if let Some(column) = index.checked_sub(user_cells)
+                    && let Some(remaps) = enum_remaps.get(column)
+                    && (!remaps.scalar.is_empty() || !remaps.payload.is_empty())
+                {
+                    return PhysicalWriteField::Enum { source, column };
+                }
+                if history_descriptor.fields()[source].value_type == field.value_type {
+                    PhysicalWriteField::Copy(source)
+                } else {
+                    PhysicalWriteField::Decode(source)
+                }
+            })
+            .collect();
         let plan = Arc::new(PreparedPhysicalWritePlan {
             storage_table,
             source_table,
+            #[cfg(test)]
             source_mapping,
+            #[cfg(test)]
             physical_table,
             logical_descriptor,
             physical_descriptor,
+            history_descriptor,
+            write_fields,
+            enum_remaps,
         });
         self.catalogue
             .physical_write_plan_cache
@@ -393,11 +441,144 @@ where
         Ok(history_primary_key(version))
     }
 
-    /// Re-encode every enum occurrence in a logical storage record before it
-    /// crosses into a physical table.  History, settled-current and
-    /// ahead-current writes share this boundary; allowing one of those paths
-    /// to raw-copy an authored tag would make the durable table internally
-    /// inconsistent after concurrent schema introductions.
+    /// Prepare authored-to-physical enum identities once per catalogue write
+    /// plan. Local ordinals cannot be copied across concurrently introduced
+    /// cases; the same prepared remaps serve history and current encoders.
+    fn prepare_authored_enum_cells_for_physical(
+        &self,
+        source_table: &TableSchema,
+        source_mapping: &TablePhysicalMapping,
+    ) -> Result<Vec<EnumOccurrenceRemaps>, Error> {
+        let mut plans = Vec::with_capacity(source_table.columns.len());
+        for column in &source_table.columns {
+            let column_id = source_mapping.columns.get(&column.name).copied().ok_or(
+                Error::InvalidStoredValue("physical enum write column mapping missing"),
+            )?;
+            let mut remaps = EnumOccurrenceRemaps::default();
+            if let Some(authored_cases) = source_mapping.scalar_enum_cases.get(&column_id) {
+                let physical_cases =
+                    self.physical_scalar_enum_cases(source_mapping.table_id, column_id)?;
+                remaps.scalar.insert(
+                    "root".to_owned(),
+                    authored_cases
+                        .iter()
+                        .map(|identity| {
+                            physical_cases
+                                .iter()
+                                .position(|candidate| candidate == identity)
+                                .map(|tag| {
+                                    u8::try_from(tag).map_err(|_| {
+                                        Error::InvalidStoredValue(
+                                            "physical scalar enum tag exhausted",
+                                        )
+                                    })
+                                })
+                                .transpose()
+                        })
+                        .collect::<Result<_, _>>()?,
+                );
+            }
+            if let Some(authored_cases) = source_mapping.payload_enum_cases.get(&column_id) {
+                let physical_cases =
+                    self.physical_payload_enum_cases(source_mapping.table_id, column_id)?;
+                remaps.payload.insert(
+                    "root".to_owned(),
+                    authored_cases
+                        .iter()
+                        .map(|identity| {
+                            physical_cases
+                                .iter()
+                                .position(|candidate| candidate == identity)
+                                .map(|tag| {
+                                    u32::try_from(tag).map_err(|_| {
+                                        Error::InvalidStoredValue(
+                                            "physical payload enum tag exhausted",
+                                        )
+                                    })
+                                })
+                                .transpose()
+                        })
+                        .collect::<Result<_, _>>()?,
+                );
+                remaps.payload_children.insert(
+                    "root".to_owned(),
+                    authored_cases
+                        .iter()
+                        .map(|identity| Some(global_case_path("root", identity)))
+                        .collect(),
+                );
+            }
+            if let Some(authored_paths) = source_mapping.nested_scalar_enum_cases.get(&column_id) {
+                for (path, authored_cases) in authored_paths {
+                    let physical_cases = self.physical_nested_scalar_enum_cases(
+                        source_mapping.table_id,
+                        column_id,
+                        path,
+                    )?;
+                    remaps.scalar.insert(
+                        path.clone(),
+                        authored_cases
+                            .iter()
+                            .map(|identity| {
+                                physical_cases
+                                    .iter()
+                                    .position(|candidate| candidate == identity)
+                                    .map(|tag| {
+                                        u8::try_from(tag).map_err(|_| {
+                                            Error::InvalidStoredValue(
+                                                "physical nested scalar enum tag exhausted",
+                                            )
+                                        })
+                                    })
+                                    .transpose()
+                            })
+                            .collect::<Result<_, _>>()?,
+                    );
+                }
+            }
+            if let Some(authored_paths) = source_mapping.nested_payload_enum_cases.get(&column_id) {
+                for (path, authored_cases) in authored_paths {
+                    let physical_cases = self.physical_nested_payload_enum_cases(
+                        source_mapping.table_id,
+                        column_id,
+                        path,
+                    )?;
+                    remaps.payload.insert(
+                        path.clone(),
+                        authored_cases
+                            .iter()
+                            .map(|identity| {
+                                physical_cases
+                                    .iter()
+                                    .position(|candidate| candidate == identity)
+                                    .map(|tag| {
+                                        u32::try_from(tag).map_err(|_| {
+                                            Error::InvalidStoredValue(
+                                                "physical nested payload enum tag exhausted",
+                                            )
+                                        })
+                                    })
+                                    .transpose()
+                            })
+                            .collect::<Result<_, _>>()?,
+                    );
+                    remaps.payload_children.insert(
+                        path.clone(),
+                        authored_cases
+                            .iter()
+                            .map(|identity| Some(global_case_path(path, identity)))
+                            .collect(),
+                    );
+                }
+            }
+            plans.push(remaps);
+        }
+        Ok(plans)
+    }
+
+    // Retain the previous per-row remapper as the independent byte oracle.
+    // Storage/query equality alone cannot pin the physical enum representation.
+    #[cfg(test)]
     pub(super) fn remap_authored_enum_cells_for_physical(
         &self,
         values: &mut [Value],
@@ -584,170 +765,98 @@ where
             version.table(),
             PhysicalWriteTarget::History,
         )?;
-        // The authored row carries declaration-local enum ordinals.  Rewrite
-        // those cells through their durable global UUID identities before
-        // giving the record to the physical table; raw-copying would alias two
-        // concurrent siblings which both authored ordinal 2.
-        let mut values = version.record.to_values()?;
-        for (column_index, column) in plan.source_table.columns.iter().enumerate() {
-            let column_id = plan.source_mapping.columns.get(&column.name).copied().ok_or(
-                Error::InvalidStoredValue("physical scalar enum write column mapping missing"),
-            )?;
-            let value_index = HistoryRowRecord::USER_CELLS + column_index;
-            let value = values
-                .get_mut(value_index)
-                .ok_or(Error::InvalidStoredValue(
-                    "history scalar enum write field missing",
-                ))?;
-            let mut remaps = EnumOccurrenceRemaps::default();
-            if let Some(authored_cases) = plan.source_mapping.scalar_enum_cases.get(&column_id) {
-                let physical_cases =
-                    self.physical_scalar_enum_cases(plan.source_mapping.table_id, column_id)?;
-                remaps.scalar.insert(
-                    "root".to_owned(),
-                    authored_cases
-                        .iter()
-                        .map(|identity| {
-                            physical_cases
-                                .iter()
-                                .position(|candidate| candidate == identity)
-                                .map(|tag| {
-                                    u8::try_from(tag).map_err(|_| {
-                                        Error::InvalidStoredValue(
-                                            "physical scalar enum tag exhausted",
-                                        )
-                                    })
-                                })
-                                .transpose()
-                        })
-                        .collect::<Result<_, _>>()?,
-                );
-            }
-            if let Some(authored_cases) = plan.source_mapping.payload_enum_cases.get(&column_id) {
-                let physical_cases =
-                    self.physical_payload_enum_cases(plan.source_mapping.table_id, column_id)?;
-                remaps.payload.insert(
-                    "root".to_owned(),
-                    authored_cases
-                        .iter()
-                        .map(|identity| {
-                            physical_cases
-                                .iter()
-                                .position(|candidate| candidate == identity)
-                                .map(|tag| {
-                                    u32::try_from(tag).map_err(|_| {
-                                        Error::InvalidStoredValue(
-                                            "physical payload enum tag exhausted",
-                                        )
-                                    })
-                                })
-                                .transpose()
-                        })
-                        .collect::<Result<_, _>>()?,
-                );
-                remaps.payload_children.insert(
-                    "root".to_owned(),
-                    authored_cases
-                        .iter()
-                        .map(|identity| Some(global_case_path("root", identity)))
-                        .collect(),
-                );
-            }
-            if let Some(authored_paths) = plan.source_mapping.nested_scalar_enum_cases.get(&column_id) {
-                for (path, authored_cases) in authored_paths {
-                    let physical_cases = self.physical_nested_scalar_enum_cases(
-                        plan.source_mapping.table_id,
-                        column_id,
-                        path,
-                    )?;
-                    remaps.scalar.insert(
-                        path.clone(),
-                        authored_cases
-                            .iter()
-                            .map(|identity| {
-                                physical_cases
-                                    .iter()
-                                    .position(|candidate| candidate == identity)
-                                    .map(|tag| {
-                                        u8::try_from(tag).map_err(|_| {
-                                            Error::InvalidStoredValue(
-                                                "physical nested scalar enum tag exhausted",
-                                            )
-                                        })
-                                    })
-                                    .transpose()
-                            })
-                            .collect::<Result<_, _>>()?,
-                    );
-                }
-            }
-            if let Some(authored_paths) = plan.source_mapping.nested_payload_enum_cases.get(&column_id) {
-                for (path, authored_cases) in authored_paths {
-                    let physical_cases = self.physical_nested_payload_enum_cases(
-                        plan.source_mapping.table_id,
-                        column_id,
-                        path,
-                    )?;
-                    remaps.payload.insert(
-                        path.clone(),
-                        authored_cases
-                            .iter()
-                            .map(|identity| {
-                                physical_cases
-                                    .iter()
-                                    .position(|candidate| candidate == identity)
-                                    .map(|tag| {
-                                        u32::try_from(tag).map_err(|_| {
-                                            Error::InvalidStoredValue(
-                                                "physical nested payload enum tag exhausted",
-                                            )
-                                        })
-                                    })
-                                    .transpose()
-                            })
-                            .collect::<Result<_, _>>()?,
-                    );
-                    remaps.payload_children.insert(
-                        path.clone(),
-                        authored_cases
-                            .iter()
-                            .map(|identity| Some(global_case_path(path, identity)))
-                            .collect(),
-                    );
-                }
-            }
-            if remaps.scalar.is_empty() && remaps.payload.is_empty() {
-                continue;
-            }
-            let physical_type = plan.physical_table
-                .columns
-                .iter()
-                .find(|physical| physical.name == physical_user_column_field(column_id))
-                .map(|physical| &physical.column_type)
-                .ok_or(Error::InvalidStoredValue(
-                    "physical enum write column missing",
-                ))?;
-            let (Value::Nullable(Some(inner)), records::ValueType::Nullable(physical)) =
-                (value.clone(), physical_type)
-            else {
-                continue;
-            };
-            *value = Value::Nullable(Some(Box::new(remap_nested_enum_value(
-                *inner,
-                &column.column_type,
-                physical,
-                &remaps,
-                "root",
-            )?)));
-        }
         Ok((
             groove::Intern::new(plan.storage_table.clone()),
-            groove::records::ValidatedVariantRecord::create(
-                groove_variant_tag(version.schema_version_alias())?,
-                plan.physical_descriptor,
-                &values,
-            )?,
+            self.encode_physical_version_record(&plan, version, None)?,
         ))
+    }
+
+    /// Reuse encoded history fields; only current timestamps and enum tags
+    /// need representation changes. Plans belong to the catalogue and are
+    /// invalidated alongside physical registry/descriptor changes.
+    pub(super) fn encode_physical_version_record(
+        &self,
+        plan: &PreparedPhysicalWritePlan,
+        version: &VersionRow,
+        global_time: Option<GlobalTime>,
+    ) -> Result<groove::records::ValidatedVariantRecord, Error> {
+        let input = version.record.borrowed();
+        let matching_layout = input.descriptor() == plan.history_descriptor;
+        let encoded = groove::records::ValidatedVariantRecord::create_with_encoded_fields::<Error>(
+            groove_variant_tag(version.schema_version_alias())?,
+            plan.physical_descriptor,
+            input.raw().len() + 16,
+            |index, output| {
+                let value = match &plan.write_fields[index] {
+                    PhysicalWriteField::Copy(source) if matching_layout => {
+                        let span = input.descriptor().field_span(input.raw(), *source)?;
+                        output.extend_from_slice(&input.raw()[span]);
+                        return Ok(());
+                    }
+                    PhysicalWriteField::Copy(source) | PhysicalWriteField::Decode(source) => {
+                        input.get_idx(*source)?
+                    }
+                    PhysicalWriteField::CreatedAtMillis => {
+                        Value::U64(version.created_at().physical_ms())
+                    }
+                    PhysicalWriteField::UpdatedAtMillis => {
+                        Value::U64(version.updated_at().physical_ms())
+                    }
+                    PhysicalWriteField::GlobalTime => {
+                        Value::Nullable(global_time.map(|time| Box::new(Value::U64(time.0))))
+                    }
+                    PhysicalWriteField::Enum { source, column } => {
+                        let value = input.get_idx(*source)?;
+                        match (value, &plan.physical_descriptor.fields()[index].value_type) {
+                            (
+                                Value::Nullable(Some(inner)),
+                                records::ValueType::Nullable(physical),
+                            ) => Value::Nullable(Some(Box::new(remap_nested_enum_value(
+                                *inner,
+                                &plan.source_table.columns[*column].column_type,
+                                physical,
+                                &plan.enum_remaps[*column],
+                                "root",
+                            )?))),
+                            (value, _) => value,
+                        }
+                    }
+                };
+                plan.physical_descriptor
+                    .encode_field_into(index, &value, output)?;
+                Ok(())
+            },
+        )?;
+        #[cfg(test)]
+        {
+            // Internal byte oracle: public query equality cannot detect a
+            // different durable authored/physical enum or timestamp encoding.
+            let current = plan
+                .write_fields
+                .iter()
+                .any(|field| matches!(field, PhysicalWriteField::GlobalTime));
+            let mut values = if current {
+                global_current_values(&plan.source_table, version, global_time)?
+            } else {
+                version.record.to_values()?
+            };
+            self.remap_authored_enum_cells_for_physical(
+                &mut values,
+                &plan.source_table,
+                &plan.source_mapping,
+                &plan.physical_table,
+                if current {
+                    GlobalCurrentRowRecord::USER_CELLS
+                } else {
+                    HistoryRowRecord::USER_CELLS
+                },
+            )?;
+            assert_eq!(
+                encoded.record().raw(),
+                plan.physical_descriptor.create(&values)?
+            );
+        }
+        Ok(encoded)
     }
 
     /// Encode a deletion/register version into the fixed shared history table.

--- a/dev/benchmarks/prepared-physical-row-encoding.md
+++ b/dev/benchmarks/prepared-physical-row-encoding.md
@@ -1,0 +1,65 @@
+# Prepared physical row encoding
+
+Implementation: `2099f3bad42418fc463d9355d76cd537a20550a5`, on #2803.
+
+Physical writes previously decoded every history field into owned values,
+constructed enum remaps per row, and encoded everything again. Current carriers
+then structurally validated the freshly encoded result. The existing physical
+write plan now prepares field actions and enum remaps once. Matching unchanged
+fields copy their encoded spans; timestamps and enum-bearing fields retain their
+required conversions. Descriptor mismatch uses the decoded fallback.
+
+This changes neither storage bytes nor wire semantics. Test builds compare every
+new physical record with the previous value-based encoder, including its
+independent per-row enum remapping. Authored-column alias validation remains.
+
+## Optimized native measurements
+
+Same preseeded, anonymized 39-subscription member fixture with 27,518 visible rows,
+empty relay/client and RocksDB WalNoSync. Settling excludes seed and final
+diagnostic queries. Both runs have identical phase instrumentation and no
+concurrent build/test activity.
+
+| Measurement                           |   #2803 | This slice |
+| ------------------------------------- | ------: | ---------: |
+| Settling                              | 28.181s |    27.287s |
+| Dominant subscription ready           | 28.670s |    27.781s |
+| Ingestion, exclusive across nodes     |  3.372s |     2.571s |
+| Storage apply, exclusive across nodes |  3.066s |     2.972s |
+
+The targeted ingestion phase improves about 24%; overall settling improves 3.2%.
+These are single large-fixture runs, not a confidence interval. Phase times are
+components of settling and must not be added to it.
+
+The separate native todo workload inserts 1,500 rows and updates exactly 1,350
+of them in one transaction. It exercises a RocksDB worker and memory foreground,
+wire encoding, publication, ingest, reopen and exact visible-result checks.
+It excludes browser/IndexedDB, JS, real network latency and external auth.
+
+| Measurement                        |    #2803 | This slice, first run |
+| ---------------------------------- | -------: | --------------------: |
+| Measured batch-update roundtrip    | 411.87ms |              378.65ms |
+| Batch authoring                    |  46.08ms |               37.06ms |
+| Worker batch ingest                | 147.77ms |              140.10ms |
+| Fresh receiver ingest after update |  74.41ms |               61.71ms |
+
+Three additional unchanged-code roundtrips measured 375.08, 371.34 and 386.93ms;
+fresh post-update ingestion measured 62.83, 62.84 and 63.70ms. The parent has only
+one recorded run here. Retain provisionally: the whole todo roundtrip improves
+roughly 8–10%, while the large fixture gains less. This is not a claim of browser
+performance or achievement of the 5s cold-load target.
+
+## Validation
+
+Jazz library: 2,005 passed, 2 ignored. Groove library: 743 passed, 2 ignored.
+All three incremental canaries and the two-seed maintained/one-shot oracle at
+churn depths 10 and 1,000 passed. Scoped Clippy and formatting passed.
+Replacing the created-at millisecond conversion with packed HLC bytes made
+`version_bearing_current_source_preserves_provenance_timestamps` fail at the
+byte oracle. Exact restoration passed. No mutation remains.
+
+Full canonical CI, browser acceptance and independent review are not claimed.
+
+Tooling friction: optimized native binaries keep the iteration narrower than
+WASM rebuilds, but separate feature sets still rebuild Jazz. Allocation samples
+must span the full workload rather than hit their cap early.


### PR DESCRIPTION
🤖 Physical history and current-row writes previously reconstructed every field as an owned Value, prepared authored-to-physical enum remaps for every row, and encoded the whole record again. Current writes then passed freshly encoded records through structural validation a second time.

Extend the existing catalogue-owned write plan with field actions and enum remaps. Unchanged fields copy encoded spans into one output buffer. Current rows transform packed provenance timestamps into Unix milliseconds and add global time. Enum-bearing cells retain the existing recursive remapper. The plan is invalidated with the physical descriptors when catalogue state changes.

For example, a row containing a title, nested record, parents and author records keeps those encodings while moving to physical history. Its current-row carrier copies the same values but converts timestamps. If concurrent schema branches each introduce local enum tag 1, their global case identities still map to distinct physical tags; equal local ordinals are never treated as equal meanings. Nested enum occurrences follow the same rule. If an input descriptor differs from the expected authored layout, the encoder falls back to decoding affected fields rather than copying under an assumed layout.

Groove exposes a variant counterpart to its existing trusted field-encoder assembly API. The descriptor assembles offsets, and the caller must emit the specified field encoding. This produces the existing ValidatedVariantRecord for commit without revalidating freshly encoded bytes. It is not a network admission API. Current writes still validate authored-column aliases against the exact schema/table before producing a carrier.

No wire or storage format change. Test builds run the previous whole-value encoding/remapping path alongside the new encoder and compare exact output bytes. The complete Jazz library suite passes: 2,005 passed, 2 ignored, including enum lineage and schema evolution cases. Groove library tests also pass (743 passed, 2 ignored), as do all three incremental canaries and the two-seed maintained-query oracle. Deliberately encoding packed HLC instead of milliseconds fails the byte oracle; restoring the source passes.

Native measurements: the 27,518-row permissioned fixture settles in 27.287s versus 28.181s on the parent (3.2% overall; ingestion 3.372s → 2.571s). The 1,500-todo/1,350-update measured roundtrip improves from 411.87ms to 378.65ms, with three repeats at 371–387ms. Fresh ingestion after the update improves from 74.41ms to 62–64ms. Retained provisionally for the whole todo gain as well as reduced ingestion work; the large cold-load target is still far away. These are native measurements, not browser claims. Details and limits: `dev/benchmarks/prepared-physical-row-encoding.md`. Draft; no independent review or full canonical CI claimed.

Continues #2789, on top of #2803.
