### PR TITLE
perf(groove): prepare old-row descriptors once per batch variant

### DIFF
--- a/crates/groove/src/db/storage_helpers.rs
+++ b/crates/groove/src/db/storage_helpers.rs
@@ -923,6 +923,9 @@ where
     // previous path allocated a singleton TableDelta (and Vec) per old/new
     // record, then hashed every group and record again in a second pass.
     let mut by_table = HashMap::<(&str, u32, RecordDescriptor), HashMap<bytes::Bytes, i64>>::new();
+    // The schema is fixed for this batch. Old rows may use several variants,
+    // but each variant's descriptor needs preparation only once.
+    let mut old_descriptors = HashMap::<(&str, u32), RecordDescriptor>::new();
 
     for (write, store) in pending_writes.iter().zip(stores) {
         let overlay_key = (write.table(), write.key());
@@ -957,12 +960,19 @@ where
             .ok_or_else(|| Error::TableNotFound(write.table().to_owned()))?;
         if let Some(current) = current.as_deref() {
             let (variant_tag, payload) = split_variant_record(current)?;
-            let descriptor = table_schema
-                .record_schema_for_variant(variant_tag)
-                .ok_or_else(|| Error::UnknownTableVariant {
-                    table: table_schema.name.clone(),
-                    version: u64::from(variant_tag),
-                })?;
+            let descriptor_key = (write.table(), variant_tag);
+            let descriptor = if let Some(descriptor) = old_descriptors.get(&descriptor_key) {
+                *descriptor
+            } else {
+                let descriptor = table_schema
+                    .record_schema_for_variant(variant_tag)
+                    .ok_or_else(|| Error::UnknownTableVariant {
+                        table: table_schema.name.clone(),
+                        version: u64::from(variant_tag),
+                    })?;
+                old_descriptors.insert(descriptor_key, descriptor);
+                descriptor
+            };
             *by_table
                 .entry((write.table(), variant_tag, descriptor))
                 .or_default()

--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -5767,3 +5767,98 @@ async fn immutable_batch_rejects_later_overwrite_and_other_database() {
         Err(Error::StaleImmutableBatch)
     ));
 }
+
+// Internal because correct row output alone cannot prove batch-amortized
+// descriptor preparation. Exercise two stored layouts and verify their deltas.
+#[futures_test::test]
+async fn old_row_delta_descriptors_are_prepared_once_per_batch_variant() {
+    use super::super::storage_helpers::{PendingTableWrite, compute_table_deltas};
+    use crate::storage::{OwnedWriteOperation, RecordStore};
+
+    let table = crate::schema::TableSchema::new(
+        "variant_rows",
+        [
+            ColumnSchema::new("id", ColumnType::U64),
+            ColumnSchema::new("label", ColumnType::String),
+        ],
+    )
+    .with_variant(1, ["id"])
+    .with_variant(2, ["id", "label"]);
+    let first = table.record_schema_for_variant(1).unwrap();
+    let second = table.record_schema_for_variant(2).unwrap();
+    let carrier = table.record_schema();
+    let schema = DatabaseSchema::new([table]);
+    let storage = MemoryStorage::new(&["variant_rows"]).unwrap();
+    let mut seeds = Vec::new();
+    let mut writes = Vec::new();
+    for id in 0..1000u64 {
+        let (tag, payload) = if id % 2 == 0 {
+            (1, first.create(&[Value::U64(id)]).unwrap())
+        } else {
+            (
+                2,
+                second
+                    .create(&[Value::U64(id), Value::String("row".into())])
+                    .unwrap(),
+            )
+        };
+        let key = id.to_be_bytes().to_vec();
+        seeds.push(OwnedWriteOperation::Set {
+            cf: "variant_rows".into(),
+            key: key.clone(),
+            value: crate::records::encode_variant_record(tag, &payload),
+        });
+        writes.push(PendingTableWrite::Delete {
+            table: "variant_rows".into(),
+            key,
+            descriptor: carrier,
+        });
+    }
+    storage.write_many(seeds).await.unwrap();
+    let stores = writes
+        .iter()
+        .map(|_| RecordStore::new(&storage, "variant_rows", &carrier))
+        .collect::<Vec<_>>();
+    crate::schema::VARIANT_DESCRIPTOR_BUILDS.with(|count| count.set(0));
+    let deltas = compute_table_deltas(&writes, &stores, &schema)
+        .await
+        .unwrap();
+    assert_eq!(
+        crate::schema::VARIANT_DESCRIPTOR_BUILDS.with(|count| count.get()),
+        2
+    );
+    assert_eq!(deltas.len(), 2);
+    for group in deltas {
+        assert_eq!(
+            group.descriptor,
+            if group.variant_tag == 1 {
+                first
+            } else {
+                second
+            }
+        );
+        assert_eq!(group.deltas.len(), 500);
+        for delta in group.deltas {
+            assert_eq!(delta.weight, -1);
+            let record = group.descriptor.bind(&delta.record);
+            let id = record.get_u64(0).unwrap();
+            assert!(id < 1000);
+            assert_eq!(id % 2, u64::from(group.variant_tag - 1));
+            if group.variant_tag == 2 {
+                assert_eq!(record.get_str(1).unwrap(), "row");
+            }
+        }
+    }
+    storage
+        .write_many(vec![OwnedWriteOperation::Set {
+            cf: "variant_rows".into(),
+            key: writes[0].key().to_vec(),
+            value: crate::records::encode_variant_record(3, &[]),
+        }])
+        .await
+        .unwrap();
+    assert!(matches!(
+        compute_table_deltas(&writes[..1], &stores[..1], &schema).await,
+        Err(Error::UnknownTableVariant { version: 3, .. })
+    ));
+}


### PR DESCRIPTION
🤖 Prepare each old-row record descriptor once per table/variant in a write batch, instead of rebuilding it for every overwritten or deleted row. The cache lives only for the batch, whose schema is immutable.

For example, deleting 1,000 stored rows split between two variants now prepares two descriptors rather than 1,000. Each row still uses its own variant; an unknown stored variant still returns the same error. Same-batch write overlays, net delta grouping, record bytes and storage/wire formats are unchanged.

The focused test verifies both decoded deltas and the number of preparations, including mixed variants and an unknown variant. This is intentionally an internal test because public result equality cannot prove amortized preparation. Disabling cache reuse makes it fail with 1,000 preparations instead of 2; exact restoration passes. All 745 Groove library tests pass (2 ignored), as do commit checks and optimized benchmark builds.

Initial matched-build native measurements: permissioned cold settle 18.300s → 18.603s with all 27,518 expected rows; todo batch roundtrip 280.519ms → 259.870ms. Worker ingest itself is effectively unchanged (90.349ms → 89.655ms), so the total difference is not yet attributed to this change. Three alternating todo repeats are effectively flat: median 269.463ms before and 269.120ms after. No end-to-end speedup is claimed. This retains a small, batch-local simplification; all 2,006 Jazz library tests pass (2 ignored), along with all three scaling canaries and the two-seed maintained/one-shot comparison at churn depths 10 and 1,000. Draft on #2836; broader acceptance and independent review remain outstanding.
