### PR TITLE
perf: grow cursor output buffers with returned rows

### DIFF
--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -1885,7 +1885,8 @@ impl StorageCursor for OverlayScanCursor<'_> {
                 return Ok(None);
             };
 
-            let mut values = Vec::with_capacity(batch_len);
+            // Short and empty scans should not reserve a full page.
+            let mut values = Vec::new();
             while values.len() < batch_len {
                 let Some(entry) = self.next_entry().await? else {
                     break;

--- a/crates/jazz-storage-rocksdb/src/lib.rs
+++ b/crates/jazz-storage-rocksdb/src/lib.rs
@@ -160,7 +160,8 @@ impl StorageCursor for RocksDbCursor<'_> {
                 return Ok(None);
             }
             let batch_limit = self.remaining.unwrap_or(256).min(256);
-            let mut batch = Vec::with_capacity(batch_limit);
+            // Short and empty scans should not reserve a full page.
+            let mut batch = Vec::new();
             while batch.len() < batch_limit {
                 let Some(item) = self.iterator.next() else {
                     self.done = true;


### PR DESCRIPTION
🤖 Overlay and RocksDB cursors reserved a full 256-entry output vector before finding out whether a scan returned any rows. Allocation profiling attributed gigabytes of cumulative requested capacity to these cursor buffers, including short prefix scans.

Let the output vectors grow as entries arrive. Empty scans allocate no output vector, short scans use a small vector, and full scans still return the same batches of up to 256 entries. Keys, values, ordering, bounds, limits and persistence are unchanged. This trades vector growth on full batches for avoiding oversized allocations on short scans.

Groove library: 744 passed, 2 ignored. RocksDB library: 25 passed. All three scaling canaries and the two-seed maintained-query oracle pass. Scoped Clippy and formatting pass. Clean cold settling is 22.951s versus 22.934s, with all 27,518 rows correct: no elapsed improvement is claimed. Retained as a two-line removal of unconditional full-page capacity; it is not evidence toward the latency target. Draft experiment on #2816; no format change or full acceptance claim.
