### PR TITLE
Reject intentional pre-hello WebSocket closes

### DIFF
--- a/.changeset/bug-189-prehello-close.md
+++ b/.changeset/bug-189-prehello-close.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reject intentional WebSocket closes before server hello.

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.test.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import { readFileSync } from "node:fs";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import type { BrowserWebSocket } from "./websocket.js";
 import { PostcardReader, PostcardWriter } from "./native-codec.js";
 import {
@@ -704,6 +704,61 @@ describe("websocket frame carrier", () => {
     expect(delivered).toEqual([]);
     expect(socket!.closed).toBe(true);
   });
+  it("rejects readiness when intentionally closed before server hello and ignores late socket events", async () => {
+    vi.useFakeTimers();
+    try {
+      let socket: MessageWebSocket | undefined;
+      const errors: unknown[] = [];
+      const terminals: unknown[] = [];
+      const carrier = new WebSocketCarrier({
+        endpointUrl: "ws://127.0.0.1:4200/apps/app-a/ws",
+        peerIdentity: new Uint8Array(16),
+        onFrame: () => {},
+        onError: (error) => errors.push(error),
+        onTerminal: (error) => terminals.push(error),
+        WebSocket: class extends MessageWebSocket {
+          constructor(url: string) {
+            super(url, (created) => {
+              socket = created;
+            });
+          }
+        },
+      });
+
+      const ready = carrier.ready();
+      expect(carrier.ready()).toBe(ready);
+      carrier.close();
+      carrier.close();
+
+      const readiness = Promise.race([
+        ready.then(
+          () => ({ kind: "resolved" as const }),
+          (error) => ({ kind: "rejected" as const, error }),
+        ),
+        new Promise<{ kind: "timeout" }>((resolve) => {
+          setTimeout(() => resolve({ kind: "timeout" }), 100);
+        }),
+      ]);
+      await vi.advanceTimersByTimeAsync(100);
+      const result = await readiness;
+      expect(result.kind).toBe("rejected");
+      if (result.kind === "rejected") {
+        expect(result.error).toBeInstanceOf(Error);
+      }
+
+      socket!.emitError(new Error("late transport error"));
+      socket!.emitClose({ code: 1000, reason: "intentional" });
+      socket!.emitMessage(encodeWebSocketFrameBatch([encodeServerHello(1n)]));
+      await Promise.resolve();
+
+      expect(socket!.closeCalls).toBe(1);
+      expect(socket!.closed).toBe(true);
+      expect(errors).toEqual([]);
+      expect(terminals).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it("surfaces an authentication failure before server hello without negotiating", async () => {
     let socket: MessageWebSocket | undefined;
@@ -1017,6 +1072,8 @@ class MessageWebSocket {
   binaryType: "arraybuffer" | "blob" = "arraybuffer";
   readonly readyState = 1;
   private readonly messageListeners: Array<(event: { data: unknown }) => void> = [];
+  private readonly errorListeners: Array<(event: unknown) => void> = [];
+  private readonly closeListeners: Array<(event: { code: number; reason: string }) => void> = [];
 
   constructor(
     readonly url: string,
@@ -1028,8 +1085,10 @@ class MessageWebSocket {
   send(_data: Uint8Array | string): void {}
 
   closed = false;
+  closeCalls = 0;
 
   close(): void {
+    this.closeCalls += 1;
     this.closed = true;
   }
 
@@ -1043,11 +1102,23 @@ class MessageWebSocket {
   addEventListener(type: string, listener: unknown): void {
     if (type === "message") {
       this.messageListeners.push(listener as (event: { data: unknown }) => void);
+    } else if (type === "error") {
+      this.errorListeners.push(listener as (event: unknown) => void);
+    } else if (type === "close") {
+      this.closeListeners.push(listener as (event: { code: number; reason: string }) => void);
     }
   }
 
   emitMessage(data: Uint8Array): void {
     for (const listener of this.messageListeners) listener({ data });
+  }
+
+  emitError(event: unknown): void {
+    for (const listener of this.errorListeners) listener(event);
+  }
+
+  emitClose(event: { code: number; reason: string }): void {
+    for (const listener of this.closeListeners) listener(event);
   }
 }
 

--- a/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/websocket.ts
@@ -252,6 +252,7 @@ export class WebSocketCarrier {
     });
     void waitForOpen(this.socket).then(
       () => {
+        if (this.closing) return;
         this.socket.send(
           encodeWebSocketPrelude(
             options.authJson ?? "{}",
@@ -339,6 +340,16 @@ export class WebSocketCarrier {
   close(): void {
     if (this.closing) return;
     this.closing = true;
+    this.reportTerminal(
+      {
+        code: "websocket_closed",
+        retry: "never",
+        message: "websocket closed before server hello",
+      },
+      new Error("websocket closed before server hello"),
+      false,
+      false,
+    );
     try {
       this.socket.close();
     } catch {
@@ -351,12 +362,13 @@ export class WebSocketCarrier {
     error: WireError,
     negotiationError = new Error(error.message),
     notifyError = true,
+    notifyTerminal = true,
   ): void {
-    if (this.closing || this.terminated) return;
+    if (this.terminated) return;
     this.terminated = true;
     this.rejectNegotiation(negotiationError);
     if (notifyError) this.onError?.(error);
-    this.onTerminal?.(error);
+    if (notifyTerminal) this.onTerminal?.(error);
   }
 
   private async handleMessage(data: unknown): Promise<void> {


### PR DESCRIPTION
🤖 ## Summary
- Reject intentional WebSocket closes before the server hello.
- Ignore late socket events after readiness has been rejected.

## Before
An intentional close before the server hello could leave the readiness promise unresolved.

## After
The close settles readiness with an error and prevents late socket events from mutating the closed connection.

## Test plan
- [x] Focused WebSocket regression test

## Integration status

Rebased into the stable-fixes stack on main. Independent review and readiness-close regression passed, including a mutation omitting rejection. Full combined CI is green; user merge approval remains separate.
