### PR TITLE
perf(groove): append variable encodings directly into record output

### DIFF
--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -2229,16 +2229,29 @@ pub fn encode_stored_scalar(kind: LargeValueKind, value: &StoredScalar) -> Resul
 /// Encode the primitive arm from borrowed logical bytes. Its sole raw payload
 /// field is the complete record payload, so only ordinary variant framing is
 /// needed; no Value, field map, or intermediate record is required.
+#[cfg(test)]
 pub(crate) fn encode_primitive_stored_scalar(
     kind: LargeValueKind,
     bytes: &[u8],
 ) -> Result<Vec<u8>, Error> {
+    let mut output = Vec::new();
+    encode_primitive_stored_scalar_into(kind, bytes, &mut output)?;
+    Ok(output)
+}
+
+pub(crate) fn encode_primitive_stored_scalar_into(
+    kind: LargeValueKind,
+    bytes: &[u8],
+    output: &mut Vec<u8>,
+) -> Result<(), Error> {
     #[cfg(test)]
     {
         STORED_SCALAR_ENCODE_CALLS.with(|calls| calls.set(calls.get() + 1));
         STORED_SCALAR_CANONICAL_ENCODE_CALLS.with(|calls| calls.set(calls.get() + 1));
     }
-    encode_primitive_payload(kind, bytes)
+    validate_logical(kind, bytes)?;
+    crate::records::append_variant_record(output, 2, bytes);
+    Ok(())
 }
 
 fn encode_primitive_payload(kind: LargeValueKind, bytes: &[u8]) -> Result<Vec<u8>, Error> {

--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -537,8 +537,13 @@ impl RecordDescriptor {
         if field.value_type.is_fixed_size() {
             encode_fixed_value(output, value, &field.value_type)
         } else {
-            output.extend_from_slice(&encode_value(value, &field.value_type)?);
-            Ok(())
+            let start = output.len();
+            let result = values::encode_value_into(output, value, &field.value_type);
+            if result.is_err() {
+                // The allocating variable-field path appended nothing on error.
+                output.truncate(start);
+            }
+            result
         }
     }
 
@@ -1932,9 +1937,13 @@ impl ValidatedVariantRecord {
 
 pub fn encode_variant_record(variant_tag: u32, payload: &[u8]) -> Vec<u8> {
     let mut stored = Vec::with_capacity(MAX_VARIANT_TAG_LEN + payload.len());
-    put_canonical_u32_varint(&mut stored, variant_tag);
-    stored.extend_from_slice(payload);
+    append_variant_record(&mut stored, variant_tag, payload);
     stored
+}
+
+pub(crate) fn append_variant_record(stored: &mut Vec<u8>, variant_tag: u32, payload: &[u8]) {
+    put_canonical_u32_varint(stored, variant_tag);
+    stored.extend_from_slice(payload);
 }
 
 pub fn split_variant_record(stored: &[u8]) -> Result<(u32, &[u8]), Error> {

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -2644,3 +2644,79 @@ fn indirect_reference_visitor_preserves_nested_multiplicity_and_early_stop() {
     );
     assert_eq!(count, 1);
 }
+
+// Internal byte fixtures pin array-relative offsets and nullable/scalar framing,
+// which are deliberately not visible in database query results.
+#[test]
+fn variable_fields_append_exact_bytes_into_existing_output() {
+    let nullable_string = ValueType::Nullable(Box::new(ValueType::String));
+    let nested_type = ValueType::Array(Box::new(ValueType::Array(Box::new(
+        nullable_string.clone(),
+    ))));
+    let cases = [
+        (
+            nullable_string,
+            Value::Nullable(Some(Box::new(Value::String("abc".into())))),
+            vec![1, 2, b'a', b'b', b'c'],
+        ),
+        (
+            ValueType::Array(Box::new(ValueType::String)),
+            Value::Array(vec![
+                Value::String("a".into()),
+                Value::String("bc".into()),
+                Value::String(String::new()),
+            ]),
+            vec![
+                3, 0, 0, 0, 14, 0, 0, 0, 17, 0, 0, 0, 2, b'a', 2, b'b', b'c', 2,
+            ],
+        ),
+        (
+            nested_type,
+            Value::Array(vec![
+                Value::Array(vec![
+                    Value::Nullable(Some(Box::new(Value::String("a".into())))),
+                    Value::Nullable(None),
+                ]),
+                Value::Array(vec![]),
+            ]),
+            vec![
+                2, 0, 0, 0, 20, 0, 0, 0, 2, 0, 0, 0, 11, 0, 0, 0, 1, 2, b'a', 0, 0, 0, 0, 0,
+            ],
+        ),
+        (
+            ValueType::Bytes,
+            Value::Bytes(vec![0, 255]),
+            vec![2, 0, 255],
+        ),
+        (
+            ValueType::Array(Box::new(ValueType::String)),
+            Value::Array(vec![]),
+            vec![0, 0, 0, 0],
+        ),
+    ];
+    for (value_type, value, expected) in cases {
+        let d = descriptor([value_type]);
+        let mut output = Vec::with_capacity(512);
+        output.extend_from_slice(&[91, 92, 93]);
+        let pointer = output.as_ptr();
+        d.encode_field_into(0, &value, &mut output).unwrap();
+        assert_eq!(&output[..3], &[91, 92, 93]);
+        assert_eq!(&output[3..], expected);
+        assert_eq!(output.as_ptr(), pointer);
+        assert_eq!(d.bind(&output[3..]).get_idx(0).unwrap(), value);
+    }
+}
+
+#[test]
+fn variable_field_failure_preserves_preexisting_output() {
+    let d = descriptor([ValueType::Array(Box::new(ValueType::stored_scalar(
+        crate::large_values::LargeValueKind::Json,
+    )))]);
+    let value = Value::Array(vec![
+        Value::String("{}".into()),
+        Value::String("invalid-json".into()),
+    ]);
+    let mut output = vec![91, 92, 93];
+    assert!(d.encode_field_into(0, &value, &mut output).is_err());
+    assert_eq!(output, [91, 92, 93]);
+}

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -1562,18 +1562,29 @@ impl ValueType {
 
 pub(super) fn encode_value(value: &Value, value_type: &ValueType) -> Result<Vec<u8>, Error> {
     let mut bytes = Vec::new();
+    encode_value_into(&mut bytes, value, value_type)?;
+    Ok(bytes)
+}
+
+pub(super) fn encode_value_into(
+    bytes: &mut Vec<u8>,
+    value: &Value,
+    value_type: &ValueType,
+) -> Result<(), Error> {
     match (value, value_type) {
         (Value::String(value), ValueType::String) => {
-            return Ok(crate::large_values::encode_primitive_stored_scalar(
+            crate::large_values::encode_primitive_stored_scalar_into(
                 crate::large_values::LargeValueKind::String,
                 value.as_bytes(),
-            )?);
+                bytes,
+            )?;
         }
         (Value::Bytes(value), ValueType::Bytes) => {
-            return Ok(crate::large_values::encode_primitive_stored_scalar(
+            crate::large_values::encode_primitive_stored_scalar_into(
                 crate::large_values::LargeValueKind::Bytes,
                 value,
-            )?);
+                bytes,
+            )?;
         }
         (
             Value::String(value),
@@ -1589,10 +1600,11 @@ pub(super) fn encode_value(value: &Value, value_type: &ValueType) -> Result<Vec<
                 crate::large_values::LargeValueKind::Bytes,
             ))),
         ) => {
-            return Ok(crate::large_values::encode_primitive_stored_scalar(
+            crate::large_values::encode_primitive_stored_scalar_into(
                 crate::large_values::LargeValueKind::Bytes,
                 value,
-            )?);
+                bytes,
+            )?;
         }
         (
             Value::String(value),
@@ -1601,10 +1613,11 @@ pub(super) fn encode_value(value: &Value, value_type: &ValueType) -> Result<Vec<
                 | crate::large_values::LargeValueKind::Json),
             ))),
         ) => {
-            return Ok(crate::large_values::encode_primitive_stored_scalar(
+            crate::large_values::encode_primitive_stored_scalar_into(
                 *kind,
                 value.as_bytes(),
-            )?);
+                bytes,
+            )?;
         }
         (
             Value::Large(value),
@@ -1635,13 +1648,13 @@ pub(super) fn encode_value(value: &Value, value_type: &ValueType) -> Result<Vec<
         }
         (Value::EnumTag(value), ValueType::EnumTag(_)) => bytes.push(*value),
         (Value::Tuple(values), ValueType::Tuple(members)) => {
-            encode_tuple(&mut bytes, values, members)?;
+            encode_tuple(bytes, values, members)?;
         }
         (Value::Array(values), ValueType::Array(element_type)) => {
-            encode_array(&mut bytes, values, element_type)?;
+            encode_array(bytes, values, element_type)?;
         }
         (Value::Nullable(value), ValueType::Nullable(inner_type)) => {
-            encode_nullable(&mut bytes, value.as_deref(), inner_type)?;
+            encode_nullable(bytes, value.as_deref(), inner_type)?;
         }
         (Value::Record(record), ValueType::Record(_)) => {
             ensure_value_type(value, value_type)?;
@@ -1649,19 +1662,16 @@ pub(super) fn encode_value(value: &Value, value_type: &ValueType) -> Result<Vec<
         }
         (Value::Enum(enum_value), ValueType::Enum(schema)) => {
             ensure_enum_value(enum_value, schema)?;
-            bytes.extend(super::encode_variant_record(
-                enum_value.tag,
-                enum_value.record.raw(),
-            ));
+            super::append_variant_record(bytes, enum_value.tag, enum_value.record.raw());
         }
