### PR TITLE
bench: scope external CPU sampling to cold-load readiness

### DIFF
--- a/crates/benchmark-guard/src/lib.rs
+++ b/crates/benchmark-guard/src/lib.rs
@@ -13,6 +13,14 @@ pub struct ContaminatingInstrumentation {
 /// wall-clock or storage-counter benchmark and receipt measurements.
 pub const CONTAMINATING_INSTRUMENTATION: &[ContaminatingInstrumentation] = &[
     ContaminatingInstrumentation {
+        name: "JAZZ_PERF_CONTROL_FIFO",
+        reason: "it enables externally controlled CPU profiling during cold-load attribution",
+    },
+    ContaminatingInstrumentation {
+        name: "JAZZ_PERF_ACK_FIFO",
+        reason: "it configures CPU profiler acknowledgement during cold-load attribution",
+    },
+    ContaminatingInstrumentation {
         name: "JAZZ_REHYDRATE_TRACE",
         reason: "it resets storage-read metrics and adds timing plus formatted stderr output inside rehydration",
     },

--- a/crates/jazz-sim/Cargo.toml
+++ b/crates/jazz-sim/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [features]
 default = []
 bench-alloc-metrics = []
+bench-perf-control = []
 bench-alloc-sites = ["dep:backtrace"]
 profiling = ["dep:pprof"]
 transport-compression-lz4 = ["jazz/transport-compression-lz4"]

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -425,18 +425,66 @@ const RESOURCE_SPECS: [ResourceSpec; 14] = [
     ResourceSpec::new("res_n", 1, 2, None),
 ];
 
+// External perf starts disabled. Acknowledged commands bound CPU sampling to
+// the same connect/subscribe/settle interval as allocation attribution.
+#[cfg(feature = "bench-perf-control")]
+struct PerfControl {
+    control: std::fs::File,
+    acknowledgements: std::io::BufReader<std::fs::File>,
+}
+
+#[cfg(feature = "bench-perf-control")]
+impl PerfControl {
+    fn start() -> Self {
+        let open = |name| {
+            std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(std::env::var_os(name).expect("perf control requires control and ack FIFOs"))
+                .expect("open perf control FIFO")
+        };
+        let mut control = Self {
+            control: open("JAZZ_PERF_CONTROL_FIFO"),
+            acknowledgements: std::io::BufReader::new(open("JAZZ_PERF_ACK_FIFO")),
+        };
+        control.command("enable");
+        control
+    }
+
+    fn command(&mut self, command: &str) {
+        use std::io::{BufRead, Write};
+        writeln!(self.control, "{command}").expect("write perf command");
+        self.control.flush().expect("flush perf command");
+        let mut acknowledgement = String::new();
+        self.acknowledgements
+            .read_line(&mut acknowledgement)
+            .expect("read perf acknowledgement");
+        assert_eq!(
+            acknowledgement.trim(),
+            "ack",
+            "unexpected perf acknowledgement"
+        );
+    }
+}
+
 fn main() {
     #[cfg(feature = "cold-settle-attribution")]
     let _phase_subscriber =
         tracing::subscriber::set_default(jazz_sim::phase_attribution::Collector);
     // Allocation attribution deliberately instruments the workload. Its timing
     // is not a benchmark receipt, and sampler configuration must remain usable.
-    #[cfg(not(any(feature = "bench-alloc-sites", feature = "bench-alloc-metrics")))]
+    #[cfg(not(any(
+        feature = "bench-alloc-sites",
+        feature = "bench-alloc-metrics",
+        feature = "bench-perf-control"
+    )))]
     jazz_benchmark_guard::refuse_contaminated_measurement();
     #[cfg(any(feature = "bench-alloc-sites", feature = "bench-alloc-metrics"))]
     eprintln!(
         "allocation attribution run: wall-clock timings are not comparable to clean receipts"
     );
+    #[cfg(feature = "bench-perf-control")]
+    eprintln!("scoped CPU attribution run: wall-clock timings are not clean receipts");
     let config = Config::from_env();
     let schema = schema();
     let seeded = seed_core(&schema, &config);
