### PR TITLE
Keep finite f64 averages stable

### DIFF
--- a/.changeset/finite-average-overflow.md
+++ b/.changeset/finite-average-overflow.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Keep averages of large finite numbers finite when their intermediate sum overflows, while preserving cancellation, subscription updates and retractions.

--- a/crates/groove/src/ivm/runtime/aggregate.rs
+++ b/crates/groove/src/ivm/runtime/aggregate.rs
@@ -240,7 +240,10 @@ fn aggregate_avg(
         return Err(IvmRuntimeError::UnsupportedOperator);
     };
     let mut sum = 0_f64;
+    let mut scale = 0_f64;
     let mut count = 0_i64;
+    let mut has_f64 = false;
+    let mut has_non_finite = false;
     for (record, weight) in records {
         if *weight <= 0 {
             continue;
@@ -252,11 +255,41 @@ fn aggregate_avg(
         let numeric = numeric_value_as_f64(&value)?;
         sum += numeric * (*weight as f64);
         count += *weight;
+        has_f64 |= matches!(value, Value::F64(_));
+        if numeric.is_finite() {
+            scale = scale.max(numeric.abs());
+        } else {
+            has_non_finite = true;
+        }
     }
     if count <= 0 {
         return Ok(None);
     }
-    Ok(Some(Value::F64(sum / (count as f64))))
+
+    // Keep the established accumulation order for integer and non-finite
+    // inputs. Scaling is only needed for finite F64 values, and falling back
+    // here preserves the existing NaN/infinity behavior exactly.
+    if !has_f64 || has_non_finite || sum.is_finite() {
+        return Ok(Some(Value::F64(sum / (count as f64))));
+    }
+    if scale == 0.0 {
+        return Ok(Some(Value::F64(0.0)));
+    }
+
+    let mut scaled_sum = 0_f64;
+    for (record, weight) in records {
+        if *weight <= 0 {
+            continue;
+        }
+        let value = evaluate_aggregate_expr(&BorrowedRecord::new(record, &input_desc), expr)?;
+        let Some(value) = unwrap_nullable_value(value) else {
+            continue;
+        };
+        let numeric = numeric_value_as_f64(&value)?;
+        scaled_sum += (numeric / scale) * (*weight as f64);
+    }
+    let normalized = (scaled_sum / (count as f64)).clamp(-1.0, 1.0);
+    Ok(Some(Value::F64(scale * normalized)))
 }
 
 fn aggregate_extremum(

--- a/crates/groove/tests/aggregate_sql_semantics.rs
+++ b/crates/groove/tests/aggregate_sql_semantics.rs
@@ -244,6 +244,55 @@ async fn signed_i64_inputs_are_supported() {
     );
 }
 
+/// AVG must not overflow while summing two distinct finite `f64::MAX` rows.
+#[futures_test::test]
+async fn avg_of_two_f64_max_values_stays_finite() {
+    let storage = MemoryStorage::new(&["metrics"]).expect("valid memory storage families");
+    let mut database = Database::new(metric_schema(ColumnType::F64), storage)
+        .await
+        .unwrap();
+    let mut batch = database.open_batch();
+    batch.insert(
+        "metrics",
+        vec![Value::U64(1), Value::U64(10), Value::F64(f64::MAX)],
+    );
+    batch.insert(
+        "metrics",
+        vec![Value::U64(2), Value::U64(10), Value::F64(f64::MAX)],
+    );
+    let applied = database.apply_batch(batch).await.unwrap();
+    let persisted = applied.persist().await;
+    database.finish_persistence(persisted).unwrap();
+
+    let graph = GraphBuilder::aggregate(
+        GraphBuilder::table("metrics"),
+        ["bucket"],
+        [aggregate(
+            AggregateFunction::Avg,
+            Some("score"),
+            "avg_score",
+        )],
+    );
+    let rows = database
+        .query_graph(graph)
+        .await
+        .unwrap()
+        .to_values()
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    let (values, weight) = &rows[0];
+    assert_eq!(*weight, 1);
+    assert_eq!(values[0], Value::U64(10));
+    let Value::Nullable(Some(value)) = &values[1] else {
+        panic!("AVG result should be non-null: {values:?}");
+    };
+    let Value::F64(average) = value.as_ref() else {
+        panic!("AVG result should be F64: {values:?}");
+    };
+    assert!(average.is_finite(), "AVG must remain finite");
+    assert_eq!(*average, f64::MAX, "AVG must equal f64::MAX exactly");
+}
+
 #[futures_test::test]
 async fn sum_overflow_fails_with_a_named_error_at_the_declared_width() {
     let storage = MemoryStorage::new(&["metrics"]).expect("valid memory storage families");
@@ -269,4 +318,47 @@ async fn sum_overflow_fails_with_a_named_error_at_the_declared_width() {
             IvmRuntimeError::AggregateOverflow
         ))
     ));
