### PR TITLE
bench: allow explicit full-load allocation attribution

### DIFF
--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -308,7 +308,14 @@ fn main() {
     #[cfg(feature = "cold-settle-attribution")]
     let _phase_subscriber =
         tracing::subscriber::set_default(jazz_sim::phase_attribution::Collector);
+    // Allocation attribution deliberately instruments the workload. Its timing
+    // is not a benchmark receipt, and sampler configuration must remain usable.
+    #[cfg(not(any(feature = "bench-alloc-sites", feature = "bench-alloc-metrics")))]
     jazz_benchmark_guard::refuse_contaminated_measurement();
+    #[cfg(any(feature = "bench-alloc-sites", feature = "bench-alloc-metrics"))]
+    eprintln!(
+        "allocation attribution run: wall-clock timings are not comparable to clean receipts"
+    );
     let config = Config::from_env();
     let schema = schema();
     let seeded = seed_core(&schema, &config);
@@ -2157,6 +2164,13 @@ fn pending_description(subscriptions: &[OpenSubscription]) -> String {
 
 fn emit_summary(config: &Config, phase: &str, summary: &RunSummary) {
     let mut fields = metadata_fields("customer_cold_start", "native", config.seed, "full");
+    fields.insert(
+        "allocation_instrumented".to_owned(),
+        json!(cfg!(any(
+            feature = "bench-alloc-sites",
+            feature = "bench-alloc-metrics"
+        ))),
+    );
     fields
         .get_mut("knobs")
         .and_then(JsonValue::as_object_mut)

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -90,6 +90,7 @@ mod alloc_metrics {
     const MAX_FRAMES: usize = 24;
     const DEFAULT_SAMPLE_RATE: u64 = 4096;
     const DEFAULT_MAX_SAMPLES: usize = 50_000;
+    const BYTE_SAMPLE_INTERVAL: u64 = 16 * 1024 * 1024;
 
     pub struct SiteAllocator;
 
@@ -97,7 +98,8 @@ mod alloc_metrics {
     struct StackSample {
         frames: [usize; MAX_FRAMES],
         len: usize,
-        requested_bytes: usize,
+        count_sample: bool,
+        byte_weight: u64,
     }
 
     static ACTIVE: AtomicBool = AtomicBool::new(false);
@@ -112,12 +114,21 @@ mod alloc_metrics {
         unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
             if ACTIVE.load(Ordering::Relaxed) {
                 let alloc_index = ALLOCS.fetch_add(1, Ordering::Relaxed) + 1;
-                BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+                let size = layout.size() as u64;
+                let before_bytes = BYTES.fetch_add(size, Ordering::Relaxed);
+                let byte_sample = before_bytes / BYTE_SAMPLE_INTERVAL
+                    != (before_bytes + size) / BYTE_SAMPLE_INTERVAL;
                 let sample_rate = SAMPLE_RATE.load(Ordering::Relaxed).max(1);
-                if alloc_index.is_multiple_of(sample_rate)
-                    && !IN_SAMPLE.swap(true, Ordering::Relaxed)
-                {
-                    sample_stack(layout.size());
+                let count_sample = alloc_index.is_multiple_of(sample_rate);
+                if (count_sample || byte_sample) && !IN_SAMPLE.swap(true, Ordering::Relaxed) {
+                    sample_stack(
+                        count_sample,
+                        if byte_sample {
+                            size.max(BYTE_SAMPLE_INTERVAL)
+                        } else {
+                            0
+                        },
+                    );
                     IN_SAMPLE.store(false, Ordering::Relaxed);
                 }
             }
@@ -173,12 +184,13 @@ mod alloc_metrics {
         snapshot
     }
 
-    fn sample_stack(requested_bytes: usize) {
+    fn sample_stack(count_sample: bool, byte_weight: u64) {
         let max_samples = MAX_SAMPLES.load(Ordering::Relaxed) as usize;
         let mut sample = StackSample {
             frames: [0; MAX_FRAMES],
             len: 0,
-            requested_bytes,
+            count_sample,
+            byte_weight,
         };
         unsafe {
             backtrace::trace_unsynchronized(|frame| {
@@ -203,19 +215,21 @@ mod alloc_metrics {
             .lock()
             .expect("allocation samples lock poisoned")
             .clone();
+        let sampled_stacks = samples.len();
         let mut counts: HashMap<Vec<usize>, (u64, u64)> = HashMap::new();
         for sample in samples {
             let totals = counts
                 .entry(sample.frames[..sample.len].to_vec())
                 .or_default();
-            totals.0 += 1;
-            totals.1 += sample.requested_bytes as u64;
+            totals.0 += u64::from(sample.count_sample);
+            totals.1 += sample.byte_weight;
         }
         let mut ranked: Vec<_> = counts.into_iter().collect();
         eprintln!(
-            "ALLOC_SITE_SUMMARY sample_rate={} sampled_stacks={} total_allocs={} total_bytes={}",
+            "ALLOC_SITE_SUMMARY sample_rate={} sampled_stacks={} byte_sample_interval={} total_allocs={} total_bytes={}",
             sample_rate,
-            ranked.iter().map(|(_, (count, _))| *count).sum::<u64>(),
+            sampled_stacks,
+            BYTE_SAMPLE_INTERVAL,
             ALLOCS.load(Ordering::Relaxed),
             BYTES.load(Ordering::Relaxed)
         );
@@ -234,7 +248,7 @@ mod alloc_metrics {
                     rank + 1,
                     samples,
                     samples * sample_rate,
-                    sampled_bytes * sample_rate
+                    sampled_bytes
                 );
                 for (index, ip) in frames.iter().copied().enumerate().take(16) {
                     let mut printed = false;

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -97,6 +97,7 @@ mod alloc_metrics {
     struct StackSample {
         frames: [usize; MAX_FRAMES],
         len: usize,
+        requested_bytes: usize,
     }
 
     static ACTIVE: AtomicBool = AtomicBool::new(false);
@@ -116,7 +117,7 @@ mod alloc_metrics {
                 if alloc_index.is_multiple_of(sample_rate)
                     && !IN_SAMPLE.swap(true, Ordering::Relaxed)
                 {
-                    sample_stack();
+                    sample_stack(layout.size());
                     IN_SAMPLE.store(false, Ordering::Relaxed);
                 }
             }
@@ -172,11 +173,12 @@ mod alloc_metrics {
         snapshot
     }
 
-    fn sample_stack() {
+    fn sample_stack(requested_bytes: usize) {
         let max_samples = MAX_SAMPLES.load(Ordering::Relaxed) as usize;
         let mut sample = StackSample {
             frames: [0; MAX_FRAMES],
             len: 0,
+            requested_bytes,
         };
         unsafe {
             backtrace::trace_unsynchronized(|frame| {
@@ -201,44 +203,56 @@ mod alloc_metrics {
             .lock()
             .expect("allocation samples lock poisoned")
             .clone();
-        let mut counts: HashMap<Vec<usize>, u64> = HashMap::new();
+        let mut counts: HashMap<Vec<usize>, (u64, u64)> = HashMap::new();
         for sample in samples {
-            *counts
+            let totals = counts
                 .entry(sample.frames[..sample.len].to_vec())
-                .or_default() += 1;
+                .or_default();
+            totals.0 += 1;
+            totals.1 += sample.requested_bytes as u64;
         }
         let mut ranked: Vec<_> = counts.into_iter().collect();
-        ranked.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
         eprintln!(
             "ALLOC_SITE_SUMMARY sample_rate={} sampled_stacks={} total_allocs={} total_bytes={}",
             sample_rate,
-            ranked.iter().map(|(_, count)| *count).sum::<u64>(),
+            ranked.iter().map(|(_, (count, _))| *count).sum::<u64>(),
             ALLOCS.load(Ordering::Relaxed),
             BYTES.load(Ordering::Relaxed)
         );
-        for (rank, (frames, samples)) in ranked.into_iter().take(25).enumerate() {
-            eprintln!(
-                "ALLOC_SITE rank={} samples={} estimated_allocs={}",
-                rank + 1,
-                samples,
-                samples * sample_rate
-            );
-            for (index, ip) in frames.iter().copied().enumerate().take(16) {
-                let mut printed = false;
-                backtrace::resolve(ip as *mut _, |symbol| {
-                    let name = symbol
-                        .name()
-                        .map(|name| name.to_string())
-                        .unwrap_or_else(|| "<unknown>".to_owned());
-                    if let (Some(file), Some(line)) = (symbol.filename(), symbol.lineno()) {
-                        eprintln!("  #{index:<2} {name} {}:{line}", file.display());
-                    } else {
-                        eprintln!("  #{index:<2} {name}");
+        for metric in ["count", "bytes"] {
+            ranked.sort_by_key(|(_, totals)| {
+                std::cmp::Reverse(if metric == "count" {
+                    totals.0
+                } else {
+                    totals.1
+                })
+            });
+            for (rank, (frames, (samples, sampled_bytes))) in ranked.iter().take(25).enumerate() {
+                eprintln!(
+                    "ALLOC_SITE metric={} rank={} samples={} estimated_allocs={} estimated_bytes={}",
+                    metric,
+                    rank + 1,
+                    samples,
+                    samples * sample_rate,
+                    sampled_bytes * sample_rate
+                );
+                for (index, ip) in frames.iter().copied().enumerate().take(16) {
+                    let mut printed = false;
+                    backtrace::resolve(ip as *mut _, |symbol| {
+                        let name = symbol
+                            .name()
+                            .map(|name| name.to_string())
+                            .unwrap_or_else(|| "<unknown>".to_owned());
+                        if let (Some(file), Some(line)) = (symbol.filename(), symbol.lineno()) {
+                            eprintln!("  #{index:<2} {name} {}:{line}", file.display());
+                        } else {
+                            eprintln!("  #{index:<2} {name}");
+                        }
+                        printed = true;
+                    });
+                    if !printed {
+                        eprintln!("  #{index:<2} 0x{ip:x}");
                     }
-                    printed = true;
-                });
-                if !printed {
-                    eprintln!("  #{index:<2} 0x{ip:x}");
                 }
             }
         }
@@ -1581,6 +1595,9 @@ fn run_connect_and_subscribe(
         ticks += 1;
     }
     let settle_ms = settle_start.elapsed().as_millis();
+    // Match the readiness boundary: later one-shot verification and storage
+    // sizing are diagnostics, not work needed to make subscriptions usable.
+    let alloc_snapshot = alloc_metrics::stop();
     #[cfg(feature = "cold-settle-attribution")]
     {
         attribution.phase_timing = jazz_sim::phase_attribution::snapshot();
@@ -1689,7 +1706,6 @@ fn run_connect_and_subscribe(
     let encoded_storage_bytes =
         core_encoded_storage_bytes + relay_encoded_storage_bytes + client_encoded_storage_bytes;
     let peak_rss_bytes = peak_rss_bytes();
-    let alloc_snapshot = alloc_metrics::stop();
     let memory_amplification = if encoded_storage_bytes == 0 {
         0.0
     } else {
@@ -2340,6 +2356,10 @@ fn emit_summary(config: &Config, phase: &str, summary: &RunSummary) {
     fields.insert(
         "core_hydration_memo_entries".to_owned(),
         json!(summary.core_hydration_memo_entries),
+    );
+    fields.insert(
+        "allocation_scope".to_owned(),
+        json!("connect_subscribe_settle"),
     );
     fields.insert("peak_rss_bytes".to_owned(), json!(summary.peak_rss_bytes));
     fields.insert(


### PR DESCRIPTION
🤖 Allocation profiles now stop when subscriptions are ready, matching the cold-load phase boundary. Final one-shot verification and storage-size scans no longer inflate allocation totals. Receipts identify this scope as `connect_subscribe_settle`.

Explicit allocation-feature builds permit their sampler settings, print that their timings are not comparable, and emit `allocation_instrumented: true`. Ordinary builds retain the timing guard. Count sampling uses the configured allocation interval; a separate 16MiB volume interval attributes bytes without extrapolating one rare large allocation by the count interval. Allocations larger than that volume interval are sampled at their actual size. Both rankings are estimates; total allocator counters are direct counts.

The full anonymized fixture passes all 27,518 expected rows. The readiness-scoped run reports 241,155,830 allocations and 262,420,969,705 cumulative requested bytes, with 19,533 sampled stacks below the 50,000 cap. This is allocated volume, not resident memory. Native Zstd decompression dominates the largest byte stacks: its bulk API reserves the supplied 256MiB maximum because the dependency’s experimental upper-bound helper is disabled. This is a lead for a separately measured fix, not evidence that decompression dominates elapsed time.

Optimized allocation-feature build, scoped Clippy and formatting pass; the original clean binary rejects allocation settings with exit 2. No product/storage/wire behavior changes. Draft on #2804; continues #2789. Independent review and broad gates are not claimed.
