### PR TITLE
bench: record CPU only within the selected todo phase

### DIFF
--- a/crates/jazz/benches/local_batch_phases.rs
+++ b/crates/jazz/benches/local_batch_phases.rs
@@ -2,6 +2,8 @@
 //! Direct nodes intentionally expose phase boundaries that the public Db owner
 //! loop combines. This excludes JS, IndexedDB, scheduling and auth bootstrap.
 use std::{collections::BTreeMap, time::Instant};
+#[path = "support/perf_control.rs"]
+mod perf_control;
 mod schema_fixture;
 mod support;
 use jazz::{
@@ -40,14 +42,17 @@ fn clock_ns() -> u64 {
 }
 #[inline(never)]
 fn phase<T>(backend: &str, count: usize, name: &str, f: impl FnOnce() -> T) -> T {
+    let profile = perf_control::PerfControl::selected(backend, name);
+    let cpu_profiled = profile.is_some();
     let start_ns = clock_ns();
     let start = Instant::now();
     let result = f();
     let elapsed = start.elapsed();
     let end_ns = clock_ns();
+    drop(profile);
     println!(
         "{}",
-        json!({"backend":backend,"rows":count,"phase":name,"wall_us":elapsed.as_micros(),"start_ns":start_ns,"end_ns":end_ns})
+        json!({"backend":backend,"rows":count,"phase":name,"wall_us":elapsed.as_micros(),"start_ns":start_ns,"end_ns":end_ns,"cpu_profiled":cpu_profiled})
     );
     result
 }
@@ -361,7 +366,11 @@ pub(crate) fn correctness_smoke() {
 }
 
 fn main() {
-    jazz_benchmark_guard::refuse_contaminated_measurement();
+    if std::env::var_os("JAZZ_PERF_PHASE").is_some() {
+        eprintln!("scoped CPU attribution run: timings are not clean latency receipts");
+    } else {
+        jazz_benchmark_guard::refuse_contaminated_measurement();
+    }
     let percent = support::env_usize("JAZZ_BATCH_UPDATE_PERCENT", 90);
     for count in support::csv_usizes("JAZZ_BATCH_ROWS", "1500") {
         run_fixture(count, percent);

--- a/crates/jazz/benches/support/perf_control.rs
+++ b/crates/jazz/benches/support/perf_control.rs
@@ -1,0 +1,49 @@
+//! Acknowledged external perf control for a selected benchmark phase.
+pub(super) struct PerfControl {
+    control: std::fs::File,
+    acknowledgements: std::io::BufReader<std::fs::File>,
+}
+
+impl PerfControl {
+    pub(super) fn selected(backend: &str, phase: &str) -> Option<Self> {
+        if std::env::var("JAZZ_PERF_PHASE").ok().as_deref() != Some(phase)
+            || std::env::var("JAZZ_PERF_BACKEND").ok().as_deref() != Some(backend)
+        {
+            return None;
+        }
+        let open = |name| {
+            std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(std::env::var_os(name).expect("perf control requires control and ack FIFOs"))
+                .expect("open perf control FIFO")
+        };
+        let mut control = Self {
+            control: open("JAZZ_PERF_CONTROL_FIFO"),
+            acknowledgements: std::io::BufReader::new(open("JAZZ_PERF_ACK_FIFO")),
+        };
+        control.command("enable");
+        Some(control)
+    }
+
+    fn command(&mut self, command: &str) {
+        use std::io::{BufRead, Write};
+        writeln!(self.control, "{command}").expect("write perf command");
+        self.control.flush().expect("flush perf command");
+        let mut acknowledgement = String::new();
+        self.acknowledgements
+            .read_line(&mut acknowledgement)
+            .expect("read perf acknowledgement");
+        assert_eq!(
+            acknowledgement.trim_matches(|ch: char| ch == '\0' || ch.is_ascii_whitespace()),
+            "ack",
+            "unexpected perf acknowledgement"
+        );
+    }
+}
+
+impl Drop for PerfControl {
+    fn drop(&mut self) {
+        self.command("disable");
+    }
+}

--- a/dev/benchmarks/todo-phase-profiling.md
+++ b/dev/benchmarks/todo-phase-profiling.md
@@ -11,8 +11,12 @@ Set `JAZZ_PERF_BACKEND=rocksdb_wal` and, for example,
 paths use `JAZZ_PERF_CONTROL_FIFO` and `JAZZ_PERF_ACK_FIFO`, as in the permissioned
 benchmark. Start perf disabled with `--delay=-1 --control fd:3,4`, where those
 file descriptors are opened read/write on the respective FIFOs. Repeat the
-benchmark process to collect enough samples for these short phases. Each process
+fixture within one process to collect enough samples for these short phases,
+using a repeated list such as `JAZZ_BATCH_ROWS=1500,1500,1500`. Each fixture
 enables only the requested phase and disables capture before printing its result.
+Repeated child processes while recording is disabled left later executable
+mappings unavailable to the unwinder in this environment; their empty stacks
+must not be treated as zero CPU cost.
 
 Use an explicit event (`-e cycles`) and retain the event configuration alongside
 the capture. Use `perf script --no-inline --ns` for stack extraction, then select
@@ -31,3 +35,10 @@ for 1,350 updates among 1,500 rows. Worker ingest was 91.041ms, publication
 85.635ms, and receiver ingest 36.007ms. The worker's recorded storage-write phase
 was 5.493ms within ingest. These are native synthetic measurements, not browser
 or IndexedDB results.
+
+A selected worker-ingest capture at retained runtime #2827, with these benchmark
+changes, recorded 996 samples in 62.6MiB. Filtering by the 20 actual phase windows
+left 961 samples, all with nonempty stacks, and perf reported no sample loss.
+Named allocation/free routines account for approximately 21% of weighted samples,
+byte comparison 7%, and copying 6%. Some outer callers remain unresolved; these
+are sampling estimates, not independently additive elapsed-time savings.

--- a/dev/benchmarks/todo-phase-profiling.md
+++ b/dev/benchmarks/todo-phase-profiling.md
@@ -1,0 +1,33 @@
+# Attribute CPU to a todo phase
+
+`local_batch_phases` already reports monotonic start/end timestamps for each
+phase. Its optional external-perf control now bounds capture to one backend and
+phase, with acknowledgements before starting the phase timer and after stopping
+it. `cpu_profiled` explicitly identifies the selected phase. Profiled runs are
+not clean latency receipts.
+
+Set `JAZZ_PERF_BACKEND=rocksdb_wal` and, for example,
+`JAZZ_PERF_PHASE=batch_worker_ingest` or `batch_publish`. The control and ack FIFO
+paths use `JAZZ_PERF_CONTROL_FIFO` and `JAZZ_PERF_ACK_FIFO`, as in the permissioned
+benchmark. Start perf disabled with `--delay=-1 --control fd:3,4`, where those
+file descriptors are opened read/write on the respective FIFOs. Repeat the
+benchmark process to collect enough samples for these short phases. Each process
+enables only the requested phase and disables capture before printing its result.
+
+Use an explicit event (`-e cycles`) and retain the event configuration alongside
+the capture. Use `perf script --no-inline --ns` for stack extraction, then select
+samples inside the matching JSON timestamp windows. Kernel symbol limitations,
+lost samples and unresolvable callers must remain explicit; do not infer callers
+from an inclusive call graph filtered by a leaf symbol.
+
+The first whole-process 999Hz/32KiB capture lost approximately 14% of samples.
+A second 499Hz/64KiB capture with a larger buffer still reported lost chunks and
+produced over 4GiB, mostly outside the requested phase. Those captures are
+preliminary diagnostic evidence, not precise caller percentages. Limiting
+recording at the source avoids paying for and storing unrelated setup work.
+
+The last clean native receipt before this instrumentation change was 274.082ms
+for 1,350 updates among 1,500 rows. Worker ingest was 91.041ms, publication
+85.635ms, and receiver ingest 36.007ms. The worker's recorded storage-write phase
+was 5.493ms within ingest. These are native synthetic measurements, not browser
+or IndexedDB results.


### PR DESCRIPTION
🤖 Add optional acknowledged perf control around a selected native todo benchmark phase. Set JAZZ_PERF_BACKEND and JAZZ_PERF_PHASE plus the existing control/ack FIFO variables. Sampling starts before the phase timer and stops after it; the phase JSON reports cpu_profiled. Explicit profiling mode prints that its timings are not clean receipts; ordinary runs retain the contamination guard.

This avoids recording several gigabytes of setup when the question is where roughly 90ms of worker ingest goes. Whole-process trials had sample/chunk loss, so their caller percentages remain preliminary. The report describes the method and its limits. No production/runtime behavior changes.

Optimized build and commit checks pass. Selected worker-ingest capture completed: 996 samples / 62.6MiB, with 961 samples inside the 20 phase windows, no empty in-phase stacks and no reported sample loss. Repeat fixtures inside one process using the existing row-count list; repeated child processes left later mappings unavailable in this environment. Based on #2831, which is based directly on retained runtime #2827. The rejected #2828/#2830 trials are not included.