+}
+
+#[futures_test::test]
+async fn avg_preserves_small_finite_residual_after_large_cancellation() {
+    let storage = MemoryStorage::new(&["metrics"]).expect("valid memory storage families");
+    let mut database = Database::new(metric_schema(ColumnType::F64), storage)
+        .await
+        .unwrap();
+    let mut batch = database.open_batch();
+    for (index, score) in [f64::MAX, -f64::MAX, 1.0e-20].into_iter().enumerate() {
+        batch.insert(
+            "metrics",
+            vec![
+                Value::U64(index as u64 + 1),
+                Value::U64(10),
+                Value::F64(score),
+            ],
+        );
+    }
+    let applied = database.apply_batch(batch).await.unwrap();
+    let persisted = applied.persist().await;
+    database.finish_persistence(persisted).unwrap();
+    let graph = GraphBuilder::aggregate(
+        GraphBuilder::table("metrics"),
+        ["bucket"],
+        [aggregate(
+            AggregateFunction::Avg,
+            Some("score"),
+            "avg_score",
+        )],
+    );
+    let rows = database
+        .query_graph(graph)
+        .await
+        .unwrap()
+        .to_values()
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1, 1);
+    assert_eq!(
+        rows[0].0[1],
+        Value::Nullable(Some(Box::new(Value::F64(1.0e-20 / 3.0))))
+    );
 }

--- a/crates/jazz-testkit/tests/aggregate_subscriptions.rs
+++ b/crates/jazz-testkit/tests/aggregate_subscriptions.rs
@@ -1142,6 +1142,128 @@ async fn maintained_integer_sum_accumulates_multiple_deltas_and_retracts_empty_g
         .await;
 }
 
