### PR TITLE
perf: trial composition through total prepared projections

### DIFF
--- a/crates/groove/src/ivm/runtime/compilation.rs
+++ b/crates/groove/src/ivm/runtime/compilation.rs
@@ -757,10 +757,10 @@ impl IvmRuntime {
                         })
                     })
                     .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
-                // Compose only total field selections. Dropping an unselected
-                // enum conversion or constant expression could change whether
-                // a row is omitted or an error is raised. Never cross those,
-                // filters, joins, winner selection or other semantic operators.
+                // A selection may bypass a parent only if every parent field
+                // is total for its declared input layout. Reuse preparation to
+                // prove this, including nullable wrappers and valid constants.
+                // Fallible constants and semantic conversions remain barriers.
                 while expressions
                     .iter()
                     .all(|expr| matches!(expr.expression, ProjectExpr::Field(_)))
@@ -772,12 +772,34 @@ impl IvmRuntime {
                     let OpType::MapProject(parent_project) = &parent.descriptor.operator else {
                         break;
                     };
-                    if parent_project.expressions.is_empty()
-                        || !parent_project
-                            .expressions
-                            .iter()
-                            .all(|expr| matches!(expr.expression, ProjectExpr::Field(_)))
-                    {
+                    if parent_project.expressions.is_empty() {
+                        break;
+                    }
+                    let parent_input = self
+                        .graph
+                        .node(parent.descriptor.inputs[0])
+                        .ok_or(IvmRuntimeError::GraphNodeNotFound(
+                            parent.descriptor.inputs[0],
+                        ))?
+                        .descriptor
+                        .output
+                        .records();
+                    let total = raw_projection_fields(
+                        parent_project,
+                        &parent_input,
+                        parent.descriptor.output.records(),
+                    )
+                    .ok()
+                    .flatten()
+                    .is_some_and(|plan| {
+                        plan.fields.iter().all(|field| {
+                            !matches!(
+                                field,
+                                RawProjectionField::Error(_) | RawProjectionField::Evaluate
+                            )
+                        })
+                    });
+                    if !total {
                         break;
                     }
                     for expr in &mut expressions {

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -3178,6 +3178,39 @@ fn projection_composition_skips_only_adjacent_total_selections() {
         outer.output.bind(&output).get_idx(0).unwrap(),
         Value::String("album".into())
     );
+    // Internal: inspect the graph to prove a whole operator was removed, then
+    // verify the composed nullable/constant output through record evaluation.
+    let decorated = source.clone().project_fields([
+        ProjectField::nullable("title", "label"),
+        ProjectField::literal("kind", LiteralValue::String("album".into())),
+    ]);
+    let decorated_selection = runtime
+        .add_dedup_graph(&decorated.project(["label", "kind"]))
+        .unwrap();
+    let decorated_node = runtime.graph.node(decorated_selection.node).unwrap();
+    assert_eq!(decorated_node.descriptor.inputs, vec![base.node]);
+    let OpType::MapProject(decorated_op) = &decorated_node.descriptor.operator else {
+        panic!("projection expected")
+    };
+    let decorated_raw = project_record(
+        &decorated_op.expressions,
+        &decorated_op.mapping,
+        decorated_selection.output,
+        &descriptor,
+        &raw,
+    )
+    .unwrap();
+    assert_eq!(
+        decorated_selection
+            .output
+            .bind(&decorated_raw)
+            .to_values()
+            .unwrap(),
+        vec![
+            Value::Nullable(Some(Box::new(Value::String("album".into())))),
+            Value::String("album".into()),
+        ]
+    );
     let partial = source.project_fields([
         ProjectField::named("id"),
         ProjectField::literal_typed(


### PR DESCRIPTION
🤖 Trial: allow a field-selection projection to compose through a preceding projection whose prepared fields are all total for valid input records. This includes nullable wrapping, nested record fields and successfully encoded constants. Previously only plain field selections could compose.

For example, selecting `label` after constructing `label = nullable(title)` can read the source directly instead of materializing an intermediate row batch. A discarded invalid typed constant still prevents composition, preserving the original error. Enum conversions remain barriers; joins, filters and other semantic operators are not crossed.

All 744 Groove library tests pass (2 ignored), including graph-shape and nullable/constant result checks and the existing invalid-constant boundary. Optimized uninstrumented measurement: 18.912s settle / 19.380s dominant readiness, all 27,518 expected rows, clean revision. Parent measured 18.866s / 19.332s. No measurable improvement: discard this experiment because it does not justify the additional compiler logic. Draft on #2827, not ready for merge; broader tests and independent review remain outstanding.
