### PR TITLE
perf: reuse scalar join key scratch across batches

### DIFF
--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -799,15 +799,18 @@ fn keyed_join_deltas<'a>(
 ) -> Result<Vec<KeyedRecordDelta<'a>>, IvmRuntimeError> {
     if let Some(field_indices) = scalar_join_field_indices(descriptor, fields)? {
         let mut keyed = Vec::with_capacity(deltas.len());
+        // Short keys are retained inline by JoinKey. Reuse the temporary encoder
+        // buffer instead of allocating and discarding it for every input row.
+        let mut key = Vec::new();
         for delta in deltas {
-            let mut key = Vec::new();
+            key.clear();
             for field_idx in &field_indices {
                 let value = descriptor.get_idx(delta.raw(), *field_idx)?;
                 encode_join_key_part(&mut key, &value, comparison)?;
             }
             keyed.push(KeyedRecordDelta {
                 delta,
-                key: JoinKey::from_vec(key),
+                key: JoinKey::from_slice(&key),
             });
         }
         return Ok(keyed);


### PR DESCRIPTION
🤖 Scalar join input rows built a new heap-backed key buffer each time, then copied short keys into the existing inline JoinKey and discarded the buffer. Reuse one temporary encoder buffer across the batch and clear it before each row.

For example, thousands of UUID equality keys now share the temporary capacity while each retained key still owns its bytes. Composite, nullable and policy-comparison encoding remains unchanged; retained keys never borrow the scratch buffer. Longer keys still use JoinKey’s existing owned heap representation.

Groove library tests pass: 743 passed, 2 ignored. Scoped Clippy and formatting pass. The first clean optimized large-fixture run settles in 27.215s versus 27.287s on #2804, with all 27,518 rows. This difference is within noise; this is a small allocation simplification, not a demonstrated end-to-end speedup. Further attribution is in progress; draft, no broad acceptance or independent review claimed. Continues #2789 on #2805.
