### PR TITLE
perf: prepare view descriptors once per validation batch

### DIFF
--- a/crates/jazz/src/node/ingest/validation.rs
+++ b/crates/jazz/src/node/ingest/validation.rs
@@ -921,8 +921,17 @@ where
         &self,
         versions: &[VersionRecord],
     ) -> Result<(), Error> {
+        self.validate_view_payload_versions_prepared(versions, &mut BTreeMap::new())
+    }
+
+    pub(super) fn validate_view_payload_versions_prepared<'a>(
+        &self,
+        versions: &'a [VersionRecord],
+        descriptors: &mut BTreeMap<(SchemaVersionId, &'a str), groove::records::RecordDescriptor>,
+    ) -> Result<(), Error> {
         // View/repair bodies come from an admitted authority encoder. Check
         // semantic catalogue compatibility below, not their byte representation.
+        // Catalogue state cannot change during this shared-borrow preflight.
         for version in versions {
             let schema = self
                 .catalogue
@@ -939,7 +948,10 @@ where
                 .ok_or(Error::MalformedViewUpdate(
                     "row version table is absent from its authored schema",
                 ))?;
-            if version.record().descriptor() != &table.wire_record_descriptor() {
+            let descriptor = descriptors
+                .entry((version.schema_version(), version.table()))
+                .or_insert_with(|| table.wire_record_descriptor());
+            if version.record().descriptor() != descriptor {
                 return Err(Error::MalformedViewUpdate(
                     "row version does not carry the complete descriptor of its authored schema",
                 ));

--- a/crates/jazz/src/node/views.rs
+++ b/crates/jazz/src/node/views.rs
@@ -1731,6 +1731,7 @@ where
     /// Validate all row bundles carried by a receiver frame without changing
     /// storage or in-memory receiver state.
     fn validate_view_update_payloads(&self, updates: &[ViewUpdateParts]) -> Result<(), Error> {
+        let mut descriptors = BTreeMap::new();
         for update in updates {
             // An opening-pending marker makes no source or body claim. It
             // must not mutate a prior closure while withholding settlement.
@@ -1798,7 +1799,7 @@ where
                 // shared transaction boundary keeps view payloads from being
                 // a durable-ingress bypass for operation provenance.
                 self.admit_contribution_merge_for_storage(bundle.tx)?;
-                self.validate_view_payload_versions(bundle.versions)?;
+                self.validate_view_payload_versions_prepared(bundle.versions, &mut descriptors)?;
             }
         }
         Ok(())


### PR DESCRIPTION
🤖 Incoming view validation rebuilt a table's complete wire descriptor for every row. Prepare each expected descriptor once per validation batch, keyed by authored schema version and table name. Reuse that preparation across all bundles in the receiver frame.

For example, 1,000 rows from one table under one authored schema construct one expected descriptor rather than 1,000. A row from a different schema version or table gets its own expected descriptor. Every incoming row is still compared against that descriptor; unknown schemas/tables, incomplete layouts, invalid provenance and invalid branch keys still reject before receiver mutation. The map lives only for the shared-borrow validation pass, so no catalogue invalidation or retained cache is introduced. Direct ingress retains its own full validation pass.

Jazz library: 2,005 passed, 2 ignored. Scoped Clippy and formatting pass. All three scaling canaries and the two-seed maintained-query oracle pass. Clean optimized cold settling is 22.966s versus 23.541s (~2.4%), with all 27,518 rows correct. This is a modest single-run gain, retained as a small batch-local preparation change; no persistent cache or invalidation machinery. Draft on #2813; no format change, independent review or full canonical acceptance claimed.
