### PR TITLE
perf(jazz): borrow incoming versions during batch preparation

### DIFF
--- a/crates/jazz/src/node/codec.rs
+++ b/crates/jazz/src/node/codec.rs
@@ -2149,6 +2149,10 @@ thread_local! {
     static HISTORY_DESCRIPTOR_BUILDS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
+pub(super) fn prepared_wire_record_descriptor(table: &TableSchema) -> records::RecordDescriptor {
+    version_record_descriptors(table).1
+}
+
 fn history_record_descriptor(table: &TableSchema) -> records::RecordDescriptor {
     version_record_descriptors(table).0
 }

--- a/crates/jazz/src/node/ingest/commit_bundles.rs
+++ b/crates/jazz/src/node/ingest/commit_bundles.rs
@@ -1226,7 +1226,6 @@ where
             .flat_map(|(tx_bundles, _, _)| {
                 tx_bundles.iter().flat_map(|bundle| bundle.versions)
             })
-            .cloned()
             .collect::<Vec<_>>();
         self.prepare_authored_schema_variants_for_commit(&eligible_versions).await?;
 
@@ -1234,7 +1233,7 @@ where
         for (tx_bundles, tx, _) in &eligible {
             let versions = tx_bundles
                 .iter()
-                .flat_map(|bundle| bundle.versions.iter().cloned())
+                .flat_map(|bundle| bundle.versions.iter())
                 .collect::<Vec<_>>();
             if let Some(versions) = self.complete_parent_versions(tx, &versions).await? {
                 complete_parents.push((tx.tx_id, versions));
@@ -1316,15 +1315,16 @@ where
             versions.sort();
             for version in versions {
                 let author_schema = version.schema_version();
-                let source_table_schema = self.table_in_schema(version.table(), author_schema)?;
+                self.table_in_schema_ref(version.table(), author_schema)?;
                 let schema_version_alias = self.ensure_schema_version_alias(author_schema).await?;
+                let source_table_schema = self.table_in_schema_ref(version.table(), author_schema)?;
                 let authored_column_ids = self.authored_column_ids_for_names(
                     author_schema,
                     version.table(),
                     version.authored_columns(),
                 )?;
                 let stored = VersionRow::from_wire_with_schema_version(
-                    &source_table_schema,
+                    source_table_schema,
                     version,
                     authored_column_ids,
                     tx_node_alias,

--- a/crates/jazz/src/node/ingest/validation.rs
+++ b/crates/jazz/src/node/ingest/validation.rs
@@ -102,10 +102,10 @@ where
     }
 
     #[cfg_attr(feature = "cold-settle-attribution", tracing::instrument(skip_all, name = "cold.phase.parent_completion"))]
-    async fn complete_parent_versions(
+    async fn complete_parent_versions<V: std::borrow::Borrow<VersionRecord>>(
         &mut self,
         tx: &Transaction,
-        incoming: &[VersionRecord],
+        incoming: &[V],
     ) -> Result<Option<Vec<VersionRecord>>, Error> {
         let mut assembled = BTreeMap::new();
         if self.query_transaction(tx.tx_id).await?.is_some() {
@@ -115,6 +115,7 @@ where
             }
         }
         for version in incoming {
+            let version = version.borrow();
             match assembled.get(&view_version_key_for_ingest(version)) {
                 Some(existing) if existing != version => {
                     return Err(Error::ConflictingCommitUnit(tx.tx_id));
@@ -823,8 +824,9 @@ where
     /// but a known schema must never accept a descriptor borrowed from another
     /// version: that would make the omitted trailing columns indistinguishable
     /// from an authored value and reintroduce partial-row sync semantics.
-    fn malformed_authored_version_reason(&self, versions: &[VersionRecord]) -> Option<String> {
+    fn malformed_authored_version_reason<V: std::borrow::Borrow<VersionRecord>>(&self, versions: &[V]) -> Option<String> {
         for version in versions {
+            let version = version.borrow();
             for (field, physical_ms) in [
                 ("created_at_ms", version.created_at_ms()),
                 ("updated_at_ms", version.updated_at_ms()),
@@ -859,7 +861,7 @@ where
                     version.table()
                 ));
             };
-            if version.record().descriptor() != &table.wire_record_descriptor() {
+            if version.record().descriptor() != &prepared_wire_record_descriptor(table) {
                 return Some(format!(
                     "row version for table '{}' does not carry the complete descriptor of its authored schema",
                     version.table()
@@ -1001,9 +1003,9 @@ where
     /// Ensure every known authored schema named by an arriving commit has a
     /// local alias and registered shared-storage variant. Unknown schemas stay
     /// parked until their catalogue lineage arrives and re-enters this path.
-    async fn prepare_authored_schema_variants_for_commit(
+    async fn prepare_authored_schema_variants_for_commit<V: std::borrow::Borrow<VersionRecord>>(
         &mut self,
-        versions: &[VersionRecord],
+        versions: &[V],
     ) -> Result<(), Error> {
         if self.malformed_authored_version_reason(versions).is_some() {
             return Err(Error::InvalidStoredValue(
@@ -1011,6 +1013,7 @@ where
             ));
         }
         if versions.iter().any(|version| {
+            let version = version.borrow();
             !self
                 .catalogue
                 .catalogue_schemas
@@ -1021,11 +1024,11 @@ where
 
         let authored_variants = versions
             .iter()
-            .map(|version| (version.table().to_owned(), version.schema_version()))
+            .map(|version| { let version = version.borrow(); (version.table().to_owned(), version.schema_version()) })
             .collect::<BTreeSet<_>>();
         let mut registered_mapping = false;
         for (table, schema_version) in authored_variants {
-            self.table_in_schema(&table, schema_version)?;
+            self.table_in_schema_ref(&table, schema_version)?;
             registered_mapping |= !self
                 .catalogue
                 .schema_version_aliases


### PR DESCRIPTION
🤖 Keep incoming version bodies borrowed during bulk ingestion preparation. The schema check and parent-completeness assembly previously received freshly cloned VersionRecords even though they only needed to inspect them; they now accept either owned or borrowed records. Parent assembly still owns the versions it retains and performs the same conflict/cardinality checks.

Expected wire descriptors use the existing bounded schema-shape cache from #2822 instead of rebuilding per row. The bulk row loop borrows its table schema after alias preparation rather than cloning the schema; the pre-alias table-existence check is retained. No admission check, transaction ordering, storage format or wire format is removed or changed.

This targets allocation stacks under schema preparation in the 20.684M-allocation ingest phase of the phase-enabled fixture. Cargo check and Clippy pass. All 2,005 Jazz library tests pass (2 ignored). Clean optimized fixture materializes all 27,518 rows: 20.958s settle / 21.445s readiness versus 21.037s / 21.522s. Total time is effectively flat (0.4%); exclusive ingest falls 2.497s → 2.229s (~11%) but variation elsewhere offsets most of that. Retained as a small borrowing/metadata-preparation simplification, not an end-to-end performance milestone. Draft on #2822.
