### PR TITLE
perf(jazz): project stored versions directly into wire records

### DIFF
--- a/crates/jazz/src/node/codec.rs
+++ b/crates/jazz/src/node/codec.rs
@@ -1905,29 +1905,74 @@ impl VersionRecord {
         schema_version: SchemaVersionId,
         authored_columns: Option<BTreeSet<String>>,
     ) -> Result<Self, Error> {
-        // Wire records remain the replicated immutable projection. Content and
-        // register rows now live in different storage tables, so projection at
-        // this API boundary is assembled from typed row accessors.
-        let cells = table
-            .columns
-            .iter()
-            .map(|column| stored.cell(table, &column.name))
-            .collect::<Result<Vec<_>, _>>()?;
-        VersionRecord::encode(
-            table,
+        let descriptor = version_record_descriptors(table).1;
+        let input = stored.record.borrowed();
+        let register = stored.is_register_record();
+        let raw = descriptor.create_with_encoded_fields::<Error>(
+            input.raw().len(),
+            |index, output| {
+                // Both stored layouts share the provenance prefix. Timestamps
+                // are packed HLC values in storage and milliseconds on wire.
+                let source = match index {
+                    0 => Some(HistoryRowRecord::FIELD_ROW_UUID_IDX),
+                    1 => Some(HistoryRowRecord::FIELD_PARENTS_IDX),
+                    2 => Some(HistoryRowRecord::FIELD_CREATED_BY_IDX),
+                    4 => Some(HistoryRowRecord::FIELD_UPDATED_BY_IDX),
+                    i if i >= WireRowRecord::USER_CELLS && !register => {
+                        Some(HistoryRowRecord::USER_CELLS + i - WireRowRecord::USER_CELLS)
+                    }
+                    _ => None,
+                };
+                if let Some(source) = source {
+                    let span = input.descriptor().field_span(input.raw(), source)?;
+                    output.extend_from_slice(&input.raw()[span]);
+                    return Ok(());
+                }
+                let value = match index {
+                    3 => Value::U64(stored.created_at().physical_ms()),
+                    5 => Value::U64(stored.updated_at().physical_ms()),
+                    6 => Value::Nullable(stored.deletion().map(|deletion| {
+                        Box::new(Value::EnumTag(match deletion {
+                            DeletionEvent::Deleted => 0,
+                            DeletionEvent::Restored => 1,
+                        }))
+                    })),
+                    _ => Value::Nullable(None),
+                };
+                descriptor.encode_field_into(index, &value, output)?;
+                Ok(())
+            },
+        )?;
+        #[cfg(test)]
+        {
+            // Application equality cannot detect changed durable bytes. Keep
+            // the former value-based encoder as an independent byte oracle.
+            let cells = table
+                .columns
+                .iter()
+                .map(|column| stored.cell(table, &column.name))
+                .collect::<Result<Vec<_>, _>>()?;
+            let expected = VersionRecord::encode(
+                table,
+                schema_version,
+                stored.row_uuid(),
+                stored.parents(),
+                stored.created_by(),
+                stored.created_at().physical_ms(),
+                stored.updated_by(),
+                stored.updated_at().physical_ms(),
+                &cells,
+                stored.deletion(),
+            )?;
+            assert_eq!(raw.as_slice(), expected.record().raw());
+        }
+        Ok(VersionRecord::new(
+            table.name.clone(),
             schema_version,
-            stored.row_uuid(),
-            stored.parents(),
-            stored.created_by(),
-            stored.created_at().physical_ms(),
-            stored.updated_by(),
-            stored.updated_at().physical_ms(),
-            &cells,
-            stored.deletion(),
+            OwnedRecord::new(raw, descriptor),
         )
-        .map(|record| record.with_branch_key(stored.branch_key().clone()))
-        .map(|record| record.with_authored_columns(authored_columns))
-        .map_err(Error::from)
+        .with_branch_key(stored.branch_key().clone())
+        .with_authored_columns(authored_columns))
     }
 }
 
