### PR TITLE
Reject terminal browser reconnect readiness waiters

### DIFF
--- a/.changeset/bug-195-reconnect-waiters.md
+++ b/.changeset/bug-195-reconnect-waiters.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reject browser reconnect readiness waiters after terminal worker failure.

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.test.ts
@@ -973,6 +973,54 @@ describe("BrowserConnectionManager explicit transport transitions", () => {
     await expect(manager.ensureReady("edge")).resolves.toBeUndefined();
   });
 
+  it("rejects remote readiness on terminal failure while explicitly offline", async () => {
+    const fixture = await leasedManagerFixture();
+    const failure = new Error("browser worker terminated");
+    const bothWaitersParked = deferred();
+    let waitForReconnectCalls = 0;
+    const waitForReconnect = fixture.manager.waitForReconnect.bind(fixture.manager);
+    vi.spyOn(fixture.manager, "waitForReconnect").mockImplementation((signal) => {
+      waitForReconnectCalls += 1;
+      if (waitForReconnectCalls === 2) bothWaitersParked.resolve();
+      return waitForReconnect(signal);
+    });
+
+    fixture.contexts[0]?.onExplicitOfflineChange?.(true);
+    expect(fixture.manager.isExplicitlyOffline()).toBe(true);
+
+    let edgeResult: unknown;
+    let globalResult: unknown;
+    const edgeReady = fixture.manager.ensureReady("edge").then(
+      () => {
+        edgeResult = "resolved";
+      },
+      (error) => {
+        edgeResult = error;
+      },
+    );
+    const globalReady = fixture.manager.ensureReady("global").then(
+      () => {
+        globalResult = "resolved";
+      },
+      (error) => {
+        globalResult = error;
+      },
+    );
+    await bothWaitersParked.promise;
+    fixture.fail(failure);
+
+    await vi.waitFor(() => {
+      expect(edgeResult).toBe(failure);
+      expect(globalResult).toBe(failure);
+    });
+    await Promise.all([edgeReady, globalReady]);
+    expect(fixture.manager.isExplicitlyOffline()).toBe(true);
+
+    await expect(fixture.manager.reconnect()).resolves.toBeUndefined();
+    expect(fixture.manager.isExplicitlyOffline()).toBe(false);
+    await expect(fixture.manager.ensureReady("edge")).resolves.toBeUndefined();
+  });
+
   it("disconnects a worker created while offline before an immediate reconnect", async () => {
     const disconnectGate = deferred();
     const connection = {

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -247,8 +247,11 @@ export class BrowserConnectionManager extends ConnectionManager {
       if (!this.disconnected) return;
     }
     await new Promise<void>((resolve, reject) => {
+      let settled = false;
       const finish = (error?: Error) => {
-        if (!this.reconnectWaiters.delete(finish)) return;
+        if (settled) return;
+        settled = true;
+        this.reconnectWaiters.delete(finish);
         signal?.removeEventListener("abort", onAbort);
         if (error) reject(error);
         else resolve();

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -37,7 +37,7 @@ export class BrowserConnectionManager extends ConnectionManager {
   private initialExplicitOfflineStateKnown = false;
   private connectionError: Error | null = null;
   private disconnected = false;
-  private readonly reconnectWaiters = new Set<() => void>();
+  private readonly reconnectWaiters = new Set<(error?: Error) => void>();
   private transportTransition: Promise<void> = Promise.resolve();
   private storageReset: Promise<void> | null = null;
   private storageResetError: Error | null = null;
@@ -165,6 +165,7 @@ export class BrowserConnectionManager extends ConnectionManager {
     if (this.connection !== connection) return;
     this.connectionError = error;
     this.recoverableConnectionFailure = true;
+    this.rejectReconnectWaiters(error);
   }
 
   async ensureReady(tier?: DurabilityTier, signal?: AbortSignal): Promise<void> {
@@ -242,17 +243,21 @@ export class BrowserConnectionManager extends ConnectionManager {
     if (signal?.aborted) return;
     if (!this.disconnected) {
       await this.transportTransition;
+      if (this.connectionError) throw this.connectionError;
       if (!this.disconnected) return;
     }
-    await new Promise<void>((resolve) => {
-      const finish = () => {
-        this.reconnectWaiters.delete(finish);
+    await new Promise<void>((resolve, reject) => {
+      const finish = (error?: Error) => {
+        if (!this.reconnectWaiters.delete(finish)) return;
         signal?.removeEventListener("abort", onAbort);
-        resolve();
+        if (error) reject(error);
+        else resolve();
       };
       const onAbort = () => finish();
       signal?.addEventListener("abort", onAbort, { once: true });
       this.reconnectWaiters.add(finish);
+      if (signal?.aborted) finish();
+      else if (this.connectionError) finish(this.connectionError);
     });
   }
 
@@ -530,7 +535,13 @@ export class BrowserConnectionManager extends ConnectionManager {
   private resolveReconnectWaiters(): void {
     const waiters = [...this.reconnectWaiters];
     this.reconnectWaiters.clear();
-    for (const resolve of waiters) resolve();
+    for (const settle of waiters) settle();
+  }
+
+  private rejectReconnectWaiters(error: Error): void {
+    const waiters = [...this.reconnectWaiters];
+    this.reconnectWaiters.clear();
+    for (const settle of waiters) settle(error);
   }
 
   /**


### PR DESCRIPTION
🤖 ## Summary
- Reject browser reconnect readiness waiters after terminal worker failure.
- Settle waiters cleared while the connection is explicitly offline.

## Before
A terminal browser-worker failure could leave reconnect readiness waiters pending indefinitely.

## After
All affected readiness waiters are rejected exactly once when the worker reaches a terminal failure.

## Test plan
- [x] Focused browser reconnect readiness regression test

## Integration status

Rebased into the stable-fixes stack on main. Independent review and terminal/offline waiter regressions passed, including a mutation omitting rejection. Full combined CI is green; user merge approval remains separate.
