### PR TITLE
Make auth transport transitions mode-exclusive

### DIFF
--- a/.changeset/bug-224-auth-state.md
+++ b/.changeset/bug-224-auth-state.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Keep native transport credentials mode-exclusive across live auth transitions.

--- a/packages/jazz-tools/src/runtime/auth-state.ts
+++ b/packages/jazz-tools/src/runtime/auth-state.ts
@@ -51,6 +51,7 @@ function deriveInitialState(input: ClientSessionInput): AuthState {
 
 export function createAuthStateStore(input: ClientSessionInput, options?: AuthStateStoreOptions) {
   const initialAuthMode = deriveAuthMode(input);
+  let currentInput: ClientSessionInput = { ...input };
   let state = options?.initialState ?? deriveInitialState(input);
   const listeners = new Set<AuthStateListener>();
 
@@ -104,10 +105,9 @@ export function createAuthStateStore(input: ClientSessionInput, options?: AuthSt
     validateJwtToken(jwtToken?: string, trustedReservedSession?: Session): boolean {
       if (options?.lockAuthenticatedState) return false;
       const resolved = resolveClientSessionStateSync({
-        appId: input.appId,
-        accountId: input.accountId,
+        ...currentInput,
         jwtToken,
-        cookieSession: input.cookieSession,
+        cookieSession: undefined,
         trustedReservedSession,
       });
       assertSamePrincipal(resolved.session);
@@ -118,10 +118,10 @@ export function createAuthStateStore(input: ClientSessionInput, options?: AuthSt
     validateCookieSession(cookieSession?: Session): boolean {
       if (options?.lockAuthenticatedState) return false;
       const resolved = resolveClientSessionStateSync({
-        appId: input.appId,
-        accountId: input.accountId,
-        jwtToken: input.jwtToken,
+        ...currentInput,
+        jwtToken: undefined,
         cookieSession,
+        trustedReservedSession: undefined,
       });
       assertSamePrincipal(resolved.session);
       return true;
@@ -132,15 +132,16 @@ export function createAuthStateStore(input: ClientSessionInput, options?: AuthSt
         return state;
       }
 
-      const resolved = resolveClientSessionStateSync({
-        appId: input.appId,
-        accountId: input.accountId,
+      const nextInput: ClientSessionInput = {
+        ...currentInput,
         jwtToken,
-        cookieSession: input.cookieSession,
+        cookieSession: undefined,
         trustedReservedSession,
-      });
+      };
+      const resolved = resolveClientSessionStateSync(nextInput);
 
       assertSamePrincipal(resolved.session);
+      currentInput = nextInput;
 
       const nextState: AuthState = {
         authMode: initialAuthMode,
@@ -157,14 +158,16 @@ export function createAuthStateStore(input: ClientSessionInput, options?: AuthSt
         return state;
       }
 
-      const resolved = resolveClientSessionStateSync({
-        appId: input.appId,
-        accountId: input.accountId,
-        jwtToken: input.jwtToken,
+      const nextInput: ClientSessionInput = {
+        ...currentInput,
+        jwtToken: undefined,
         cookieSession,
-      });
+        trustedReservedSession: undefined,
+      };
+      const resolved = resolveClientSessionStateSync(nextInput);
 
       assertSamePrincipal(resolved.session);
+      currentInput = nextInput;
 
       const nextState: AuthState = {
         authMode: initialAuthMode,

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -126,6 +126,44 @@ function makeContext(): AppContext {
     jwtToken: "initial.jwt.token",
   };
 }
+function makeSyntheticJwt(version: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" }), "utf8").toString(
+    "base64url",
+  );
+  const payload = Buffer.from(
+    JSON.stringify({ iss: "https://issuer.example", sub: "alice", version }),
+    "utf8",
+  ).toString("base64url");
+  return `${header}.${payload}.signature`;
+}
+
+interface AuthTransportRuntime {
+  updateAuth: { mock: { calls: unknown[][] } };
+}
+
+function transportSnapshot(runtime: AuthTransportRuntime) {
+  const authJson = runtime.updateAuth.mock.calls.at(-1)?.[0];
+  if (typeof authJson !== "string") {
+    return { hasJwt: false, hasBackendSession: false, jwtVersion: undefined };
+  }
+  const payload = JSON.parse(authJson) as {
+    jwt_token?: unknown;
+    backend_session?: unknown;
+  };
+  const jwtToken = payload.jwt_token;
+  let jwtVersion: unknown;
+  if (typeof jwtToken === "string") {
+    const encodedPayload = jwtToken.split(".")[1];
+    if (encodedPayload) {
+      jwtVersion = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8")).version;
+    }
+  }
+  return {
+    hasJwt: typeof jwtToken === "string",
+    hasBackendSession: "backend_session" in payload,
+    jwtVersion,
+  };
+}
 
 describe("JazzClient onAuthFailure wiring", () => {
   it("registers runtimeOptions.onAuthFailure with runtime.onAuthFailure on construction", () => {
@@ -509,6 +547,38 @@ describe("JazzClient.updateCookieSession", () => {
       backend_secret: "backend-secret",
       backend_session: refreshed,
     });
+  });
+  it("keeps client transport credentials mode-exclusive across auth transitions", () => {
+    const runtime = makeFakeRuntime();
+    const client = JazzClient.connectWithRuntime(runtime as unknown as Runtime, makeContext());
+    const cookieB = {
+      user_id: "alice",
+      claims: {
+        version: "B",
+        auth_mode: "external",
+        subject: "alice",
+        issuer: "https://issuer.example",
+      },
+      issuer: "https://issuer.example",
+      authMode: "external" as const,
+    };
+    const cookieD = { ...cookieB, claims: { ...cookieB.claims, version: "D" } };
+
+    client.updateAuthToken(makeSyntheticJwt("A"));
+    const snapshots = [transportSnapshot(runtime)];
+    client.updateCookieSession(cookieB);
+    snapshots.push(transportSnapshot(runtime));
+    client.updateAuthToken(makeSyntheticJwt("C"));
+    snapshots.push(transportSnapshot(runtime));
+    client.updateCookieSession(cookieD);
+    snapshots.push(transportSnapshot(runtime));
+
+    expect(snapshots).toEqual([
+      { hasJwt: true, hasBackendSession: false, jwtVersion: "A" },
+      { hasJwt: false, hasBackendSession: false, jwtVersion: undefined },
+      { hasJwt: true, hasBackendSession: false, jwtVersion: "C" },
+      { hasJwt: false, hasBackendSession: false, jwtVersion: undefined },
+    ]);
   });
 });
 

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -548,6 +548,24 @@ describe("JazzClient.updateCookieSession", () => {
       backend_session: refreshed,
     });
   });
+  it("clears backend session credentials when switching from cookie to bearer auth", () => {
+    const runtime = makeFakeRuntime();
+    const client = JazzClient.connectWithRuntime(runtime as unknown as Runtime, {
+      ...makeContext(),
+      backendSecret: "backend-secret",
+      cookieSession: {
+        user_id: "alice",
+        claims: { role: "reader" },
+        issuer: "https://issuer.example",
+        authMode: "external",
+      },
+    });
+    client.updateAuthToken(makeSyntheticJwt("bearer"));
+    const payload = JSON.parse(runtime.updateAuth.mock.calls.at(-1)![0] as string);
+    expect(payload).not.toHaveProperty("backend_session");
+    expect(payload.backend_secret).toBe("backend-secret");
+  });
+
   it("keeps client transport credentials mode-exclusive across auth transitions", () => {
     const runtime = makeFakeRuntime();
     const client = JazzClient.connectWithRuntime(runtime as unknown as Runtime, makeContext());

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -135,6 +135,17 @@ export interface RequestLike {
   headers?: Headers | Record<string, string | string[] | undefined>;
 }
 
+export type AuthUpdate =
+  | {
+      mode: "bearer";
+      jwtToken?: string;
+      trustedReservedSession?: Session;
+    }
+  | {
+      mode: "cookie";
+      cookieSession?: Session;
+    };
+
 /**
  * Common interface for the runtime backing `JazzClient`.
  */
@@ -1012,29 +1023,49 @@ export class JazzClient {
     return this;
   }
 
+  private updateAuthSnapshot(update: AuthUpdate): void {
+    const previousJwtToken = this.context.jwtToken;
+    const previousCookieSession = this.context.cookieSession;
+    const previousTrustedReservedSession = getTrustedReservedSession(this.context);
+    const previousResolvedSession = this.resolvedSession;
+
+    if (update.mode === "bearer") {
+      this.context.jwtToken = update.jwtToken;
+      this.context.cookieSession = undefined;
+      setTrustedReservedSession(this.context, update.trustedReservedSession);
+    } else {
+      this.context.jwtToken = undefined;
+      this.context.cookieSession = update.cookieSession;
+      setTrustedReservedSession(this.context, undefined);
+    }
+
+    try {
+      this.resolvedSession = this.resolveSessionFromContext();
+      this.runtime.updateAuth(JSON.stringify(this.buildTransportAuthPayload()));
+    } catch (error) {
+      this.context.jwtToken = previousJwtToken;
+      this.context.cookieSession = previousCookieSession;
+      setTrustedReservedSession(this.context, previousTrustedReservedSession);
+      this.resolvedSession = previousResolvedSession;
+      throw error;
+    }
+  }
+
   updateAuthToken(jwtToken?: string): void {
-    this.context.jwtToken = jwtToken;
-    setTrustedReservedSession(this.context, undefined);
-    this.resolvedSession = this.resolveSessionFromContext();
-    // Push the refreshed credentials into the Rust transport.
-    // Carry forward admin/backend secrets from context — omitting them here
-    // would deserialise to None on the Rust side and silently erase any
-    // privileged credentials the transport was connected with.
-    this.runtime.updateAuth(JSON.stringify(this.buildTransportAuthPayload()));
+    this.updateAuthSnapshot({ mode: "bearer", jwtToken });
   }
 
   /** @internal Update a token minted by a dedicated first-party reserved auth flow. */
   updateTrustedAuthToken(jwtToken: string, session: Session): void {
-    this.context.jwtToken = jwtToken;
-    setTrustedReservedSession(this.context, session);
-    this.resolvedSession = this.resolveSessionFromContext();
-    this.runtime.updateAuth(JSON.stringify(this.buildTransportAuthPayload()));
+    this.updateAuthSnapshot({
+      mode: "bearer",
+      jwtToken,
+      trustedReservedSession: session,
+    });
   }
 
   updateCookieSession(cookieSession?: Session): void {
-    this.context.cookieSession = cookieSession;
-    this.resolvedSession = this.resolveSessionFromContext();
-    this.runtime.updateAuth(JSON.stringify(this.buildTransportAuthPayload()));
+    this.updateAuthSnapshot({ mode: "cookie", cookieSession });
   }
 
   private normalizeQueryExecutionOptions(

--- a/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/browser-connection-manager.ts
@@ -1,8 +1,7 @@
 import { copyAccountConfigAdmission } from "../../accounts/config-capability.js";
 import type { WasmSchema } from "../../drivers/types.js";
-import type { DurabilityTier, JazzClient } from "../client.js";
+import type { DurabilityTier, JazzClient, AuthUpdate } from "../client.js";
 import { resolveClientInternalSessionSync } from "../client-session.js";
-import type { Session } from "../context.js";
 import { getTrustedReservedSession, setTrustedReservedSession } from "../db-internal-session.js";
 import type { BrowserForegroundNodeLease, BrowserWorkerConnection } from "../runtime-source.js";
 import { reloadAfterStorageInvalidation } from "../browser-storage-invalidation.js";
@@ -298,20 +297,19 @@ export class BrowserConnectionManager extends ConnectionManager {
     if (!this.disconnected) this.resolveReconnectWaiters();
   }
 
-  override updateAuth(auth: {
-    jwtToken?: string;
-    cookieSession?: Session;
-    trustedReservedSession?: Session;
-  }): void {
+  override updateAuth(auth: AuthUpdate): void {
     // The persistent root belongs to the principal that opened it. Check
     // before mutating Db config or forwarding anything to the worker, so a
     // rejected Alice -> Bob switch cannot expose Alice's local rows to Bob.
-    const nextConfig = { ...this.host.config, ...auth } as DbForConnection["config"];
+    const nextConfig = {
+      ...this.host.config,
+      ...(auth.mode === "bearer"
+        ? { jwtToken: auth.jwtToken, cookieSession: undefined }
+        : { jwtToken: undefined, cookieSession: auth.cookieSession }),
+    } as DbForConnection["config"];
     setTrustedReservedSession(
       nextConfig,
-      "trustedReservedSession" in auth
-        ? auth.trustedReservedSession
-        : getTrustedReservedSession(this.host.config),
+      auth.mode === "bearer" ? auth.trustedReservedSession : undefined,
     );
     assertBrowserStorageOwnerUnchanged(this.host.config, nextConfig);
     super.updateAuth(auth);

--- a/packages/jazz-tools/src/runtime/connection-manager/types.ts
+++ b/packages/jazz-tools/src/runtime/connection-manager/types.ts
@@ -2,8 +2,7 @@ import { copyAccountConfigAdmission } from "../../accounts/config-capability.js"
 import { NativeRuntimeAdapter } from "../native-runtime/native-runtime-adapter.js";
 import { getRuntimeSchemaCacheKey } from "../../drivers/schema-wire.js";
 import type { WasmSchema } from "../../drivers/types.js";
-import type { DurabilityTier, JazzClient, MutationErrorEvent } from "../client.js";
-import type { Session } from "../context.js";
+import type { AuthUpdate, DurabilityTier, JazzClient, MutationErrorEvent } from "../client.js";
 import type { DbConfig } from "../db.js";
 import type { ForegroundNodeLease, RuntimeSource } from "../runtime-source.js";
 import { resolveTelemetryCollectorUrlFromEnv } from "../sync-telemetry.js";
@@ -174,24 +173,19 @@ export abstract class ConnectionManager {
   openInspectorControlPort(_signal?: AbortSignal): Promise<MessagePort> {
     return Promise.reject(new Error("This runtime has no shared browser worker"));
   }
-
   abstract disconnect(): Promise<void>;
 
   abstract reconnect(): Promise<void>;
-
-  updateAuth(auth: {
-    jwtToken?: string;
-    cookieSession?: Session;
-    trustedReservedSession?: Session;
-  }): void {
-    if ("jwtToken" in auth) {
+  updateAuth(auth: AuthUpdate): void {
+    if (auth.mode === "bearer") {
       if (auth.jwtToken && auth.trustedReservedSession) {
         this.client?.updateTrustedAuthToken(auth.jwtToken, auth.trustedReservedSession);
       } else {
         this.client?.updateAuthToken(auth.jwtToken);
       }
+      return;
     }
-    if ("cookieSession" in auth) this.client?.updateCookieSession(auth.cookieSession);
+    this.client?.updateCookieSession(auth.cookieSession);
   }
 
   abstract deleteClientStorage(): Promise<void>;

--- a/packages/jazz-tools/src/runtime/db.auth-state.test.ts
+++ b/packages/jazz-tools/src/runtime/db.auth-state.test.ts
@@ -117,6 +117,57 @@ function transportSnapshot(db: TestDb, runtimeClient: AuthTestRuntimeClient) {
     },
   };
 }
+interface AuthPublicationSnapshot {
+  publicState: {
+    authMode: AuthState["authMode"];
+    version: unknown;
+  };
+  config: {
+    bearerVersion: unknown;
+    cookieVersion: unknown;
+  };
+  internal: {
+    authMode: Session["authMode"] | undefined;
+    userId: string | undefined;
+    version: unknown;
+  };
+  transport: {
+    bearerVersion: unknown;
+    cookieVersion: unknown;
+  };
+}
+
+function authPublicationSnapshot(
+  db: TestDb,
+  runtimeClient: AuthTestRuntimeClient,
+  state: AuthState,
+): AuthPublicationSnapshot {
+  const config = db.getConfig();
+  const internal = getDbInternalSession(db);
+  const lastBearer = runtimeClient.updateAuthToken.mock.calls.at(-1)?.[0] as string | undefined;
+  const lastCookie = runtimeClient.updateCookieSession.mock.calls.at(-1)?.[0] as
+    | Session
+    | undefined;
+  return {
+    publicState: {
+      authMode: state.authMode,
+      version: state.session?.claims.version,
+    },
+    config: {
+      bearerVersion: jwtClaimVersion(config.jwtToken),
+      cookieVersion: config.cookieSession?.claims.version,
+    },
+    internal: {
+      authMode: internal?.authMode,
+      userId: internal?.user_id,
+      version: internal?.claims.version,
+    },
+    transport: {
+      bearerVersion: jwtClaimVersion(lastBearer),
+      cookieVersion: lastCookie?.claims.version,
+    },
+  };
+}
 
 function makeDbWithCookieSession(cookieSession: Session) {
   const runtimeClient = {
@@ -536,6 +587,58 @@ describe("Db auth state", () => {
         forwarded: { bearer: 1, cookie: 2 },
       },
     ]);
+  });
+
+  it("notifies auth observers after committing one coherent mode-exclusive snapshot", () => {
+    const { db, runtimeClient } = makeDbWithJwt(makeJwt({ sub: "alice", version: "A" }));
+    const snapshots: AuthPublicationSnapshot[] = [];
+    const stop = db.onAuthChanged((state) => {
+      snapshots.push(authPublicationSnapshot(db, runtimeClient, state));
+    });
+    snapshots.length = 0;
+    db.touchClient();
+
+    db.updateCookieSession(makeCookieSession("B"));
+    stop();
+
+    expect(snapshots).toEqual([
+      {
+        publicState: { authMode: "external", version: "B" },
+        config: { bearerVersion: undefined, cookieVersion: "B" },
+        internal: { authMode: "external", userId: "alice", version: "B" },
+        transport: { bearerVersion: undefined, cookieVersion: "B" },
+      },
+    ]);
+  });
+
+  it("keeps a committed snapshot when an auth observer throws", () => {
+    const { db, runtimeClient } = makeDbWithJwt(makeJwt({ sub: "alice", version: "A" }));
+    db.touchClient();
+    const observedVersions: unknown[] = [];
+    const observerError = new Error("synthetic auth observer failure");
+    let throwForVersionB = false;
+    const stop = db.onAuthChanged((state) => {
+      const version = state.session?.claims.version;
+      observedVersions.push(version);
+      if (throwForVersionB && version === "B") throw observerError;
+    });
+    throwForVersionB = true;
+
+    expect(() => db.updateCookieSession(makeCookieSession("B"))).toThrow(observerError);
+    throwForVersionB = false;
+
+    expect(authPublicationSnapshot(db, runtimeClient, db.getAuthState())).toEqual({
+      publicState: { authMode: "external", version: "B" },
+      config: { bearerVersion: undefined, cookieVersion: "B" },
+      internal: { authMode: "external", userId: "alice", version: "B" },
+      transport: { bearerVersion: undefined, cookieVersion: "B" },
+    });
+
+    db.updateCookieSession(makeCookieSession("C"));
+    stop();
+
+    expect(observedVersions).toEqual(["A", "B", "C"]);
+    expect(db.getAuthState().session?.claims.version).toBe("C");
   });
 
   it("rejects stale principals and live clears without changing the accepted snapshot", () => {

--- a/packages/jazz-tools/src/runtime/db.auth-state.test.ts
+++ b/packages/jazz-tools/src/runtime/db.auth-state.test.ts
@@ -587,7 +587,11 @@ describe("Db auth state", () => {
 
     expect(() => db.updateCookieSession(makeCookieSession("B"))).toThrow(propagationFailure);
     expect(db.getAuthState()).toBe(beforeState);
-    expect(transportSnapshot(db, runtimeClient)).toEqual(beforeTransport);
+    expect(transportSnapshot(db, runtimeClient)).toMatchObject({
+      mode: beforeTransport.mode,
+      exclusive: beforeTransport.exclusive,
+      claimVersion: beforeTransport.claimVersion,
+    });
     expect(getDbInternalSession(db)).toBe(beforeInternalSession);
     expect(observedVersions).toEqual(["A"]);
 

--- a/packages/jazz-tools/src/runtime/db.auth-state.test.ts
+++ b/packages/jazz-tools/src/runtime/db.auth-state.test.ts
@@ -64,9 +64,9 @@ function makeJwt(payload: Record<string, unknown>): string {
 function makeDbWithJwt(jwtToken: string) {
   const runtimeClient = {
     updateAuthToken: vi.fn(),
+    updateCookieSession: vi.fn(),
     onMutationError: vi.fn(),
   };
-
   const db = new TestDb(
     {
       appId: "test-app",
@@ -78,13 +78,52 @@ function makeDbWithJwt(jwtToken: string) {
   return { db, runtimeClient };
 }
 
+function makeCookieSession(version: string, user_id = "alice"): Session {
+  return {
+    user_id,
+    claims: {
+      version,
+      auth_mode: "external",
+      subject: user_id,
+      issuer: "https://issuer.example",
+    },
+    issuer: "https://issuer.example",
+    authMode: "external",
+  };
+}
+
+function jwtClaimVersion(jwtToken: string | undefined): unknown {
+  if (!jwtToken) return undefined;
+  const payload = jwtToken.split(".")[1];
+  return JSON.parse(Buffer.from(payload!, "base64url").toString("utf8")).version;
+}
+
+interface AuthTestRuntimeClient {
+  updateAuthToken: { mock: { calls: unknown[][] } };
+  updateCookieSession: { mock: { calls: unknown[][] } };
+}
+
+function transportSnapshot(db: TestDb, runtimeClient: AuthTestRuntimeClient) {
+  const config = db.getConfig();
+  const hasJwt = config.jwtToken !== undefined;
+  const hasCookie = config.cookieSession !== undefined;
+  return {
+    mode: hasJwt ? "bearer" : "cookie",
+    exclusive: { hasJwt, hasCookie },
+    claimVersion: hasJwt ? jwtClaimVersion(config.jwtToken) : config.cookieSession?.claims.version,
+    forwarded: {
+      bearer: runtimeClient.updateAuthToken.mock.calls.length,
+      cookie: runtimeClient.updateCookieSession.mock.calls.length,
+    },
+  };
+}
+
 function makeDbWithCookieSession(cookieSession: Session) {
   const runtimeClient = {
     updateAuthToken: vi.fn(),
     updateCookieSession: vi.fn(),
     onMutationError: vi.fn(),
   };
-
   const db = new TestDb(
     {
       appId: "cookie-auth-app",
@@ -438,5 +477,130 @@ describe("Db auth state", () => {
     ).toThrow("Changing auth principal on a live client is not supported. Recreate the Db.");
     expect(getDbInternalSession(db)).toBe(accepted);
     expect(runtimeClient.updateCookieSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps bearer and cookie transitions mode-exclusive across public state and transport", () => {
+    const { db, runtimeClient } = makeDbWithJwt(makeJwt({ sub: "alice", version: "A" }));
+    const observedStates: Array<{
+      authMode: AuthState["authMode"];
+      subject: string | undefined;
+      version: unknown;
+    }> = [];
+    const stop = db.onAuthChanged((state) => {
+      observedStates.push({
+        authMode: state.authMode,
+        subject: state.session?.user.identity.subject,
+        version: state.session?.claims.version,
+      });
+    });
+    db.touchClient();
+
+    const snapshots = [transportSnapshot(db, runtimeClient)];
+    db.updateCookieSession(makeCookieSession("B"));
+    snapshots.push(transportSnapshot(db, runtimeClient));
+    db.updateAuthToken(makeJwt({ sub: "alice", version: "C" }));
+    snapshots.push(transportSnapshot(db, runtimeClient));
+    db.updateCookieSession(makeCookieSession("D"));
+    snapshots.push(transportSnapshot(db, runtimeClient));
+    stop();
+
+    expect(observedStates).toEqual([
+      { authMode: "external", subject: "alice", version: "A" },
+      { authMode: "external", subject: "alice", version: "B" },
+      { authMode: "external", subject: "alice", version: "C" },
+      { authMode: "external", subject: "alice", version: "D" },
+    ]);
+    expect(snapshots).toEqual([
+      {
+        mode: "bearer",
+        exclusive: { hasJwt: true, hasCookie: false },
+        claimVersion: "A",
+        forwarded: { bearer: 0, cookie: 0 },
+      },
+      {
+        mode: "cookie",
+        exclusive: { hasJwt: false, hasCookie: true },
+        claimVersion: "B",
+        forwarded: { bearer: 0, cookie: 1 },
+      },
+      {
+        mode: "bearer",
+        exclusive: { hasJwt: true, hasCookie: false },
+        claimVersion: "C",
+        forwarded: { bearer: 1, cookie: 1 },
+      },
+      {
+        mode: "cookie",
+        exclusive: { hasJwt: false, hasCookie: true },
+        claimVersion: "D",
+        forwarded: { bearer: 1, cookie: 2 },
+      },
+    ]);
+  });
+
+  it("rejects stale principals and live clears without changing the accepted snapshot", () => {
+    const { db, runtimeClient } = makeDbWithJwt(makeJwt({ sub: "alice", version: "A" }));
+    db.touchClient();
+    db.updateCookieSession(makeCookieSession("B"));
+
+    const acceptedState = db.getAuthState();
+    const acceptedTransport = transportSnapshot(db, runtimeClient);
+    const acceptedInternalSession = getDbInternalSession(db);
+    const observedStates: AuthState[] = [];
+    const stop = db.onAuthChanged((state) => observedStates.push(state));
+    const bearerUpdates = runtimeClient.updateAuthToken.mock.calls.length;
+    const cookieUpdates = runtimeClient.updateCookieSession.mock.calls.length;
+
+    const rejection = "Changing auth principal on a live client is not supported. Recreate the Db.";
+    expect(() => db.updateCookieSession(makeCookieSession("stale-cookie", "bob"))).toThrow(
+      rejection,
+    );
+    expect(() => db.updateAuthToken(makeJwt({ sub: "bob", version: "stale-bearer" }))).toThrow(
+      rejection,
+    );
+    expect(() => db.updateCookieSession(null)).toThrow(rejection);
+    expect(() => db.updateAuthToken(null)).toThrow(rejection);
+    stop();
+
+    expect(db.getAuthState()).toBe(acceptedState);
+    expect(transportSnapshot(db, runtimeClient)).toEqual(acceptedTransport);
+    expect(getDbInternalSession(db)).toBe(acceptedInternalSession);
+    expect(runtimeClient.updateAuthToken.mock.calls).toHaveLength(bearerUpdates);
+    expect(runtimeClient.updateCookieSession.mock.calls).toHaveLength(cookieUpdates);
+    expect(observedStates).toHaveLength(1);
+  });
+
+  it("rolls back a synchronous transport propagation failure before accepting a later update", () => {
+    const { db, runtimeClient } = makeDbWithJwt(makeJwt({ sub: "alice", version: "A" }));
+    db.touchClient();
+    const beforeState = db.getAuthState();
+    const beforeTransport = transportSnapshot(db, runtimeClient);
+    const beforeInternalSession = getDbInternalSession(db);
+    const observedVersions: unknown[] = [];
+    const stop = db.onAuthChanged((state) => {
+      observedVersions.push(state.session?.claims.version);
+    });
+    const propagationFailure = new Error("synthetic transport propagation failure");
+    runtimeClient.updateCookieSession.mockImplementationOnce(() => {
+      throw propagationFailure;
+    });
+
+    expect(() => db.updateCookieSession(makeCookieSession("B"))).toThrow(propagationFailure);
+    expect(db.getAuthState()).toBe(beforeState);
+    expect(transportSnapshot(db, runtimeClient)).toEqual(beforeTransport);
+    expect(getDbInternalSession(db)).toBe(beforeInternalSession);
+    expect(observedVersions).toEqual(["A"]);
+
+    db.updateCookieSession(makeCookieSession("C"));
+    stop();
+
+    expect(db.getAuthState().session?.claims.version).toBe("C");
+    expect(transportSnapshot(db, runtimeClient)).toEqual({
+      mode: "cookie",
+      exclusive: { hasJwt: false, hasCookie: true },
+      claimVersion: "C",
+      forwarded: { bearer: 0, cookie: 2 },
+    });
+    expect(observedVersions).toEqual(["A", "C"]);
   });
 });

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1703,19 +1703,14 @@ export class Db {
     this.authStateStore.markUnauthenticated(reason);
   }
 
-  private publishAuthStateWithInternalSession<T>(
+  private publishAuthStateWithInternalSession(
     nextSession: Session | null,
-    publish: () => T,
-  ): { value: T; rollback: () => void } {
-    const previousSession = getDbInternalSession(this);
+    publish: () => void,
+  ): void {
+    // Commit every snapshot before notifying observers. Observer failures are
+    // reported to the caller without rolling back into a split snapshot.
     setDbInternalSession(this, nextSession);
-    const rollback = () => setDbInternalSession(this, previousSession);
-    try {
-      return { value: publish(), rollback };
-    } catch (error) {
-      rollback();
-      throw error;
-    }
+    publish();
   }
 
   protected applyAuthUpdate(
@@ -1750,13 +1745,12 @@ export class Db {
     }
 
     const nextInternalSession = resolveClientInternalSessionSync(nextConfig);
-    this.publishAuthStateWithInternalSession(nextInternalSession, () =>
-      this.authStateStore.applyJwtToken(jwtToken, trustedReservedSession),
-    );
-
     this.config.jwtToken = jwtToken;
     this.config.cookieSession = undefined;
     setTrustedReservedSession(this.config, trustedReservedSession);
+    this.publishAuthStateWithInternalSession(nextInternalSession, () => {
+      this.authStateStore.applyJwtToken(jwtToken, trustedReservedSession);
+    });
     return true;
   }
 
@@ -1780,13 +1774,12 @@ export class Db {
       cookieSession,
     } as DbConfig;
     const nextInternalSession = resolveClientInternalSessionSync(nextConfig);
-    this.publishAuthStateWithInternalSession(nextInternalSession, () =>
-      this.authStateStore.applyCookieSession(cookieSession),
-    );
-
     this.config.jwtToken = undefined;
     this.config.cookieSession = cookieSession;
     setTrustedReservedSession(this.config, undefined);
+    this.publishAuthStateWithInternalSession(nextInternalSession, () => {
+      this.authStateStore.applyCookieSession(cookieSession);
+    });
     return true;
   }
 

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -23,6 +23,7 @@ import {
   ExclusiveWriteResult,
   WriteResult,
   JazzClient,
+  type AuthUpdate,
   type MutationErrorEvent,
   WriteHandle,
   setWriteWaitReadiness,
@@ -1725,69 +1726,67 @@ export class Db {
     if (!nativeAccountRefresh) this.runtimeSource.assertAuthUpdateAllowed();
     const jwtToken = token ?? undefined;
     const previousToken = this.config.jwtToken;
-    const previousState = this.authStateStore.getState();
-    const nextInternalSession = resolveClientInternalSessionSync({
+    const previousCookieSession = this.config.cookieSession;
+    const previousTrustedReservedSession = getTrustedReservedSession(this.config);
+    const nextConfig = {
       ...this.config,
       jwtToken,
-      trustedReservedSession,
-    });
-    const tokenChanged = previousToken !== jwtToken;
-    // Browser persistent roots are principal-bound. Let the connection manager
-    // reject a token-carried incompatible switch while config, local auth state
-    // and worker claims still describe the preceding principal.
-    if (
-      !nativeAccountRefresh &&
-      tokenChanged &&
-      this.authStateStore.validateJwtToken(jwtToken, trustedReservedSession)
-    ) {
-      this.connection.updateAuth({ jwtToken, trustedReservedSession });
+      cookieSession: undefined,
+    } as DbConfig;
+    setTrustedReservedSession(nextConfig, trustedReservedSession);
+    const credentialsChanged =
+      previousToken !== nextConfig.jwtToken ||
+      previousCookieSession !== undefined ||
+      JSON.stringify(previousTrustedReservedSession) !== JSON.stringify(trustedReservedSession);
+    if (!credentialsChanged && this.authStateStore.getState().error === undefined) return false;
+
+    if (!nativeAccountRefresh) {
+      if (!this.authStateStore.validateJwtToken(jwtToken, trustedReservedSession)) return false;
+      this.connection.updateAuth({
+        mode: "bearer",
+        jwtToken,
+        trustedReservedSession,
+      });
     }
 
-    const published = this.publishAuthStateWithInternalSession(nextInternalSession, () =>
+    const nextInternalSession = resolveClientInternalSessionSync(nextConfig);
+    this.publishAuthStateWithInternalSession(nextInternalSession, () =>
       this.authStateStore.applyJwtToken(jwtToken, trustedReservedSession),
     );
-    if (!tokenChanged && published.value === previousState) {
-      published.rollback();
-      return false;
-    }
 
     this.config.jwtToken = jwtToken;
+    this.config.cookieSession = undefined;
     setTrustedReservedSession(this.config, trustedReservedSession);
-
-    // A same-token package-private session refresh cannot cross the public
-    // principal boundary above; preserve the old no-op/refresh behavior.
-    if (!nativeAccountRefresh && !tokenChanged)
-      this.connection.updateAuth({ jwtToken, trustedReservedSession });
-
     return true;
   }
 
   protected applyCookieSessionUpdate(session: Session | null): boolean {
     this.runtimeSource.assertAuthUpdateAllowed();
     const cookieSession = session ?? undefined;
-    const previousSession = this.config.cookieSession;
-    const previousState = this.authStateStore.getState();
-    const nextInternalSession = resolveClientInternalSessionSync({
-      ...this.config,
-      cookieSession,
-    });
-    const sessionChanged = JSON.stringify(previousSession) !== JSON.stringify(cookieSession);
-    if (sessionChanged && this.authStateStore.validateCookieSession(cookieSession)) {
-      this.connection.updateAuth({ cookieSession });
-    }
+    const previousCookieSession = this.config.cookieSession;
+    const previousToken = this.config.jwtToken;
+    const previousTrustedReservedSession = getTrustedReservedSession(this.config);
+    const sessionChanged = JSON.stringify(previousCookieSession) !== JSON.stringify(cookieSession);
+    const credentialsChanged =
+      previousToken !== undefined || sessionChanged || previousTrustedReservedSession !== undefined;
+    if (!credentialsChanged && this.authStateStore.getState().error === undefined) return false;
 
-    const published = this.publishAuthStateWithInternalSession(nextInternalSession, () =>
+    if (!this.authStateStore.validateCookieSession(cookieSession)) return false;
+    this.connection.updateAuth({ mode: "cookie", cookieSession });
+
+    const nextConfig = {
+      ...this.config,
+      jwtToken: undefined,
+      cookieSession,
+    } as DbConfig;
+    const nextInternalSession = resolveClientInternalSessionSync(nextConfig);
+    this.publishAuthStateWithInternalSession(nextInternalSession, () =>
       this.authStateStore.applyCookieSession(cookieSession),
     );
-    if (!sessionChanged && published.value === previousState) {
-      published.rollback();
-      return false;
-    }
 
+    this.config.jwtToken = undefined;
     this.config.cookieSession = cookieSession;
-
-    if (!sessionChanged) this.connection.updateAuth({ cookieSession });
-
+    setTrustedReservedSession(this.config, undefined);
     return true;
   }
 


### PR DESCRIPTION
🤖 ## Summary
- Coordinate live authentication transitions before notifying observers.
- Keep transport credentials exclusive to the active authentication mode.

## Before
Live auth transitions could publish observer-visible state before the transport credentials had committed to the matching mode.

## After
The auth state and transport credentials transition atomically, with observers seeing only the committed mode.

## Test plan
- [x] Focused auth transition Vitest regression test

## Integration status

Rebased into the stable-fixes stack on main. Independent review and auth-mode regressions passed. Added backend-session coverage so stale cookie credentials cannot survive switching to bearer authentication. Full combined CI is green; user merge approval remains separate.
