### PR TITLE
perf: size native Zstd output from known frame content length

### DIFF
--- a/crates/jazz-compression/src/lib.rs
+++ b/crates/jazz-compression/src/lib.rs
@@ -49,7 +49,21 @@ pub fn compress_zstd(_payload: &[u8]) -> Result<Vec<u8>, String> {
 
 #[cfg(feature = "zstd")]
 pub fn decompress_zstd(payload: &[u8], max_decoded_len: usize) -> Result<Vec<u8>, String> {
-    zstd::bulk::decompress(payload, max_decoded_len)
+    // The stable bulk API otherwise reserves the entire caller-supplied limit.
+    // A frame content size applies to one frame, not a concatenated stream.
+    // Keep the existing bounded decoder path when that size is unavailable.
+    let capacity =
+        if zstd::zstd_safe::find_frame_compressed_size(payload).ok() == Some(payload.len()) {
+            zstd::zstd_safe::get_frame_content_size(payload)
+                .ok()
+                .flatten()
+                .and_then(|size| usize::try_from(size).ok())
+                .unwrap_or(max_decoded_len)
+                .min(max_decoded_len)
+        } else {
+            max_decoded_len
+        };
+    zstd::bulk::decompress(payload, capacity)
         .map_err(|error| format!("failed to decompress zstd payload: {error}"))
 }
 
@@ -105,6 +119,47 @@ mod tests {
             payload
         );
         assert!(super::decompress_zstd(&compressed, payload.len() - 1).is_err());
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn known_zstd_frame_reserves_its_content_size_not_the_message_limit() {
+        // Capacity is the behavior under test: value equality alone cannot
+        // detect reserving a maximum-sized buffer for each small message.
+        for payload in [Vec::new(), b"small frame".repeat(64)] {
+            let compressed = super::compress_zstd(&payload).unwrap();
+            let decoded = super::decompress_zstd(&compressed, 4 * 1024 * 1024).unwrap();
+            assert_eq!(decoded, payload);
+            assert_eq!(decoded.capacity(), payload.len());
+        }
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn native_zstd_preserves_unknown_size_and_concatenated_frames() {
+        let first = b"first frame".repeat(64);
+        let second = b"second frame".repeat(32);
+        let unknown_size = zstd::stream::encode_all(first.as_slice(), 3).unwrap();
+        assert_eq!(
+            zstd::zstd_safe::get_frame_content_size(&unknown_size).unwrap(),
+            None
+        );
+        assert_eq!(
+            super::decompress_zstd(&unknown_size, first.len()).unwrap(),
+            first
+        );
+        assert!(super::decompress_zstd(&unknown_size, first.len() - 1).is_err());
+
+        let mut concatenated = super::compress_zstd(&first).unwrap();
+        concatenated.extend(super::compress_zstd(&second).unwrap());
+        let mut expected = first;
+        expected.extend(second);
+        assert_eq!(
+            super::decompress_zstd(&concatenated, expected.len()).unwrap(),
+            expected
+        );
+        assert!(super::decompress_zstd(&concatenated, expected.len() - 1).is_err());
+        assert!(super::decompress_zstd(b"not a zstd frame", 1024).is_err());
     }
 
     #[cfg(all(feature = "ruzstd", not(feature = "zstd")))]


### PR DESCRIPTION
🤖 Native Zstd decoding reserved the caller’s maximum decoded length for every message. Jazz supplies 256MiB; the dependency’s bulk upper-bound helper is disabled without its experimental feature. Even a small ordinary frame therefore reserved a maximum-sized output buffer.

For a single frame with a known content size, use that size capped by the existing maximum. For example, a 1KiB decoded message gets a 1KiB output buffer. Unknown-size frames and concatenated frames retain the previous bounded bulk-decoder path, because the first frame’s size is not the size of an entire concatenated stream. Decoding still rejects an output beyond the limit. No wire format or accepted-message semantics change is intended.

Tests cover empty and small known-size frames, output limits, unknown-size streaming frames, concatenated frames and invalid input. Restoring the old maximum-sized allocation makes the capacity test fail; exact restoration passes. Native/LZ4 tests: 4 passed. Pure-Rust Zstd test: 1 passed. All-feature/all-target Clippy and formatting pass.

The readiness-scoped allocation profile identified this reservation pattern among the largest byte-volume stacks. Cumulative allocated bytes are not touched bytes or peak resident memory; the first clean optimized cold-load measurement is 27.394s versus 27.215s on the parent, with all 27,518 rows. That is within run-to-run noise; no elapsed-time speedup is claimed. Retain as a small resource-allocation correction, not as progress toward the cold-load time target. Draft on #2806; continues #2789. No independent review or broad acceptance claimed.