-        _ if value_type.is_fixed_size() => encode_fixed_value(&mut bytes, value, value_type)?,
+        _ if value_type.is_fixed_size() => encode_fixed_value(bytes, value, value_type)?,
         _ => {
             return Err(Error::TypeMismatch {
                 expected: value_type.clone(),
             });
         }
     }
-    Ok(bytes)
+    Ok(())
 }
 
 pub(super) fn encode_fixed_value(
@@ -2010,7 +2020,7 @@ fn encode_nullable(
                 // need no temporary Vec, including nested nullable values.
                 encode_fixed_value(bytes, value, inner_type)?;
             } else {
-                bytes.extend(encode_value(value, inner_type)?);
+                encode_value_into(bytes, value, inner_type)?;
             }
         }
         None => {
@@ -2129,22 +2139,20 @@ fn encode_array(
         return Ok(());
     }
 
+    let base = bytes.len();
     write_u32(bytes, usize_to_u32(values.len())?);
-    let encoded_values = values
-        .iter()
-        .map(|value| encode_value(value, element_type))
-        .collect::<Result<Vec<_>, _>>()?;
-    let offset_table_size = encoded_values.len().saturating_sub(1) * 4;
-    let mut next_offset = 4 + offset_table_size;
-    for encoded in encoded_values
-        .iter()
-        .take(encoded_values.len().saturating_sub(1))
-    {
-        next_offset = checked_add(next_offset, encoded.len())?;
-        write_u32(bytes, usize_to_u32(next_offset)?);
-    }
-    for encoded in encoded_values {
-        bytes.extend(encoded);
+    let offset_count = values.len().saturating_sub(1);
+    let payload_start = checked_add(bytes.len(), offset_count * 4)?;
+    bytes.resize(payload_start, 0);
+    for (index, value) in values.iter().enumerate() {
+        encode_value_into(bytes, value, element_type)?;
+        if index < offset_count {
+            // Offsets belong to this array, even when nested inside another
+            // array, nullable value or a record's shared output buffer.
+            let end = usize_to_u32(bytes.len() - base)?;
+            let slot = base + 4 + index * 4;
+            bytes[slot..slot + 4].copy_from_slice(&end.to_le_bytes());
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
🤖 Encode variable-width values directly into the record output buffer. Previously, record encoding created a temporary field buffer; nullable values created another payload buffer; variable arrays materialized a vector of encoded element buffers; primitive scalar and enum framing could add another copy. The new append path shares the destination through these layers.

For example, a nullable string now appends its presence flag, primitive tag and string bytes directly. A variable array reserves its count/offset header, appends each element, and fills each completed offset in place. Offsets remain relative to that array, including an array nested in another array or appended after existing record bytes. Empty arrays retain their four-byte zero count. Fixed-width arrays and tuple ordering retain their existing encoding. Indirect large-value encoding keeps its existing path.

This is an encoder implementation change, not a storage/wire format change: record offsets, nullable flags, scalar/enum variant tags, primitive payloads and all decoding rules remain identical. It adds no serializer or encoding version. Existing input validation remains in place. If variable-field encoding fails after appending an earlier element, the caller's original output is restored, matching the old temporary-buffer behavior.

All 747 Groove library tests pass (2 ignored). New internal literal-byte fixtures cover nested arrays, nullable strings, empty arrays, byte payloads and a nonempty destination; these byte-level invariants are deliberately hidden by the database API. Separate sensitivity checks confirm failure when offsets become destination-relative or error rollback is removed. Both mutations are restored. Commit checks pass. The full 2,007-test Jazz library suite also passes (2 ignored), as do all three scaling canaries and the two-seed maintained/one-shot comparison. Clean native measurements are effectively flat: cold settle 18.665s → 18.546s with all 27,518 rows; todo batch roundtrip 271.474ms → 277.209ms. Refreshed cold allocation attribution across the recent slices is 115,600,178 allocations / 32,651,257,883 requested bytes, down from 128,343,865 / 34,351,374,780 at the earlier retained runtime. Temporary variable encoding buffers no longer lead allocation callers. This cross-slice allocation reduction is not an isolated latency improvement for this PR.

Draft on #2840. No material latency improvement is claimed; broader acceptance and independent review remain outstanding.
