### PR TITLE
perf: encode record values without redundant staging

### DIFF
--- a/crates/groove/src/db/encoding.rs
+++ b/crates/groove/src/db/encoding.rs
@@ -147,8 +147,19 @@ pub(super) fn encode_record(
         }
         .into());
     }
-    // Callers provide values in SQL declaration order. RecordDescriptor stores
-    // fixed-width fields first, so we reorder here before positional encoding.
+    // Descriptors retain logical declaration order even though fixed fields
+    // come first in the physical byte layout. Ordinary table writes therefore
+    // already have the encoder's order and need no cloned staging vector.
+    if descriptor.fields().len() == table.columns.len()
+        && descriptor
+            .fields()
+            .iter()
+            .zip(&table.columns)
+            .all(|(field, column)| field.name.as_deref() == Some(column.name.as_str()))
+    {
+        return Ok(descriptor.create(values)?);
+    }
+    // Variant descriptors can select or reorder declaration fields.
     let values_by_descriptor_order = descriptor
         .fields()
         .iter()
@@ -156,7 +167,7 @@ pub(super) fn encode_record(
             let name = field
                 .name
                 .as_deref()
-                .ok_or(records::Error::FieldNotFound("<unnamed>".to_owned()))?;
+                .ok_or_else(|| records::Error::FieldNotFound("<unnamed>".to_owned()))?;
             let declaration_idx = table
                 .columns
                 .iter()

--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -201,45 +201,10 @@ impl RecordDescriptor {
             });
         }
 
-        for (field, value) in self.fields.iter().zip(values) {
-            ensure_value_type(value, &field.value_type)?;
-        }
-
-        let fixed_size = self.fixed_size();
-        let variable_count = self.variable_count();
-        let offset_table_size = variable_count.saturating_sub(1) * 4;
-        let mut record = Vec::with_capacity(fixed_size + offset_table_size);
-        let mut variable_values = Vec::with_capacity(variable_count);
-
-        for logical_idx in &self.layout.logical_by_physical {
-            let field = &self.fields[*logical_idx];
-            let value = &values[*logical_idx];
-            let layout = &self.layout.fields[*logical_idx];
-            match layout {
-                FieldLayout::Static { .. } => {
-                    encode_fixed_value(&mut record, value, &field.value_type)?;
-                }
-                FieldLayout::Variable { .. } => {
-                    variable_values.push(encode_value(value, &field.value_type)?);
-                }
-            }
-        }
-
-        let variable_start = fixed_size + offset_table_size;
-        let mut next_offset = variable_start;
-        for encoded in variable_values
-            .iter()
-            .take(variable_values.len().saturating_sub(1))
-        {
-            next_offset = checked_add(next_offset, encoded.len())?;
-            write_u32(&mut record, usize_to_u32(next_offset)?);
-        }
-
-        for encoded in variable_values {
-            record.extend(encoded);
-        }
-
-        Ok(record)
+        let capacity = self.fixed_size() + self.variable_count().saturating_sub(1) * 4;
+        self.create_with_encoded_fields(capacity, |index, output| {
+            self.encode_field_into(index, &values[index], output)
+        })
     }
 
     pub fn project(


### PR DESCRIPTION
🤖 Ordinary table writes cloned their entire value vector into descriptor order even though descriptors now preserve logical declaration order. Record encoding then staged each encoded variable field in a separate vector before appending it to the output.

Use the supplied values directly when declaration and descriptor order match. Variant descriptors that select or reorder fields retain the existing mapping fallback. Assemble fields into the output through the existing encoded-field builder instead of staging a vector of encoded fields. Field type validation remains in the per-field encoder; invalid input still returns an error before any encoded record is returned.

For example, a title/author/nested-record write no longer deep-clones those values merely to put them back in the same order. The physical fixed-field/offset/variable-field layout remains the same. Individual variable-field encoders still use temporary buffers; this does not claim allocation-free encoding.

Groove library tests pass: 743 passed, 2 ignored, including byte fixtures and layout cases. Scoped Clippy and formatting pass. The full Jazz library also passes: 2,005 passed, 2 ignored. The first clean optimized permissioned run settles in 25.560s versus 25.693s on the parent; this is within noise. Storage apply falls from 2.993s to 2.820s. Retain as a smaller shared encoding implementation, not a demonstrated material end-to-end speedup. Allocation attribution continues to guide the next larger change. Draft on #2808; continues #2789. No independent review or full canonical acceptance claimed.
