### PR TITLE
perf(jazz): name physical fields without constructing storage schemas

### DIFF
--- a/crates/groove/src/records/macros.rs
+++ b/crates/groove/src/records/macros.rs
@@ -814,6 +814,8 @@ macro_rules! define_record {
             $crate::records::macros::paste::paste! {
                 $(pub const [<FIELD_ $field:upper _IDX>]: usize = $idx;)*
             }
+            /// Names of the declared fields before the dynamic user-cell tail.
+            pub const PREFIX_FIELD_NAMES: &'static [&'static str] = &[$(stringify!($field)),*];
             pub const USER_BASE: usize = 0 $(+ { let _ = stringify!($field); 1 })*;
             pub const USER_CELLS: usize = Self::USER_BASE;
 

--- a/crates/jazz/src/node/physical/descriptors.rs
+++ b/crates/jazz/src/node/physical/descriptors.rs
@@ -1251,44 +1251,14 @@ fn physical_history_field_names_for_case(
     mapping: &TablePhysicalMapping,
     present: Option<&BTreeSet<String>>,
 ) -> Result<Vec<String>, Error> {
-    let logical_descriptor = table.history_storage_table().record_schema();
-    let mut fields = logical_descriptor
-        .fields()
-        .iter()
-        .take(HistoryRowRecord::USER_CELLS)
-        .map(|field| {
-            field.name.clone().ok_or(Error::InvalidStoredValue(
-                "physical history system field unnamed",
-            ))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    for column in &table.columns {
-        if present.is_some_and(|present| !present.contains(&column.name)) {
-            continue;
-        }
-        let column_id =
-            mapping
-                .columns
-                .get(&column.name)
-                .copied()
-                .ok_or(Error::InvalidStoredValue(
-                    "physical history column mapping missing",
-                ))?;
-        fields.push(physical_user_column_field(column_id));
-    }
-    fields.extend(
-        logical_descriptor
-            .fields()
-            .iter()
-            .skip(HistoryRowRecord::USER_CELLS + table.columns.len())
-            .map(|field| {
-                field.name.clone().ok_or(Error::InvalidStoredValue(
-                    "physical history trailing field unnamed",
-                ))
-            })
-            .collect::<Result<Vec<_>, _>>()?,
-    );
-    Ok(fields)
+    physical_row_field_names(
+        table,
+        mapping,
+        present,
+        HistoryRowRecord::PREFIX_FIELD_NAMES,
+        &["authored_columns"],
+        "physical history column mapping missing",
+    )
 }
 
 pub(super) fn physical_current_field_names(
@@ -1303,44 +1273,14 @@ fn physical_current_field_names_for_case(
     mapping: &TablePhysicalMapping,
     present: Option<&BTreeSet<String>>,
 ) -> Result<Vec<String>, Error> {
-    let logical_descriptor = table.global_current_storage_tables()[0].record_schema();
-    let mut fields = logical_descriptor
-        .fields()
-        .iter()
-        .take(GlobalCurrentRowRecord::USER_CELLS)
-        .map(|field| {
-            field.name.clone().ok_or(Error::InvalidStoredValue(
-                "physical current system field unnamed",
-            ))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    for column in &table.columns {
-        if present.is_some_and(|present| !present.contains(&column.name)) {
-            continue;
-        }
-        let column_id =
-            mapping
-                .columns
-                .get(&column.name)
-                .copied()
-                .ok_or(Error::InvalidStoredValue(
-                    "physical current column mapping missing",
-                ))?;
-        fields.push(physical_user_column_field(column_id));
-    }
-    fields.extend(
-        logical_descriptor
-            .fields()
-            .iter()
-            .skip(GlobalCurrentRowRecord::USER_CELLS + table.columns.len())
-            .map(|field| {
-                field.name.clone().ok_or(Error::InvalidStoredValue(
-                    "physical current trailing field unnamed",
-                ))
-            })
-            .collect::<Result<Vec<_>, _>>()?,
-    );
-    Ok(fields)
+    physical_row_field_names(
+        table,
+        mapping,
+        present,
+        GlobalCurrentRowRecord::PREFIX_FIELD_NAMES,
+        &["authored_columns"],
+        "physical current column mapping missing",
+    )
 }
 
 fn physical_rejected_version_field_names(
@@ -1355,31 +1295,41 @@ fn physical_rejected_version_field_names_for_case(
     mapping: &TablePhysicalMapping,
     present: Option<&BTreeSet<String>>,
 ) -> Result<Vec<String>, Error> {
-    let logical_descriptor = table.rejected_versions_storage_table().record_schema();
-    let mut fields = logical_descriptor
-        .fields()
-        .iter()
-        .take(RejectedVersionRowRecord::USER_CELLS)
-        .map(|field| {
-            field.name.clone().ok_or(Error::InvalidStoredValue(
-                "physical rejected-version system field unnamed",
-            ))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    physical_row_field_names(
+        table,
+        mapping,
+        present,
+        RejectedVersionRowRecord::PREFIX_FIELD_NAMES,
+        &[],
+        "physical rejected-version column mapping missing",
+    )
+}
+
+// Naming a projection does not require constructing storage tables, indexes or
+// type registries. The fixed prefix comes from the record wrapper declaration;
+// user fields retain schema order and their durable physical column identities.
+fn physical_row_field_names(
+    table: &TableSchema,
+    mapping: &TablePhysicalMapping,
+    present: Option<&BTreeSet<String>>,
+    prefix: &[&str],
+    suffix: &[&str],
+    missing_mapping: &'static str,
+) -> Result<Vec<String>, Error> {
+    let mut fields = Vec::with_capacity(prefix.len() + table.columns.len() + suffix.len());
+    fields.extend(prefix.iter().map(|name| (*name).to_owned()));
     for column in &table.columns {
         if present.is_some_and(|present| !present.contains(&column.name)) {
             continue;
         }
-        let column_id =
-            mapping
-                .columns
-                .get(&column.name)
-                .copied()
-                .ok_or(Error::InvalidStoredValue(
-                    "physical rejected-version column mapping missing",
-                ))?;
+        let column_id = mapping
+            .columns
+            .get(&column.name)
+            .copied()
+            .ok_or(Error::InvalidStoredValue(missing_mapping))?;
         fields.push(physical_user_column_field(column_id));
     }
+    fields.extend(suffix.iter().map(|name| (*name).to_owned()));
     Ok(fields)
 }
 

--- a/crates/jazz/src/node/physical/tests.rs
+++ b/crates/jazz/src/node/physical/tests.rs
@@ -86,6 +86,58 @@ mod variant_case_tests {
         fields
     }
 
+    // Internal layout equivalence is the contract here: public row results do
+    // not expose the physical names or ordering of a partial projection.
+    #[test]
+    fn physical_projection_names_match_storage_layouts_without_building_them() {
+        let public = PublicSchemaBuilder::new()
+            .table(PublicTableSchemaBuilder::new("entries")
+                .column("body", PublicColumnType::Text)
+                .column("status", PublicColumnType::ScalarEnum {
+                    name: "state".to_owned(),
+                    variants: vec!["open".to_owned(), "closed".to_owned()],
+                }))
+            .build();
+        let schema = JazzSchema::new(&public).unwrap();
+        let table = &schema.tables[0];
+        let mut mapping = mapping(7, &[]).tables.remove("entries").unwrap();
+        for (index, column) in table.columns.iter().enumerate() {
+            mapping.columns.insert(column.name.clone(), PhysicalColumnId(index as u64 + 100));
+        }
+        let storage_tables = [
+            table.history_storage_table(),
+            table.global_current_storage_tables().remove(0),
+            table.rejected_versions_storage_table(),
+        ];
+        let prefixes = [HistoryRowRecord::USER_CELLS, GlobalCurrentRowRecord::USER_CELLS,
+            RejectedVersionRowRecord::USER_CELLS];
+        let all = table.columns.iter().map(|column| column.name.clone()).collect();
+        for present in [None, Some(BTreeSet::new()), Some(BTreeSet::from(["body".to_owned()])), Some(all)] {
+            let actual = [
+                physical_history_field_names_for_case(table, &mapping, present.as_ref()).unwrap(),
+                physical_current_field_names_for_case(table, &mapping, present.as_ref()).unwrap(),
+                physical_rejected_version_field_names_for_case(table, &mapping, present.as_ref()).unwrap(),
+            ];
+            for ((actual, storage), prefix) in actual.iter().zip(&storage_tables).zip(prefixes) {
+                let mut expected = storage.columns[..prefix].iter().map(|c| c.name.clone()).collect::<Vec<_>>();
+                expected.extend(table.columns.iter()
+                    .filter(|column| present.as_ref().is_none_or(|set| set.contains(&column.name)))
+                    .map(|column| physical_user_column_field(mapping.columns[&column.name])));
+                expected.extend(storage.columns[prefix + table.columns.len()..].iter().map(|c| c.name.clone()));
+                assert_eq!(*actual, expected);
+            }
+        }
+        mapping.columns.remove("body");
+        assert!(physical_current_field_names(table, &mapping).is_err());
+        assert!(physical_history_field_names(table, &mapping).is_err());
+        assert!(physical_rejected_version_field_names(table, &mapping).is_err());
+        // A column absent from this variant does not require a mapping lookup.
+        let none = BTreeSet::new();
+        assert!(physical_current_field_names_for_case(table, &mapping, Some(&none)).is_ok());
+        assert!(physical_history_field_names_for_case(table, &mapping, Some(&none)).is_ok());
+        assert!(physical_rejected_version_field_names_for_case(table, &mapping, Some(&none)).is_ok());
+    }
+
     #[test]
     fn schema_layout_cases_allocate_durably_without_collisions() {
         let v1 = schema(1);


### PR DESCRIPTION
🤖 Build physical projection field names directly from the record prefix and physical column mapping. Previously, naming a history/current/rejected projection constructed complete storage-table schemas, indexes and type registries, then discarded everything except the names.

For a current-row projection, the output is still the declared system prefix, selected user columns in schema order under their physical identities, and `authored_columns`. Partial variants omit only absent user columns. A missing mapping for an included column remains an error; an excluded column requires no mapping. History and rejected-row projections follow their existing respective layouts. No storage or wire bytes, tags, descriptors or authorization semantics change.

The record macro exposes its declared prefix names as a static slice, avoiding a second manually maintained prefix list. One shared helper replaces the three schema-building implementations. An internal test compares all output names and their order against the real storage schemas for full, empty and partial variants. This is an internal contract because public query rows do not expose physical projection names. Temporarily omitting the trailing metadata field makes the test fail; exact restoration passes.

All 745 Groove and 2,007 Jazz library tests pass (2 ignored in each), along with the three scaling canaries, the two-seed maintained/one-shot comparison and commit checks. Optimized native cold settle is effectively flat: 18.603s → 18.665s, all 27,518 rows; readiness 19.072s → 19.063s. Todo roundtrip is 271.474ms, within the preceding repeat range. No end-to-end speedup is claimed; retain the smaller implementation because it removes unnecessary schema construction. Draft on #2838; broader acceptance and independent review remain outstanding.
