### PR TITLE
perf: use direct primitive scalar encoding and owned decoding

### DIFF
--- a/crates/groove/SPEC/9_large_values.md
+++ b/crates/groove/SPEC/9_large_values.md
@@ -96,6 +96,11 @@ The primitive arm contains only slot 1, a trailing raw field: its payload is
 exactly the logical bytes, without record headers, offsets, or reserved slots.
 Borrowed inline access validates the enum framing and logical kind directly;
 this preserves decode/recreate acceptance without constructing owned values.
+Owned primitive decoding copies that same raw payload after logical validation;
+it does not construct field maps or re-encode a record. Primitive encoding may
+pass the raw payload directly to the ordinary variant-record encoder for tag 2.
+These are specialized implementations of the same enum/record layout, not a
+separate scalar format; byte fixtures compare them with the generic codecs.
 Every independently addressed immutable tree node carries and authenticates its
 own format and kind before traversal. Internal raw string/bytes backing primitives
 only terminate this self-hosting enum encoding and are impossible at the public

--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -2226,6 +2226,26 @@ pub fn encode_stored_scalar(kind: LargeValueKind, value: &StoredScalar) -> Resul
     encode_stored_scalar_canonical(kind, value)
 }
 
+/// Encode the primitive arm from borrowed logical bytes. Its sole raw payload
+/// field is the complete record payload, so only ordinary variant framing is
+/// needed; no Value, field map, or intermediate record is required.
+pub(crate) fn encode_primitive_stored_scalar(
+    kind: LargeValueKind,
+    bytes: &[u8],
+) -> Result<Vec<u8>, Error> {
+    #[cfg(test)]
+    {
+        STORED_SCALAR_ENCODE_CALLS.with(|calls| calls.set(calls.get() + 1));
+        STORED_SCALAR_CANONICAL_ENCODE_CALLS.with(|calls| calls.set(calls.get() + 1));
+    }
+    encode_primitive_payload(kind, bytes)
+}
+
+fn encode_primitive_payload(kind: LargeValueKind, bytes: &[u8]) -> Result<Vec<u8>, Error> {
+    validate_logical(kind, bytes)?;
+    Ok(crate::records::encode_variant_record(2, bytes))
+}
+
 /// The physical scalar encoder shared by public writes and raw canonicality
 /// checks. The test-only public-write counter intentionally lives in the
 /// wrapper above: decoding an already-inline row must not look like a write
