### PR TITLE
perf: avoid redundant staged operation and index copies

### DIFF
--- a/crates/groove/src/db/commit.rs
+++ b/crates/groove/src/db/commit.rs
@@ -371,11 +371,9 @@ impl Database {
         let tick = self
             .ivm_runtime
             .assign_resident_publication(resident_tick, publication);
-        let staged_operations = staged_state.borrow().clone().into_operations();
-
         self.resident_writes
             .borrow_mut()
-            .extend(staged_operations.iter().cloned());
+            .extend(staged_state.borrow().operations().iter().cloned());
         self.resident_publications
             .insert(publication, Rc::clone(&staged_state));
         if !roots.is_empty() {
@@ -463,7 +461,7 @@ impl Database {
     pub(super) fn refresh_resident_writes(&mut self) {
         let mut resident_writes = StagedWriteState::default();
         for operations in self.resident_publications.values() {
-            resident_writes.extend(operations.borrow().clone().into_operations());
+            resident_writes.extend(operations.borrow().operations().iter().cloned());
         }
         *self.resident_writes.borrow_mut() = resident_writes;
     }

--- a/crates/groove/src/db/mod.rs
+++ b/crates/groove/src/db/mod.rs
@@ -1463,7 +1463,7 @@ impl AppliedBatch {
             Poll::Pending
         })
         .await;
-        let operations = self.operations.borrow().clone().into_operations();
+        let operations = self.operations.borrow().operations().to_vec();
         let storage_writes = StorageWriteMetrics::from_operations(
             &operations
                 .iter()

--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -1646,6 +1646,10 @@ impl StagedWriteState {
         }
     }
 
+    pub(crate) fn operations(&self) -> &[OwnedWriteOperation] {
+        &self.operations
+    }
+
     pub(crate) fn into_operations(self) -> Vec<OwnedWriteOperation> {
         self.operations
     }


### PR DESCRIPTION
🤖 Publication copied the staged write container into a temporary operation vector, then copied every operation again into the resident overlay. The container copy also duplicated its point-lookup index, which was immediately discarded. Persistence and resident-overlay rebuilding made the same unnecessary index copy.

Expose an internal borrowed operation slice. Publication and overlay rebuilding clone directly from that slice; persistence copies only the operation vector it must hand to the storage backend. For example, a batch with 1,000 sets still retains its original staged operations and creates the same resident/backend copies, but no longer creates the intermediate publication copy or discarded lookup-index copies. No ownership is taken from the original batch, and publication order, cancellation, failure handling and durability semantics are unchanged.

The public DatabaseBatch Clone implementation is retained; an attempted removal of the internal Clone derive exposed that dependency and was reverted before this commit. Groove library: 744 passed, 2 ignored. Scoped Clippy and formatting pass. Jazz library: 2,005 passed, 2 ignored. All three scaling canaries and the two-seed maintained-query oracle pass. Clean native cold settling is 22.934s versus 22.966s, essentially unchanged. Todo roundtrips are 325.44/327.92/319.07ms versus the earlier #2811 checkpoint of 317.24ms (this comparison includes #2813 and #2814 too). No elapsed-time improvement is claimed; this small change removes demonstrably redundant intermediate/index copies without adding state or changing ordering. Draft on #2814; no format change or full acceptance claim.
