### PR TITLE
perf: reclaim expired graph runtime state in one batch

### DIFF
--- a/crates/groove/src/ivm/runtime/graph_lifecycle.rs
+++ b/crates/groove/src/ivm/runtime/graph_lifecycle.rs
@@ -218,20 +218,25 @@ impl IvmRuntime {
         if self.pending_incremental_polling {
             return;
         }
-        for node in self.gc_ephemeral_nodes(0) {
-            self.remove_node_runtime(node);
+        let removed = self.gc_ephemeral_nodes(0);
+        if !removed.is_empty() {
+            let removed: HashSet<_> = removed.into_iter().collect();
+            // Reclaim a batch with one pass per state map, not one full scan
+            // for every expired node. Shared and suspended nodes are retained
+            // by gc_ephemeral_nodes before this set is constructed.
+            self.operator_states
+                .retain(|key, _| !removed.contains(&key.node));
+            self.arrangement_states
+                .retain(|key, _| !removed.contains(&key.input));
+            self.eval_memo.retain(|key, _| !removed.contains(&key.node));
+            for node in removed {
+                self.arrangement_keys_by_input.remove(&node);
+                self.node_meta.remove(&node);
+            }
         }
         if !self.pending_incremental.is_pending() {
             self.ephemeral_graph_gc_pending = false;
         }
-    }
-
-    pub(super) fn remove_node_runtime(&mut self, node: NodeId) {
-        self.operator_states.retain(|key, _| key.node != node);
-        self.arrangement_states.retain(|key, _| key.input != node);
-        self.arrangement_keys_by_input.remove(&node);
-        self.eval_memo.retain(|key, _| key.node != node);
-        self.node_meta.remove(&node);
     }
 
     pub(super) fn affected_recursive_nodes_are_current(


### PR DESCRIPTION
🤖 Reclaim expired query-graph runtime state as one batch. Previously, removing each node rescanned every operator-state, arrangement and memo entry. Removing K nodes from M retained entries could therefore perform K full scans. The new path collects removed IDs once and visits each state map once.

For example, when a temporary query releases a chain of nodes while another subscription remains active, only the expired IDs are removed from runtime state; shared or suspended graph nodes remain protected by the existing retention calculation. The retention rules, graph-node removal and point-index cleanup are unchanged. Empty removal batches do not scan the state maps.

All 744 Groove library tests pass (2 ignored), as do commit checks. Matching combined-build measurements: cold settle 18.356s → 18.300s, all 27,518 expected rows; todo batch roundtrip 278.147ms → 280.519ms. These are effectively flat and no speedup is claimed. Retain this small batching change for its improved scaling behavior. The full Jazz library suite also passes (2,006 passed, 2 ignored), along with all three incremental boundary canaries and the two-seed maintained/one-shot comparison at churn depths 10 and 1,000. Draft on #2833; broader acceptance and independent review remain outstanding.
