### PR TITLE
perf: decode only selected collection and sort fields

### DIFF
--- a/crates/groove/src/ivm/runtime/windows.rs
+++ b/crates/groove/src/ivm/runtime/windows.rs
@@ -238,13 +238,13 @@ pub(super) fn collect_by_output_value(output_type: &ValueType, value: Value) -> 
 }
 
 fn collect_by_projected_value(
-    values: &[Value],
+    record: &BorrowedRecord<'_>,
     field: &CollectByProjection,
 ) -> Result<Value, IvmRuntimeError> {
-    let value = values
-        .get(field.field_idx)
-        .cloned()
-        .ok_or(IvmRuntimeError::GraphFieldIndexOutOfBounds(field.field_idx))?;
+    if field.field_idx >= record.descriptor().fields().len() {
+        return Err(IvmRuntimeError::GraphFieldIndexOutOfBounds(field.field_idx));
+    }
+    let value = record.get_idx(field.field_idx)?;
     if !field.unwrap_nullable {
         return Ok(value);
     }
@@ -388,9 +388,7 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
         if !emit || (before_weight > 0) == (after_weight > 0) {
             continue;
         }
-        let source_values = BorrowedRecord::new(delta.raw(), &input_desc)
-            .to_values()
-            .map_err(IvmRuntimeError::RecordEncoding)?;
+        let source_input = BorrowedRecord::new(delta.raw(), &input_desc);
         let child_fields = direct_tree_slot
             .map(|slot| slot.child_fields.as_slice())
             .unwrap_or(collect_by.child_fields.as_slice());
@@ -406,7 +404,7 @@ pub(super) fn update_unbounded_collect_by_terminal_state(
             .map(|(index, field)| {
                 Ok::<Value, IvmRuntimeError>(collect_by_output_value(
                     &child_descriptor.fields()[index].value_type,
-                    collect_by_projected_value(&source_values, field)?,
+                    collect_by_projected_value(&source_input, field)?,
                 ))
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -845,17 +843,13 @@ pub(super) fn collect_by_root_from_records(
     let Some((parent_record, _)) = records.iter().find(|(_, weight)| *weight > 0) else {
         return Ok(None);
     };
-    let parent_values = BorrowedRecord::new(parent_record, &input_desc)
-        .to_values()
-        .map_err(|error| {
-            IvmRuntimeError::InvalidCollectBy(format!("root input decode failed: {error}"))
-        })?;
+    let parent_input = BorrowedRecord::new(parent_record, &input_desc);
     let values = collect_by
         .parent_fields
         .iter()
         .enumerate()
         .map(|(index, field)| {
-            let value = collect_by_projected_value(&parent_values, field)?;
+            let value = collect_by_projected_value(&parent_input, field)?;
             let output_type = &output_desc.fields()[index].value_type;
             Ok::<Value, IvmRuntimeError>(collect_by_output_value(output_type, value))
         })
@@ -875,15 +869,13 @@ pub(super) fn collect_by_parent_from_records(
     let Some((parent_record, _)) = records.iter().find(|(_, weight)| *weight > 0) else {
         return Ok(None);
     };
-    let parent_values = BorrowedRecord::new(parent_record, &input_desc)
-        .to_values()
-        .map_err(IvmRuntimeError::RecordEncoding)?;
+    let parent_input = BorrowedRecord::new(parent_record, &input_desc);
     let mut values = collect_by
         .parent_fields
         .iter()
         .enumerate()
         .map(|(index, field)| {
-            let value = collect_by_projected_value(&parent_values, field)?;
+            let value = collect_by_projected_value(&parent_input, field)?;
             let output_type = &output_desc.fields()[index].value_type;
             Ok::<Value, IvmRuntimeError>(collect_by_output_value(output_type, value))
         })
@@ -891,9 +883,7 @@ pub(super) fn collect_by_parent_from_records(
     let window = collect_by_window_from_records(input_desc, records, collect_by)?;
     let mut children = Vec::new();
     for (record, copies) in window {
-        let source_values = BorrowedRecord::new(&record, &input_desc)
-            .to_values()
-            .map_err(IvmRuntimeError::RecordEncoding)?;
+        let source_input = BorrowedRecord::new(&record, &input_desc);
         let child_values = collect_by
             .child_fields
             .iter()
@@ -901,7 +891,7 @@ pub(super) fn collect_by_parent_from_records(
             .map(|(index, field)| {
                 Ok::<Value, IvmRuntimeError>(collect_by_output_value(
                     &collect_by.child_descriptor.fields()[index].value_type,
-                    collect_by_projected_value(&source_values, field)?,
+                    collect_by_projected_value(&source_input, field)?,
                 ))
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -926,9 +916,7 @@ pub(super) fn collect_by_tree_parent_from_records(
     let Some((parent_record, _)) = records.iter().find(|(_, weight)| *weight > 0) else {
         return Ok(None);
     };
-    let parent_values = BorrowedRecord::new(parent_record, &input_desc)
-        .to_values()
-        .map_err(IvmRuntimeError::RecordEncoding)?;
+    let parent_input = BorrowedRecord::new(parent_record, &input_desc);
     let mut values = collect_by
         .parent_fields
         .iter()
@@ -936,7 +924,7 @@ pub(super) fn collect_by_tree_parent_from_records(
         .map(|(index, field)| {
             Ok::<Value, IvmRuntimeError>(collect_by_output_value(
                 &output_desc.fields()[index].value_type,
-                collect_by_projected_value(&parent_values, field)?,
+                collect_by_projected_value(&parent_input, field)?,
             ))
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -990,13 +978,11 @@ fn render_collect_by_slots(
                 {
                     continue;
                 }
-                let source_values = BorrowedRecord::new(record, &input_desc)
-                    .to_values()
-                    .map_err(IvmRuntimeError::RecordEncoding)?;
+                let source_input = BorrowedRecord::new(record, &input_desc);
                 let child_values = slot
                     .child_fields
                     .iter()
-                    .map(|field| collect_by_projected_value(&source_values, field))
+                    .map(|field| collect_by_projected_value(&source_input, field))
                     .collect::<Result<Vec<_>, _>>()?;
                 candidates
                     .entry(child_key_descriptor.create(&child_values)?.into())
@@ -1009,9 +995,7 @@ fn render_collect_by_slots(
             )?;
             let mut children = Vec::with_capacity(selected.len());
             for record in selected {
-                let source_values = BorrowedRecord::new(&record, &input_desc)
-                    .to_values()
-                    .map_err(IvmRuntimeError::RecordEncoding)?;
+                let source_input = BorrowedRecord::new(&record, &input_desc);
                 let mut child_values = slot
                     .child_fields
                     .iter()
@@ -1019,7 +1003,7 @@ fn render_collect_by_slots(
                     .map(|(index, field)| {
                         Ok::<Value, IvmRuntimeError>(collect_by_output_value(
                             &slot.child_descriptor.fields()[index].value_type,
-                            collect_by_projected_value(&source_values, field)?,
+                            collect_by_projected_value(&source_input, field)?,
                         ))
                     })
                     .collect::<Result<Vec<_>, _>>()?;
@@ -1093,13 +1077,11 @@ pub(super) fn collect_by_expanded_window(
         if copies != 1 || expanded.contains_key(&occurrence) {
             return Err(IvmRuntimeError::DuplicateCollectByOccurrenceId);
         }
-        let values = BorrowedRecord::new(&record, &input_desc)
-            .to_values()
-            .map_err(IvmRuntimeError::RecordEncoding)?;
+        let input = BorrowedRecord::new(&record, &input_desc);
         let tuple = collect_by
             .tuple_fields
             .iter()
-            .map(|field| collect_by_projected_value(&values, field))
+            .map(|field| collect_by_projected_value(&input, field))
             .collect::<Result<Vec<_>, _>>()?;
         expanded.insert(occurrence, output_desc.create(&tuple)?.into());
     }
@@ -1168,9 +1150,7 @@ fn collect_by_sort_key_for_fields(
     sort_field_indices: &[usize],
     sort_directions: &[TopByDirection],
 ) -> Result<Vec<TopBySortPart>, IvmRuntimeError> {
-    let values = BorrowedRecord::new(record, &descriptor)
-        .to_values()
-        .map_err(IvmRuntimeError::RecordEncoding)?;
+    let input = BorrowedRecord::new(record, &descriptor);
     sort_field_indices
         .iter()
         .zip(sort_directions)
@@ -1179,10 +1159,7 @@ fn collect_by_sort_key_for_fields(
                 .fields()
                 .get(*field_idx)
                 .ok_or(IvmRuntimeError::GraphFieldIndexOutOfBounds(*field_idx))?;
-            let value = values
-                .get(*field_idx)
-                .cloned()
-                .ok_or(IvmRuntimeError::GraphFieldIndexOutOfBounds(*field_idx))?;
+            let value = input.get_idx(*field_idx)?;
             Ok(TopBySortPart {
                 key: top_by_sort_value(&field.value_type, value)?,
                 direction: *direction,

--- a/dev/benchmarks/borrowed-collection-fields.md
+++ b/dev/benchmarks/borrowed-collection-fields.md
@@ -1,0 +1,55 @@
+# Borrowed collection and sort fields
+
+Implementation `6a3554f3ee73cffaa178375d76a0898a7c1642dd`, on #2807.
+Nine collection/sort sites previously decoded complete records into owned Value
+vectors before selecting and cloning a few fields. They now borrow the record
+and decode only selected fields. Empty sort-key lists perform no field decoding.
+Nullable unwrapping, ordering, multiplicity and encoded outputs are preserved.
+
+## Native permissioned fixture
+
+Same 39-subscription anonymized member fixture, 27,518 visible rows, preseeded
+Core and empty relay/client. Optimized build with phase attribution, no concurrent
+build/test during timings. Seed and final verification queries are excluded from
+settling. Both implementation and parent measurements use clean committed trees.
+
+| Measure                       |  Parent | This slice |
+| ----------------------------- | ------: | ---------: |
+| Settling                      | 27.394s |    25.693s |
+| Dominant subscription ready   | 27.882s |    26.181s |
+| Collection/results, exclusive |  3.032s |     1.661s |
+| IVM updates, exclusive        |  3.190s |     2.819s |
+| Storage apply, exclusive      |  3.021s |     2.993s |
+| Ingestion, exclusive          |  2.562s |     2.597s |
+| Output decoding, exclusive    |  2.516s |     2.496s |
+
+About 6.2% less settling time. The targeted phase reduction (1.74s) accounts for
+the observed overall reduction (1.70s). Single-run comparisons, not confidence
+intervals. The 5s target remains unmet.
+
+## Native todo checkpoint
+
+1,500 rows, exactly 1,350 batch updates; RocksDB worker, memory foreground.
+The previous measured tip was #2804, so this comparison also includes #2806 and
+#2807. It does not isolate the collection change. No browser/IndexedDB, JS,
+real network or external auth is included.
+
+| Measure                               |    #2804 | Current stack |
+| ------------------------------------- | -------: | ------------: |
+| Measured batch-update roundtrip       | 378.65ms |      364.47ms |
+| Batch authoring                       |  37.06ms |       36.90ms |
+| Initial publication                   | 142.29ms |      116.68ms |
+| Initial receiver ingestion            |  67.89ms |       54.19ms |
+| Initial receiver query                |  14.97ms |       13.76ms |
+| Fresh receiver ingestion after update |  61.71ms |       64.09ms |
+
+The previous batch repeats ranged 371–387ms; treat small differences cautiously.
+All exact visible-result checks pass.
+
+Validation: Groove library 743 passed, 2 ignored; all three scaling canaries and
+two-seed maintained/one-shot oracle at depths 10 and 1,000 passed. Scoped Clippy
+and formatting pass. Full canonical gates, browser acceptance and independent
+review are not claimed.
+
+Tooling friction: native optimized rebuilds still take about 1–2 minutes when
+Jazz/Groove changes. Keep timing runs isolated from those builds.


### PR DESCRIPTION
🤖 Collection rendering and sorting decoded whole input records into owned Value vectors, then cloned only the selected fields. This included sorting paths with no sort fields, where the full decode produced no useful output.

Read the selected fields directly from a borrowed record. A query sorting by one timestamp no longer reconstructs the row’s unrelated author, nested values or other columns. Collection roots, children, nested slots and tuple projections likewise decode only their requested fields. Existing nullable unwrapping, multiplicity, grouping, ordering and output encoding remain in place. No wire/storage format changes.

Groove library tests pass: 743 passed, 2 ignored. Scoped Clippy and formatting pass. All three scaling canaries and the two-seed maintained/one-shot oracle also pass. The clean optimized permissioned fixture settles in 25.693s versus 27.394s on the parent (6.2% less), with all 27,518 rows. Collection/results drops from 3.032s to 1.661s and IVM updates from 3.190s to 2.819s; those exclusive phase reductions explain the overall gain. The native todo checkpoint is 364.47ms for the measured 1,350-update roundtrip, compared with 371–387ms repeats at #2804; this comparison includes intervening changes and is not an isolated collection result. Details and limits: `dev/benchmarks/borrowed-collection-fields.md`. Draft on #2807; continues #2789. No independent review or full canonical acceptance claimed.