@@ -1548,6 +1596,8 @@ fn run_connect_and_subscribe(
     expected: &BTreeMap<String, usize>,
     config: &Config,
 ) -> RunSummary {
+    #[cfg(feature = "bench-perf-control")]
+    let mut perf_control = PerfControl::start();
     alloc_metrics::reset_and_start();
     #[cfg(feature = "cold-settle-attribution")]
     {
@@ -1702,6 +1752,8 @@ fn run_connect_and_subscribe(
         ticks += 1;
     }
     let settle_ms = settle_start.elapsed().as_millis();
+    #[cfg(feature = "bench-perf-control")]
+    perf_control.command("disable");
     // Match the readiness boundary: later one-shot verification and storage
     // sizing are diagnostics, not work needed to make subscriptions usable.
     let alloc_snapshot = alloc_metrics::stop();
@@ -2307,6 +2359,14 @@ fn emit_summary(config: &Config, phase: &str, summary: &RunSummary) {
         WireCompression::Lz4 => "lz4",
         WireCompression::Zstd => "zstd",
     };
+    fields.insert(
+        "cpu_profile_scope".to_owned(),
+        json!(if cfg!(feature = "bench-perf-control") {
+            Some("connect_subscribe_settle")
+        } else {
+            None
+        }),
+    );
     fields.insert("phase".to_owned(), json!(phase));
     fields.insert("scale".to_owned(), json!(config.scale));
     fields.insert("active_transport_codec".to_owned(), json!(transport_codec));

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -460,7 +460,7 @@ impl PerfControl {
             .read_line(&mut acknowledgement)
             .expect("read perf acknowledgement");
         assert_eq!(
-            acknowledgement.trim(),
+            acknowledgement.trim_matches(|ch: char| ch == '\0' || ch.is_ascii_whitespace()),
             "ack",
             "unexpected perf acknowledgement"
         );

--- a/dev/benchmarks/scoped-cold-cpu-profile.md
+++ b/dev/benchmarks/scoped-cold-cpu-profile.md
@@ -1,0 +1,58 @@
+# CPU profiling through cold-load readiness
+
+The `customer_cold_start` benchmark's `bench-perf-control` feature uses external
+Linux perf control/ack FIFOs. Sampling starts before connect/subscribe and ends
+when every subscription has its expected rows. Post-readiness diagnostic queries
+are excluded. JSON reports `cpu_profile_scope: connect_subscribe_settle`.
+Ordinary benchmark builds reject the control variables. Profiling timings are
+not clean performance receipts.
+
+Build with `cargo build -p jazz-sim --bench customer_cold_start --profile perf
+--features cold-settle-attribution,bench-perf-control`. Use the emitted benchmark
+executable under `target/perf/deps/` in this shell pattern:
+
+```bash
+ulimit -n 65536
+profile_control_dir=$(mktemp -d /tmp/jazz-cold-perf.XXXXXX)
+mkfifo "$profile_control_dir/control" "$profile_control_dir/ack"
+exec 3<>"$profile_control_dir/control"
+exec 4<>"$profile_control_dir/ack"
+JAZZ_PERF_CONTROL_FIFO="$profile_control_dir/control" \
+JAZZ_PERF_ACK_FIFO="$profile_control_dir/ack" \
+JAZZ_CUSTOMER_IDENTITY=member JAZZ_CUSTOMER_PHASES=cold \
+JAZZ_CUSTOMER_SCALE=1.0 JAZZ_CUSTOMER_MAX_TICKS=200000 \
+perf record -F 99 --call-graph dwarf,65528 --delay=-1 --control fd:3,4 \
+  -o cold-cpu.data -- "$profile_benchmark"
+profile_result=$?
+exec 3>&-
+exec 4>&-
+unlink "$profile_control_dir/control"
+unlink "$profile_control_dir/ack"
+rmdir "$profile_control_dir"
+exit "$profile_result"
+```
+
+Set `profile_benchmark` to that executable first. Both FIFOs are opened read/write
+before perf starts so their opening cannot deadlock with benchmark startup.
+Perf acknowledgements may include NUL framing after the newline; accept that
+framing explicitly. A first run exposed this and aborted after disabling samples;
+use the subsequent completed runs, not that incomplete receipt.
+
+On runtime #2815, the completed 199Hz/default-stack and 99Hz/65,528-byte-stack
+captures both materialized all 27,518 rows and reported zero lost samples.
+The larger snapshots improve caller recovery through large async frames, but
+some outer stacks remain unresolved. Kernel symbols are unavailable on this
+host. Inclusive function percentages overlap and are not an additive phase
+breakdown; the existing exclusive phase timers provide that breakdown.
+
+The scoped samples still show roughly a quarter of CPU in allocation/freeing,
+about 6% in memory movement, plus record field access, hashing and result handling.
+This does not imply a quarter of allocations can be removed for a quarter of
+elapsed time: the small #2813–#2815 cleanups moved cold settling from 23.881s to
+22.934s, and todo roundtrips remained around 319–328ms versus 317ms previously.
+Allocation-count rankings need CPU callers and code walks before prioritization.
+The cold-load target of about 5s remains unmet.
+
+Tooling friction: default 8KiB stack snapshots hide many async callers; perf's
+NUL-framed acknowledgement is not obvious from the short help text. The scoped
+feature and this command make both requirements explicit for future profiles.


### PR DESCRIPTION
🤖 Whole-process CPU profiles included seed checks and diagnostic queries performed after subscriptions were ready. Add an explicit bench-perf-control feature that uses perf's acknowledged enable/disable commands to collect only connection setup, subscription setup and settling to all expected rows.

Start external perf disabled with control/ack FIFOs. The benchmark enables sampling before setup and disables it at readiness, before post-readiness diagnostics. JSON labels this scope and stderr identifies a profiling-only run; ordinary benchmark builds reject the control environment through the existing contamination guard. No product runtime code changes.

The optimized profiling target compiles; benchmark-guard tests (2), scoped Clippy and formatting pass. Completed scoped captures at 199Hz and 99Hz both materialize all 27,518 rows with zero lost samples. Larger DWARF snapshots improve async caller recovery; some outer frames and kernel symbols remain unresolved. The first control trial exposed a NUL-framed acknowledgement and failed after disabling sampling; the corrected implementation completes. A committed report records the exact procedure and limits. Draft on #2815. Profile wall-clock values are not clean timing receipts.