@@ -2238,17 +2258,7 @@ fn encode_stored_scalar_canonical(
     STORED_SCALAR_CANONICAL_ENCODE_CALLS.with(|calls| calls.set(calls.get() + 1));
     let schema = stored_scalar_schema(kind);
     let enum_value = match value {
-        StoredScalar::Primitive(bytes) => {
-            validate_logical(kind, bytes)?;
-            let fields = primitive_payload_schema(kind)
-                .ordered_values([(PRIMITIVE_VALUE_FIELD, primitive_value(kind, bytes.clone()))])?;
-            EnumValue::create(
-                2,
-                schema.case(2).map_err(|_| Error::MalformedScalar)?.payload,
-                &fields,
-            )
-            .map_err(|_| Error::MalformedScalar)?
-        }
+        StoredScalar::Primitive(bytes) => return encode_primitive_payload(kind, bytes),
         StoredScalar::Chunked(value) => {
             if value.kind != kind {
                 return Err(Error::DescriptorMismatch);
@@ -2301,11 +2311,9 @@ pub fn decode_stored_scalar(kind: LargeValueKind, encoded: &[u8]) -> Result<Stor
         crate::records::split_variant_record(encoded).map_err(|_| Error::MalformedScalar)?;
     let decoded = match tag {
         2 => {
-            // split_variant_record has checked every tag byte for canonical
-            // framing. The primitive decoder reconstructs the complete payload
-            // exactly, checks reserved slots and validates the declared logical
-            // kind. Together those checks cover the entire envelope; rebuilding
-            // that same envelope would repeat payload decoding and allocation.
+            // The primitive arm is one raw field. After ordinary tag framing,
+            // logical validation covers the payload without reconstructing or
+            // re-encoding a record to recover those same bytes.
             return decode_primitive_payload(kind, payload).map(StoredScalar::Primitive);
         }
         3 => {
@@ -2778,6 +2786,7 @@ pub(crate) fn decode_large_value_ref(encoded: &[u8]) -> Result<LargeValueRef, Er
     Ok(decoded)
 }
 
+#[cfg(test)]
 fn primitive_value(kind: LargeValueKind, bytes: Vec<u8>) -> Value {
     match kind {
         LargeValueKind::Bytes => Value::Bytes(bytes),
@@ -2787,6 +2796,7 @@ fn primitive_value(kind: LargeValueKind, bytes: Vec<u8>) -> Value {
     }
 }
 
+#[cfg(test)]
 fn primitive_bytes(kind: LargeValueKind, value: &Value) -> Result<Vec<u8>, Error> {
     let bytes = match (kind, value) {
         (LargeValueKind::Bytes, Value::Bytes(bytes)) => Ok(bytes.clone()),
@@ -2800,26 +2810,11 @@ fn primitive_bytes(kind: LargeValueKind, value: &Value) -> Result<Vec<u8>, Error
 }
 
 fn decode_primitive_payload(kind: LargeValueKind, payload: &[u8]) -> Result<Vec<u8>, Error> {
-    let schema = primitive_payload_schema(kind);
-    let values = schema
-        .descriptor
-        .bind(payload)
-        .to_values()
-        .map_err(|error| match error {
-            crate::records::Error::InvalidUtf8 => Error::InvalidUtf8,
-            _ => Error::MalformedScalar,
-        })?;
-    if schema
-        .descriptor
-        .create(&values)
-        .map_err(|_| Error::MalformedScalar)?
-        != payload
-    {
-        return Err(Error::MalformedScalar);
-    }
-    let mut fields = schema.decode_values(&values)?;
-    let value = take_durable_large_value_field(&mut fields, PRIMITIVE_VALUE_FIELD)?;
-    primitive_bytes(kind, &value)
+    // Slot 1 is the only field and is raw string/bytes: the record encoding is
+    // exactly its payload. Match borrowed inline access without reconstructing
+    // and re-encoding an owned record merely to recover those same bytes.
+    validate_logical(kind, payload)?;
+    Ok(payload.to_vec())
 }
 
 /// Read precisely the V1-independent selector: the descriptor payload starts
@@ -8039,6 +8034,49 @@ mod tests {
                     "a byte-identical node must retain its exact locator"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn primitive_scalar_fast_codec_matches_generic_record_codec() {
+        // Internal byte contract: public value equality cannot detect a changed
+        // durable envelope. Build the reference through the ordinary enum/record
+        // codecs, independently of the specialized scalar encoder.
+        for (kind, payload) in [
+            (LargeValueKind::Bytes, b"".as_slice()),
+            (LargeValueKind::Bytes, b"\0\xffbytes".as_slice()),
+            (LargeValueKind::String, "".as_bytes()),
+            (LargeValueKind::String, "text 🙂".as_bytes()),
+            (LargeValueKind::Json, b"null".as_slice()),
+            (LargeValueKind::Json, br#" {"a":1,"a":2} "#.as_slice()),
+        ] {
+            let fields = primitive_payload_schema(kind)
+                .ordered_values([(
+                    PRIMITIVE_VALUE_FIELD,
+                    primitive_value(kind, payload.to_vec()),
+                )])
+                .unwrap();
+            let value = EnumValue::create(
+                2,
+                stored_scalar_schema(kind).case(2).unwrap().payload,
+                &fields,
+            )
+            .unwrap();
+            let reference = crate::records::encode_single_field_value(
+                &Value::Enum(value),
+                stored_scalar_value_type(kind),
+            )
+            .unwrap();
+            let encoded = encode_primitive_stored_scalar(kind, payload).unwrap();
+            assert_eq!(encoded, reference);
+            assert_eq!(
+                encode_stored_scalar(kind, &StoredScalar::Primitive(payload.to_vec())).unwrap(),
+                reference
+            );
+            assert_eq!(
+                decode_stored_scalar(kind, &encoded).unwrap(),
+                StoredScalar::Primitive(payload.to_vec())
+            );
         }
     }
 

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -1564,16 +1564,16 @@ pub(super) fn encode_value(value: &Value, value_type: &ValueType) -> Result<Vec<
     let mut bytes = Vec::new();
     match (value, value_type) {
         (Value::String(value), ValueType::String) => {
-            bytes.extend(crate::large_values::encode_stored_scalar(
+            return Ok(crate::large_values::encode_primitive_stored_scalar(
                 crate::large_values::LargeValueKind::String,
-                &crate::large_values::StoredScalar::Primitive(value.as_bytes().to_vec()),
-            )?)
+                value.as_bytes(),
+            )?);
         }
         (Value::Bytes(value), ValueType::Bytes) => {
-            bytes.extend(crate::large_values::encode_stored_scalar(
+            return Ok(crate::large_values::encode_primitive_stored_scalar(
                 crate::large_values::LargeValueKind::Bytes,
-                &crate::large_values::StoredScalar::Primitive(value.clone()),
-            )?)
+                value,
+            )?);
         }
         (
             Value::String(value),
@@ -1588,20 +1588,24 @@ pub(super) fn encode_value(value: &Value, value_type: &ValueType) -> Result<Vec<
             ValueType::Internal(InternalValueType(InternalValueTypeRepr::StoredScalar(
                 crate::large_values::LargeValueKind::Bytes,
             ))),
-        ) => bytes.extend(crate::large_values::encode_stored_scalar(
-            crate::large_values::LargeValueKind::Bytes,
-            &crate::large_values::StoredScalar::Primitive(value.clone()),
-        )?),
+        ) => {
+            return Ok(crate::large_values::encode_primitive_stored_scalar(
+                crate::large_values::LargeValueKind::Bytes,
+                value,
+            )?);
+        }
         (
             Value::String(value),
             ValueType::Internal(InternalValueType(InternalValueTypeRepr::StoredScalar(
                 kind @ (crate::large_values::LargeValueKind::String
                 | crate::large_values::LargeValueKind::Json),
             ))),
-        ) => bytes.extend(crate::large_values::encode_stored_scalar(
-            *kind,
-            &crate::large_values::StoredScalar::Primitive(value.as_bytes().to_vec()),
-        )?),
+        ) => {
+            return Ok(crate::large_values::encode_primitive_stored_scalar(
+                *kind,
+                value.as_bytes(),
+            )?);
+        }
         (
             Value::Large(value),
             ValueType::Internal(InternalValueType(InternalValueTypeRepr::StoredScalar(kind))),

--- a/dev/benchmarks/direct-inline-scalar-codec.md
+++ b/dev/benchmarks/direct-inline-scalar-codec.md
@@ -1,0 +1,57 @@
+# Direct inline scalar encoding and owned decoding
+
+Implementation: `174079da325521251a94aa93e4d76b0bf0d49fcd`, on #2810.
+
+Primitive scalars use ordinary enum tag 2 and a record with one trailing raw
+field. The payload is exactly the logical bytes. Encoding now borrows those
+bytes and calls the ordinary variant-record encoder; owned decoding validates
+the logical kind and copies the payload. Maps, Value vectors, intermediate
+records and decode/re-encode comparison are unnecessary for this arm. Chunked
+values retain their existing path. The physical format is unchanged.
+
+## Optimized native member fixture
+
+Same anonymized 39 subscriptions and 27,518 visible rows, preseeded Core and
+empty relay/client. Clean committed trees; no concurrent build/test during
+measurements. Settling excludes seed and post-readiness diagnostics.
+
+| Measure                       |   #2809 | This slice |
+| ----------------------------- | ------: | ---------: |
+| Settling                      | 25.560s |    23.881s |
+| Dominant subscription ready   | 26.049s |    24.374s |
+| Collection/results, exclusive |  1.655s |     1.201s |
+| Storage apply, exclusive      |  2.820s |     2.664s |
+| Ingestion, exclusive          |  2.590s |     2.571s |
+| Output decoding, exclusive    |  2.529s |     2.351s |
+
+About 6.6% less settling time. This is a single-run comparison, not a confidence
+interval. The 5s target remains unmet.
+
+## Native todo checkpoint
+
+1,500 rows, exactly 1,350 batch updates. RocksDB worker and memory foreground.
+The prior measured tip was #2808; this comparison includes #2809 too. It excludes
+browser/IndexedDB, JS, real network latency and external authentication.
+
+| Measure                               |    #2808 | Current stack |
+| ------------------------------------- | -------: | ------------: |
+| Measured batch-update roundtrip       | 364.47ms |      317.24ms |
+| Batch authoring                       |  36.90ms |       30.61ms |
+| Initial publication                   | 116.68ms |      111.84ms |
+| Initial receiver ingestion            |  54.19ms |       46.25ms |
+| Initial receiver query                |  13.76ms |       13.89ms |
+| Fresh receiver ingestion after update |  64.09ms |       52.44ms |
+
+The measured roundtrip improves about 13%; fresh ingestion after the update
+improves about 18%. All exact row/update assertions pass.
+
+Validation: Groove library 744 passed, 2 ignored; Jazz library 2,005 passed,
+2 ignored. All three scaling canaries and the two-seed maintained/one-shot
+oracle at depths 10 and 1,000 pass. The new byte test independently constructs
+ordinary enum/record encodings for Bytes, String and JSON. Changing the fast
+encoder tag makes it fail; exact restoration passes. Scoped Clippy and
+formatting pass. Full canonical CI, browser acceptance and independent review
+are not claimed.
+
+Tooling friction: grouped allocation callers exposed this shared scalar path;
+full-stack rankings alone scattered its cost across many call sites.


### PR DESCRIPTION
🤖 Ordinary inline strings and bytes still passed through a field map, owned values, an enum payload record and another encoding wrapper. Owned primitive decoding also reconstructed and re-encoded its one-field record before returning the original payload. The borrowed-read path already avoided that work.

The primitive arm has one trailing raw field, so its record payload is exactly the logical bytes. Feed borrowed bytes to the ordinary variant-record encoder for tag 2, and let owned decoding copy the logically validated payload directly. For example, the primitive string `hello` remains the ordinary tag-2 record followed by its UTF-8 bytes. This is an implementation specialization of the existing format, not a new private scalar codec.

String/JSON logical validation remains. Chunked descriptors retain their existing path. The spec now explicitly describes the direct primitive implementations. A new internal byte test compares Bytes, String and JSON cases against the generic enum/record codecs. Changing the primitive tag makes it fail; exact restoration passes.

Groove library: 744 passed, 2 ignored. Jazz library: 2,005 passed, 2 ignored. Scoped Clippy and formatting pass. All three scaling canaries and the two-seed maintained-query oracle pass. Optimized native cold settling is 23.881s versus 25.560s (~6.6% faster), with all 27,518 rows correct. The 1,500-todo/1,350-update batch roundtrip is 317.238ms versus the preceding 364.470ms checkpoint (~13% faster; this comparison also includes #2809). Post-update fresh ingest is 52.444ms versus 64.094ms. These are native measurements, not browser acceptance. The committed benchmark report records scope and evidence. Draft on #2810; continues #2789. No independent review or full canonical acceptance claimed.
