### PR TITLE
bench: correlate cold-load CPU samples with phase timelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,6 +2348,7 @@ dependencies = [
  "postcard",
  "pprof",
  "rusqlite",
+ "serde",
  "serde_json",
  "tempfile",
  "tracing",

--- a/crates/jazz-sim/Cargo.toml
+++ b/crates/jazz-sim/Cargo.toml
@@ -11,7 +11,7 @@ bench-alloc-sites = ["dep:backtrace"]
 profiling = ["dep:pprof"]
 transport-compression-lz4 = ["jazz/transport-compression-lz4"]
 transport-compression-zstd = ["jazz/transport-compression-zstd"]
-cold-settle-attribution = ["jazz/cold-settle-attribution", "dep:tracing"]
+cold-settle-attribution = ["jazz/cold-settle-attribution", "dep:tracing", "dep:serde"]
 
 [dependencies]
 tracing = { version = "0.1", optional = true }
@@ -29,6 +29,7 @@ libc = "0.2"
 pprof = { version = "0.15.0", features = ["flamegraph"], optional = true }
 postcard = { version = "1.1.3", features = ["alloc"] }
 rusqlite = { version = "0.34", features = ["bundled"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = "1.0.145"
 tempfile = "3.27.0"
 uuid = "1.18.1"

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -1610,15 +1610,15 @@ fn run_connect_and_subscribe(
     expected: &BTreeMap<String, usize>,
     config: &Config,
 ) -> RunSummary {
-    #[cfg(feature = "bench-perf-control")]
-    let mut perf_control = PerfControl::start();
-    alloc_metrics::reset_and_start();
     #[cfg(feature = "cold-settle-attribution")]
     {
         jazz_sim::phase_attribution::reset();
         jazz::cold_settle_attribution::reset();
         jazz::groove::cold_settle_attribution::reset();
     }
+    alloc_metrics::reset_and_start();
+    #[cfg(feature = "bench-perf-control")]
+    let mut perf_control = PerfControl::start();
     let start = Instant::now();
     let relay_core = duplex_counted();
     let client_relay = duplex_counted();
@@ -1774,6 +1774,11 @@ fn run_connect_and_subscribe(
     #[cfg(feature = "cold-settle-attribution")]
     {
         attribution.phase_timing = jazz_sim::phase_attribution::snapshot();
+        if let Some(mut path) = std::env::var_os("JAZZ_PHASE_TIMELINE") {
+            path.push(format!(".{label}.json"));
+            jazz_sim::phase_attribution::write_timeline(std::path::Path::new(&path))
+                .expect("write phase CPU timeline");
+        }
     }
     if label == "warm" {
         // Warm readiness is relay-local, but the benchmark also asserts that

--- a/crates/jazz-sim/src/phase_attribution.rs
+++ b/crates/jazz-sim/src/phase_attribution.rs
@@ -46,8 +46,13 @@ struct Frame {
     start: u64,
     children: u64,
 }
+const MAX_TIMELINE_INTERVALS: usize = 1_000_000;
+
 struct State {
     epoch: Instant,
+    // [start_ns, end_ns, phase, role, depth], recorded only when requested.
+    timeline: Option<Vec<[u64; 5]>>,
+    timeline_dropped: u64,
     stack: Vec<Frame>,
     totals: [[Timing; PHASES.len()]; ROLES.len()],
 }
@@ -55,12 +60,33 @@ impl Default for State {
     fn default() -> Self {
         Self {
             epoch: Instant::now(),
+            timeline: None,
+            timeline_dropped: 0,
             stack: Vec::new(),
             totals: [[Timing::default(); PHASES.len()]; ROLES.len()],
         }
     }
 }
 impl State {
+    fn now(&self) -> u64 {
+        if self.timeline.is_some() {
+            #[cfg(target_os = "linux")]
+            {
+                let mut time = libc::timespec {
+                    tv_sec: 0,
+                    tv_nsec: 0,
+                };
+                assert_eq!(
+                    unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut time) },
+                    0
+                );
+                return time.tv_sec as u64 * 1_000_000_000 + time.tv_nsec as u64;
+            }
+            #[cfg(not(target_os = "linux"))]
+            unreachable!("phase CPU timelines require Linux CLOCK_MONOTONIC");
+        }
+        self.epoch.elapsed().as_nanos() as u64
+    }
     fn enter(&mut self, phase: usize, now: u64) {
         let role = if phase < 3 {
             phase + 1
@@ -79,6 +105,19 @@ impl State {
     fn exit(&mut self, phase: usize, now: u64) {
         let frame = self.stack.pop().expect("balanced phase spans");
         assert_eq!(frame.phase, phase, "phase span exit must match enter");
+        if let Some(timeline) = &mut self.timeline {
+            if timeline.len() < MAX_TIMELINE_INTERVALS {
+                timeline.push([
+                    frame.start,
+                    now,
+                    phase as u64,
+                    frame.role as u64,
+                    self.stack.len() as u64,
+                ]);
+            } else {
+                self.timeline_dropped += 1;
+            }
+        }
         let elapsed = now.saturating_sub(frame.start);
         assert!(
             frame.children <= elapsed,
@@ -168,14 +207,14 @@ impl Subscriber for Collector {
     fn enter(&self, id: &Id) {
         STATE.with(|s| {
             let mut s = s.borrow_mut();
-            let now = s.epoch.elapsed().as_nanos() as u64;
+            let now = s.now();
             s.enter(id.into_u64() as usize - 1, now);
         });
     }
     fn exit(&self, id: &Id) {
         STATE.with(|s| {
             let mut s = s.borrow_mut();
-            let now = s.epoch.elapsed().as_nanos() as u64;
+            let now = s.now();
             s.exit(id.into_u64() as usize - 1, now);
         });
     }
@@ -184,11 +223,58 @@ impl Subscriber for Collector {
 pub fn reset() {
     STATE.with(|s| {
         assert!(s.borrow().stack.is_empty());
-        *s.borrow_mut() = State::default();
+        let mut state = State::default();
+        if std::env::var_os("JAZZ_PHASE_TIMELINE").is_some() {
+            assert!(
+                cfg!(target_os = "linux"),
+                "phase CPU timelines require Linux CLOCK_MONOTONIC"
+            );
+            state.timeline = Some(Vec::with_capacity(MAX_TIMELINE_INTERVALS));
+        }
+        *s.borrow_mut() = state;
         #[cfg(feature = "bench-alloc-sites")]
         allocations::set_current(None);
     });
 }
+/// Write the requested timeline after readiness and after CPU recording stops.
+/// Other threads must remain a separate bucket when joining samples by TID.
+pub fn write_timeline(path: &std::path::Path) -> std::io::Result<()> {
+    #[derive(serde::Serialize)]
+    struct Document<'a> {
+        clock: &'static str,
+        owner_tid: u64,
+        columns: [&'static str; 5],
+        phases: &'a [&'static str],
+        roles: &'a [&'static str],
+        dropped_intervals: u64,
+        intervals: &'a [[u64; 5]],
+    }
+    STATE.with(|state| {
+        let state = state.borrow();
+        assert!(state.stack.is_empty());
+        let intervals = state
+            .timeline
+            .as_deref()
+            .expect("timeline must be enabled at reset");
+        #[cfg(target_os = "linux")]
+        let owner_tid = unsafe { libc::syscall(libc::SYS_gettid) } as u64;
+        #[cfg(not(target_os = "linux"))]
+        let owner_tid = 0;
+        let document = Document {
+            clock: "CLOCK_MONOTONIC",
+            owner_tid,
+            columns: ["start_ns", "end_ns", "phase", "role", "depth"],
+            phases: &PHASES,
+            roles: &ROLES,
+            dropped_intervals: state.timeline_dropped,
+            intervals,
+        };
+        let mut writer = std::io::BufWriter::new(std::fs::File::create(path)?);
+        serde_json::to_writer(&mut writer, &document)?;
+        std::io::Write::flush(&mut writer)
+    })
+}
+
 /// Capture before diagnostic queries. Inclusive times overlap; exclusive times
 /// partition outer ticks. `entries` counts span entries (polls and scoped cleanup), not logical operations.
 pub fn snapshot() -> serde_json::Value {
@@ -208,7 +294,7 @@ pub fn snapshot() -> serde_json::Value {
             roles.insert((*name).into(), phases.into());
         }
         #[allow(unused_mut)]
-        let mut result = serde_json::json!({"roles":roles, "scope":"setup_and_settle_only", "units":"nanoseconds", "exclusive_times_are_additive":true, "inclusive_times_overlap":true});
+        let mut result = serde_json::json!({"roles":roles, "scope":"setup_and_settle_only", "units":"nanoseconds", "exclusive_times_are_additive":true, "inclusive_times_overlap":true, "timeline_enabled":s.timeline.is_some(), "timeline_dropped_intervals":s.timeline_dropped});
         #[cfg(feature = "bench-alloc-sites")]
         { result["allocation_counts"] = allocations::snapshot(); }
         result
@@ -218,6 +304,36 @@ pub fn snapshot() -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Internal deterministic timestamps establish nesting and bounded capture;
+    // neither property is observable through the database API.
+    #[test]
+    fn timeline_records_nested_intervals_and_reports_truncation() {
+        let mut state = State::default();
+        state.timeline = Some(Vec::new());
+        state.enter(0, 10);
+        state.enter(4, 20);
+        state.exit(4, 40);
+        state.exit(0, 50);
+        assert_eq!(
+            state.timeline.as_ref().unwrap(),
+            &[[20, 40, 4, 1, 1], [10, 50, 0, 1, 0],]
+        );
+        assert_eq!(state.totals[1][0].exclusive_ns, 20);
+        state
+            .timeline
+            .as_mut()
+            .unwrap()
+            .resize(MAX_TIMELINE_INTERVALS, [0; 5]);
+        state.enter(1, 60);
+        state.exit(1, 70);
+        assert_eq!(
+            state.timeline.as_ref().unwrap().len(),
+            MAX_TIMELINE_INTERVALS
+        );
+        assert_eq!(state.timeline_dropped, 1);
+        assert_eq!(state.totals[2][1].inclusive_ns, 10);
+    }
+
     #[cfg(feature = "bench-alloc-sites")]
     #[test]
     fn allocation_counts_follow_innermost_phase_and_restore_parent() {

--- a/dev/benchmarks/phase-cpu-summary.py
+++ b/dev/benchmarks/phase-cpu-summary.py
@@ -1,0 +1,61 @@
+import argparse, bisect, collections, heapq, json, re
+from pathlib import Path
+p=argparse.ArgumentParser()
+p.add_argument('timeline', type=Path)
+p.add_argument('perf_script', type=Path)
+p.add_argument('--kernel-symbols', type=Path)
+a=p.parse_args()
+doc=json.loads(a.timeline.read_text())
+assert doc['clock']=='CLOCK_MONOTONIC', 'capture perf with --clockid mono'
+assert doc['dropped_intervals']==0, 'timeline truncated; do not attribute this capture'
+assert doc['columns']==['start_ns','end_ns','phase','role','depth']
+intervals=sorted(doc['intervals']); owner=doc['owner_tid']
+kernel=[]
+if a.kernel_symbols:
+ for line in a.kernel_symbols.open():
+  parts=line.split()
+  if len(parts)>=3:
+   address=int(parts[0],16)
+   if address>=0xffff000000000000: kernel.append((address,parts[2]))
+ kernel.sort()
+addresses=[x[0] for x in kernel]
+samples=[]; current=None
+for line in a.perf_script.open():
+ m=re.match(r'\s*(\d+)/(\d+)\s+(\d+)\.(\d+):\s+(\d+)\s+cycles',line)
+ if m:
+  current={'tid':int(m[2]),'time':int(m[3])*10**9+int(m[4].ljust(9,'0')),'period':int(m[5]),'stack':[]}
+  samples.append(current)
+ elif current is not None and line.startswith('\t'):
+  m=re.match(r'\s*([0-9a-f]+)\s+(.*?)\s+\([^)]*\)\s*$',line)
+  if m:
+   name=m[2]; addr=int(m[1],16)
+   if name=='[unknown]' and kernel and addr>=0xffff000000000000:
+    i=bisect.bisect_right(addresses,addr)-1
+    if i>=0 and addr-addresses[i]<65536: name='kernel:'+kernel[i][1]
+   current['stack'].append(name)
+assert samples, 'no samples; use perf script --ns -F pid,tid,time,period,event,ip,sym,dso'
+phases=collections.Counter(); counts=collections.Counter(); leaves=collections.defaultdict(collections.Counter)
+active=[]; index=0
+for sample in sorted(samples,key=lambda s:s['time']):
+ t=sample['time']
+ while index<len(intervals) and intervals[index][0]<=t:
+  start,end,phase,role,depth=intervals[index]
+  if end>t: heapq.heappush(active,(-depth,end,index,phase,role))
+  index+=1
+ while active and active[0][1]<=t: heapq.heappop(active)
+ if sample['tid']!=owner: name='other threads'
+ elif not active: name='outside recorded phases'
+ else:
+  _,_,_,phase,role=active[0]
+  name=doc['roles'][role]+'/'+doc['phases'][phase]
+ period=sample['period']; phases[name]+=period; counts[name]+=1
+ leaves[name][sample['stack'][0] if sample['stack'] else '[empty stack]']+=period
+ sample['phase']=name
+print('Samples:',len(samples),'empty stacks:',sum(not s['stack'] for s in samples),'intervals:',len(intervals))
+total=sum(phases.values())
+print('Exclusive phase attribution (% of all sampled cycles; not wall time):')
+for name,period in phases.most_common():
+ print(f'{100*period/total:6.2f}% {counts[name]:5d} samples {name}')
+for name,_ in phases.most_common(12):
+ print('\n'+name+' — leading self frames (% within phase):')
+ for leaf,period in leaves[name].most_common(10): print(f'{100*period/phases[name]:6.2f}% {leaf}')

--- a/dev/benchmarks/phase-cpu-timeline.md
+++ b/dev/benchmarks/phase-cpu-timeline.md
@@ -1,0 +1,51 @@
+# Match CPU samples to benchmark phases
+
+Build `customer_cold_start` with `cold-settle-attribution,bench-perf-control`.
+Set `JAZZ_PHASE_TIMELINE` to an output prefix, alongside the existing perf control
+and acknowledgement FIFO variables. The benchmark writes `<prefix>.cold.json`
+or `<prefix>.warm.json` after readiness. Capture with `perf record --clockid mono`
+and the existing acknowledged `--delay=-1 --control fd:3,4` setup. Keep CPU
+sampling and allocation sampling separate.
+
+Extract and summarize:
+
+```sh
+perf script -i capture.data --no-inline --ns \
+  -F pid,tid,time,period,event,ip,sym,dso > capture.script
+python3 dev/benchmarks/phase-cpu-summary.py phases.cold.json capture.script
+```
+
+The parser assigns each owner-thread sample to the deepest active interval.
+Other threads and samples outside all intervals remain explicit buckets.
+Percentages use sampled cycle periods, not sample counts or wall time. The
+optional `--kernel-symbols` file must come from the same host boot as the capture;
+without it unresolved kernel addresses stay unknown.
+
+Capture is bounded at one million intervals; a nonzero dropped count rejects
+analysis. Intervals use Linux CLOCK_MONOTONIC directly. They do not depend on
+recovering an async caller or on correlating two independently sampled epochs.
+The interval buffer is reserved before measurement and written afterward.
+These are diagnostic builds: clock reads, tracing and sampling have overhead.
+In particular this host's HPET clock path makes phase instrumentation noticeable.
+Use the feature-free executable for absolute latency.
+
+## First receipt
+
+At runtime #2841, the timeline capture materialized all 27,518 rows and recorded
+641,651 intervals without truncation. Perf reported 10,164 samples, none with an
+empty stack, and no sample loss. About 0.97% of sampled cycles belonged to other
+threads and 0.86% were outside recorded phases. Incomplete repository stacks no
+longer prevent phase attribution.
+
+The largest exclusive role/phase pairs were relay ingest (7.06%), relay storage
+apply (6.90%), relay IVM update (5.66%), Core query-output decoding (5.07%), and
+relay query setup (4.99%). No single small helper dominates. Allocation, freeing
+and copying occur across these phases, so reducing common value representation
+cost is a stronger next thesis than optimizing the roughly 2% fresh join-index
+construction seen in the preceding uninstrumented CPU capture.
+
+Compiler-emitted layout constants confirm that `Value` occupies 152 bytes,
+`LargeValueRef` 152 bytes, `OwnedRecord` 32 bytes and `EnumValue` 40 bytes on this
+native target. The inline large-reference variant makes even ordinary scalar
+`Value` entries large. Moving that uncommon payload behind indirection is a
+candidate, not yet a measured improvement in this receipt.


### PR DESCRIPTION
🤖 Record an optional phase timeline so native CPU samples can be attributed even when async or stack-switching boundaries leave incomplete call stacks. Set `JAZZ_PHASE_TIMELINE` to an output prefix in a Linux `cold-settle-attribution` benchmark build; the benchmark writes `<prefix>.cold.json` or `<prefix>.warm.json` after readiness.

Each interval names its phase, runtime role and nesting depth and uses absolute `CLOCK_MONOTONIC` timestamps. The file identifies the owner thread; matching perf samples must use `--clockid mono` and include TID. Attribute an owner-thread sample to the deepest active interval, while keeping other threads and samples outside intervals separate. Inclusive intervals overlap; resulting innermost sample assignments do not.

Capture reserves bounded space for one million intervals before measurement, reports dropped intervals explicitly, and performs file I/O only after CPU capture and allocation counting stop. A truncated timeline must not be used for attribution. Without the opt-in variable, no interval buffer is allocated and the existing relative clock path remains. This is benchmark-only diagnostics, not a production storage or wire format.

All four phase tests pass, including allocation accounting. A sensitivity check fails when nesting depth is removed; exact restoration passes. The affected benchmark compiles, and commit checks pass. The optimized end-to-end capture materialized all 27,518 rows and recorded 641,651 intervals without truncation. Perf reported 10,164 samples, no empty stacks and no sample loss. The included analyzer preserves other-thread and unscoped buckets; synthetic nesting/thread/truncation checks pass. The report records phase shares and the next value-layout thesis. Draft on #2841; diagnostic overhead is explicit and these runs are not clean latency measurements.
