### PR TITLE
bench: remove misleading query attribution and observer graph walks

### DIFF
--- a/crates/groove/src/cold_settle_attribution.rs
+++ b/crates/groove/src/cold_settle_attribution.rs
@@ -4,7 +4,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-const BUCKETS: usize = 4;
+const BUCKETS: usize = 2;
 
 static MAP_CALLS: [AtomicU64; BUCKETS] = [const { AtomicU64::new(0) }; BUCKETS];
 static MAP_INPUT_RECORDS: [AtomicU64; BUCKETS] = [const { AtomicU64::new(0) }; BUCKETS];
@@ -25,8 +25,8 @@ pub struct Snapshot {
     pub join_output_records: [u64; BUCKETS],
 }
 
-fn bucket(hydrate: bool, dominant_child: bool) -> usize {
-    (usize::from(hydrate) << 1) | usize::from(dominant_child)
+fn bucket(hydrate: bool) -> usize {
+    usize::from(hydrate)
 }
 
 pub fn reset() {
@@ -60,13 +60,8 @@ pub fn snapshot() -> Snapshot {
     }
 }
 
-pub fn record_map(
-    hydrate: bool,
-    dominant_child: bool,
-    input_records: usize,
-    output_records: usize,
-) {
-    let index = bucket(hydrate, dominant_child);
+pub fn record_map(hydrate: bool, input_records: usize, output_records: usize) {
+    let index = bucket(hydrate);
     MAP_CALLS[index].fetch_add(1, Ordering::Relaxed);
     MAP_INPUT_RECORDS[index].fetch_add(input_records as u64, Ordering::Relaxed);
     MAP_OUTPUT_RECORDS[index].fetch_add(output_records as u64, Ordering::Relaxed);
@@ -74,12 +69,11 @@ pub fn record_map(
 
 pub fn record_join(
     hydrate: bool,
-    dominant_child: bool,
     left_records: usize,
     right_records: usize,
     output_records: usize,
 ) {
-    let index = bucket(hydrate, dominant_child);
+    let index = bucket(hydrate);
     JOIN_CALLS[index].fetch_add(1, Ordering::Relaxed);
     JOIN_LEFT_RECORDS[index].fetch_add(left_records as u64, Ordering::Relaxed);
     JOIN_RIGHT_RECORDS[index].fetch_add(right_records as u64, Ordering::Relaxed);

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -1181,7 +1181,6 @@ impl TickEvaluator<'_> {
                     if let Ok(output) = &result {
                         crate::cold_settle_attribution::record_map(
                             self.context.eval_mode == EvalMode::Hydrate,
-                            self.depends_on_dominant_child(node)?,
                             input.deltas.len(),
                             output.deltas.len(),
                         );
@@ -1639,45 +1638,6 @@ impl TickEvaluator<'_> {
         Ok(deltas)
     }
 
-    #[cfg(feature = "cold-settle-attribution")]
-    pub(super) fn depends_on_dominant_child(&self, node: NodeId) -> Result<bool, IvmRuntimeError> {
-        let graph_node = self
-            .graph
-            .node(node)
-            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
-        if matches!(
-            &graph_node.descriptor.operator,
-            OpType::TableSource(source) if source.table == "res_l_child_3"
-        ) {
-            return Ok(true);
-        }
-        // Policy lowering can replace the direct table source with an indexed
-        // source. The anonymous child shape is unique in this benchmark, so
-        // retain the tag through that lowering as well.
-        if ["parent_id", "value_text", "value_json"]
-            .into_iter()
-            .all(|field| {
-                graph_node
-                    .descriptor
-                    .output
-                    .records()
-                    .fields()
-                    .iter()
-                    .any(|candidate| candidate.name.as_deref() == Some(field))
-            })
-        {
-            return Ok(true);
-        }
-        graph_node
-            .descriptor
-            .inputs
-            .iter()
-            .copied()
-            .map(|input| self.depends_on_dominant_child(input))
-            .collect::<Result<Vec<_>, _>>()
-            .map(|dependencies| dependencies.into_iter().any(|dependency| dependency))
-    }
-
     #[allow(clippy::too_many_arguments)]
     fn update_join(
         &mut self,
@@ -1777,7 +1737,6 @@ impl TickEvaluator<'_> {
         #[cfg(feature = "cold-settle-attribution")]
         crate::cold_settle_attribution::record_join(
             self.context.eval_mode == EvalMode::Hydrate,
-            self.depends_on_dominant_child(node)?,
             left_delta.len(),
             right_delta.len(),
             deltas.len(),
@@ -1857,7 +1816,6 @@ impl TickEvaluator<'_> {
             #[cfg(feature = "cold-settle-attribution")]
             crate::cold_settle_attribution::record_join(
                 self.context.eval_mode == EvalMode::Hydrate,
-                self.depends_on_dominant_child(node)?,
                 left_delta.len(),
                 right_delta.len(),
                 deltas.len(),
@@ -1938,7 +1896,6 @@ impl TickEvaluator<'_> {
         #[cfg(feature = "cold-settle-attribution")]
         crate::cold_settle_attribution::record_join(
             self.context.eval_mode == EvalMode::Hydrate,
-            self.depends_on_dominant_child(node)?,
             left_delta.len(),
             right_delta.len(),
             deltas.len(),

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -1689,7 +1689,6 @@ impl HydrationEvaluator<'_> {
                     if let Ok(output) = &result {
                         crate::cold_settle_attribution::record_map(
                             true,
-                            self.depends_on_dominant_child(node)?,
                             input.deltas.len(),
                             output.deltas.len(),
                         );
@@ -1793,7 +1792,6 @@ impl HydrationEvaluator<'_> {
                     #[cfg(feature = "cold-settle-attribution")]
                     crate::cold_settle_attribution::record_join(
                         true,
-                        self.depends_on_dominant_child(node)?,
                         left.deltas.len(),
                         right.deltas.len(),
                         deltas.len(),
@@ -1841,7 +1839,6 @@ impl HydrationEvaluator<'_> {
                     #[cfg(feature = "cold-settle-attribution")]
                     crate::cold_settle_attribution::record_join(
                         true,
-                        self.depends_on_dominant_child(node)?,
                         left.deltas.len(),
                         right.deltas.len(),
                         deltas.len(),
@@ -1970,39 +1967,6 @@ impl HydrationEvaluator<'_> {
             .first()
             .ok_or(IvmRuntimeError::GraphInputMissing(node))?;
         self.eval_node(input).await
-    }
-
-    #[cfg(feature = "cold-settle-attribution")]
-    fn depends_on_dominant_child(&self, node: NodeId) -> Result<bool, IvmRuntimeError> {
-        let graph_node = self
-            .graph
-            .node(node)
-            .ok_or(IvmRuntimeError::GraphNodeNotFound(node))?;
-        if matches!(
-            &graph_node.descriptor.operator,
-            OpType::TableSource(source) if source.table == "res_l_child_3"
-        ) || ["parent_id", "value_text", "value_json"]
-            .into_iter()
-            .all(|field| {
-                graph_node
-                    .descriptor
-                    .output
-                    .records()
-                    .fields()
-                    .iter()
-                    .any(|candidate| candidate.name.as_deref() == Some(field))
-            })
-        {
-            return Ok(true);
-        }
-        graph_node
-            .descriptor
-            .inputs
-            .iter()
-            .copied()
-            .map(|input| self.depends_on_dominant_child(input))
-            .collect::<Result<Vec<_>, _>>()
-            .map(|dependencies| dependencies.into_iter().any(|dependency| dependency))
     }
 }
 

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -760,13 +760,13 @@ struct AttributionSummary {
 
 #[derive(Clone, Default)]
 struct OperatorAttribution {
-    map_calls: [u64; 4],
-    map_input_records: [u64; 4],
-    map_output_records: [u64; 4],
-    join_calls: [u64; 4],
-    join_left_records: [u64; 4],
-    join_right_records: [u64; 4],
-    join_output_records: [u64; 4],
+    map_calls: [u64; 2],
+    map_input_records: [u64; 2],
+    map_output_records: [u64; 2],
+    join_calls: [u64; 2],
+    join_left_records: [u64; 2],
+    join_right_records: [u64; 2],
+    join_output_records: [u64; 2],
 }
 
 #[cfg(feature = "cold-settle-attribution")]
@@ -776,7 +776,7 @@ impl OperatorAttribution {
         before: jazz::groove::cold_settle_attribution::Snapshot,
         after: jazz::groove::cold_settle_attribution::Snapshot,
     ) {
-        for index in 0..4 {
+        for index in 0..2 {
             self.map_calls[index] += after.map_calls[index] - before.map_calls[index];
             self.map_input_records[index] +=
                 after.map_input_records[index] - before.map_input_records[index];
@@ -2713,7 +2713,7 @@ fn emit_summary(config: &Config, phase: &str, summary: &RunSummary) {
                 "selected_payload_bytes": attribution.selected_payload_bytes,
             },
             "operator_cardinality": {
-                "bucket_order": ["tick_other", "tick_dominant_child", "hydrate_other", "hydrate_dominant_child"],
+                "bucket_order": ["tick", "hydrate"],
                 "core_to_relay": operator_json(&attribution.core_operators),
                 "relay_to_client": operator_json(&attribution.relay_operators),
                 "client": operator_json(&attribution.client_operators),

--- a/dev/benchmarks/profile-observer-overhead.md
+++ b/dev/benchmarks/profile-observer-overhead.md
@@ -54,3 +54,31 @@ mangled names through `c++filt -s rust` when grouping callers.
 Do not interpret a filtered inclusive call graph as an exclusive caller
 breakdown. The next analysis groups raw samples by sampled leaf and nearest
 recovered repository caller, weighted by recorded event period.
+
+## Operator counter correction
+
+The old `tick_other` / `tick_dominant_child` split was not reliable after
+lowering: the classifier looked for a logical table name or logical field
+names, whereas the evaluated graph uses physical identities. All dominant
+buckets were zero in the recent captures. Do not interpret those zeroes as
+absence of work for the dominant query. Counts summed across both buckets
+remain useful.
+
+The classifier also recursively traversed the graph, allocating a vector at
+each visited node, every time an operator recorded its counters. This was
+additional observer work, separate from clock reads. Remove that classification
+and report only the directly known `tick` / `hydrate` modes, separated by the
+benchmark's runtime roles. Dominant-query readiness remains measured from its
+actual subscription; this correction affects operator attribution only.
+
+The retained runtime at `1111af7539` measured 18.866s settle and 19.332s dominant
+readiness without instrumentation. The 1,350-of-1,500 todo update roundtrip was
+274.082ms; the worker storage-write phase was 5.493ms within 91.041ms ingest.
+These remain native measurements, not browser reopen timings.
+
+Two subsequent experiments were discarded: broader total-projection composition
+(#2828, 18.912s settle) and direct witness metadata copying (#2830, 18.729s).
+Neither showed a meaningful elapsed improvement over the retained baseline,
+so the extra compiler/encoding logic is not in the retained branch. The latter
+passed all 2,006 Jazz tests after correcting the test shell's file-descriptor
+limit; its initial 14 failures all explicitly reported too many open files.


### PR DESCRIPTION
🤖 Correct operator attribution by removing the unreliable logical-name classifier and its recursive graph walks. Report hydration/incremental operator cardinalities by runtime role instead.

The prior counters attempted to recognize the dominant child table by logical names after the graph had been lowered to physical identities. Recent captures therefore put all activity into “other”; zero dominant buckets did not mean the dominant query performed no work. The classifier also allocated and traversed ancestors on every counter update, perturbing profiling. This change removes that work rather than introducing another heuristic. Actual subscription-based dominant-query readiness measurements remain unchanged.

Feature-enabled benchmark check and commit checks pass. Optimized instrumented acceptance passed with all 27,518 expected rows, 20.234s settle and 20.720s dominant readiness. Every aggregate map/join cardinality matches the preceding capture exactly after summing the former buckets. These instrumented times are not uninstrumented latency claims. Default runtime behavior is unchanged. The report records current native timings and the two discarded experiments (#2828 and #2830). Based directly on #2827; neither discarded trial is included.
