### PR TITLE
bench: show representative allocation caller contexts

### DIFF
--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -237,6 +237,7 @@ mod alloc_metrics {
         // each sample once to its nearest repository allocation site as well.
         let mut callers: HashMap<String, (u64, u64)> = HashMap::new();
         let mut resolved: HashMap<usize, Option<String>> = HashMap::new();
+        let mut examples: HashMap<String, (u64, Vec<usize>)> = HashMap::new();
         for (frames, totals) in &ranked {
             for ip in frames {
                 let caller = resolved.entry(*ip).or_insert_with(|| {
@@ -271,6 +272,10 @@ mod alloc_metrics {
                     let entry = callers.entry(caller.clone()).or_default();
                     entry.0 += totals.0;
                     entry.1 += totals.1;
+                    let example = examples.entry(caller.clone()).or_default();
+                    if totals.0 > example.0 {
+                        *example = (totals.0, frames.clone());
+                    }
                     break;
                 }
             }
@@ -293,6 +298,31 @@ mod alloc_metrics {
                     totals.1,
                     caller
                 );
+                // Show the most frequently count-sampled calling context, not
+                // an invented aggregate stack. Reporting runs after tracking stops.
+                if metric == "count" {
+                    if let Some((samples, frames)) = examples.get(caller) {
+                        eprintln!("  representative_context_samples={samples}");
+                        for ip in frames {
+                            backtrace::resolve(*ip as *mut _, |symbol| {
+                                let Some(file) = symbol.filename() else {
+                                    return;
+                                };
+                                let path = file.to_string_lossy();
+                                if !path.contains("/crates/") || path.contains("/benches/") {
+                                    return;
+                                }
+                                if let Some(name) = symbol.name() {
+                                    eprintln!(
+                                        "    {name} {}:{}",
+                                        file.display(),
+                                        symbol.lineno().unwrap_or(0)
+                                    );
+                                }
+                            });
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
🤖 Allocation totals identify repeated schema/descriptor construction, but the same allocator caller appears under many application paths. Keep the most frequently count-sampled full stack for each grouped caller and print its repository frames, including inline frames, alongside the aggregate counts.

For example, a TableSchema clone total can now be followed to the publication or ingestion operation responsible for a representative sample. This context is explicitly a representative stack, not a stack shared by every allocation in the aggregate. Byte and count rankings and sampling are unchanged. Symbol resolution runs after allocation tracking stops; this adds no product runtime behavior.

Optimized allocation-enabled benchmark compilation and scoped Clippy/formatting pass. The full anonymized cold-load allocation run passed with 27,518 rows. Through readiness it counted 158,399,558 Rust allocations and 48,278,579,856 cumulative requested bytes; 12,320 sampled stacks remain below the 50,000 cap. This is Rust allocator coverage, not native C/C++ allocations or resident memory. The sample contexts identify discarded schema clones during row identity checks and per-row wire descriptor reconstruction during incoming validation. Draft profiling tool on #2811; no product performance claim.
