### PR TITLE
Return embedded server bind failures

### DIFF
--- a/.changeset/bug-207-bind-failures.md
+++ b/.changeset/bug-207-bind-failures.md
@@ -1,0 +1,5 @@
+---
+"jazz-napi": patch
+---
+
+Return embedded server listener bind failures as NAPI errors.

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -4671,7 +4671,8 @@ impl JazzServer {
             opts.admin_secret.clone(),
             opts.backend_secret.clone(),
         )
-        .await;
+        .await
+        .map_err(napi::Error::from_reason)?;
 
         Ok(Self::from_inner(JazzServerInner::Core(server)))
     }
@@ -5182,7 +5183,8 @@ mod tests {
             "napi-stop-test-admin".to_owned(),
             "napi-stop-test-backend".to_owned(),
         )
-        .await;
+        .await
+        .expect("start NAPI test server");
         JazzServer::from_inner(JazzServerInner::Core(server))
     }
 

--- a/crates/jazz-native-relay/examples/rn_edge_session_harness.rs
+++ b/crates/jazz-native-relay/examples/rn_edge_session_harness.rs
@@ -45,7 +45,8 @@ async fn run() {
         .with_jwks_url(issuer.endpoint())
         .with_native_transport_connector(native_connector())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let edge = JazzServer::builder()
         .with_app_id(core.app_id())
         .with_schema(schema.clone())
@@ -54,7 +55,8 @@ async fn run() {
         .with_upstream_url(core.base_url())
         .with_native_transport_connector(native_connector())
         .start()
-        .await;
+        .await
+        .expect("start test server");
 
     for _ in 0..300 {
         if edge.server_state().edge_upstream_health() == EdgeUpstreamHealth::Connected {
@@ -153,7 +155,8 @@ async fn run() {
         .with_upstream_url(core.base_url())
         .with_native_transport_connector(native_connector())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     for _ in 0..300 {
         if edge.server_state().edge_upstream_health() == EdgeUpstreamHealth::Connected {
             break;

--- a/crates/jazz-native-relay/examples/support/device_fixture.rs
+++ b/crates/jazz-native-relay/examples/support/device_fixture.rs
@@ -110,7 +110,8 @@ mod tests {
                         .with_jwks_url(issuer.endpoint())
                         .with_native_transport_connector(native_connector())
                         .start()
-                        .await;
+                        .await
+                        .expect("start test server");
                     let mut clients = Vec::new();
                     let mut dirs = Vec::new();
                     for scope in ["a", "b"] {

--- a/crates/jazz-native-relay/src/lib.rs
+++ b/crates/jazz-native-relay/src/lib.rs
@@ -7619,7 +7619,8 @@ mod tests {
             .with_jwks_url(issuer.endpoint())
             .with_native_transport_connector(jazz_testkit::native_connector())
             .start()
-            .await;
+            .await
+            .expect("start test server");
         let storage = tempfile::tempdir().unwrap();
         let fixture = NativeHostAbiFixture::new();
         let bearer = TestJwtIssuer::jwt_for_user("native-advice-alice");
@@ -7716,7 +7717,8 @@ mod tests {
             .with_jwks_url(issuer.endpoint())
             .with_native_transport_connector(jazz_testkit::native_connector())
             .start()
-            .await;
+            .await
+            .expect("start test server");
         let storage = tempfile::tempdir().unwrap();
         let fixture = NativeHostAbiFixture::new();
         let bearer = TestJwtIssuer::jwt_for_user("native-advice-alice");
@@ -7934,7 +7936,8 @@ mod tests {
             .with_jwks_url(issuer.endpoint())
             .with_native_transport_connector(jazz_testkit::native_connector())
             .start()
-            .await;
+            .await
+            .expect("start test server");
         let storage = tempfile::tempdir().unwrap();
         let fixture = NativeHostAbiFixture::new();
         let mut bearer = TestJwtIssuer::jwt_for_user("native-private-alice");
@@ -7993,7 +7996,8 @@ mod tests {
             .with_jwks_url(issuer.endpoint())
             .with_native_transport_connector(jazz_testkit::native_connector())
             .start()
-            .await;
+            .await
+            .expect("start test server");
         let edge = JazzServer::builder()
             .with_app_id(core.app_id())
             .with_schema(public_schema)
@@ -8002,7 +8006,8 @@ mod tests {
             .with_upstream_url(core.base_url())
             .with_native_transport_connector(jazz_testkit::native_connector())
             .start()
-            .await;
+            .await
+            .expect("start test server");
 
         jazz_testkit::wait_for(
             Duration::from_secs(15),

--- a/crates/jazz-otel/tests/sync_telemetry_otel.rs
+++ b/crates/jazz-otel/tests/sync_telemetry_otel.rs
@@ -47,7 +47,9 @@ async fn sync_layers_emit_otel_spans() {
             let subscriber_guard = tracing::subscriber::set_default(subscriber);
 
             let schema = test_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let alice = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema.clone())

--- a/crates/jazz-server/src/server/routes/accounts.rs
+++ b/crates/jazz-server/src/server/routes/accounts.rs
@@ -515,12 +515,13 @@ mod tests {
     /// one immutable assignment, including when routed through an edge.
     #[tokio::test]
     async fn login_or_register_is_atomic_and_revocation_is_permanent() {
-        let core = JazzServer::start().await;
+        let core = JazzServer::start().await.expect("start test server");
         let edge = JazzServer::builder()
             .with_app_id(core.app_id())
             .with_upstream_url(core.base_url())
             .start()
-            .await;
+            .await
+            .expect("start test server");
         let client = reqwest::Client::new();
         let base = format!("{}/apps/{}/accounts", edge.base_url(), edge.app_id());
         let token = TestJwtIssuer::jwt_for_user("new-account");
@@ -584,12 +585,13 @@ mod tests {
     /// Service lookup is deliberately read-only and rejects user credentials.
     #[tokio::test]
     async fn edge_forwards_identity_proof_and_core_resolves_revocation() {
-        let core = JazzServer::start().await;
+        let core = JazzServer::start().await.expect("start test server");
         let edge = JazzServer::builder()
             .with_app_id(core.app_id())
             .with_upstream_url(core.base_url())
             .start()
-            .await;
+            .await
+            .expect("start test server");
         let client = reqwest::Client::new();
         let base = format!("{}/apps/{}/accounts", edge.base_url(), edge.app_id());
         let alice = TestJwtIssuer::jwt_for_user("alice");
@@ -677,7 +679,7 @@ mod tests {
     /// alice -> request(bob) -> bob accepts -> alice revokes -> replay denied
     #[tokio::test]
     async fn ordinary_jwts_link_only_the_target_and_replay_cannot_undo_revocation() {
-        let server = JazzServer::start().await;
+        let server = JazzServer::start().await.expect("start test server");
         let client = reqwest::Client::new();
         let base = format!("{}/apps/{}/accounts", server.base_url(), server.app_id());
         let alice = TestJwtIssuer::jwt_for_user("alice");

--- a/crates/jazz-server/src/server/testing.rs
+++ b/crates/jazz-server/src/server/testing.rs
@@ -692,6 +692,29 @@ mod tests {
 
         panic!("jazz server did not stop after internal shutdown");
     }
+    #[tokio::test]
+    async fn occupied_explicit_port_returns_contextual_error() {
+        let blocker = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("reserve occupied server port");
+        let port = blocker
+            .local_addr()
+            .expect("read occupied server port")
+            .port();
+
+        let result: Result<JazzServer, String> =
+            JazzServer::builder().with_port(port).start().await;
+        drop(blocker);
+
+        let error = match result {
+            Ok(_) => panic!("occupied explicit port should reject server startup"),
+            Err(error) => error,
+        };
+        assert!(
+            error.contains("bind") || error.contains("server listener"),
+            "startup error should identify the server listener: {error}"
+        );
+    }
 
     #[tokio::test]
     async fn default_jazz_server_keeps_built_in_jwt_helpers_enabled() {

--- a/crates/jazz-server/src/server/testing.rs
+++ b/crates/jazz-server/src/server/testing.rs
@@ -135,7 +135,7 @@ impl JazzServerBuilder {
         self
     }
 
-    pub async fn start(self) -> JazzServer {
+    pub async fn start(self) -> Result<JazzServer, String> {
         JazzServer::from_builder(self).await
     }
 }
@@ -257,15 +257,15 @@ impl JazzServer {
         JazzServerBuilder::new()
     }
 
-    pub async fn start() -> Self {
+    pub async fn start() -> Result<Self, String> {
         Self::builder().start().await
     }
 
-    pub async fn start_with_schema(schema: Schema) -> Self {
+    pub async fn start_with_schema(schema: Schema) -> Result<Self, String> {
         Self::builder().with_schema(schema).start().await
     }
 
-    async fn from_builder(builder: JazzServerBuilder) -> Self {
+    async fn from_builder(builder: JazzServerBuilder) -> Result<Self, String> {
         let JazzServerBuilder {
             port,
             app_id,
@@ -332,13 +332,16 @@ impl JazzServer {
         if let Some(schema) = schema {
             server_builder = server_builder.with_schema(schema);
         }
-        let built = server_builder.build().await.expect("build test server");
+        let built = server_builder
+            .build()
+            .await
+            .map_err(|error| error.to_string())?;
 
         let mut server =
-            Self::from_built(built, port, app_id, data_dir, admin_secret, backend_secret).await;
+            Self::from_built(built, port, app_id, data_dir, admin_secret, backend_secret).await?;
         server.embedded_jwks_server = embedded_jwks_server;
         server.auth_clock = auth_clock;
-        server
+        Ok(server)
     }
 
     /// Create a Jazz server from an already-built router/state pair.
@@ -353,11 +356,14 @@ impl JazzServer {
         data_dir: ServerDataDir,
         admin_secret: String,
         backend_secret: String,
-    ) -> Self {
+    ) -> Result<Self, String> {
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", port.unwrap_or(0)))
             .await
-            .expect("bind server listener");
-        let port = listener.local_addr().expect("local addr").port();
+            .map_err(|error| format!("bind server listener: {error}"))?;
+        let port = listener
+            .local_addr()
+            .map_err(|error| format!("read server listener local address: {error}"))?
+            .port();
 
         let (serve_shutdown_tx, serve_shutdown_rx) = oneshot::channel();
         let shutdown_state = built.state.clone();
@@ -390,7 +396,7 @@ impl JazzServer {
             auth_clock: crate::middleware::auth::AuthClock::default(),
         };
         server.wait_ready().await;
-        server
+        Ok(server)
     }
 
     pub fn default_app_id() -> AppId {
@@ -659,7 +665,7 @@ mod tests {
 
     #[tokio::test]
     async fn internal_shutdown_stops_jazz_server() {
-        let server = JazzServer::start().await;
+        let server = JazzServer::start().await.expect("start test server");
         let base_url = server.base_url();
         let admin_secret = server.admin_secret().to_string();
         let client = reqwest::Client::new();
@@ -718,7 +724,7 @@ mod tests {
 
     #[tokio::test]
     async fn default_jazz_server_keeps_built_in_jwt_helpers_enabled() {
-        let server = JazzServer::start().await;
+        let server = JazzServer::start().await.expect("start test server");
         let context = server.make_client_context_for_user(Schema::new(), "default-helper-user");
 
         assert!(context.jwt_token.is_some());
@@ -733,7 +739,8 @@ mod tests {
         let server = JazzServer::builder()
             .with_jwks_url(external_jwks.endpoint())
             .start()
-            .await;
+            .await
+            .expect("start test server");
 
         let health = reqwest::Client::new()
             .get(format!("{}/health", server.base_url()))
@@ -783,7 +790,8 @@ mod tests {
             JazzServer::ADMIN_SECRET.to_owned(),
             JazzServer::BACKEND_SECRET.to_owned(),
         )
-        .await;
+        .await
+        .expect("start embedded server");
 
         assert_eq!(server.shutdown().await, ShutdownPhase::Failed);
         drop(active_request);

--- a/crates/jazz-testkit/tests/admin_schema_api.rs
+++ b/crates/jazz-testkit/tests/admin_schema_api.rs
@@ -10,6 +10,7 @@ async fn start_server() -> JazzServer {
         .with_admin_secret(ADMIN_SECRET)
         .start()
         .await
+        .expect("start test server")
 }
 
 fn app_url(server: &JazzServer, path: &str) -> String {
@@ -208,7 +209,8 @@ async fn admin_schema_api_persists_catalogue_in_the_production_storage_backend()
         .with_data_dir(data_dir.path())
         .with_storage_factory(jazz_testkit::persistent_storage_factory())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let client = reqwest::Client::new();
     let published = admin_request(client.post(app_url(&server, "/admin/schemas")))
         .json(&publish_body(schema_with_column(
@@ -232,7 +234,8 @@ async fn admin_schema_api_persists_catalogue_in_the_production_storage_backend()
         .with_data_dir(data_dir.path())
         .with_storage_factory(jazz_testkit::persistent_storage_factory())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let list = admin_request(client.get(app_url(&restarted, "/schemas")))
         .send()
         .await

--- a/crates/jazz-testkit/tests/aggregate_subscriptions.rs
+++ b/crates/jazz-testkit/tests/aggregate_subscriptions.rs
@@ -551,7 +551,9 @@ async fn aggregate_subscription_count_and_grouped_sum_track_full_state() {
                 eprintln!("JAZZ_COVERED_INPUT_TRACE stage=aggregate_test_start");
             }
             let schema = metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             if std::env::var_os("JAZZ_COVERED_INPUT_TRACE").is_some() {
                 eprintln!("JAZZ_COVERED_INPUT_TRACE stage=aggregate_test_server_started");
             }
@@ -713,7 +715,9 @@ async fn aggregate_subscription_group_field_named_count_uses_structural_wire_slo
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = count_named_metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let writer = jazz_testkit::connect(server.make_client_context_for_user(
                 schema.clone(),
                 "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa21",
@@ -767,7 +771,9 @@ async fn aggregate_subscription_uses_core_canonical_order_for_mixed_outputs() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = mixed_metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let writer = jazz_testkit::connect(server.make_client_context_for_user(
                 schema.clone(),
                 "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa23",
@@ -843,7 +849,9 @@ async fn aggregate_sum_public_boundary_preserves_nullable_results() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = nullable_metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = jazz_testkit::connect(
                 server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa3"),
             )
@@ -919,7 +927,9 @@ async fn grouped_null_aggregate_membership_survives_absence_and_replacement() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = nullable_metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let writer = jazz_testkit::connect(server.make_client_context_for_user(
                 schema.clone(),
                 "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa7",
@@ -1047,7 +1057,9 @@ async fn maintained_integer_sum_accumulates_multiple_deltas_and_retracts_empty_g
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let writer = jazz_testkit::connect(server.make_client_context_for_user(
                 schema.clone(),
                 "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa6",
@@ -1135,7 +1147,9 @@ async fn maintained_bigint_sum_replaces_a_multi_row_group_after_insert() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = bigint_metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let writer = jazz_testkit::connect(server.make_client_context_for_user(
                 schema.clone(),
                 "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa9",
@@ -1187,7 +1201,9 @@ async fn maintained_double_sum_and_avg_replace_a_multi_row_group_after_insert() 
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = double_metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let writer = jazz_testkit::connect(server.make_client_context_for_user(
                 schema.clone(),
                 "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa10",
@@ -1269,7 +1285,9 @@ async fn maintained_min_and_max_replace_multi_row_groups() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let writer = jazz_testkit::connect(server.make_client_context_for_user(
                 schema.clone(),
                 "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa15",
@@ -1345,7 +1363,9 @@ async fn integer_sum_uses_public_signed_values_for_multi_row_groups() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = jazz_testkit::connect(
                 server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa2"),
             )
@@ -1381,7 +1401,9 @@ async fn integer_avg_uses_public_signed_values_for_multi_row_groups() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = jazz_testkit::connect(
                 server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa3"),
             )
@@ -1415,7 +1437,9 @@ async fn integer_min_max_and_order_by_remain_signed() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema)
@@ -1493,7 +1517,9 @@ async fn bigint_aggregates_keep_signed_value_semantics() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = bigint_metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = jazz_testkit::connect(
                 server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa5"),
             )
@@ -1550,7 +1576,9 @@ async fn aggregate_sum_bigint_survives_public_client_boundary() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = bigint_metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = jazz_testkit::connect(
                 server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa4"),
             )
@@ -1609,7 +1637,9 @@ async fn integer_counter_columns_merge_signed_public_values() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = counter_schema(ColumnType::Integer);
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let alice = jazz_testkit::connect(server.make_client_context_for_user(
                 schema.clone(),
                 "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa7",
@@ -1693,7 +1723,9 @@ async fn bigint_counter_columns_merge_signed_public_values() {
         .run_until(async {
             let base = 3_000_000_000_i64;
             let schema = counter_schema(ColumnType::BigInt);
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let alice = jazz_testkit::connect(server.make_client_context_for_user(
                 schema.clone(),
                 "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbb7",
@@ -1788,7 +1820,9 @@ async fn aggregate_subscription_spy_stays_at_policy_visible_truth() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = policy_metrics_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let admin_id = test_user_id("aggregate-admin");
             let spy_id = test_user_id("aggregate-spy");
             let mut admin_context =

--- a/crates/jazz-testkit/tests/array_reference_policies.rs
+++ b/crates/jazz-testkit/tests/array_reference_policies.rs
@@ -198,7 +198,8 @@ async fn array_reference_membership_grants_read_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "projects", READY_TIMEOUT).await;
 
     let atlas = create_project(&admin, "Atlas").await;
@@ -232,7 +233,8 @@ async fn array_reference_grant_updates_incrementally_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "projects", READY_TIMEOUT).await;
     let alice = connect_ready_user(
         &server,
@@ -327,7 +329,8 @@ async fn unindexed_array_reference_still_grants_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "projects", READY_TIMEOUT).await;
 
     let atlas = create_project(&admin, "Atlas").await;

--- a/crates/jazz-testkit/tests/bigint_integration.rs
+++ b/crates/jazz-testkit/tests/bigint_integration.rs
@@ -29,7 +29,9 @@ async fn bigint_insert_query_order_predicate_and_subscribe_are_lossless() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = bigint_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema)

--- a/crates/jazz-testkit/tests/branch_claims_integration.rs
+++ b/crates/jazz-testkit/tests/branch_claims_integration.rs
@@ -132,7 +132,9 @@ async fn query_applies_claims_select_policy() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = branch_claims_gated_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
 
             let admin = TestingClient::builder()
                 .with_server(&server)
@@ -226,7 +228,9 @@ async fn numeric_claims_match_integer_columns_across_core_widths() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = numeric_claims_gated_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
 
             let admin = TestingClient::builder()
                 .with_server(&server)
@@ -323,7 +327,9 @@ async fn session_role_in_list_matches_equivalent_or_policy() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = role_claims_gated_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
 
             let admin = TestingClient::builder()
                 .with_server(&server)
@@ -450,7 +456,9 @@ async fn subscription_matches_claims_select_query() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = branch_claims_gated_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
 
             let admin = TestingClient::builder()
                 .with_server(&server)
@@ -596,7 +604,7 @@ async fn same_identity_sessions_keep_claims_isolated() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = admin_claims_gated_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone()).await.expect("start test server");
 
             let writer = TestingClient::builder()
                 .with_server(&server)
@@ -696,7 +704,9 @@ async fn same_shape_subscriptions_route_claims_per_identity() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = branch_claims_gated_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
 
             let admin = TestingClient::builder()
                 .with_server(&server)
@@ -853,7 +863,9 @@ async fn numeric_claims_authorize_writes_across_core_widths() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = numeric_claims_write_gated_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
 
             let bigint_claim_user = TestingClient::builder()
                 .with_server(&server)

--- a/crates/jazz-testkit/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-testkit/tests/catalogue_sync_integration.rs
@@ -85,7 +85,7 @@ async fn cold_old_schema_id_query_reads_new_array_column_row() {
                     default: Value::Array(Vec::new()),
                 }]),
             );
-            let server = JazzServer::start().await;
+            let server = JazzServer::start().await.expect("start test server");
             push_catalogue_in_memory(
                 server.server_state(),
                 server.app_id(),
@@ -652,13 +652,19 @@ async fn edge_catalogue_http_reads_and_writes_forward_to_real_core() {
 
 async fn edge_catalogue_http_reads_and_writes_forward_to_real_core_impl() {
     let app_id = JazzServer::default_app_id();
-    let core = JazzServer::builder().with_app_id(app_id).start().await;
+    let core = JazzServer::builder()
+        .with_app_id(app_id)
+        .start()
+        .await
+        .expect("start test server")
+        .expect("start test server");
     let edge = JazzServer::builder()
         .with_app_id(app_id)
         .with_native_transport_connector(jazz_testkit::native_connector())
         .with_upstream_url(core.base_url())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let schema = schema_v1();
     let schema_hash = SchemaHash::compute(&schema).to_string();
     let client = reqwest::Client::new();
@@ -788,19 +794,26 @@ async fn edge_catalogue_publish_reaches_peer_edge_through_core_sync() {
 async fn edge_catalogue_publish_reaches_peer_edge_through_core_sync_impl() {
     let app_id = JazzServer::default_app_id();
     let schema = schema_v1();
-    let core = JazzServer::builder().with_app_id(app_id).start().await;
+    let core = JazzServer::builder()
+        .with_app_id(app_id)
+        .start()
+        .await
+        .expect("start test server")
+        .expect("start test server");
     let edge_us = JazzServer::builder()
         .with_app_id(app_id)
         .with_native_transport_connector(jazz_testkit::native_connector())
         .with_upstream_url(core.base_url())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let edge_eu = JazzServer::builder()
         .with_app_id(app_id)
         .with_native_transport_connector(jazz_testkit::native_connector())
         .with_upstream_url(core.base_url())
         .start()
-        .await;
+        .await
+        .expect("start test server");
 
     seed_schema_catalogue(&edge_us, &schema).await;
     publish_allow_all_permissions(&edge_us.base_url(), app_id, edge_us.admin_secret(), &schema)
@@ -869,7 +882,12 @@ async fn persisted_stale_edge_reconnect_replays_catalogue_before_client_work_imp
     let v1_schema = schema_v1();
     let v2_schema = schema_v2();
     let edge_data_dir = TempDir::new().expect("create persistent edge data directory");
-    let core = JazzServer::builder().with_app_id(app_id).start().await;
+    let core = JazzServer::builder()
+        .with_app_id(app_id)
+        .start()
+        .await
+        .expect("start test server")
+        .expect("start test server");
 
     seed_schema_catalogue(&core, &v1_schema).await;
     publish_allow_all_permissions(&core.base_url(), app_id, core.admin_secret(), &v1_schema).await;
@@ -881,7 +899,8 @@ async fn persisted_stale_edge_reconnect_replays_catalogue_before_client_work_imp
         .with_data_dir(edge_data_dir.path())
         .with_storage_factory(jazz_testkit::persistent_storage_factory())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice_v1 = TestingClient::builder()
         .with_server(&edge_before_restart)
         .with_schema(v1_schema.clone())
@@ -903,7 +922,8 @@ async fn persisted_stale_edge_reconnect_replays_catalogue_before_client_work_imp
         .with_data_dir(edge_data_dir.path())
         .with_storage_factory(jazz_testkit::persistent_storage_factory())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice_v2 = TestingClient::builder()
         .with_server(&edge_after_restart)
         .with_schema(v2_schema.clone())
@@ -963,7 +983,12 @@ async fn persistent_dynamic_edge_reopens_catalogue_for_trusted_client_while_regi
     let app_id = JazzServer::default_app_id();
     let schema = schema_v1();
     let edge_data_dir = TempDir::new().expect("create persistent edge data directory");
-    let core = JazzServer::builder().with_app_id(app_id).start().await;
+    let core = JazzServer::builder()
+        .with_app_id(app_id)
+        .start()
+        .await
+        .expect("start test server")
+        .expect("start test server");
     let unavailable_core_url = core.base_url();
     seed_schema_catalogue(&core, &schema).await;
     publish_allow_all_permissions(&core.base_url(), app_id, core.admin_secret(), &schema).await;
@@ -975,7 +1000,8 @@ async fn persistent_dynamic_edge_reopens_catalogue_for_trusted_client_while_regi
         .with_data_dir(edge_data_dir.path())
         .with_storage_factory(jazz_testkit::persistent_storage_factory())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let warmup = TestingClient::builder()
         .with_server(&edge_before_shutdown)
         .with_schema(schema.clone())
@@ -1004,7 +1030,8 @@ async fn persistent_dynamic_edge_reopens_catalogue_for_trusted_client_while_regi
         .with_data_dir(edge_data_dir.path())
         .with_storage_factory(jazz_testkit::persistent_storage_factory())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     returning_context.server_url = edge_after_restart.base_url();
     let public_error = match jazz_testkit::connect(returning_context).await {
         Err(error) => error,
@@ -1061,7 +1088,12 @@ async fn core_permission_retightening_reaches_subscribed_clients_on_every_edge()
 async fn core_permission_retightening_reaches_subscribed_clients_on_every_edge_impl() {
     let app_id = JazzServer::default_app_id();
     let schema = schema_v1();
-    let core = JazzServer::builder().with_app_id(app_id).start().await;
+    let core = JazzServer::builder()
+        .with_app_id(app_id)
+        .start()
+        .await
+        .expect("start test server")
+        .expect("start test server");
     seed_schema_catalogue(&core, &schema).await;
     let allow_head =
         publish_allow_all_permissions(&core.base_url(), app_id, core.admin_secret(), &schema).await;
@@ -1070,13 +1102,15 @@ async fn core_permission_retightening_reaches_subscribed_clients_on_every_edge_i
         .with_native_transport_connector(jazz_testkit::native_connector())
         .with_upstream_url(core.base_url())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let edge_eu = JazzServer::builder()
         .with_app_id(app_id)
         .with_native_transport_connector(jazz_testkit::native_connector())
         .with_upstream_url(core.base_url())
         .start()
-        .await;
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&edge_us)
@@ -1209,13 +1243,19 @@ async fn edge_migration_publish_forwards_to_real_core_and_is_readable_through_ed
 
 async fn edge_migration_publish_forwards_to_real_core_and_is_readable_through_edge_impl() {
     let app_id = JazzServer::default_app_id();
-    let core = JazzServer::builder().with_app_id(app_id).start().await;
+    let core = JazzServer::builder()
+        .with_app_id(app_id)
+        .start()
+        .await
+        .expect("start test server")
+        .expect("start test server");
     let edge = JazzServer::builder()
         .with_app_id(app_id)
         .with_native_transport_connector(jazz_testkit::native_connector())
         .with_upstream_url(core.base_url())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let v1_schema = schema_v1();
     let v2_schema = schema_v2();
     let v1_hash = SchemaHash::compute(&v1_schema).to_string();
@@ -1326,7 +1366,7 @@ async fn dynamic_server_denies_reads_until_permissions_head_is_published() {
 }
 
 async fn dynamic_server_denies_reads_until_permissions_head_is_published_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let schema = schema_v1();
     seed_schema_catalogue(&server, &schema).await;
 
@@ -1407,7 +1447,7 @@ async fn dynamic_server_keeps_pre_permissions_user_write_hidden_after_publish() 
 }
 
 async fn dynamic_server_keeps_pre_permissions_user_write_hidden_after_publish_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let schema = schema_v1();
     seed_schema_catalogue(&server, &schema).await;
     let query = jazz::query::Query::from("users");
@@ -1574,7 +1614,7 @@ async fn dynamic_server_rejects_user_write_after_permissions_timeout() {
 }
 
 async fn dynamic_server_rejects_user_write_after_permissions_timeout_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let schema = schema_v1();
     seed_schema_catalogue(&server, &schema).await;
     let query = jazz::query::Query::from("users");
@@ -1657,7 +1697,7 @@ async fn dynamic_server_live_subscription_replays_on_first_permissions_head_and_
 
 async fn dynamic_server_live_subscription_replays_on_first_permissions_head_and_retightening_impl()
 {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let schema = schema_v1();
     seed_schema_catalogue(&server, &schema).await;
     let query = jazz::query::Query::from("users");
@@ -1769,7 +1809,7 @@ async fn column_addition_new_client_can_read_old_rows() {
 }
 
 async fn column_addition_new_client_can_read_old_rows_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let target_schema = schema_v2();
 
     // === Push v2 schema + lens to server through the real sync pipeline ===
@@ -1866,7 +1906,7 @@ async fn cannot_read_from_old_schema_until_lens_is_added() {
 }
 
 async fn cannot_read_from_old_schema_until_lens_is_added_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let v1_schema = schema_v1();
     let v2_schema = schema_v2();
 
@@ -1986,7 +2026,7 @@ async fn multi_hop_column_additions_new_client_can_read_old_rows() {
 }
 
 async fn multi_hop_column_additions_new_client_can_read_old_rows_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let v3_schema = schema_v3();
 
     push_catalogue_in_memory(
@@ -2137,7 +2177,7 @@ async fn multi_hop_column_renames_new_client_can_read_old_rows() {
 }
 
 async fn multi_hop_column_renames_new_client_can_read_old_rows_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let v1_schema = rename_chain_schema_v1();
     let v2_schema = rename_chain_schema_v2();
     let v3_schema = rename_chain_schema_v3();
@@ -2220,7 +2260,7 @@ async fn multi_hop_column_renames_old_client_can_read_new_rows() {
 }
 
 async fn multi_hop_column_renames_old_client_can_read_new_rows_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let v1_schema = rename_chain_schema_v1();
     let v2_schema = rename_chain_schema_v2();
     let v3_schema = rename_chain_schema_v3();
@@ -2300,7 +2340,7 @@ async fn table_rename_new_client_can_read_old_rows() {
 }
 
 async fn table_rename_new_client_can_read_old_rows_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let v1_schema = table_rename_schema_v1();
     let v2_schema = table_rename_schema_v2();
 
@@ -2375,7 +2415,7 @@ async fn table_rename_subscription_reacts_to_old_branch_updates() {
 }
 
 async fn table_rename_subscription_reacts_to_old_branch_updates_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let v1_schema = table_rename_schema_v1();
     let v2_schema = table_rename_schema_v2();
 
@@ -2488,7 +2528,7 @@ async fn table_rename_subscription_reacts_to_new_branch_updates_after_schema_evo
 }
 
 async fn table_rename_subscription_reacts_to_new_branch_updates_after_schema_evolution_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let v1_schema = table_rename_schema_v1();
     let v2_schema = table_rename_schema_v2();
 
@@ -2603,7 +2643,7 @@ async fn table_rename_update_and_delete_copy_on_write() {
 }
 
 async fn table_rename_update_and_delete_copy_on_write_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let v1_schema = table_rename_schema_v1();
     let v2_schema = table_rename_copy_on_write_schema_v2();
 
@@ -2733,7 +2773,7 @@ async fn table_rename_join_query_translates_join_target_on_old_branch() {
 }
 
 async fn table_rename_join_query_translates_join_target_on_old_branch_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let v1_schema = table_rename_join_schema_v1();
     let v2_schema = table_rename_join_schema_v2();
 
@@ -2843,7 +2883,7 @@ async fn table_rename_fk_array_lookup_finds_related_rows_on_old_branch() {
 }
 
 async fn table_rename_fk_array_lookup_finds_related_rows_on_old_branch_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let v1_schema = table_rename_join_schema_v1();
     let v2_schema = table_rename_join_schema_v2();
 
@@ -2945,7 +2985,7 @@ async fn local_join_query_uses_current_permissions_for_joined_provenance_after_l
 
 async fn local_join_query_uses_current_permissions_for_joined_provenance_after_lens_transform_impl()
 {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let legacy_schema = legacy_join_provenance_schema();
     let current_schema = current_join_provenance_permission_schema();
 
@@ -3137,7 +3177,7 @@ async fn multi_hop_table_renames_and_column_rename() {
 }
 
 async fn multi_hop_table_renames_and_column_rename_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let v1_schema = multi_hop_table_rename_schema_v1();
     let v2_schema = multi_hop_table_rename_schema_v2();
     let v3_schema = multi_hop_table_rename_schema_v3();
@@ -3278,7 +3318,7 @@ async fn removed_table_then_readded_does_not_resurface_old_rows() {
 }
 
 async fn removed_table_then_readded_does_not_resurface_old_rows_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let v1_schema = removed_readded_schema_v1();
     let v2_schema = removed_readded_schema_v2();
     let v3_schema = removed_readded_schema_v3();
@@ -3396,7 +3436,7 @@ async fn column_addition_old_client_can_read_new_rows() {
 }
 
 async fn column_addition_old_client_can_read_new_rows_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let target_schema = schema_v2();
 
     // Seed the server with both schemas and the v1<->v2 lens before clients connect.
@@ -3488,7 +3528,7 @@ async fn keeps_authorization_through_v1_head() {
 }
 
 async fn keeps_authorization_through_v1_head_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     let query = jazz::query::Query::from("users");
     let v1_schema = schema_v1();
     push_catalogue_in_memory(

--- a/crates/jazz-testkit/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-testkit/tests/catalogue_sync_integration.rs
@@ -655,7 +655,8 @@ async fn edge_catalogue_http_reads_and_writes_forward_to_real_core_impl() {
     let core = JazzServer::builder()
         .with_app_id(app_id)
         .start()
-        .await.expect("start test server");
+        .await
+        .expect("start test server");
     let edge = JazzServer::builder()
         .with_app_id(app_id)
         .with_native_transport_connector(jazz_testkit::native_connector())
@@ -795,7 +796,8 @@ async fn edge_catalogue_publish_reaches_peer_edge_through_core_sync_impl() {
     let core = JazzServer::builder()
         .with_app_id(app_id)
         .start()
-        .await.expect("start test server");
+        .await
+        .expect("start test server");
     let edge_us = JazzServer::builder()
         .with_app_id(app_id)
         .with_native_transport_connector(jazz_testkit::native_connector())
@@ -881,7 +883,8 @@ async fn persisted_stale_edge_reconnect_replays_catalogue_before_client_work_imp
     let core = JazzServer::builder()
         .with_app_id(app_id)
         .start()
-        .await.expect("start test server");
+        .await
+        .expect("start test server");
 
     seed_schema_catalogue(&core, &v1_schema).await;
     publish_allow_all_permissions(&core.base_url(), app_id, core.admin_secret(), &v1_schema).await;
@@ -980,7 +983,8 @@ async fn persistent_dynamic_edge_reopens_catalogue_for_trusted_client_while_regi
     let core = JazzServer::builder()
         .with_app_id(app_id)
         .start()
-        .await.expect("start test server");
+        .await
+        .expect("start test server");
     let unavailable_core_url = core.base_url();
     seed_schema_catalogue(&core, &schema).await;
     publish_allow_all_permissions(&core.base_url(), app_id, core.admin_secret(), &schema).await;
@@ -1083,7 +1087,8 @@ async fn core_permission_retightening_reaches_subscribed_clients_on_every_edge_i
     let core = JazzServer::builder()
         .with_app_id(app_id)
         .start()
-        .await.expect("start test server");
+        .await
+        .expect("start test server");
     seed_schema_catalogue(&core, &schema).await;
     let allow_head =
         publish_allow_all_permissions(&core.base_url(), app_id, core.admin_secret(), &schema).await;
@@ -1236,7 +1241,8 @@ async fn edge_migration_publish_forwards_to_real_core_and_is_readable_through_ed
     let core = JazzServer::builder()
         .with_app_id(app_id)
         .start()
-        .await.expect("start test server");
+        .await
+        .expect("start test server");
     let edge = JazzServer::builder()
         .with_app_id(app_id)
         .with_native_transport_connector(jazz_testkit::native_connector())

--- a/crates/jazz-testkit/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-testkit/tests/catalogue_sync_integration.rs
@@ -655,9 +655,7 @@ async fn edge_catalogue_http_reads_and_writes_forward_to_real_core_impl() {
     let core = JazzServer::builder()
         .with_app_id(app_id)
         .start()
-        .await
-        .expect("start test server")
-        .expect("start test server");
+        .await.expect("start test server");
     let edge = JazzServer::builder()
         .with_app_id(app_id)
         .with_native_transport_connector(jazz_testkit::native_connector())
@@ -797,9 +795,7 @@ async fn edge_catalogue_publish_reaches_peer_edge_through_core_sync_impl() {
     let core = JazzServer::builder()
         .with_app_id(app_id)
         .start()
-        .await
-        .expect("start test server")
-        .expect("start test server");
+        .await.expect("start test server");
     let edge_us = JazzServer::builder()
         .with_app_id(app_id)
         .with_native_transport_connector(jazz_testkit::native_connector())
@@ -885,9 +881,7 @@ async fn persisted_stale_edge_reconnect_replays_catalogue_before_client_work_imp
     let core = JazzServer::builder()
         .with_app_id(app_id)
         .start()
-        .await
-        .expect("start test server")
-        .expect("start test server");
+        .await.expect("start test server");
 
     seed_schema_catalogue(&core, &v1_schema).await;
     publish_allow_all_permissions(&core.base_url(), app_id, core.admin_secret(), &v1_schema).await;
@@ -986,9 +980,7 @@ async fn persistent_dynamic_edge_reopens_catalogue_for_trusted_client_while_regi
     let core = JazzServer::builder()
         .with_app_id(app_id)
         .start()
-        .await
-        .expect("start test server")
-        .expect("start test server");
+        .await.expect("start test server");
     let unavailable_core_url = core.base_url();
     seed_schema_catalogue(&core, &schema).await;
     publish_allow_all_permissions(&core.base_url(), app_id, core.admin_secret(), &schema).await;
@@ -1091,9 +1083,7 @@ async fn core_permission_retightening_reaches_subscribed_clients_on_every_edge_i
     let core = JazzServer::builder()
         .with_app_id(app_id)
         .start()
-        .await
-        .expect("start test server")
-        .expect("start test server");
+        .await.expect("start test server");
     seed_schema_catalogue(&core, &schema).await;
     let allow_head =
         publish_allow_all_permissions(&core.base_url(), app_id, core.admin_secret(), &schema).await;
@@ -1246,9 +1236,7 @@ async fn edge_migration_publish_forwards_to_real_core_and_is_readable_through_ed
     let core = JazzServer::builder()
         .with_app_id(app_id)
         .start()
-        .await
-        .expect("start test server")
-        .expect("start test server");
+        .await.expect("start test server");
     let edge = JazzServer::builder()
         .with_app_id(app_id)
         .with_native_transport_connector(jazz_testkit::native_connector())

--- a/crates/jazz-testkit/tests/claims_merge_integration.rs
+++ b/crates/jazz-testkit/tests/claims_merge_integration.rs
@@ -64,7 +64,9 @@ async fn ephemeral_claims_merged_into_session() {
 }
 
 async fn ephemeral_claims_merged_into_session_impl() {
-    let server = JazzServer::start_with_schema(claims_gated_schema()).await;
+    let server = JazzServer::start_with_schema(claims_gated_schema())
+        .await
+        .expect("start test server");
     let schema = claims_gated_schema();
 
     // Admin creates a room with join_code = "secret-123"

--- a/crates/jazz-testkit/tests/client_storage_shutdown_integration.rs
+++ b/crates/jazz-testkit/tests/client_storage_shutdown_integration.rs
@@ -22,7 +22,9 @@ async fn shutdown_releases_persistent_storage_for_reopen() {
 }
 
 async fn shutdown_releases_persistent_storage_for_reopen_impl() {
-    let server = JazzServer::start_with_schema(test_schema()).await;
+    let server = JazzServer::start_with_schema(test_schema())
+        .await
+        .expect("start test server");
     let data_dir = TempDir::new().expect("create persistent client directory");
     let mut context = server.make_client_context_for_user(test_schema(), "storage-release-user");
     context.storage = ClientStorage::Persistent;

--- a/crates/jazz-testkit/tests/clients_sync.rs
+++ b/crates/jazz-testkit/tests/clients_sync.rs
@@ -96,7 +96,9 @@ async fn fresh_client_resolves_object_with_deep_update_history_impl() {
     const DEEP_HISTORY_UPDATES: usize = 100;
 
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let writer =
         jazz_testkit::connect(server.make_client_context_for_user(schema.clone(), "alice-history"))
             .await
@@ -181,7 +183,9 @@ async fn jazz_tools_cli_two_clients_sync_values() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = test_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client_a = jazz_testkit::connect(
                 server.make_client_context_for_user(schema.clone(), "sync-values-user"),
             )
@@ -311,7 +315,9 @@ async fn update_through_one_client_waits_for_ack_and_updates_peer_query_results(
 
 async fn update_through_one_client_waits_for_ack_and_updates_peer_query_results_impl() {
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client_a = jazz_testkit::connect(
         server.make_client_context_for_user(schema.clone(), "update-through-server-user"),
     )
@@ -390,7 +396,9 @@ async fn delete_through_one_client_removes_row_from_peer_query_results() {
 
 async fn delete_through_one_client_removes_row_from_peer_query_results_impl() {
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client_a = jazz_testkit::connect(
         server.make_client_context_for_user(schema.clone(), "delete-through-server-user"),
     )
@@ -454,7 +462,9 @@ async fn caller_supplied_uuid_is_used_for_created_row() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = test_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             publish_allow_all_permissions(
                 &server.base_url(),
                 server.app_id(),
@@ -515,7 +525,9 @@ async fn wait_for_transaction_reaches_edge_and_global_tiers() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = test_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let alice = jazz_testkit::connect(
                 server.make_client_context_for_user(schema, "alice-direct-wait-for-tx"),
             )
@@ -561,7 +573,9 @@ async fn caller_supplied_uuid_keeps_created_at_as_explicit_metadata() {
 
 async fn caller_supplied_uuid_keeps_created_at_as_explicit_metadata_impl() {
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     publish_allow_all_permissions(
         &server.base_url(),
         server.app_id(),
@@ -640,7 +654,9 @@ async fn upsert_uses_external_uuid_for_insert_and_updates_existing_row() {
 
 async fn upsert_uses_external_uuid_for_insert_and_updates_existing_row_impl() {
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     publish_allow_all_permissions(
         &server.base_url(),
         server.app_id(),
@@ -722,7 +738,9 @@ async fn jazz_tools_cli_two_different_users_sync_values() {
 
 async fn jazz_tools_cli_two_different_users_sync_values_impl() {
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client_alice = jazz_testkit::connect(
         server.make_client_context_for_user(schema.clone(), "alice-sync-user"),
     )

--- a/crates/jazz-testkit/tests/durable_local_write_replay_integration.rs
+++ b/crates/jazz-testkit/tests/durable_local_write_replay_integration.rs
@@ -28,7 +28,9 @@ async fn persistent_restart_replays_pending_write_with_valid_token() {
 }
 
 async fn persistent_restart_replays_pending_write_with_valid_token_impl() {
-    let server = JazzServer::start_with_schema(test_schema()).await;
+    let server = JazzServer::start_with_schema(test_schema())
+        .await
+        .expect("start test server");
     let mut context = server.make_client_context_for_user(test_schema(), "durable-replay-user");
     context.backend_secret = None;
     context.admin_secret = None;

--- a/crates/jazz-testkit/tests/edge_server_mode.rs
+++ b/crates/jazz-testkit/tests/edge_server_mode.rs
@@ -1167,7 +1167,8 @@ async fn edge_reconnects_after_established_core_drop() {
                     .start(),
             )
             .await
-            .expect("initial Core start timed out");
+            .expect("initial Core start timed out")
+            .expect("start Core server");
             let edge = tokio::time::timeout(
                 Duration::from_secs(10),
                 JazzServer::builder()
@@ -1178,7 +1179,8 @@ async fn edge_reconnects_after_established_core_drop() {
                     .start(),
             )
             .await
-            .expect("Edge start timed out");
+            .expect("Edge start timed out")
+            .expect("start Edge server");
             let edge_state = edge.server_state();
             tokio::time::timeout(Duration::from_secs(5), async {
                 while edge_state.edge_upstream_health()
@@ -1213,7 +1215,8 @@ async fn edge_reconnects_after_established_core_drop() {
                     .start(),
             )
             .await
-            .expect("replacement Core start timed out");
+            .expect("replacement Core start timed out")
+            .expect("restart Core server");
             tokio::time::timeout(Duration::from_secs(5), async {
                 while edge_state.edge_upstream_health()
                     != jazz_server::EdgeUpstreamHealth::Connected

--- a/crates/jazz-testkit/tests/edge_server_mode.rs
+++ b/crates/jazz-testkit/tests/edge_server_mode.rs
@@ -86,7 +86,9 @@ async fn subscription_orders_by_unprojected_field() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = ranked_todo_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema)
@@ -170,7 +172,9 @@ async fn edge_tier_public_subscription_opens_and_receives_rows() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = todo_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema)
@@ -230,7 +234,9 @@ async fn public_root_default_order_and_windows_are_stable_across_reset() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = todo_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema)
@@ -328,7 +334,9 @@ async fn maintained_window_uses_row_id_tie_breaker_and_tracks_rows_crossing_boun
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = todo_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema)
@@ -472,7 +480,9 @@ async fn public_subscription_stream_yields_delta_items_for_normal_changes() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = todo_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema)
@@ -1008,7 +1018,7 @@ async fn assert_policy_graph_member_rows(member: &JazzClient, rows: &PolicyGraph
 async fn dynamic_server_publishes_seeded_reachable_policy_and_serves_member_rows() {
     tokio::task::LocalSet::new()
         .run_until(async {
-            let server = JazzServer::start().await;
+            let server = JazzServer::start().await.expect("start test server");
             let schema = policy_graph_policy_schema();
             let app_id = server.app_id();
             let response = reqwest::Client::new()
@@ -1101,7 +1111,8 @@ async fn fixed_schema_data_dir_reopen_bootstraps_policy_graph_policy_serving_sta
                     .with_data_dir(data_dir.path())
                     .with_storage_factory(jazz_testkit::persistent_storage_factory())
                     .start()
-                    .await;
+                    .await
+                    .expect("start test server");
                 let admin = TestingClient::builder()
                     .with_server(&server)
                     .with_schema(schema.clone())
@@ -1120,7 +1131,8 @@ async fn fixed_schema_data_dir_reopen_bootstraps_policy_graph_policy_serving_sta
                 .with_data_dir(data_dir.path())
                 .with_storage_factory(jazz_testkit::persistent_storage_factory())
                 .start()
-                .await;
+                .await
+                .expect("start test server");
             let member = TestingClient::builder()
                 .with_server(&reopened)
                 .with_schema(schema.clone())
@@ -1239,7 +1251,8 @@ async fn edge_to_core_relay_retains_write_while_upstream_is_unavailable() {
                 .with_native_transport_connector(jazz_testkit::native_connector())
                 .with_upstream_url(format!("http://127.0.0.1:{core_port}"))
                 .start()
-                .await;
+                .await
+                .expect("start test server");
             let edge_state = edge.server_state();
             tokio::time::timeout(Duration::from_secs(5), async {
                 while !matches!(
@@ -1272,7 +1285,8 @@ async fn edge_to_core_relay_retains_write_while_upstream_is_unavailable() {
                 .with_port(core_port)
                 .with_schema(schema)
                 .start()
-                .await;
+                .await
+                .expect("start test server");
             tokio::time::timeout(Duration::from_secs(5), async {
                 while edge_state.edge_upstream_health()
                     != jazz_server::EdgeUpstreamHealth::Connected
@@ -1311,21 +1325,24 @@ async fn core_write_reaches_clients_on_both_edges() {
                 .with_app_id(app_id)
                 .with_schema(schema.clone())
                 .start()
-                .await;
+                .await
+                .expect("start test server");
             let edge_us = JazzServer::builder()
                 .with_app_id(app_id)
                 .with_schema(schema.clone())
                 .with_native_transport_connector(jazz_testkit::native_connector())
                 .with_upstream_url(core.base_url())
                 .start()
-                .await;
+                .await
+                .expect("start test server");
             let edge_eu = JazzServer::builder()
                 .with_app_id(app_id)
                 .with_schema(schema.clone())
                 .with_native_transport_connector(jazz_testkit::native_connector())
                 .with_upstream_url(core.base_url())
                 .start()
-                .await;
+                .await
+                .expect("start test server");
 
             let alice =
                 connect_user_after_catalogue_bootstrap(&edge_us, schema.clone(), "alice-edge-us")
@@ -1422,21 +1439,24 @@ async fn edge_write_reaches_client_on_peer_edge() {
                 .with_app_id(app_id)
                 .with_schema(schema.clone())
                 .start()
-                .await;
+                .await
+                .expect("start test server");
             let edge_us = JazzServer::builder()
                 .with_app_id(app_id)
                 .with_schema(schema.clone())
                 .with_native_transport_connector(jazz_testkit::native_connector())
                 .with_upstream_url(core.base_url())
                 .start()
-                .await;
+                .await
+                .expect("start test server");
             let edge_eu = JazzServer::builder()
                 .with_app_id(app_id)
                 .with_schema(schema.clone())
                 .with_native_transport_connector(jazz_testkit::native_connector())
                 .with_upstream_url(core.base_url())
                 .start()
-                .await;
+                .await
+                .expect("start test server");
 
             let alice = connect_user(&edge_us, schema.clone(), "alice-edge-us-writer").await;
             let bob = connect_user(&edge_eu, schema, "bob-edge-eu-reader").await;

--- a/crates/jazz-testkit/tests/gset_merge.rs
+++ b/crates/jazz-testkit/tests/gset_merge.rs
@@ -138,7 +138,9 @@ async fn concurrent_writes_converge_to_sorted_union() {
 async fn concurrent_writes_converge_to_sorted_union_impl() {
     let _suite_guard = lock_gset_suite().await;
     let schema = gset_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -235,7 +237,9 @@ async fn concurrent_writes_never_remove_a_shared_element() {
 async fn concurrent_writes_never_remove_a_shared_element_impl() {
     let _suite_guard = lock_gset_suite().await;
     let schema = gset_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -338,7 +342,9 @@ async fn same_elements_in_different_orders_converge_to_one_canonical_order() {
 async fn same_elements_in_different_orders_converge_to_one_canonical_order_impl() {
     let _suite_guard = lock_gset_suite().await;
     let schema = gset_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -408,7 +414,9 @@ async fn duplicate_insertions_are_idempotent() {
 async fn duplicate_insertions_are_idempotent_impl() {
     let _suite_guard = lock_gset_suite().await;
     let schema = gset_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -474,7 +482,9 @@ async fn later_writes_cannot_remove_existing_elements() {
 async fn later_writes_cannot_remove_existing_elements_impl() {
     let _suite_guard = lock_gset_suite().await;
     let schema = gset_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema)
@@ -526,7 +536,9 @@ async fn empty_and_non_empty_sets_union_in_both_propagation_orders() {
 async fn empty_and_non_empty_sets_union_in_both_propagation_orders_impl() {
     let _suite_guard = lock_gset_suite().await;
     let schema = gset_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -662,7 +674,9 @@ async fn distinct_float_representations_converge_deterministically() {
 async fn distinct_float_representations_converge_deterministically_impl() {
     let _suite_guard = lock_gset_suite().await;
     let schema = gset_float_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)

--- a/crates/jazz-testkit/tests/history_conflict.rs
+++ b/crates/jazz-testkit/tests/history_conflict.rs
@@ -64,7 +64,9 @@ async fn concurrent_updates_resolve_to_lww_winner() {
 async fn concurrent_updates_resolve_to_lww_winner_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -189,7 +191,9 @@ async fn concurrent_creates_both_survive() {
 async fn concurrent_creates_both_survive_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -280,7 +284,9 @@ async fn rapid_concurrent_updates_converge() {
 async fn rapid_concurrent_updates_converge_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -405,7 +411,9 @@ async fn fresh_client_sees_lww_winner_after_conflict() {
 async fn fresh_client_sees_lww_winner_after_conflict_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -564,7 +572,9 @@ async fn subscription_reflects_concurrent_update() {
 async fn subscription_reflects_concurrent_update_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -728,7 +738,9 @@ async fn sequential_updates_preserve_latest() {
 async fn sequential_updates_preserve_latest_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -825,7 +837,9 @@ async fn concurrent_edits_on_different_fields() {
 async fn concurrent_edits_on_different_fields_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -961,7 +975,9 @@ async fn post_conflict_update_rebases_on_merged_preview() {
 async fn post_conflict_update_rebases_on_merged_preview_impl() {
     let _suite_guard = lock_history_conflict_suite().await;
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -1104,7 +1120,9 @@ async fn establish_offline_reconnect_baseline(
     bob_user_id: &str,
 ) -> OfflineReconnectBaseline {
     let schema = test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)

--- a/crates/jazz-testkit/tests/inherited_policies.rs
+++ b/crates/jazz-testkit/tests/inherited_policies.rs
@@ -320,7 +320,7 @@ async fn connect_ready_user(
 async fn inherited_select_policy_exposes_child_row_through_parent() {
     tokio::task::LocalSet::new()
         .run_until(async {
-            let server = JazzServer::start().await;
+            let server = JazzServer::start().await.expect("start test server");
             let schema = inherited_select_schema();
             publish_schema(&server, &schema).await;
 
@@ -408,7 +408,7 @@ async fn inherited_select_policy_exposes_child_row_through_parent() {
 async fn reverse_inherited_select_retains_nested_source_inheritance() {
     tokio::task::LocalSet::new()
         .run_until(async {
-            let server = JazzServer::start().await;
+            let server = JazzServer::start().await.expect("start test server");
             let schema = reverse_inherited_select_schema();
             publish_schema(&server, &schema).await;
 
@@ -487,7 +487,7 @@ async fn reverse_inherited_select_retains_nested_source_inheritance() {
 async fn inherited_select_policy_exposes_child_row_through_multi_hop_parent_chain() {
     tokio::task::LocalSet::new()
         .run_until(async {
-            let server = JazzServer::start().await;
+            let server = JazzServer::start().await.expect("start test server");
             let schema = inherited_select_schema();
             publish_schema(&server, &schema).await;
 
@@ -565,7 +565,7 @@ async fn inherited_select_policy_exposes_child_row_through_multi_hop_parent_chai
 async fn inherited_select_policy_exposes_child_row_through_any_forward_parent() {
     tokio::task::LocalSet::new()
         .run_until(async {
-            let server = JazzServer::start().await;
+            let server = JazzServer::start().await.expect("start test server");
             let schema = inherited_select_schema();
             publish_schema(&server, &schema).await;
 
@@ -643,7 +643,7 @@ async fn inherited_select_policy_exposes_child_row_through_any_forward_parent() 
 async fn inherited_select_policy_expands_both_forward_parent_branches() {
     tokio::task::LocalSet::new()
         .run_until(async {
-            let server = JazzServer::start().await;
+            let server = JazzServer::start().await.expect("start test server");
             let schema = inherited_select_schema();
             publish_schema(&server, &schema).await;
 
@@ -732,7 +732,7 @@ async fn inherited_select_policy_expands_both_forward_parent_branches() {
 async fn inherited_update_policy_allows_update_through_parent() {
     tokio::task::LocalSet::new()
         .run_until(async {
-            let server = JazzServer::start().await;
+            let server = JazzServer::start().await.expect("start test server");
             let schema = inherited_update_schema();
 
             push_catalogue_in_memory(
@@ -846,7 +846,7 @@ async fn inherited_update_policy_allows_update_through_parent() {
 async fn inherited_update_policy_allows_multi_hop_update_chain() {
     tokio::task::LocalSet::new()
         .run_until(async {
-            let server = JazzServer::start().await;
+            let server = JazzServer::start().await.expect("start test server");
             let schema = inherited_update_schema();
 
             push_catalogue_in_memory(
@@ -945,7 +945,7 @@ async fn inherited_update_policy_allows_multi_hop_update_chain() {
 async fn inherited_update_policy_allows_reparenting_when_old_and_new_parents_grant() {
     tokio::task::LocalSet::new()
         .run_until(async {
-            let server = JazzServer::start().await;
+            let server = JazzServer::start().await.expect("start test server");
             let schema = inherited_update_schema();
 
             push_catalogue_in_memory(

--- a/crates/jazz-testkit/tests/json_storage.rs
+++ b/crates/jazz-testkit/tests/json_storage.rs
@@ -28,7 +28,9 @@ async fn remote_whole_json_row_matches_explicit_projection() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = documents_schema(None);
-            let server = jazz_server::JazzServer::start().await;
+            let server = jazz_server::JazzServer::start()
+                .await
+                .expect("start test server");
             jazz_testkit::push_catalogue_in_memory(
                 server.server_state(),
                 server.app_id(),

--- a/crates/jazz-testkit/tests/local_first_auth_integration.rs
+++ b/crates/jazz-testkit/tests/local_first_auth_integration.rs
@@ -125,7 +125,9 @@ async fn same_seed_syncs_across_devices() {
 }
 
 async fn same_seed_syncs_across_devices_impl() {
-    let server = JazzServer::start_with_schema(test_schema()).await;
+    let server = JazzServer::start_with_schema(test_schema())
+        .await
+        .expect("start test server");
 
     let alice_device_a = jazz_testkit::connect(local_first_context(
         &server,
@@ -173,7 +175,9 @@ async fn different_seeds_produce_distinct_principals() {
 }
 
 async fn different_seeds_produce_distinct_principals_impl() {
-    let server = JazzServer::start_with_schema(test_schema()).await;
+    let server = JazzServer::start_with_schema(test_schema())
+        .await
+        .expect("start test server");
 
     let alice_user_id = identity::derive_user_id(&alice_seed()).to_string();
     let bob_user_id = identity::derive_user_id(&bob_seed()).to_string();
@@ -246,7 +250,9 @@ async fn persistent_seed_reconnects_as_same_principal() {
 }
 
 async fn persistent_seed_reconnects_as_same_principal_impl() {
-    let server = JazzServer::start_with_schema(test_schema()).await;
+    let server = JazzServer::start_with_schema(test_schema())
+        .await
+        .expect("start test server");
 
     let context = local_first_context(
         &server,
@@ -320,7 +326,9 @@ async fn local_first_writes_carry_derived_principal_as_created_by() {
 }
 
 async fn local_first_writes_carry_derived_principal_as_created_by_impl() {
-    let server = JazzServer::start_with_schema(test_schema()).await;
+    let server = JazzServer::start_with_schema(test_schema())
+        .await
+        .expect("start test server");
 
     let alice = jazz_testkit::connect(local_first_context(
         &server,
@@ -366,7 +374,9 @@ async fn remote_single_provenance_fields_match_complete_provenance() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = test_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let alice = jazz_testkit::connect(local_first_context(
                 &server,
                 schema,
@@ -436,7 +446,9 @@ async fn local_first_and_jwt_clients_coexist() {
 }
 
 async fn local_first_and_jwt_clients_coexist_impl() {
-    let server = JazzServer::start_with_schema(test_schema()).await;
+    let server = JazzServer::start_with_schema(test_schema())
+        .await
+        .expect("start test server");
 
     let alice = jazz_testkit::connect(local_first_context(
         &server,
@@ -526,7 +538,8 @@ async fn expired_token_reconnect_flushes_queued_writes_impl() {
         .with_schema(test_schema())
         .with_auth_clock(auth_clock.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
 
     let audience = server.app_id().to_string();
     let seed = alice_seed();

--- a/crates/jazz-testkit/tests/merged_redelivery.rs
+++ b/crates/jazz-testkit/tests/merged_redelivery.rs
@@ -118,7 +118,9 @@ async fn concurrent_column_writes_merge_and_reach_a_third_subscriber() {
 
 async fn concurrent_column_writes_merge_and_reach_a_third_subscriber_impl() {
     let _suite_guard = MERGED_REDELIVERY_SUITE_LOCK.lock().await;
-    let server = JazzServer::start_with_schema(test_schema()).await;
+    let server = JazzServer::start_with_schema(test_schema())
+        .await
+        .expect("start test server");
 
     let alice = connect_writer(&server, "alice-merge-subscriber").await;
     let bob = connect_writer(&server, "bob-merge-subscriber").await;
@@ -246,7 +248,9 @@ async fn offline_merge_redelivers_after_reconnect() {
 
 async fn offline_merge_redelivers_after_reconnect_impl() {
     let _suite_guard = MERGED_REDELIVERY_SUITE_LOCK.lock().await;
-    let server = JazzServer::start_with_schema(test_schema()).await;
+    let server = JazzServer::start_with_schema(test_schema())
+        .await
+        .expect("start test server");
 
     let alice = connect_writer(&server, "alice-offline-merge").await;
     let bob = connect_writer(&server, "bob-offline-merge").await;
@@ -372,7 +376,9 @@ async fn same_value_write_still_advances_visible_row_metadata() {
 
 async fn same_value_write_still_advances_visible_row_metadata_impl() {
     let _suite_guard = MERGED_REDELIVERY_SUITE_LOCK.lock().await;
-    let server = JazzServer::start_with_schema(test_schema()).await;
+    let server = JazzServer::start_with_schema(test_schema())
+        .await
+        .expect("start test server");
 
     let alice = connect_writer(&server, "alice-metadata-only").await;
     let charlie = connect_writer(&server, "charlie-metadata-only").await;
@@ -485,7 +491,9 @@ async fn late_subscriber_updates_merged_row_without_full_history() {
 
 async fn late_subscriber_updates_merged_row_without_full_history_impl() {
     let _suite_guard = MERGED_REDELIVERY_SUITE_LOCK.lock().await;
-    let server = JazzServer::start_with_schema(test_schema()).await;
+    let server = JazzServer::start_with_schema(test_schema())
+        .await
+        .expect("start test server");
 
     let alice = connect_writer(&server, "alice-late-writer").await;
     let bob = connect_writer(&server, "bob-late-writer").await;

--- a/crates/jazz-testkit/tests/mixed_generation_history.rs
+++ b/crates/jazz-testkit/tests/mixed_generation_history.rs
@@ -196,7 +196,7 @@ async fn newest_write_wins_when_row_history_spans_variable_column_generations() 
 }
 
 async fn newest_write_wins_when_row_history_spans_variable_column_generations_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     push_catalogue(
         &server,
         &[tasks_schema_v1(), tasks_schema_v2()],
@@ -261,7 +261,7 @@ async fn cold_client_converges_row_with_mixed_generation_history() {
 }
 
 async fn cold_client_converges_row_with_mixed_generation_history_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     push_catalogue(
         &server,
         &[tasks_schema_v1(), tasks_schema_v2()],
@@ -322,7 +322,7 @@ async fn late_write_under_prior_generation_converges_with_current_schema_update(
 }
 
 async fn late_write_under_prior_generation_converges_with_current_schema_update_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     push_catalogue(
         &server,
         &[tasks_schema_v1(), tasks_schema_v2()],
@@ -435,7 +435,7 @@ async fn read_paths_agree_on_newest_state_after_mixed_generation_writes() {
 }
 
 async fn read_paths_agree_on_newest_state_after_mixed_generation_writes_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     push_catalogue(
         &server,
         &[tasks_schema_v1(), tasks_schema_v2()],
@@ -569,7 +569,7 @@ async fn migration_published_at_runtime_still_converges_mixed_generation_row() {
 }
 
 async fn migration_published_at_runtime_still_converges_mixed_generation_row_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     push_catalogue(&server, &[tasks_schema_v1()], &[]).await;
     activate_generation(&server, &tasks_schema_v1()).await;
 
@@ -638,7 +638,7 @@ async fn draft_schema_without_lineage_does_not_affect_active_generation_reads() 
 }
 
 async fn draft_schema_without_lineage_does_not_affect_active_generation_reads_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     push_catalogue(&server, &[tasks_schema_v1()], &[]).await;
     activate_generation(&server, &tasks_schema_v1()).await;
 
@@ -763,7 +763,7 @@ async fn partial_current_schema_update_keeps_untouched_added_column_readable() {
 }
 
 async fn partial_current_schema_update_keeps_untouched_added_column_readable_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     push_catalogue(
         &server,
         &[tasks_schema_v1(), tasks_schema_v2()],

--- a/crates/jazz-testkit/tests/native_account_admission.rs
+++ b/crates/jazz-testkit/tests/native_account_admission.rs
@@ -11,7 +11,9 @@ async fn public_native_client_requires_enrollment_and_cannot_choose_another_acco
             let schema = SchemaBuilder::new()
                 .table(TableSchema::builder("notes").column("title", ColumnType::Text))
                 .build();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let mut context = server.make_client_context_for_user(schema, "native-account-fixture");
             context.backend_secret = None;
             context.admin_secret = None;

--- a/crates/jazz-testkit/tests/output_occurrence_id.rs
+++ b/crates/jazz-testkit/tests/output_occurrence_id.rs
@@ -91,7 +91,9 @@ async fn forwarded_flat_join_reset_keeps_contributor_facts_visible_to_one_shot_r
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = todos_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema)
@@ -179,7 +181,9 @@ async fn forwarded_flat_join_reconciles_joined_source_deletion() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = todos_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema)
@@ -258,7 +262,7 @@ async fn flat_join_output_occurrence_identity_addresses_additions_removals_and_r
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = todos_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone()).await.expect("start test server");
             let client = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema)
@@ -544,7 +548,9 @@ async fn flat_join_payload_netting_drops_add_then_remove_in_one_transaction() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = todos_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema)

--- a/crates/jazz-testkit/tests/policies_integration/authorship_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/authorship_policies.rs
@@ -119,7 +119,8 @@ async fn backend_session_transaction_preserves_raw_claims_and_logical_author_inn
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let backend = connect_ready_client(&server, &schema, "backend", "notes", READY_TIMEOUT).await;
     let account = jazz::account_registry::AccountId(uuid::Uuid::from_u128(0xa11ce));
     let mut session = Session::new("urn:jazz:test", super::ALICE_ID);
@@ -234,7 +235,8 @@ async fn created_by_policies_scope_crud_to_creators_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let (alice, alice_author) = connect_author(&server, &schema, super::ALICE_ID).await;
     let (bob, bob_author) = connect_author(&server, &schema, super::BOB_ID).await;
     let alice_note = create_note_as(&alice, "alice note").await;
@@ -367,7 +369,8 @@ async fn created_by_policies_hide_server_generated_rows_without_attribution_inne
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let (alice, alice_author) = connect_author(&server, &schema, super::ALICE_ID).await;
     let (bob, _bob_author) = connect_author(&server, &schema, super::BOB_ID).await;
     let backend = connect_ready_client(&server, &schema, "backend", "notes", READY_TIMEOUT).await;
@@ -453,7 +456,8 @@ async fn created_by_policies_can_allow_reads_from_system_author_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let (alice, alice_author) = connect_author(&server, &schema, super::ALICE_ID).await;
     let (bob, _bob_author) = connect_author(&server, &schema, super::BOB_ID).await;
     let backend = connect_ready_client(&server, &schema, "backend", "notes", READY_TIMEOUT).await;
@@ -548,7 +552,8 @@ async fn created_by_policies_allow_backend_attribution_to_specific_user_inner() 
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let (alice, _alice_author) = connect_author(&server, &schema, super::ALICE_ID).await;
     let (bob, _bob_author) = connect_author(&server, &schema, super::BOB_ID).await;
     let backend = connect_ready_client(&server, &schema, "backend", "notes", READY_TIMEOUT).await;
@@ -622,7 +627,8 @@ async fn updated_by_select_policy_moves_visibility_to_last_editor_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let (alice, alice_author) = connect_author(&server, &schema, super::ALICE_ID).await;
     let (bob, bob_author) = connect_author(&server, &schema, super::BOB_ID).await;
     let query = Query::from("notes").select([
@@ -755,7 +761,8 @@ async fn provenance_columns_expose_user_principals_and_insert_timestamps_inner()
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let (alice, alice_author) = connect_author(&server, &schema, super::ALICE_ID).await;
     let (bob, bob_author) = connect_author(&server, &schema, super::BOB_ID).await;
 

--- a/crates/jazz-testkit/tests/policies_integration/claims_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/claims_policies.rs
@@ -142,7 +142,8 @@ async fn admin_role_claims_allow_admin_mutations_and_member_reads_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_claims(
         &server,
         &schema,
@@ -286,7 +287,8 @@ async fn admin_role_claims_reject_member_mutations_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_claims(
         &server,
         &schema,
@@ -467,7 +469,8 @@ async fn claim_array_id_policy_gates_updates_by_primary_key_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_user(&server, &schema, "admin", table_name, READY_TIMEOUT).await;
 
     let allowed_doc = create_title_document(&admin, table_name, "allowed").await;
@@ -639,7 +642,8 @@ async fn role_claim_presence_gates_row_visibility_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let seeder =
         connect_ready_client(&server, &schema, "seed-admin", table_name, READY_TIMEOUT).await;
     let admin = connect_ready_claims(
@@ -777,7 +781,8 @@ async fn groups_allowed_claim_arrays_gate_visibility_and_live_updates_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin =
         connect_ready_client(&server, &schema, "seed-admin", table_name, READY_TIMEOUT).await;
 
@@ -1014,7 +1019,8 @@ async fn claim_null_checks_distinguish_explicit_null_from_missing_paths_inner() 
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let seeder =
         connect_ready_client(&server, &schema, "seed-admin", null_table, READY_TIMEOUT).await;
     let explicit_null = connect_ready_claims(
@@ -1187,7 +1193,8 @@ async fn row_and_claim_predicates_compose_under_and_and_or_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let seeder =
         connect_ready_client(&server, &schema, "seed-admin", all_of_table, READY_TIMEOUT).await;
     let north_eng = connect_ready_claims(

--- a/crates/jazz-testkit/tests/policies_integration/complex_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/complex_policies.rs
@@ -426,7 +426,8 @@ async fn exists_outer_row_refs_grant_deny_and_track_related_row_mutations_inner(
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "documents", READY_TIMEOUT).await;
     let bob = connect_ready_user(&server, &schema, super::BOB_ID, "documents", READY_TIMEOUT).await;
     let dave =
@@ -570,7 +571,8 @@ async fn exists_rel_join_grants_and_denies_correctly_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "documents", READY_TIMEOUT).await;
     let bob = connect_ready_user(&server, &schema, super::BOB_ID, "documents", READY_TIMEOUT).await;
     let dave =
@@ -623,7 +625,8 @@ async fn join_query_applies_policy_filter_on_joined_table_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "join_users", READY_TIMEOUT).await;
     let alice = connect_ready_user(
         &server,
@@ -709,7 +712,8 @@ async fn exists_rel_hop_grants_and_denies_correctly_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "documents", READY_TIMEOUT).await;
     let bob = connect_ready_user(&server, &schema, super::BOB_ID, "documents", READY_TIMEOUT).await;
     let dave =
@@ -810,7 +814,8 @@ async fn mixed_predicates_claims_exists_and_inherits_fail_closed_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "documents", READY_TIMEOUT).await;
     let alice_eng = connect_ready_claims(
         &server,
@@ -925,7 +930,8 @@ async fn update_with_check_exists_allows_chat_name_updates_and_rejects_protected
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "chats", READY_TIMEOUT).await;
     let alice = connect_ready_user(&server, &schema, super::ALICE_ID, "chats", READY_TIMEOUT).await;
     let observer =
@@ -1047,7 +1053,8 @@ async fn rejected_optimistic_exists_updates_reconcile_to_server_authoritative_st
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "documents", READY_TIMEOUT).await;
     let alice = connect_ready_user(
         &server,

--- a/crates/jazz-testkit/tests/policies_integration/declared_fk_inheritance.rs
+++ b/crates/jazz-testkit/tests/policies_integration/declared_fk_inheritance.rs
@@ -82,7 +82,9 @@ async fn rebac_declared_fk_inheritance_grants_select_access() {
 
 async fn rebac_declared_fk_inheritance_grants_select_access_inner() {
     let schema = declared_file_inheritance_schema(false);
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,
@@ -121,7 +123,9 @@ async fn rebac_declared_fk_inheritance_grants_update_access() {
 
 async fn rebac_declared_fk_inheritance_grants_update_access_inner() {
     let schema = declared_file_inheritance_schema(false);
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,
@@ -172,7 +176,9 @@ async fn rebac_declared_fk_inheritance_array_membership_grants_access() {
 
 async fn rebac_declared_fk_inheritance_array_membership_grants_access_inner() {
     let schema = declared_file_inheritance_schema(true);
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,
@@ -241,7 +247,9 @@ async fn rebac_declared_fk_inheritance_cycle_fails_closed_inner() {
                 .policies(b_policies),
         )
         .build();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,
@@ -304,7 +312,9 @@ async fn rebac_declared_fk_inheritance_reacts_to_fk_updates() {
 
 async fn rebac_declared_fk_inheritance_reacts_to_fk_updates_inner() {
     let schema = declared_file_inheritance_schema(false);
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,

--- a/crates/jazz-testkit/tests/policies_integration/exists_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/exists_policies.rs
@@ -89,7 +89,9 @@ async fn rebac_exists_clause_denies_non_matching_insert_inner() {
         )
         .build();
 
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let bob = connect_ready_user(
         &server,
         &schema,
@@ -170,7 +172,9 @@ async fn rebac_update_denied_by_using_exists_policy_inner() {
         )
         .build();
 
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice =
         jazz_testkit::connect(server.make_client_context_for_user(schema.clone(), super::ALICE_ID))
             .await
@@ -276,7 +280,9 @@ async fn local_update_using_exists_policy_allows_admin_and_denies_non_admin_inne
         )
         .build();
 
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client = super::support::connect_ready_client(
         &server,
         &schema,

--- a/crates/jazz-testkit/tests/policies_integration/exists_rel_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/exists_rel_policies.rs
@@ -43,7 +43,9 @@ async fn local_insert_with_exists_policy_propagates_enforcing_mode_to_nested_exi
                 .policies(projects_policies),
         )
         .build();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client = connect_ready_client(
         &server,
         &schema,
@@ -106,7 +108,9 @@ async fn local_insert_with_exists_rel_policy_denies_non_admin_inner() {
                 .policies(projects_policies),
         )
         .build();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client = connect_ready_client(
         &server,
         &schema,
@@ -161,7 +165,9 @@ async fn local_insert_with_exists_rel_policy_requires_explicit_select_on_scanned
                 .policies(projects_policies),
         )
         .build();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client = connect_ready_client(
         &server,
         &schema,
@@ -218,7 +224,9 @@ async fn local_insert_with_exists_rel_null_literal_predicate_matches_null_rows_i
                 .policies(projects_policies),
         )
         .build();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client = connect_ready_client(
         &server,
         &schema,
@@ -284,7 +292,9 @@ async fn local_delete_with_exists_rel_policy_allows_admin_and_denies_non_admin_i
                 .policies(protected_policies),
         )
         .build();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client = connect_ready_client(
         &server,
         &schema,

--- a/crates/jazz-testkit/tests/policies_integration/exists_rel_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/exists_rel_policies.rs
@@ -378,7 +378,9 @@ async fn uncorrelated_select_tracks_private_grants(policy: jazz::tools::PolicyEx
                         })),
                 )
                 .build();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let admin = connect_ready_client(
                 &server,
                 &schema,

--- a/crates/jazz-testkit/tests/policies_integration/inheritance_validation.rs
+++ b/crates/jazz-testkit/tests/policies_integration/inheritance_validation.rs
@@ -14,7 +14,9 @@ async fn rebac_recursive_inherits_cycle_does_not_overgrant() {
 
 async fn rebac_recursive_inherits_cycle_does_not_overgrant_inner() {
     let schema = recursive_folders_schema(Some(10));
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,

--- a/crates/jazz-testkit/tests/policies_integration/inherited_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/inherited_policies.rs
@@ -412,7 +412,8 @@ async fn inherited_folder_documents_are_visible_to_all_folder_owners_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -571,7 +572,8 @@ async fn inherited_folder_documents_fail_closed_for_missing_and_deleted_folder_t
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice_writer = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -746,7 +748,8 @@ async fn inherited_folder_access_extends_document_visibility_beyond_direct_owner
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -956,7 +959,8 @@ async fn inherited_folder_insert_requires_folder_owner_when_fk_present_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -1200,7 +1204,8 @@ async fn inherited_folder_delete_allows_folder_owner_to_delete_folder_and_docume
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -1354,7 +1359,8 @@ async fn inherited_folder_delete_allows_document_owner_but_blocks_other_non_owne
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -1532,7 +1538,8 @@ async fn inherited_multiple_folder_paths_compose_with_or_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "documents", READY_TIMEOUT).await;
     let alice = connect_ready_user(
         &server,
@@ -1740,7 +1747,8 @@ async fn inherited_folder_update_allows_folder_owner_and_blocks_other_users_inne
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "documents", READY_TIMEOUT).await;
     let alice = connect_ready_user(
         &server,
@@ -1862,7 +1870,8 @@ async fn inherited_referencing_scalar_paths_grant_visibility_and_compose_with_or
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "files", READY_TIMEOUT).await;
     let alice = connect_ready_user(&server, &schema, super::ALICE_ID, "files", READY_TIMEOUT).await;
     let dave = connect_ready_user(&server, &schema, super::DAVE_ID, "files", READY_TIMEOUT).await;
@@ -1931,7 +1940,8 @@ async fn inherited_referencing_scalar_subscription_updates_follow_create_delete_
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "files", READY_TIMEOUT).await;
     let alice = connect_ready_user(&server, &schema, super::ALICE_ID, "files", READY_TIMEOUT).await;
 
@@ -2050,7 +2060,8 @@ async fn inherited_referencing_array_membership_preserves_set_semantics_inner() 
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "files", READY_TIMEOUT).await;
     let alice = connect_ready_user(&server, &schema, super::ALICE_ID, "files", READY_TIMEOUT).await;
 
@@ -2184,7 +2195,8 @@ async fn inherited_multi_hop_forward_chain_grants_access_to_leaf_rows_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "file_parts", READY_TIMEOUT).await;
     let alice = connect_ready_user(
         &server,
@@ -2297,7 +2309,8 @@ async fn inherited_parent_policy_change_propagates_to_child_on_active_subscripti
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "documents", READY_TIMEOUT).await;
     let bob = connect_ready_user(&server, &schema, super::BOB_ID, "documents", READY_TIMEOUT).await;
 
@@ -2420,7 +2433,8 @@ async fn inherited_child_fk_retarget_visible_to_hidden_parent_removes_child_from
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "documents", READY_TIMEOUT).await;
     let bob = connect_ready_user(&server, &schema, super::BOB_ID, "documents", READY_TIMEOUT).await;
 
@@ -2543,7 +2557,8 @@ async fn inherited_child_fk_retarget_hidden_to_visible_parent_adds_child_to_subs
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "documents", READY_TIMEOUT).await;
     let bob = connect_ready_user(&server, &schema, super::BOB_ID, "documents", READY_TIMEOUT).await;
 
@@ -2663,7 +2678,9 @@ async fn inherits_select_denies_when_parent_operation_policy_is_missing_inner() 
                 .policies(documents_policies),
         )
         .build();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,
@@ -2752,7 +2769,9 @@ async fn local_insert_with_inherits_policy_allows_missing_parent_policy_in_permi
         )
         .build();
 
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,
@@ -2830,7 +2849,9 @@ async fn local_update_with_inherits_referencing_allows_missing_source_policy_in_
         )
         .build();
 
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin =
         connect_ready_client(&server, &schema, "inherits-admin", "files", READY_TIMEOUT).await;
     let alice = connect_ready_user(&server, &schema, super::ALICE_ID, "files", READY_TIMEOUT).await;
@@ -2908,7 +2929,9 @@ async fn local_update_with_check_inherits_denies_when_parent_is_not_updateable_i
                 .policies(folders_policies),
         )
         .build();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin =
         connect_ready_client(&server, &schema, "inherits-admin", "folders", READY_TIMEOUT).await;
     let bob = connect_ready_user(&server, &schema, super::BOB_ID, "folders", READY_TIMEOUT).await;

--- a/crates/jazz-testkit/tests/policies_integration/insert_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/insert_policies.rs
@@ -17,7 +17,9 @@ async fn rebac_insert_allowed_by_simple_policy() {
 
 async fn rebac_insert_allowed_by_simple_policy_inner() {
     let schema = rebac_test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -56,7 +58,9 @@ async fn rebac_insert_denied_by_simple_policy() {
 
 async fn rebac_insert_denied_by_simple_policy_inner() {
     let schema = rebac_test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -102,7 +106,9 @@ async fn permissive_local_runtime_without_loaded_policies_allows_sync_pending_wr
  {
     let notes_table = TableSchema::builder("notes").column("content", ColumnType::Text);
     let schema = SchemaBuilder::new().table(notes_table).build();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client =
         connect_ready_user(&server, &schema, super::ALICE_ID, "notes", READY_TIMEOUT).await;
 
@@ -144,7 +150,9 @@ async fn loaded_empty_permissions_bundle_denies_sync_pending_write_without_expli
 async fn loaded_empty_permissions_bundle_denies_sync_pending_write_without_explicit_policy_inner() {
     let notes_table = TableSchema::builder("notes").column("content", ColumnType::Text);
     let schema = SchemaBuilder::new().table(notes_table).build();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client =
         connect_ready_user(&server, &schema, super::ALICE_ID, "notes", READY_TIMEOUT).await;
 
@@ -176,7 +184,9 @@ async fn rebac_two_clients_different_sessions() {
 
 async fn rebac_two_clients_different_sessions_inner() {
     let schema = rebac_test_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -285,7 +295,9 @@ async fn local_insert_policy_with_null_literal_allows_null_rows_and_denies_non_n
         )
         .build();
 
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client =
         connect_ready_user(&server, &schema, super::ALICE_ID, "tasks", READY_TIMEOUT).await;
 

--- a/crates/jazz-testkit/tests/policies_integration/magic_provenance.rs
+++ b/crates/jazz-testkit/tests/policies_integration/magic_provenance.rs
@@ -25,7 +25,9 @@ async fn provenance_magic_columns_capture_insert_update_and_system_authors() {
 
 async fn provenance_magic_columns_capture_insert_update_and_system_authors_inner() {
     let schema = provenance_notes_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client =
         connect_ready_client(&server, &schema, "provenance-admin", "notes", READY_TIMEOUT).await;
     let alice = connect_ready_user(&server, &schema, super::ALICE_ID, "notes", READY_TIMEOUT).await;
@@ -174,7 +176,9 @@ async fn provenance_magic_columns_allow_explicit_updated_at_override() {
 
 async fn provenance_magic_columns_allow_explicit_updated_at_override_inner() {
     let schema = provenance_notes_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client =
         connect_ready_client(&server, &schema, "provenance-admin", "notes", READY_TIMEOUT).await;
     let alice = connect_ready_user(&server, &schema, super::ALICE_ID, "notes", READY_TIMEOUT).await;
@@ -263,7 +267,9 @@ async fn created_by_permissions_allow_creators_and_hide_system_rows() {
 
 async fn created_by_permissions_allow_creators_and_hide_system_rows_inner() {
     let schema = authorship_permissions_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client =
         connect_ready_client(&server, &schema, "provenance-admin", "notes", READY_TIMEOUT).await;
     let alice = connect_ready_user(&server, &schema, super::ALICE_ID, "notes", READY_TIMEOUT).await;

--- a/crates/jazz-testkit/tests/policies_integration/mutations.rs
+++ b/crates/jazz-testkit/tests/policies_integration/mutations.rs
@@ -57,7 +57,9 @@ async fn rebac_update_denied_by_using_policy_inner() {
     let schema = SchemaBuilder::new()
         .table(docs_table.policies(docs_policies))
         .build();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,
@@ -188,7 +190,9 @@ async fn synced_soft_delete_should_use_delete_policy_inner() {
         )
         .build();
 
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,

--- a/crates/jazz-testkit/tests/policies_integration/recursive_inheritance.rs
+++ b/crates/jazz-testkit/tests/policies_integration/recursive_inheritance.rs
@@ -65,7 +65,9 @@ async fn rebac_recursive_inherits_allows_ancestor_access() {
 
 async fn rebac_recursive_inherits_allows_ancestor_access_inner() {
     let schema = recursive_folders_schema(None);
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,
@@ -110,7 +112,9 @@ async fn rebac_recursive_inherits_respects_depth_override() {
 
 async fn rebac_recursive_inherits_respects_depth_override_inner() {
     let schema = recursive_folders_schema(Some(1));
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,
@@ -146,7 +150,9 @@ async fn rebac_recursive_inherits_respects_depth_override_inner() {
 
 async fn run_recursive_folder_update(max_depth: Option<usize>) -> (bool, bool) {
     let schema = recursive_folders_schema(max_depth);
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,

--- a/crates/jazz-testkit/tests/policies_integration/recursive_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/recursive_policies.rs
@@ -383,7 +383,8 @@ async fn recursive_query_step_magic_columns_use_reader_session_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "teams", READY_TIMEOUT).await;
     let alice = connect_ready_user(&server, &schema, super::ALICE_ID, "teams", READY_TIMEOUT).await;
 
@@ -464,7 +465,8 @@ async fn recursive_inherits_grants_visible_ancestor_chain_and_denies_unrelated_s
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", table_name, READY_TIMEOUT).await;
     let alice =
         connect_ready_user(&server, &schema, super::ALICE_ID, table_name, READY_TIMEOUT).await;
@@ -546,7 +548,8 @@ async fn recursive_inherits_respects_max_depth_boundaries_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", table_name, READY_TIMEOUT).await;
     let alice =
         connect_ready_user(&server, &schema, super::ALICE_ID, table_name, READY_TIMEOUT).await;
@@ -615,7 +618,8 @@ async fn recursive_inherits_cycles_fail_closed_without_poisoning_acyclic_branch_
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", table_name, READY_TIMEOUT).await;
     let alice =
         connect_ready_user(&server, &schema, super::ALICE_ID, table_name, READY_TIMEOUT).await;
@@ -698,7 +702,8 @@ async fn recursive_inherits_subscription_updates_when_graph_edges_change_inner()
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", table_name, READY_TIMEOUT).await;
     let alice =
         connect_ready_user(&server, &schema, super::ALICE_ID, table_name, READY_TIMEOUT).await;
@@ -808,7 +813,8 @@ async fn recursive_exists_rel_gather_hop_grants_reachable_ancestor_and_denies_wi
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "documents", READY_TIMEOUT).await;
     let bob = connect_ready_user(&server, &schema, super::BOB_ID, "documents", READY_TIMEOUT).await;
     let dave =
@@ -886,7 +892,8 @@ async fn recursive_exists_rel_diamond_paths_do_not_duplicate_visibility_or_delta
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(&server, &schema, "admin", "documents", READY_TIMEOUT).await;
     let bob = connect_ready_user(&server, &schema, super::BOB_ID, "documents", READY_TIMEOUT).await;
 

--- a/crates/jazz-testkit/tests/policies_integration/select_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/select_policies.rs
@@ -37,7 +37,9 @@ async fn rebac_select_policy_with_null_literal_filters_query_results() {
                 )
                 .build();
 
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let admin = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema.clone())
@@ -107,7 +109,9 @@ async fn rebac_select_policy_with_is_null_filters_query_results() {
                 )
                 .build();
 
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let admin = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema.clone())

--- a/crates/jazz-testkit/tests/policies_integration/session_cases.rs
+++ b/crates/jazz-testkit/tests/policies_integration/session_cases.rs
@@ -292,7 +292,8 @@ async fn select_policies_filter_subscription_results_per_client_session_inner() 
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -393,7 +394,8 @@ async fn select_policy_pagination_offsets_over_visible_rows_only_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -498,7 +500,8 @@ async fn session_claims_sub_scopes_each_provider_subject_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -605,7 +608,8 @@ async fn anonymous_client_cannot_see_owner_restricted_rows_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -705,7 +709,8 @@ async fn session_claims_sub_policies_scope_crud_to_owned_rows_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -916,7 +921,8 @@ async fn ownership_transfer_allowed_only_for_unarchived_documents_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -1144,7 +1150,8 @@ async fn select_policy_excludes_rows_from_join_results_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -1238,7 +1245,8 @@ async fn in_session_array_policy_gates_visibility_by_membership_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -1341,7 +1349,8 @@ async fn insert_policies_are_enforced_by_server_for_client_sync_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let intruder = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -1442,7 +1451,8 @@ async fn update_policies_block_unauthorized_server_mutations_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -1549,7 +1559,8 @@ async fn insert_policy_violation_does_not_leak_to_pristine_subscriber_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let mallory = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -1652,7 +1663,8 @@ async fn update_policy_read_clause_differs_from_write_clause_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -1753,7 +1765,8 @@ async fn delete_then_reinsert_by_owner_visible_to_others_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -1851,7 +1864,8 @@ async fn delete_policies_block_unauthorized_server_mutations_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -1967,7 +1981,8 @@ async fn single_client_operations_reach_server_in_causal_order_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -2075,7 +2090,8 @@ async fn originating_client_receives_rollback_for_rejected_mutation_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
 
     let alice = TestingClient::builder()
         .with_server(&server)

--- a/crates/jazz-testkit/tests/policies_integration/simple_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/simple_policies.rs
@@ -165,7 +165,8 @@ async fn insert_policies_boolean_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -276,7 +277,8 @@ async fn select_policies_boolean_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -395,7 +397,8 @@ async fn select_policy_dependency_data_is_retrieved_as_part_of_query_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let writer =
         jazz_testkit::connect(server.make_client_context_for_user(schema.clone(), super::ALICE_ID))
             .await
@@ -497,7 +500,8 @@ async fn select_policies_filter_out_archived_rows_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice =
         connect_ready_user(&server, &schema, super::ALICE_ID, table_name, READY_TIMEOUT).await;
     let bob = connect_ready_user(&server, &schema, super::BOB_ID, table_name, READY_TIMEOUT).await;
@@ -574,7 +578,8 @@ async fn update_policies_boolean_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -703,7 +708,8 @@ async fn delete_policies_boolean_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -835,7 +841,8 @@ async fn archived_state_policies_gate_insert_update_and_delete_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice =
         connect_ready_user(&server, &schema, super::ALICE_ID, table_name, READY_TIMEOUT).await;
     let bob = connect_ready_user(&server, &schema, super::BOB_ID, table_name, READY_TIMEOUT).await;
@@ -1002,7 +1009,8 @@ async fn select_policies_scalar_comparators_filter_rows_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -1257,7 +1265,8 @@ async fn null_predicates_on_nullable_columns_gate_reads_and_writes_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -1510,7 +1519,8 @@ async fn row_level_contains_and_in_list_policies_filter_rows_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice = connect_ready_user(
         &server,
         &schema,
@@ -1665,7 +1675,8 @@ async fn read_and_write_policies_remain_independent_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let admin = connect_ready_client(
         &server,
         &schema,
@@ -1832,7 +1843,8 @@ async fn authorized_mutations_emit_visibility_scoped_subscription_deltas_inner()
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
     let alice =
         connect_ready_user(&server, &schema, super::ALICE_ID, table_name, READY_TIMEOUT).await;
     let observer = connect_ready_user(
@@ -2050,7 +2062,8 @@ async fn admin_secret_ws_client_bypasses_row_select_policies_inner() {
     let server = JazzServer::builder()
         .with_schema(schema.clone())
         .start()
-        .await;
+        .await
+        .expect("start test server");
 
     let alice =
         connect_ready_user(&server, &schema, super::ALICE_ID, table_name, READY_TIMEOUT).await;

--- a/crates/jazz-testkit/tests/policy_branch_closure.rs
+++ b/crates/jazz-testkit/tests/policy_branch_closure.rs
@@ -292,7 +292,9 @@ fn labels_from_rows(mut rows: Vec<(jazz::tools::ObjectId, Vec<Value>)>) -> Vec<S
 
 async fn assert_policy_branch_closure(order: BranchOrder, expected_labels: Vec<&str>) {
     let schema = policy_branch_closure_schema(order);
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())

--- a/crates/jazz-testkit/tests/policy_dependency_sync.rs
+++ b/crates/jazz-testkit/tests/policy_dependency_sync.rs
@@ -156,7 +156,9 @@ async fn cold_client_receives_rows_granted_through_a_dependency_table() {
 
 async fn cold_client_receives_rows_granted_through_a_dependency_table_inner() {
     let schema = folder_grant_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_admin(&server, &schema).await;
 
     let (folder_id, _, folder_tx) = admin
@@ -239,7 +241,9 @@ async fn cold_client_receives_transitively_required_dependency_rows() {
 
 async fn cold_client_receives_transitively_required_dependency_rows_inner() {
     let schema = membership_chain_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_admin(&server, &schema).await;
 
     let (folder_id, _, folder_tx) = admin
@@ -322,7 +326,9 @@ async fn dependency_delivery_does_not_widen_visibility() {
 
 async fn dependency_delivery_does_not_widen_visibility_inner() {
     let schema = membership_chain_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_admin(&server, &schema).await;
 
     let (alice_folder_id, _, alice_folder_tx) = admin
@@ -452,7 +458,9 @@ async fn dependency_row_update_propagates_to_dependent_visibility() {
 
 async fn dependency_row_update_propagates_to_dependent_visibility_inner() {
     let schema = membership_chain_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let admin = connect_admin(&server, &schema).await;
 
     let (folder_id, _, folder_tx) = admin

--- a/crates/jazz-testkit/tests/query/common.rs
+++ b/crates/jazz-testkit/tests/query/common.rs
@@ -81,7 +81,9 @@ pub(crate) struct ClientPair {
 impl ClientPair {
     pub(crate) async fn start() -> Self {
         let schema = subscription_schema();
-        let server = JazzServer::start_with_schema(schema.clone()).await;
+        let server = JazzServer::start_with_schema(schema.clone())
+            .await
+            .expect("start test server");
         let writer = TestingClient::builder()
             .with_server(&server)
             .with_schema(schema.clone())

--- a/crates/jazz-testkit/tests/query/pagination.rs
+++ b/crates/jazz-testkit/tests/query/pagination.rs
@@ -34,7 +34,9 @@ local_tokio_test! {
 /// ```
 async fn subscribe_all_cold_ordered_subscription_supports_offset_and_limit() {
     let schema = subscription_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let writer = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -154,7 +156,9 @@ local_tokio_test! {
 /// returns all rows after the requested offset.
 async fn subscribe_all_cold_ordered_subscription_supports_offset_without_limit() {
     let schema = subscription_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let writer = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())

--- a/crates/jazz-testkit/tests/query/recursive_queries.rs
+++ b/crates/jazz-testkit/tests/query/recursive_queries.rs
@@ -51,7 +51,9 @@ struct Clients {
 
 impl Clients {
     async fn start(schema: Schema) -> Self {
-        let server = JazzServer::start_with_schema(schema.clone()).await;
+        let server = JazzServer::start_with_schema(schema.clone())
+            .await
+            .expect("start test server");
         let alice = TestingClient::builder()
             .with_server(&server)
             .with_schema(schema.clone())

--- a/crates/jazz-testkit/tests/query/subqueries.rs
+++ b/crates/jazz-testkit/tests/query/subqueries.rs
@@ -62,7 +62,9 @@ struct Clients {
 impl Clients {
     async fn start() -> Self {
         let schema = subquery_schema();
-        let server = JazzServer::start_with_schema(schema.clone()).await;
+        let server = JazzServer::start_with_schema(schema.clone())
+            .await
+            .expect("start test server");
         let alice = TestingClient::builder()
             .with_server(&server)
             .with_schema(schema.clone())

--- a/crates/jazz-testkit/tests/query/subscriptions.rs
+++ b/crates/jazz-testkit/tests/query/subscriptions.rs
@@ -164,7 +164,9 @@ local_tokio_test! {
 /// subscription result.
 async fn subscribe_all_only_returns_rows_that_match_query() {
     let schema = subscription_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let writer = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())
@@ -613,7 +615,9 @@ async fn subscribe_all_supports_condition_filters() {
     }
 
     let schema = subscription_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let writer = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())

--- a/crates/jazz-testkit/tests/readable_scope_exit.rs
+++ b/crates/jazz-testkit/tests/readable_scope_exit.rs
@@ -56,7 +56,9 @@ async fn local_rows(client: &JazzClient, query: Query) -> Vec<(ObjectId, Vec<Val
 
 async fn run_readable_exit(relayed: bool) {
     let schema = schema();
-    let authority = JazzServer::start_with_schema(schema.clone()).await;
+    let authority = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let relay = if relayed {
         Some(
             JazzServer::builder()
@@ -66,7 +68,8 @@ async fn run_readable_exit(relayed: bool) {
                 .with_upstream_url(authority.base_url())
                 .with_native_transport_connector(jazz_testkit::native_connector())
                 .start()
-                .await,
+                .await
+                .expect("start test server"),
         )
     } else {
         None
@@ -306,7 +309,9 @@ async fn run_revoked_exit_shared_case(
     shared_cache: bool,
 ) {
     let schema = revocation_schema(dependency);
-    let authority = JazzServer::start_with_schema(schema.clone()).await;
+    let authority = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let relay = if relayed {
         Some(
             JazzServer::builder()
@@ -316,7 +321,8 @@ async fn run_revoked_exit_shared_case(
                 .with_upstream_url(authority.base_url())
                 .with_native_transport_connector(jazz_testkit::native_connector())
                 .start()
-                .await,
+                .await
+                .expect("start test server"),
         )
     } else {
         None
@@ -525,7 +531,9 @@ async fn run_reconnect_scalar_query(count: usize) {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = schema();
-            let authority = JazzServer::start_with_schema(schema.clone()).await;
+            let authority = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let relay = JazzServer::builder()
                 .with_schema(schema.clone())
                 .with_app_id(authority.app_id())
@@ -533,7 +541,8 @@ async fn run_reconnect_scalar_query(count: usize) {
                 .with_upstream_url(authority.base_url())
                 .with_native_transport_connector(jazz_testkit::native_connector())
                 .start()
-                .await;
+                .await
+                .expect("start test server");
             let bob = TestingClient::builder()
                 .with_server(&authority)
                 .with_schema(schema.clone())
@@ -648,7 +657,9 @@ async fn run_reconnect_revoked_input(dependency: bool, persistent: bool) {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = revocation_schema(dependency);
-            let authority = JazzServer::start_with_schema(schema.clone()).await;
+            let authority = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let relay = JazzServer::builder()
                 .with_schema(schema.clone())
                 .with_app_id(authority.app_id())
@@ -656,7 +667,8 @@ async fn run_reconnect_revoked_input(dependency: bool, persistent: bool) {
                 .with_upstream_url(authority.base_url())
                 .with_native_transport_connector(jazz_testkit::native_connector())
                 .start()
-                .await;
+                .await
+                .expect("start test server");
             let bob = TestingClient::builder()
                 .with_server(&authority)
                 .with_schema(schema.clone())
@@ -942,7 +954,9 @@ async fn scalar_input_policy_rule_change_revokes_and_readmits() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = schema();
-            let authority = JazzServer::start_with_schema(schema.clone()).await;
+            let authority = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let relay = JazzServer::builder()
                 .with_schema(schema.clone())
                 .with_app_id(authority.app_id())
@@ -950,7 +964,8 @@ async fn scalar_input_policy_rule_change_revokes_and_readmits() {
                 .with_upstream_url(authority.base_url())
                 .with_native_transport_connector(jazz_testkit::native_connector())
                 .start()
-                .await;
+                .await
+                .expect("start test server");
             let writer = TestingClient::builder()
                 .with_server(&authority)
                 .with_schema(schema.clone())

--- a/crates/jazz-testkit/tests/reconnect_write_durability.rs
+++ b/crates/jazz-testkit/tests/reconnect_write_durability.rs
@@ -39,7 +39,9 @@ async fn offline_durable_write_keeps_global_target_and_replays_on_reconnect() {
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = document_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let alice = TestingClient::builder()
                 .with_server(&server)
                 .with_schema(schema.clone())

--- a/crates/jazz-testkit/tests/rename_write_authorization.rs
+++ b/crates/jazz-testkit/tests/rename_write_authorization.rs
@@ -351,7 +351,7 @@ fn renamed_table_update_policy_uses_projected_parent_version() {
 async fn renamed_table_insert_after_schema_evolution_reaches_edge() {
     tokio::task::LocalSet::new()
         .run_until(async {
-            let server = JazzServer::start().await;
+            let server = JazzServer::start().await.expect("start test server");
             let v1 = client_v1_schema();
             let v2 = client_v2_schema();
 

--- a/crates/jazz-testkit/tests/replica_settlement.rs
+++ b/crates/jazz-testkit/tests/replica_settlement.rs
@@ -733,7 +733,9 @@ mod client_transport {
         tokio::task::LocalSet::new()
             .run_until(async {
                 let schema = document_schema();
-                let server = JazzServer::start_with_schema(schema.clone()).await;
+                let server = JazzServer::start_with_schema(schema.clone())
+                    .await
+                    .expect("start test server");
                 let alice = TestingClient::builder()
                     .with_server(&server)
                     .with_schema(schema)
@@ -882,7 +884,8 @@ mod client_transport {
                     .with_data_dir(data_dir.path())
                     .with_storage_factory(jazz_testkit::persistent_storage_factory())
                     .start()
-                    .await;
+                    .await
+                    .expect("start test server");
                 let mut gate = RestartGate::start(first_server.port()).await;
                 let mut context = first_server
                     .make_client_context_for_user(schema.clone(), "alice-connect-failure");
@@ -942,7 +945,8 @@ mod client_transport {
                     .with_data_dir(data_dir.path())
                     .with_storage_factory(jazz_testkit::persistent_storage_factory())
                     .start()
-                    .await;
+                    .await
+                    .expect("start test server");
                 gate.forward_to(Some(second_server.port()));
                 assert!(
                     reconnect_client(&alice)
@@ -994,7 +998,8 @@ mod client_transport {
                     .with_schema(schema.clone())
                     .with_auth_clock(auth_clock.clone())
                     .start()
-                    .await;
+                    .await
+                    .expect("start test server");
                 let alice = TestingClient::builder()
                     .with_server(&server)
                     .with_schema(schema)

--- a/crates/jazz-testkit/tests/schema_migration_policies.rs
+++ b/crates/jazz-testkit/tests/schema_migration_policies.rs
@@ -245,7 +245,7 @@ async fn owner_policy_keeps_serving_v1_documents_to_v2_reader() {
 }
 
 async fn owner_policy_keeps_serving_v1_documents_to_v2_reader_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     publish_generation(&server, &[owner_schema_v1()], &[]).await;
     let (alice_ids, mallory_id) = seed_owner_documents_under_v1(&server, 3).await;
     publish_generation(
@@ -304,7 +304,7 @@ async fn owner_policy_still_denies_v1_documents_to_other_sessions_after_migratio
 }
 
 async fn owner_policy_still_denies_v1_documents_to_other_sessions_after_migration_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     publish_generation(&server, &[owner_schema_v1()], &[]).await;
     let (alice_ids, mallory_id) = seed_owner_documents_under_v1(&server, 2).await;
     publish_generation(
@@ -357,7 +357,7 @@ async fn v2_update_of_v1_document_preserves_untouched_columns() {
 }
 
 async fn v2_update_of_v1_document_preserves_untouched_columns_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     push_full_catalogue(
         &server,
         &[owner_schema_v1(), owner_schema_v2()],
@@ -425,7 +425,7 @@ async fn v2_update_denied_by_owner_policy_stays_rejected() {
 }
 
 async fn v2_update_denied_by_owner_policy_stays_rejected_impl() {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     push_full_catalogue(
         &server,
         &[owner_schema_v1(), owner_schema_v2()],
@@ -648,7 +648,7 @@ enum V2CataloguePush {
 /// Starts the dependency-fixture server, seeds all rows under v1, then moves
 /// the active generation to v2.
 async fn migrated_membership_server(push: V2CataloguePush) -> (JazzServer, MembershipSeed) {
-    let server = JazzServer::start().await;
+    let server = JazzServer::start().await.expect("start test server");
     match push {
         V2CataloguePush::BeforeSeeding => {
             push_full_catalogue(

--- a/crates/jazz-testkit/tests/scope_revocation.rs
+++ b/crates/jazz-testkit/tests/scope_revocation.rs
@@ -77,7 +77,7 @@ fn canonical_user(user_id: &str) -> String {
 async fn scope_revocation_removes_edge_results_without_redacting_local_copy() {
     tokio::task::LocalSet::new()
         .run_until(async {
-            let server = JazzServer::start().await;
+            let server = JazzServer::start().await.expect("start test server");
             let schema = owned_docs_schema();
 
             push_catalogue_in_memory(

--- a/crates/jazz-testkit/tests/subscription_initial_hydration.rs
+++ b/crates/jazz-testkit/tests/subscription_initial_hydration.rs
@@ -22,7 +22,9 @@ async fn fresh_subscription_first_delivery_reduces_from_empty_to_initial_view() 
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = hydration_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let writer = jazz_testkit::connect(server.make_client_context_for_user(
                 schema.clone(),
                 "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaa401",
@@ -111,7 +113,9 @@ async fn fresh_empty_subscription_waits_for_and_reports_the_settled_empty_view()
     tokio::task::LocalSet::new()
         .run_until(async {
             let schema = hydration_schema();
-            let server = JazzServer::start_with_schema(schema.clone()).await;
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
             let client = jazz_testkit::connect(
                 server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaa403"),
             )

--- a/crates/jazz-testkit/tests/subscription_lifecycle.rs
+++ b/crates/jazz-testkit/tests/subscription_lifecycle.rs
@@ -132,7 +132,9 @@ async fn one_shot_query_is_served_once_without_installing_live_delivery() {
 
 async fn one_shot_query_is_served_once_without_installing_live_delivery_impl() {
     let schema = documents_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice = connect_trusted(&server, &schema, ALICE_ID).await;
     let bob = connect_trusted(&server, &schema, BOB_ID).await;
     let carol = connect_trusted(&server, &schema, CAROL_ID).await;
@@ -250,7 +252,9 @@ async fn dropped_subscription_stops_delivery_and_resubscribes_cleanly() {
 
 async fn dropped_subscription_stops_delivery_and_resubscribes_cleanly_impl() {
     let schema = documents_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice = connect_trusted(&server, &schema, ALICE_ID).await;
     let bob = connect_trusted(&server, &schema, BOB_ID).await;
     let carol = connect_trusted(&server, &schema, CAROL_ID).await;
@@ -378,7 +382,9 @@ async fn rapid_drop_and_resubscribe_keeps_a_live_subscription() {
 
 async fn rapid_drop_and_resubscribe_keeps_a_live_subscription_impl() {
     let schema = documents_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice = connect_trusted(&server, &schema, ALICE_ID).await;
     let bob = connect_trusted(&server, &schema, BOB_ID).await;
 
@@ -449,7 +455,9 @@ async fn deleted_membership_row_revokes_documents_for_live_and_persisted_subscri
 
 async fn deleted_membership_row_revokes_documents_for_live_and_persisted_subscribers_impl() {
     let schema = membership_documents_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
 
     let alice =
         support::connect_ready_client(&server, &schema, ALICE_ID, "documents", READY_TIMEOUT).await;
@@ -636,7 +644,9 @@ async fn deleting_a_subscribed_row_emits_a_removal_delta() {
 
 async fn deleting_a_subscribed_row_emits_a_removal_delta_impl() {
     let schema = documents_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice = connect_trusted(&server, &schema, ALICE_ID).await;
     let bob = connect_trusted(&server, &schema, BOB_ID).await;
 

--- a/crates/jazz-testkit/tests/transactions.rs
+++ b/crates/jazz-testkit/tests/transactions.rs
@@ -73,7 +73,9 @@ fn unique_user_id(prefix: &str) -> String {
 }
 
 async fn start_two_clients(schema: Schema) -> (JazzServer, JazzClient, JazzClient) {
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let alice_id = unique_user_id("alice-transactions");
     let bob_id = unique_user_id("bob-transactions");
     let alice = connect_user(&server, schema.clone(), &alice_id).await;
@@ -407,7 +409,9 @@ async fn transaction_insert_is_visible_only_after_commit_settles() {
 local_tokio_test! {
 async fn transaction_update_can_modify_row_inserted_earlier_in_same_transaction() {
     let schema = todo_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let user_id = unique_user_id("transaction-update-inserted-row");
     let client = connect_user(&server, schema, &user_id).await;
     let tx = client
@@ -458,7 +462,9 @@ async fn transaction_update_can_modify_row_inserted_earlier_in_same_transaction(
 local_tokio_test! {
 async fn multiple_updates_to_same_row_in_transaction_compose() {
     let schema = todo_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let user_id = unique_user_id("multiple-updates-compose");
     let client = connect_user(&server, schema, &user_id).await;
     let todo_id = insert_visible_todo(&client, "draft", false).await;
@@ -512,7 +518,9 @@ async fn multiple_updates_to_same_row_in_transaction_compose() {
 local_tokio_test! {
 async fn multiple_writes_in_one_transaction_settle_atomically() {
     let schema = todo_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let user_id = unique_user_id("multiple-writes-one-transaction");
     let client = connect_user(&server, schema, &user_id).await;
     let tx = client
@@ -723,7 +731,9 @@ async fn wait_for_transaction_errors_for_unattainable_durability_tier() {
 local_tokio_test! {
 async fn global_wait_after_over_one_mib_websocket_import_settles() {
     let schema = todo_schema();
-    let server = JazzServer::start_with_schema(schema.clone()).await;
+    let server = JazzServer::start_with_schema(schema.clone())
+        .await
+        .expect("start test server");
     let client = connect_user(&server, schema, &unique_user_id("bulk-global-wait")).await;
 
     let (target_id, _, _) = client

--- a/packages/jazz-tools/src/dev/dev-server.test.ts
+++ b/packages/jazz-tools/src/dev/dev-server.test.ts
@@ -1,4 +1,5 @@
 import { access } from "node:fs/promises";
+import { createServer } from "node:net";
 import { JazzServer } from "jazz-napi";
 import { afterEach, describe, expect, it } from "vitest";
 import { WebSocket } from "undici";
@@ -58,6 +59,39 @@ describe("startLocalJazzServer via JazzServer", () => {
 
     const healthResponse = await fetch(`${handle.url}/health`);
     expect(healthResponse.ok).toBe(true);
+  }, 30_000);
+
+  it("rejects direct NAPI startup on an occupied explicit port without killing the process", async () => {
+    const blocker = createServer();
+    await new Promise<void>((resolve, reject) => {
+      blocker.once("error", reject);
+      blocker.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const address = blocker.address();
+    if (!address || typeof address === "string") {
+      await new Promise<void>((resolve, reject) => {
+        blocker.close((error) => (error ? reject(error) : resolve()));
+      });
+      throw new Error("occupied listener did not expose a numeric port");
+    }
+
+    try {
+      await expect(
+        JazzServer.start({
+          appId: "00000000-0000-0000-0000-000000000003",
+          port: address.port,
+          inMemory: true,
+          adminSecret: "occupied-port-admin",
+          backendSecret: "occupied-port-backend",
+        }),
+      ).rejects.toThrow(/bind|server listener/i);
+      expect(process.uptime()).toBeGreaterThan(0);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        blocker.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   }, 30_000);
 
   maybeIt(


### PR DESCRIPTION
🤖 ## Summary
- Propagate embedded JazzServer startup failures instead of panicking.
- Migrate callers to handle the fallible startup API.
- Preserve the host process when direct NAPI startup cannot bind its port.

## Before
An occupied explicit port could panic inside the embedded server startup path and terminate the host process.

## After
Rust returns a contextual startup error, NAPI translates it into a JavaScript error, and callers handle the `Result` explicitly.

## Test plan
- [x] Focused Rust occupied-port regression test
- [x] Focused direct-NAPI occupied-port regression test against freshly built artifacts

## Integration status

Rebased into the stable-fixes stack on main. Integrated the fallible startup API with current main callers. Independent occupied-port and backpressure regressions pass; migrated native/test callers compile. Full combined CI is green; user merge approval remains separate.
