### PR TITLE
perf: borrow schemas for row identity checks and serialization

### DIFF
--- a/crates/jazz/src/node/physical/projections.rs
+++ b/crates/jazz/src/node/physical/projections.rs
@@ -7,7 +7,7 @@ where
         schema_version: SchemaVersionId,
         logical_table: &str,
     ) -> Result<PhysicalTableId, Error> {
-        self.table_in_schema(logical_table, schema_version)?;
+        self.table_in_schema_ref(logical_table, schema_version)?;
         self.catalogue
             .physical_mappings
             .get(&schema_version)

--- a/crates/jazz/src/node/state/read_payload.rs
+++ b/crates/jazz/src/node/state/read_payload.rs
@@ -255,9 +255,9 @@ where
             .ok_or(Error::InvalidStoredValue(
                 "history schema version alias must exist",
             ))?;
-        let table = self.table_in_schema(version.table(), schema_version)?;
+        let table = self.table_in_schema_ref(version.table(), schema_version)?;
         let authored_columns = self.authored_columns_for_version(version)?;
-        VersionRecord::from_stored(version, &table, schema_version, authored_columns)
+        VersionRecord::from_stored(version, table, schema_version, authored_columns)
     }
 
     /// Resolve a projected repair name to the current name of its exact body

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -2956,7 +2956,7 @@ where
             .ok_or(Error::InvalidStoredValue(
                 "maintained witness schema version alias must exist",
             ))?;
-        match self.table_in_schema(version.table(), authored_schema) {
+        match self.table_in_schema_ref(version.table(), authored_schema) {
             Ok(_) => {}
             Err(Error::TableNotFound(_)) => {
                 // A current-query source may have been projected through a


### PR DESCRIPTION
🤖 The allocation profile traced repeated full TableSchema copies to row identity checks. Physical-table resolution and canonical maintained-witness lookup cloned the schema solely to check that the table existed, then discarded it. Version serialization also cloned a schema that it only read.

Use the existing borrowed lookup at these three sites. For example, publishing many rows from one table still checks each row's authored-schema membership and physical identity, but those checks no longer copy all column definitions, policies and references. Errors, catalogue resolution and encoded bytes are unchanged; there is no new cache or ownership abstraction.

Jazz library: 2,005 passed, 2 ignored with the established 4MiB test-thread stack. An initial invocation omitted that setting and aborted on stack overflow; the corrected invocation passes. Scoped Clippy and formatting pass. All three scaling canaries and the two-seed maintained-query oracle at depths 10 and 1,000 pass. Clean optimized cold settling is 23.541s versus 23.881s (~1.4%), with all 27,518 rows correct; this small single-run difference is not a substantial performance claim. Retained because four substitutions remove unnecessary copies using existing borrowed APIs. Draft on #2812; no independent review or full canonical acceptance claimed.
