### PR TITLE
perf(groove): append fixed nullable payloads directly

### DIFF
--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -2005,7 +2005,13 @@ fn encode_nullable(
     match value {
         Some(value) => {
             bytes.push(1);
-            bytes.extend(encode_value(value, inner_type)?);
+            if inner_type.is_fixed_size() {
+                // The parent already owns the output buffer. Fixed payloads
+                // need no temporary Vec, including nested nullable values.
+                encode_fixed_value(bytes, value, inner_type)?;
+            } else {
+                bytes.extend(encode_value(value, inner_type)?);
+            }
         }
         None => {
             bytes.push(0);


### PR DESCRIPTION
🤖 Append fixed-width nullable payloads directly into their parent buffer. Previously `Some(uuid)` allocated a temporary Vec for the 16-byte UUID and copied it after the presence flag. It now uses the existing fixed-value encoder on the parent buffer; nested fixed nullable and tuple payloads follow the same path. Null padding and variable-width encoding remain unchanged.

The phase-enabled allocation run on the parent recorded 143.367M Rust allocation requests for 27,518 visible rows; sampled callers ranked nullable encoding first at approximately 6.06M requests. This small slice tests the fixed-width portion before extending variable-width encoding. No wire/storage layout change.

Groove: 744 passed, 2 ignored. Three scaling canaries and the two-seed maintained-query differential oracle passed. Clippy and formatting pass. Clean optimized cold load materialized all 27,518 rows: 21.850s settle / 22.335s dominant-query readiness versus 21.757s / 22.247s on the parent. This is flat; no elapsed-time improvement is claimed. Retained as a small temporary-allocation simplification, not a performance milestone. Draft on #2820.
