### PR TITLE
Enforce starter password minimum

### DIFF
--- a/.changeset/bug-203-password-minimum.md
+++ b/.changeset/bug-203-password-minimum.md
@@ -1,0 +1,5 @@
+---
+"create-jazz": patch
+---
+
+Enforce an eight-character minimum password in the SvelteKit Better Auth starter.

--- a/starters/sveltekit-betterauth/e2e/todo-flow.spec.ts
+++ b/starters/sveltekit-betterauth/e2e/todo-flow.spec.ts
@@ -53,6 +53,38 @@ async function signOut(page: Page) {
   await expect(page.getByLabel("Email")).toBeVisible({ timeout: TIMEOUT });
 }
 
+test("rejects one-character passwords at the sign-up endpoint", async ({ page }) => {
+  const runId = Date.now();
+  const email = `short-password-${runId}@example.com`;
+
+  await page.goto("/", { waitUntil: "networkidle" });
+  const response = await page.request.post("/api/auth/sign-up/email", {
+    data: {
+      name: "Short Password User",
+      email,
+      password: "x",
+    },
+  });
+
+  expect(response.ok()).toBe(false);
+});
+
+test("accepts exactly eight-character passwords at the sign-up endpoint", async ({ page }) => {
+  const runId = Date.now();
+  const email = `eight-character-password-${runId}@example.com`;
+
+  await page.goto("/", { waitUntil: "networkidle" });
+  const response = await page.request.post("/api/auth/sign-up/email", {
+    data: {
+      name: "Eight Character User",
+      email,
+      password: "12345678",
+    },
+  });
+
+  expect(response.ok()).toBe(true);
+});
+
 test("todo persistence across sign-up→logout→login", async ({ page }) => {
   const runId = Date.now();
   const todo = `Todo ${runId}`;

--- a/starters/sveltekit-betterauth/src/lib/auth.ts
+++ b/starters/sveltekit-betterauth/src/lib/auth.ts
@@ -33,7 +33,7 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
     autoSignIn: true,
-    minPasswordLength: 1,
+    minPasswordLength: 8,
     requireEmailVerification: false,
   },
   plugins: [


### PR DESCRIPTION
🤖 ## Summary
- Enforce an eight-character minimum password in the SvelteKit Better Auth starter.
- Cover both rejection below the boundary and acceptance at the boundary.

## Before
The starter accepted passwords shorter than the intended minimum.

## After
Signup rejects passwords shorter than eight characters and accepts exactly eight characters.

## Test plan
- [x] Focused SvelteKit Better Auth Playwright password-boundary tests

## Integration status

Rebased into the stable-fixes stack on main, with independent review corrections included. Both password boundary endpoint tests pass; lowering the configured minimum makes the rejection regression fail. Full combined CI is green.