+/// A maintained grouped AVG keeps a finite maximum when two distinct rows each
+/// contain `f64::MAX`, and retracts the aggregate as both rows are deleted.
+///
+/// writer ──insert max──► server ──AVG update──► subscriber
+/// writer ──delete rows──► server ──retract group──► subscriber
+#[tokio::test(flavor = "current_thread")]
+async fn maintained_double_avg_of_two_max_values_stays_finite_and_retracts() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let schema = double_metrics_schema();
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
+            let writer = jazz_testkit::connect(server.make_client_context_for_user(
+                schema.clone(),
+                "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa20",
+            ))
+            .await
+            .expect("connect writer");
+            let client = jazz_testkit::connect(
+                server.make_client_context_for_user(schema, "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa21"),
+            )
+            .await
+            .expect("connect client");
+            let avg_query = jazz::query::Query::from("metrics")
+                .avg("score")
+                .group_by("bucket");
+            let mut avg_stream = ObservedSubscription::new(
+                client
+                    .subscribe(avg_query.clone())
+                    .await
+                    .expect("subscribe grouped double avg"),
+                &avg_query,
+                aggregate_descriptor([
+                    ("bucket", ValueType::String),
+                    ("avg_score", ValueType::F64),
+                ]),
+            );
+
+            let first_delivery = avg_stream.delivered_deltas + 1;
+            let max = f64::MAX;
+            let (first, _, tx) = writer
+                .insert(
+                    "metrics",
+                    row_input!("bucket" => "same", "score" => Value::Double(max)),
+                )
+                .expect("insert first maximum metric");
+            support::wait_for_edge_txs(
+                &writer,
+                &[tx.expect("ordinary mutation commits immediately")],
+            )
+            .await;
+            avg_stream
+                .wait_for_values_since(
+                    first_delivery,
+                    vec![vec![Value::Text("same".to_owned()), Value::Double(max)]],
+                    "AVG of the first maximum is finite",
+                )
+                .await;
+            let second_delivery = avg_stream.delivered_deltas + 1;
+
+            let (second, _, tx) = writer
+                .insert(
+                    "metrics",
+                    row_input!("bucket" => "same", "score" => Value::Double(max)),
+                )
+                .expect("insert second maximum metric");
+            support::wait_for_edge_txs(
+                &writer,
+                &[tx.expect("ordinary mutation commits immediately")],
+            )
+            .await;
+            avg_stream
+                .assert_values_remain(
+                    vec![vec![Value::Text("same".to_owned()), Value::Double(max)]],
+                    Duration::from_millis(250),
+                    "AVG of two maximum values remains exactly MAX",
+                )
+                .await;
+            let visible_avg = match avg_stream.values().as_slice() {
+                [row] => match row.as_slice() {
+                    [Value::Text(_), Value::Double(value)] => *value,
+                    other => panic!("unexpected AVG row: {other:?}"),
+                },
+                rows => panic!("unexpected AVG rows: {rows:?}"),
+            };
+            assert!(visible_avg.is_finite(), "AVG must remain finite");
+            assert_eq!(visible_avg, max, "AVG must equal f64::MAX exactly");
+
+            let first_delete_delivery = avg_stream.delivered_deltas + 1;
+            let tx = writer.delete(first).expect("delete first maximum metric");
+            support::wait_for_edge_txs(
+                &writer,
+                &[tx.expect("ordinary mutation commits immediately")],
+            )
+            .await;
+            avg_stream
+                .assert_values_remain(
+                    vec![vec![Value::Text("same".to_owned()), Value::Double(max)]],
+                    Duration::from_millis(250),
+                    "AVG remains MAX after deleting one maximum",
+                )
+                .await;
+
+            let last_delete_delivery = avg_stream.delivered_deltas + 1;
+            let tx = writer.delete(second).expect("delete second maximum metric");
+            support::wait_for_edge_txs(
+                &writer,
+                &[tx.expect("ordinary mutation commits immediately")],
+            )
+            .await;
+            avg_stream
+                .wait_for_values_since(
+                    last_delete_delivery,
+                    Vec::new(),
+                    "AVG group is retracted after last deletion",
+                )
+                .await;
+        })
+        .await;
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn maintained_bigint_sum_replaces_a_multi_row_group_after_insert() {
     tokio::task::LocalSet::new()


### PR DESCRIPTION
🤖 ## Summary
- Prevent finite f64 averages from overflowing during aggregate evaluation.
- Preserve correct maintained-subscription updates and retractions.

## Before
Averages of large finite f64 values could overflow an intermediate sum and become non-finite.

## After
The average calculation remains finite for valid finite inputs, including maintained aggregate updates and retractions.

## Test plan
- [x] Focused Groove SQL aggregate regression test
- [x] Focused maintained aggregate subscription regression test

## Integration status

Rebased into the stable-fixes stack on main, with independent review corrections included. Review found unconditional normalization could erase the small residual in AVG(MAX, -MAX, 1e-20). The integrated version keeps the ordinary sum when finite, using scaling only for overflow. Overflow, cancellation and maintained update/retraction regressions pass. Full combined CI is green.