@@ -2096,6 +2141,7 @@ struct HistoryDescriptorCacheEntry {
         crate::schema::LargeValueSemanticKind,
     )>,
     descriptor: records::RecordDescriptor,
+    wire_descriptor: records::RecordDescriptor,
 }
 
 #[cfg(test)]
@@ -2104,6 +2150,12 @@ thread_local! {
 }
 
 fn history_record_descriptor(table: &TableSchema) -> records::RecordDescriptor {
+    version_record_descriptors(table).0
+}
+
+fn version_record_descriptors(
+    table: &TableSchema,
+) -> (records::RecordDescriptor, records::RecordDescriptor) {
     thread_local! {
         static CACHE: std::cell::RefCell<Vec<HistoryDescriptorCacheEntry>> = const {
             std::cell::RefCell::new(Vec::new())
@@ -2124,11 +2176,12 @@ fn history_record_descriptor(table: &TableSchema) -> records::RecordDescriptor {
                             && kind == &column.large_value_kind
                     })
         }) {
-            return entry.descriptor;
+            return (entry.descriptor, entry.wire_descriptor);
         }
         #[cfg(test)]
         HISTORY_DESCRIPTOR_BUILDS.with(|count| count.set(count.get() + 1));
         let descriptor = table.authored_history_storage_table().record_schema();
+        let wire_descriptor = table.wire_record_descriptor();
         // Bound retained preparation data even for applications with continual
         // schema changes. Eviction affects preparation cost only, never bytes.
         if cache.len() == 128 {
@@ -2148,8 +2201,9 @@ fn history_record_descriptor(table: &TableSchema) -> records::RecordDescriptor {
                 })
                 .collect(),
             descriptor,
+            wire_descriptor,
         });
-        descriptor
+        (descriptor, wire_descriptor)
     })
 }
 
@@ -5186,6 +5240,10 @@ mod authority_storage_codec_tests {
             let expected = table.authored_history_storage_table().record_schema();
             for _ in 0..100 {
                 assert_eq!(history_record_descriptor(table), expected);
+                assert_eq!(
+                    version_record_descriptors(table).1,
+                    table.wire_record_descriptor()
+                );
                 assert_eq!(
                     register_record_descriptor(table),
                     table.register_storage_table().record_schema()

--- a/dev/benchmarks/direct-stored-wire-projection.md
+++ b/dev/benchmarks/direct-stored-wire-projection.md
@@ -1,0 +1,45 @@
+# Stored-version publication without value reconstruction
+
+The exact phase allocation collector (#2820) ran the 39-subscription native
+permissioned fixture with all 27,518 expected rows present. At clean commit
+02171f062c it counted 143,366,980 Rust allocation requests and 35,787,730,107
+cumulative requested bytes between connection and readiness. The exclusive
+phase buckets sum exactly to those totals. This is allocator traffic, not RSS;
+C++/RocksDB internal allocations are outside the counter. Instrumented elapsed
+times are not clean performance receipts.
+
+| Exclusive phase, summed across roles     | Allocations | Requested bytes |
+| ---------------------------------------- | ----------: | --------------: |
+| Ingest                                   |     20.684M |         2.767GB |
+| Query setup                              |     17.277M |         2.732GB |
+| Storage application                      |     16.494M |         1.962GB |
+| Supporting-row publication               |     13.180M |         2.756GB |
+| Result collection                        |     11.364M |         2.573GB |
+| Receive updates                          |      9.966M |         1.851GB |
+| Query evaluation, excluding child phases |      9.506M |         5.930GB |
+| Decode query outputs                     |      6.083M |         5.225GB |
+| Persistence                              |      4.121M |         0.398GB |
+
+This is not a CPU ranking. For example, removing fixed-nullable temporary
+buffers (#2821) left total settling flat at 21.850s versus 21.757s.
+
+Sampled allocation stacks identified another representation roundtrip:
+`version_record_from_row -> VersionRecord::from_stored -> VersionRecord::encode`.
+Every outgoing stored version decoded its cells into owned Values, reconstructed
+its provenance and parents, rebuilt its descriptor, and encoded everything.
+
+The new path copies the existing encoded parents, authors and user fields into
+one wire-record output buffer. It converts packed storage HLC timestamps to wire
+milliseconds and emits deletion/null fields explicitly. The existing bounded
+schema-shape cache prepares the wire descriptor alongside the history descriptor.
+There is no new storage or wire format. Test builds retain the old value encoder
+as an independent exact-byte oracle for every conversion.
+
+Clean optimized run at 245b1c39ae: all 27,518 rows, 21.037s settle and 21.522s
+for dominant-query readiness. Parent: 21.850s / 22.335s. Supporting-row
+publication falls from 2.022s to 1.414s (30%); total settling improves 3.7%.
+Most other phases stay close. These are individual runs, not a confidence
+interval, and the local phase gain must not be advertised as an end-to-end gain.
+
+All 2,005 Jazz library tests passed (2 ignored), including wire/history exact
+roundtrips and provenance boundary cases. Clippy and formatting passed.

--- a/dev/benchmarks/direct-stored-wire-projection.md
+++ b/dev/benchmarks/direct-stored-wire-projection.md
@@ -43,3 +43,13 @@ interval, and the local phase gain must not be advertised as an end-to-end gain.
 
 All 2,005 Jazz library tests passed (2 ignored), including wire/history exact
 roundtrips and provenance boundary cases. Clippy and formatting passed.
+
+The 1,500-row todo fixture, updating 1,350 rows, measured a 281.629ms
+batch roundtrip versus the preceding 319.211ms receipt (about 12% faster;
+that comparison also includes the small nullable-buffer change). Initial
+publication was 94.742ms, receiver ingest 44.999ms, and initial query 17.696ms.
+These native phases exclude browser/IndexedDB and real network overhead.
+
+Replacing the created-at millisecond conversion with the packed HLC value
+makes `wire_record_round_trips_through_history_bytes` fail at the new byte
+oracle. Exact source restoration passes the test again.


### PR DESCRIPTION
🤖 Project stored versions directly into wire records instead of reconstructing every cell as an owned Value and encoding it again.

For a stored task with a text title, nullable priority and structured author, publication previously decoded those fields, allocated their temporary values, rebuilt the wire descriptor, and then re-encoded them. It now copies their existing field bytes into one output record. Parents and author structures are copied too. Packed storage HLC timestamps are still converted to wire milliseconds. Deletion-register rows still emit their deletion state and null user fields; branch coordinates and authored-column metadata are retained.

The existing bounded schema-shape descriptor cache now prepares both history and wire descriptors. Its key still includes table name, ordered column names/types and large-value semantic kinds, so JSON, text and table-bound enums cannot share an incompatible layout. No new long-lived cache or wire/storage format is introduced.

This addresses the sampled allocation path through `VersionRecord::from_stored` inside supporting-row publication (13.180M allocation requests across Core and relay on the parent instrumentation run). In test builds the former value-based encoder remains an independent byte oracle for every conversion. All 2,005 Jazz library tests pass (2 ignored), including wire/history byte roundtrips and timestamp boundary cases. Clippy and formatting pass. Clean cold load: 21.037s settle / 21.522s readiness versus 21.850s / 22.335s (3.7% total improvement). Supporting-row publication falls 2.022s → 1.414s (30%). The todo 1,350-row batch roundtrip measures 281.629ms versus the preceding 319.211ms receipt (~12%; also includes #2821). All expected rows pass. A deliberate packed-HLC-as-milliseconds mutation fails the wire/history byte oracle; exact restoration passes. These are individual native measurements, not browser acceptance or confidence intervals. Draft on #2821.
