### PR TITLE
Serialize native transport retirement

### DIFF
--- a/.changeset/bug-322-transport-retirement.md
+++ b/.changeset/bug-322-transport-retirement.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Serialize native transport retirement before admitting replacements.

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -468,6 +468,17 @@ type ServerReplacementIntent = {
   url: string;
   authJson: string;
 };
+function joinServerTransportRetirements(
+  previous: Promise<void> | null,
+  next: Promise<void>,
+): Promise<void> {
+  if (!previous) return next;
+  return Promise.allSettled([previous, next]).then((results) => {
+    for (const result of results) {
+      if (result.status === "rejected") throw result.reason;
+    }
+  });
+}
 
 type AuxiliaryRelayTrace = {
   event: string;
@@ -667,6 +678,7 @@ export class NativeRuntimeAdapter implements Runtime {
   private serverCarrier: WebSocketCarrier | null = null;
   private serverCarrierPromise: Promise<WebSocketCarrier> | null = null;
   private serverConnectionAttempt: ServerConnectionAttempt | null = null;
+  private serverReplacementRetirement: Promise<void> | null = null;
   private serverReplacementIntent: ServerReplacementIntent | null = null;
   private serverReplacementPromise: Promise<WebSocketCarrier> | null = null;
   private serverTransportError: Error | null = null;
@@ -1978,10 +1990,17 @@ export class NativeRuntimeAdapter implements Runtime {
       authJson: normalizedAuthJson,
     };
     this.serverReplacementIntent = intent;
+    this.serverReplacementRetirement = joinServerTransportRetirements(
+      this.serverReplacementRetirement,
+      predecessorRetirement,
+    );
     let replacement = this.serverReplacementPromise;
     if (!replacement) {
-      replacement = predecessorRetirement.then(async () => {
+      replacement = (async () => {
         for (;;) {
+          const retirement = this.serverReplacementRetirement;
+          this.serverReplacementRetirement = null;
+          if (retirement) await retirement;
           const latest = this.serverReplacementIntent;
           if (!latest || this.closed) throw new Error("server transport disconnected");
           this.serverReplacementIntent = null;
@@ -1996,14 +2015,14 @@ export class NativeRuntimeAdapter implements Runtime {
             }
             throw error;
           }
-          if (!this.serverReplacementIntent) {
+          if (!this.serverReplacementIntent && !this.serverReplacementRetirement) {
             if (!this.serverCarrierPromise) {
               throw new Error("server transport connection was not started");
             }
             return await this.serverCarrierPromise;
           }
         }
-      });
+      })();
       this.serverReplacementPromise = replacement;
       replacement.then(
         () => {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -461,6 +461,7 @@ type ServerConnectionAttempt = {
   outcome: Error | null;
   transport: Transport | null;
   retirement: Promise<void> | null;
+  admission: Promise<Transport> | null;
   recovery?: Promise<WebSocketCarrier>;
 };
 type ServerReplacementIntent = {
@@ -2119,6 +2120,7 @@ export class NativeRuntimeAdapter implements Runtime {
       outcome: null,
       transport: null,
       retirement: null,
+      admission: null,
     };
     this.serverConnectionAttempt = attempt;
     this.serverCarrier = carrier;
@@ -2155,20 +2157,15 @@ export class NativeRuntimeAdapter implements Runtime {
         const admission = this.connectNegotiatedUpstream(negotiation).catch((error) => {
           throw contextualError("connecting the negotiated upstream transport", error);
         });
+        attempt.admission = admission;
         const outcome = await Promise.race([
           admission.then((transport) => ({ type: "admitted" as const, transport })),
           attempt.terminal.then((error) => ({ type: "terminal" as const, error })),
         ]);
         if (outcome.type === "terminal") {
-          admission.then(
-            (transport) =>
-              this.retirePeerTransport(transport).catch((error) => {
-                this.handleServerTransportError(error);
-              }),
-            () => undefined,
-          );
           throw outcome.error;
         }
+        attempt.admission = null;
         const transport = outcome.transport;
         if (
           this.closed ||
@@ -2177,7 +2174,8 @@ export class NativeRuntimeAdapter implements Runtime {
           attempt !== this.serverConnectionAttempt
         ) {
           carrier.close();
-          await this.retirePeerTransport(transport);
+          if (attempt.finished) await attempt.retirement;
+          else await this.retirePeerTransport(transport);
           return carrier;
         }
         this.networkRetryCount = 0;
@@ -3580,6 +3578,27 @@ export class NativeRuntimeAdapter implements Runtime {
           if (!this.closed) this.handleServerTransportError(error);
         });
       }
+    }
+    if (attempt.admission) {
+      const admission = attempt.admission;
+      attempt.admission = null;
+      attempt.retirement = admission.then(
+        (transport) => this.retirePeerTransport(transport),
+        () => undefined,
+      );
+      attempt.retirement.catch((retirementError) => {
+        if (!this.closed) this.handleServerTransportError(retirementError);
+      });
+    }
+    // Keep retirement reachable after retry or terminal cleanup detaches the
+    // attempt, including an admission that has not returned its transport yet.
+    if (attempt.retirement) {
+      this.serverReplacementRetirement = joinServerTransportRetirements(
+        this.serverReplacementRetirement,
+        attempt.retirement,
+      );
+      // Retry may own this barrier before any replacement consumes it.
+      this.serverReplacementRetirement.catch(() => undefined);
     }
     if (isCurrent) {
       if (publishError) this.handleServerTransportError(error);

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -1985,7 +1985,17 @@ export class NativeRuntimeAdapter implements Runtime {
           const latest = this.serverReplacementIntent;
           if (!latest || this.closed) throw new Error("server transport disconnected");
           this.serverReplacementIntent = null;
-          await this.startServerConnection(latest);
+          try {
+            await this.startServerConnection(latest);
+          } catch (error) {
+            if (
+              this.serverReplacementIntent &&
+              errorMessage(error) === "server transport replaced"
+            ) {
+              continue;
+            }
+            throw error;
+          }
           if (!this.serverReplacementIntent) {
             if (!this.serverCarrierPromise) {
               throw new Error("server transport connection was not started");

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -467,6 +467,7 @@ type ServerReplacementIntent = {
   generation: number;
   url: string;
   authJson: string;
+  features: number;
 };
 function joinServerTransportRetirements(
   previous: Promise<void> | null,
@@ -1977,6 +1978,9 @@ export class NativeRuntimeAdapter implements Runtime {
       return;
     }
     const normalizedAuthJson = normalizeBackendWebSocketAuth(authJson);
+    // Validate synchronously before retiring the current transport. Callers
+    // historically observe an incompatible native binding at connect() time.
+    const features = this.nativeWireFeatures();
     const generation = this.serverConnectionGeneration + 1;
     const predecessorRetirement = this.invalidateServerTransport({
       rejectWaiters: false,
@@ -1988,6 +1992,7 @@ export class NativeRuntimeAdapter implements Runtime {
       generation,
       url,
       authJson: normalizedAuthJson,
+      features,
     };
     this.serverReplacementIntent = intent;
     this.serverReplacementRetirement = joinServerTransportRetirements(
@@ -1998,28 +2003,29 @@ export class NativeRuntimeAdapter implements Runtime {
     if (!replacement) {
       replacement = (async () => {
         for (;;) {
-          const retirement = this.serverReplacementRetirement;
-          this.serverReplacementRetirement = null;
-          if (retirement) await retirement;
+          while (this.serverReplacementRetirement) {
+            const retirement = this.serverReplacementRetirement;
+            this.serverReplacementRetirement = null;
+            await retirement;
+          }
           const latest = this.serverReplacementIntent;
           if (!latest || this.closed) throw new Error("server transport disconnected");
           this.serverReplacementIntent = null;
+          let connected: WebSocketCarrier;
           try {
-            await this.startServerConnection(latest);
+            connected = await this.startServerConnection(latest);
           } catch (error) {
             if (
               this.serverReplacementIntent &&
-              errorMessage(error) === "server transport replaced"
+              (errorMessage(error) === "server transport replaced" ||
+                errorMessage(error) === "server transport disconnected")
             ) {
               continue;
             }
             throw error;
           }
           if (!this.serverReplacementIntent && !this.serverReplacementRetirement) {
-            if (!this.serverCarrierPromise) {
-              throw new Error("server transport connection was not started");
-            }
-            return await this.serverCarrierPromise;
+            return connected;
           }
         }
       })();
@@ -2045,7 +2051,7 @@ export class NativeRuntimeAdapter implements Runtime {
   }
 
   private async startServerConnection(intent: ServerReplacementIntent): Promise<WebSocketCarrier> {
-    const { generation, url, authJson: normalizedAuthJson } = intent;
+    const { generation, url, authJson: normalizedAuthJson, features } = intent;
     const transportIdentity = peerIdentityForWebSocketAuth(normalizedAuthJson, this.peerIdentity);
     this.serverTransportError = null;
     this.serverEndpointUrl = url;
@@ -2058,7 +2064,7 @@ export class NativeRuntimeAdapter implements Runtime {
     const carrier = new WebSocketCarrier({
       endpointUrl: url,
       peerIdentity: transportIdentity,
-      features: this.nativeWireFeatures(),
+      features,
       authJson: normalizedAuthJson,
       requestedLink: this.scopeIsolatedRelay ? "scope_isolated_client_relay" : undefined,
       onFrame: (frame) => {
@@ -2116,8 +2122,13 @@ export class NativeRuntimeAdapter implements Runtime {
     };
     this.serverConnectionAttempt = attempt;
     this.serverCarrier = carrier;
-    const connection = carrier
-      .ready()
+    const ready = Promise.race([
+      carrier.ready(),
+      attempt.terminal.then((error): never => {
+        throw error;
+      }),
+    ]);
+    const connection = ready
       .then(async (negotiation) => {
         if (
           generation !== this.serverConnectionGeneration ||
@@ -2193,12 +2204,25 @@ export class NativeRuntimeAdapter implements Runtime {
         this.finishServerConnectionAttempt(attempt, failure);
         throw attempt.outcome ?? failure;
       });
-    this.serverCarrierPromise = connection;
     connection.catch((error) => {
       if (isRetryablePreHelloWireError(error)) return;
       this.handleServerTransportError(error, generation);
     });
     return await connection;
+  }
+  private startServerRetry(url: string, authJson: string): Promise<WebSocketCarrier> {
+    const normalizedAuthJson = normalizeBackendWebSocketAuth(authJson);
+    const intent: ServerReplacementIntent = {
+      generation: this.serverConnectionGeneration,
+      url,
+      authJson: normalizedAuthJson,
+      features: this.nativeWireFeatures(),
+    };
+    // Retry from inside the active replacement runner. Calling connect() here
+    // would reuse that runner and make its carrier promise wait on itself.
+    const connection = this.startServerConnection(intent);
+    this.serverCarrierPromise = connection;
+    return connection;
   }
 
   private async connectNegotiatedUpstream(negotiation: WebSocketNegotiation): Promise<Transport> {
@@ -2288,7 +2312,8 @@ export class NativeRuntimeAdapter implements Runtime {
       });
       retirements.push(retirement);
     }
-    return Promise.all(retirements).then(() => undefined);
+    if (retirements.length === 0) return Promise.resolve();
+    return Promise.all(retirements);
   }
 
   async disconnect(
@@ -2726,8 +2751,10 @@ export class NativeRuntimeAdapter implements Runtime {
    */
   private async waitForStrictRemoteQueryTransport(tier: string | null | undefined): Promise<void> {
     if (tier !== "edge" && tier !== "global") return;
-    const endpoint = this.serverEndpointUrl;
-    const identity = peerIdentityForWebSocketAuth(this.serverAuthJson ?? "{}", this.peerIdentity);
+    const initialIntent = this.serverReplacementIntent;
+    const endpoint = initialIntent?.url ?? this.serverEndpointUrl;
+    const identityAuthJson = initialIntent?.authJson ?? this.serverAuthJson ?? "{}";
+    const identity = peerIdentityForWebSocketAuth(identityAuthJson, this.peerIdentity);
     // `connect()` starts its WebSocket handshake before it can admit the
     // native transport. A strict remote read begun in that interval must
     // await the in-flight connection instead of falling through to a local
@@ -2745,20 +2772,21 @@ export class NativeRuntimeAdapter implements Runtime {
           ? await Promise.race([connectionOutcome, attempt.terminal])
           : await connectionOutcome;
       if (this.closed) return;
+      const activeIntent = this.serverReplacementIntent;
+      const activeEndpoint = activeIntent?.url ?? this.serverEndpointUrl;
+      const activeAuthJson = activeIntent?.authJson ?? this.serverAuthJson ?? "{}";
       if (
         this.serverCarrierPromise &&
-        (this.serverEndpointUrl !== endpoint ||
-          !bytesEqual(
-            identity,
-            peerIdentityForWebSocketAuth(this.serverAuthJson ?? "{}", this.peerIdentity),
-          ))
+        (activeEndpoint !== endpoint ||
+          !bytesEqual(identity, peerIdentityForWebSocketAuth(activeAuthJson, this.peerIdentity)))
       )
         throw new Error("server transport scope changed while waiting for remote query");
-      // Reauthentication/reconnect can retire a stalled carrier while this
-      // query is waiting. Follow the replacement attempt; only surface a
-      // terminal error when this was still the current connection.
       if (terminal) {
-        if (this.serverCarrierPromise !== null && this.serverCarrierPromise !== pendingConnection) {
+        if (
+          (terminal.message === "server transport replaced" ||
+            terminal.message === "server transport disconnected") &&
+          this.serverCarrierPromise !== null
+        ) {
           continue;
         }
         throw terminal;
@@ -3440,10 +3468,8 @@ export class NativeRuntimeAdapter implements Runtime {
           ) {
             throw new Error("server transport disconnected");
           }
-          this.connect(url, authJson);
-          if (!this.serverCarrierPromise)
-            throw new Error("server transport reconnect was not started");
-          return await this.serverCarrierPromise;
+          const reconnect = this.startServerRetry(url, authJson);
+          return await reconnect;
         })().then(resolve, reject);
       }, delay);
     });
@@ -3495,12 +3521,7 @@ export class NativeRuntimeAdapter implements Runtime {
           reject(new Error("server transport disconnected"));
           return;
         }
-        this.connect(url, authJson);
-        const reconnect = this.serverCarrierPromise;
-        if (!reconnect) {
-          reject(new Error("server transport reconnect was not started"));
-          return;
-        }
+        const reconnect = this.startServerRetry(url, authJson);
         void reconnect.then(resolve, reject);
       }, delay);
     });
@@ -3539,16 +3560,26 @@ export class NativeRuntimeAdapter implements Runtime {
     attempt.transport = null;
     if (transport) {
       if (transport === this.serverTransport) this.serverTransport = null;
-      let retirement: Promise<void>;
       try {
-        retirement = Promise.resolve(this.retirePeerTransport(transport));
+        if (this.coreOperation) {
+          const retirement = Promise.resolve(this.retirePeerTransport(transport));
+          attempt.retirement = retirement;
+          retirement.catch((retirementError) => {
+            if (!this.closed) this.handleServerTransportError(retirementError);
+          });
+        } else {
+          // A synchronous close is already complete. Avoid adding an
+          // unnecessary promise barrier to the ordinary replacement path.
+          this.retirePeerTransport(transport);
+          attempt.retirement = null;
+        }
       } catch (retirementError) {
-        retirement = Promise.reject(retirementError);
+        const retirement = Promise.reject(retirementError);
+        attempt.retirement = retirement;
+        retirement.catch((error) => {
+          if (!this.closed) this.handleServerTransportError(error);
+        });
       }
-      attempt.retirement = retirement;
-      retirement.catch((retirementError) => {
-        if (!this.closed) this.handleServerTransportError(retirementError);
-      });
     }
     if (isCurrent) {
       if (publishError) this.handleServerTransportError(error);

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -2007,7 +2007,18 @@ export class NativeRuntimeAdapter implements Runtime {
           while (this.serverReplacementRetirement) {
             const retirement = this.serverReplacementRetirement;
             this.serverReplacementRetirement = null;
-            await retirement;
+            try {
+              await retirement;
+            } catch (error) {
+              // A failed close still owns its predecessor. Future connect()
+              // calls must not erase that failure and admit another transport.
+              this.serverReplacementRetirement = joinServerTransportRetirements(
+                this.serverReplacementRetirement,
+                retirement,
+              );
+              this.serverReplacementRetirement.catch(() => undefined);
+              throw error;
+            }
           }
           const latest = this.serverReplacementIntent;
           if (!latest || this.closed) throw new Error("server transport disconnected");
@@ -2281,7 +2292,7 @@ export class NativeRuntimeAdapter implements Runtime {
       this.networkRetryCount = 0;
     }
     this.clearServerReconnectTimer();
-    this.serverTransportError = null;
+    if (!this.serverReplacementRetirement) this.serverTransportError = null;
     if (options.rejectWaiters) {
       this.resolveServerTransportErrorWaiters(new Error("server transport disconnected"));
     } else if (!options.preserveRemoteWaiters) {

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -2313,7 +2313,7 @@ export class NativeRuntimeAdapter implements Runtime {
       retirements.push(retirement);
     }
     if (retirements.length === 0) return Promise.resolve();
-    return Promise.all(retirements);
+    return Promise.all(retirements).then(() => undefined);
   }
 
   async disconnect(

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -463,6 +463,11 @@ type ServerConnectionAttempt = {
   retirement: Promise<void> | null;
   recovery?: Promise<WebSocketCarrier>;
 };
+type ServerReplacementIntent = {
+  generation: number;
+  url: string;
+  authJson: string;
+};
 
 type AuxiliaryRelayTrace = {
   event: string;
@@ -662,6 +667,8 @@ export class NativeRuntimeAdapter implements Runtime {
   private serverCarrier: WebSocketCarrier | null = null;
   private serverCarrierPromise: Promise<WebSocketCarrier> | null = null;
   private serverConnectionAttempt: ServerConnectionAttempt | null = null;
+  private serverReplacementIntent: ServerReplacementIntent | null = null;
+  private serverReplacementPromise: Promise<WebSocketCarrier> | null = null;
   private serverTransportError: Error | null = null;
   private serverTransportErrorWaiters: ServerTransportErrorWaiter[] = [];
   private serverTransportWorkEpoch = 0;
@@ -1958,15 +1965,58 @@ export class NativeRuntimeAdapter implements Runtime {
       return;
     }
     const normalizedAuthJson = normalizeBackendWebSocketAuth(authJson);
-    // A new transport replaces the old one during a temporary reconnect. Server-tier
-    // waits are still meaningful across that transition, so only an explicit runtime
-    // shutdown is allowed to reject them.
-    void this.disconnect({
+    const generation = this.serverConnectionGeneration + 1;
+    const predecessorRetirement = this.invalidateServerTransport({
       rejectWaiters: false,
       preservePreHelloRetry: true,
-      preserveRemoteWaiters: this.networkRetryCount > 0,
+      preserveRemoteWaiters: true,
+      error: new Error("server transport replaced"),
     });
-    const generation = ++this.serverConnectionGeneration;
+    const intent: ServerReplacementIntent = {
+      generation,
+      url,
+      authJson: normalizedAuthJson,
+    };
+    this.serverReplacementIntent = intent;
+    let replacement = this.serverReplacementPromise;
+    if (!replacement) {
+      replacement = predecessorRetirement.then(async () => {
+        for (;;) {
+          const latest = this.serverReplacementIntent;
+          if (!latest || this.closed) throw new Error("server transport disconnected");
+          this.serverReplacementIntent = null;
+          await this.startServerConnection(latest);
+          if (!this.serverReplacementIntent) {
+            if (!this.serverCarrierPromise) {
+              throw new Error("server transport connection was not started");
+            }
+            return await this.serverCarrierPromise;
+          }
+        }
+      });
+      this.serverReplacementPromise = replacement;
+      replacement.then(
+        () => {
+          if (this.serverReplacementPromise === replacement) this.serverReplacementPromise = null;
+        },
+        (error: unknown) => {
+          if (this.serverReplacementPromise === replacement) {
+            this.serverReplacementPromise = null;
+            if (this.serverCarrierPromise === replacement) this.serverCarrierPromise = null;
+          }
+          if (!this.closed && errorMessage(error) !== "server transport disconnected") {
+            this.handleServerTransportError(error);
+          }
+        },
+      );
+    }
+    // Keep every caller that observed the old carrier on the same lifecycle
+    // barrier, even when a newer replacement supersedes its intent.
+    this.serverCarrierPromise = replacement;
+  }
+
+  private async startServerConnection(intent: ServerReplacementIntent): Promise<WebSocketCarrier> {
+    const { generation, url, authJson: normalizedAuthJson } = intent;
     const transportIdentity = peerIdentityForWebSocketAuth(normalizedAuthJson, this.peerIdentity);
     this.serverTransportError = null;
     this.serverEndpointUrl = url;
@@ -2037,7 +2087,7 @@ export class NativeRuntimeAdapter implements Runtime {
     };
     this.serverConnectionAttempt = attempt;
     this.serverCarrier = carrier;
-    this.serverCarrierPromise = carrier
+    const connection = carrier
       .ready()
       .then(async (negotiation) => {
         if (
@@ -2070,8 +2120,11 @@ export class NativeRuntimeAdapter implements Runtime {
           attempt.terminal.then((error) => ({ type: "terminal" as const, error })),
         ]);
         if (outcome.type === "terminal") {
-          void admission.then(
-            (transport) => this.retirePeerTransport(transport).catch(reportAsyncRuntimeError),
+          admission.then(
+            (transport) =>
+              this.retirePeerTransport(transport).catch((error) => {
+                this.handleServerTransportError(error);
+              }),
             () => undefined,
           );
           throw outcome.error;
@@ -2091,7 +2144,9 @@ export class NativeRuntimeAdapter implements Runtime {
         attempt.transport = transport;
         this.serverTransport = transport;
         transport.setAuxiliaryTraceEnabled?.(this.auxiliaryTraceListeners.size > 0);
-        void this.watchAuxiliaryOutbound(transport, carrier, generation);
+        this.watchAuxiliaryOutbound(transport, carrier, generation).catch((error) =>
+          this.handleServerTransportError(error, generation),
+        );
         this.flushQueuedServerFrames(carrier);
         await this.pumpServerTransport();
         this.pumpSubscriptions();
@@ -2107,10 +2162,12 @@ export class NativeRuntimeAdapter implements Runtime {
         this.finishServerConnectionAttempt(attempt, failure);
         throw attempt.outcome ?? failure;
       });
-    this.serverCarrierPromise.catch((error) => {
+    this.serverCarrierPromise = connection;
+    connection.catch((error) => {
       if (isRetryablePreHelloWireError(error)) return;
       this.handleServerTransportError(error, generation);
     });
+    return await connection;
   }
 
   private async connectNegotiatedUpstream(negotiation: WebSocketNegotiation): Promise<Transport> {
@@ -2149,6 +2206,60 @@ export class NativeRuntimeAdapter implements Runtime {
     return this.db.nativeConnectionStatus?.().configured === true;
   }
 
+  private invalidateServerTransport(options: {
+    rejectWaiters: boolean;
+    preservePreHelloRetry: boolean;
+    preserveRemoteWaiters: boolean;
+    error: Error;
+  }): Promise<void> {
+    const attempt = this.serverConnectionAttempt;
+    const transport = this.serverTransport;
+    const attemptTransport = attempt?.transport;
+    if (attempt) {
+      this.finishServerConnectionAttempt(attempt, options.error, false);
+    } else {
+      this.serverConnectionGeneration += 1;
+      this.serverConnectionAttempt = null;
+      this.serverCarrier?.close();
+      this.serverCarrier = null;
+    }
+    if (!options.preservePreHelloRetry) {
+      this.preHelloRetryCount = 0;
+      this.networkRetryCount = 0;
+    }
+    this.clearServerReconnectTimer();
+    this.serverTransportError = null;
+    if (options.rejectWaiters) {
+      this.resolveServerTransportErrorWaiters(new Error("server transport disconnected"));
+    } else if (!options.preserveRemoteWaiters) {
+      this.clearServerTransportErrorWaiters();
+    }
+    this.resolveServerTransportWorkWaiters();
+    this.serverTransport = null;
+    this.serverEndpointUrl = null;
+    this.serverAuthJson = null;
+    this.queuedServerFrames.length = 0;
+    this.pendingInboundServerFrames.length = 0;
+    this.serverPumpScheduled = false;
+    this.serverPumpAgain = false;
+    if (!this.serverReplacementPromise) this.serverCarrierPromise = null;
+    const retirements: Promise<void>[] = [];
+    if (attempt?.retirement) retirements.push(attempt.retirement);
+    if (transport && transport !== attemptTransport) {
+      let retirement: Promise<void>;
+      try {
+        retirement = Promise.resolve(this.retirePeerTransport(transport));
+      } catch (retirementError) {
+        retirement = Promise.reject(retirementError);
+      }
+      retirement.catch((error) => {
+        if (!this.closed) this.handleServerTransportError(error);
+      });
+      retirements.push(retirement);
+    }
+    return Promise.all(retirements).then(() => undefined);
+  }
+
   async disconnect(
     options: {
       rejectWaiters?: boolean;
@@ -2161,48 +2272,29 @@ export class NativeRuntimeAdapter implements Runtime {
       this.db.disconnectNativeUpstream();
       return;
     }
-    this.serverConnectionGeneration += 1;
-    this.clearServerReconnectTimer();
-    if (!options.preservePreHelloRetry) {
-      this.preHelloRetryCount = 0;
-      this.networkRetryCount = 0;
-    }
-    const attempt = this.serverConnectionAttempt;
-    this.serverConnectionAttempt = null;
-    if (attempt) {
-      this.finishServerConnectionAttempt(attempt, new Error("server transport disconnected"));
-    }
-    this.serverCarrier?.close();
-    this.serverCarrier = null;
+    this.serverReplacementIntent = null;
+    const pendingReplacement = this.serverReplacementPromise;
+    const retirement = this.invalidateServerTransport({
+      rejectWaiters: options.rejectWaiters ?? true,
+      preservePreHelloRetry: options.preservePreHelloRetry ?? false,
+      preserveRemoteWaiters: options.preserveRemoteWaiters ?? false,
+      error: new Error("server transport disconnected"),
+    });
     this.serverCarrierPromise = null;
-    this.serverTransportError = null;
-    if (options.rejectWaiters ?? true) {
-      this.resolveServerTransportErrorWaiters(new Error("server transport disconnected"));
-    } else if (!options.preserveRemoteWaiters) {
-      this.clearServerTransportErrorWaiters();
+    try {
+      if (pendingReplacement) await pendingReplacement;
+    } catch (error) {
+      if (errorMessage(error) !== "server transport disconnected") throw error;
     }
-    this.resolveServerTransportWorkWaiters();
-    const transport = this.serverTransport;
-    this.serverTransport = null;
-    this.serverEndpointUrl = null;
-    this.serverAuthJson = null;
-    this.queuedServerFrames.length = 0;
-    this.pendingInboundServerFrames.length = 0;
-    this.serverPumpScheduled = false;
-    this.serverPumpAgain = false;
-    // Db::tick borrows peer connections across its async evaluator pass.
-    // Detaching the transport while that borrow is live panics on WASM's
-    // single-threaded RefCell mutex. Remove it from new work immediately, then
-    // perform the physical detach once the owning tick has released the borrow.
-    if (transport) await this.retirePeerTransport(transport);
-    if (attempt?.retirement) await attempt.retirement;
+    await retirement;
   }
 
   updateAuth(authJson: string): Promise<void> | void {
     if (this !== this.ownerRuntime) return this.ownerRuntime.updateAuth(authJson);
     if (this.db?.rejectAuthUpdate) return this.db.rejectAuthUpdate();
-    if (!this.serverEndpointUrl) return;
-    return this.connect(this.serverEndpointUrl, authJson);
+    const endpoint = this.serverEndpointUrl ?? this.serverReplacementIntent?.url;
+    if (!endpoint) return;
+    return this.connect(endpoint, authJson);
   }
 
   onAuthFailure(callback: (reason: string) => void): void {
@@ -3392,7 +3484,11 @@ export class NativeRuntimeAdapter implements Runtime {
     this.serverReconnectReject = null;
   }
 
-  private finishServerConnectionAttempt(attempt: ServerConnectionAttempt, error: Error): void {
+  private finishServerConnectionAttempt(
+    attempt: ServerConnectionAttempt,
+    error: Error,
+    publishError = true,
+  ): void {
     if (attempt.finished) return;
     attempt.finished = true;
     attempt.outcome = error;
@@ -3405,17 +3501,26 @@ export class NativeRuntimeAdapter implements Runtime {
       this.serverConnectionGeneration += 1;
       this.serverConnectionAttempt = null;
       this.serverCarrier = null;
-      this.serverCarrierPromise = null;
+      if (!this.serverReplacementPromise) this.serverCarrierPromise = null;
     }
     attempt.carrier.close();
     const transport = attempt.transport;
     attempt.transport = null;
     if (transport) {
       if (transport === this.serverTransport) this.serverTransport = null;
-      attempt.retirement = this.retirePeerTransport(transport).catch(reportAsyncRuntimeError);
+      let retirement: Promise<void>;
+      try {
+        retirement = Promise.resolve(this.retirePeerTransport(transport));
+      } catch (retirementError) {
+        retirement = Promise.reject(retirementError);
+      }
+      attempt.retirement = retirement;
+      retirement.catch((retirementError) => {
+        if (!this.closed) this.handleServerTransportError(retirementError);
+      });
     }
     if (isCurrent) {
-      this.handleServerTransportError(error);
+      if (publishError) this.handleServerTransportError(error);
       this.resolveServerTransportWorkWaiters();
     }
   }

--- a/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/native-runtime-adapter.ts
@@ -2148,7 +2148,9 @@ export class NativeRuntimeAdapter implements Runtime {
           this.handleServerTransportError(error, generation),
         );
         this.flushQueuedServerFrames(carrier);
-        await this.pumpServerTransport();
+        this.pumpServerTransport().catch((error) =>
+          this.handleServerTransportError(error, generation),
+        );
         this.pumpSubscriptions();
         return carrier;
       })

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -469,6 +469,263 @@ describe("NativeRuntimeAdapter server transport", () => {
     await runtime.close();
   });
 
+  it("holds replacement admission until predecessor raw retirement closes", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+    const oldTick = deferred<number>();
+    let oldTickStarted = false;
+    let oldRawClosed = false;
+    const oldTransport = new FakeTransport([]);
+    oldTransport.tick = (() => {
+      oldTickStarted = true;
+      return oldTick.promise;
+    }) as never;
+    oldTransport.close = () => {
+      oldRawClosed = true;
+      oldTransport.closed = true;
+      return true;
+    };
+    const nextTransport = new FakeTransport([]);
+    const admitted: FakeTransport[] = [];
+    const transports = [oldTransport, nextTransport];
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            connectUpstream: () => {
+              const transport = transports.shift();
+              if (!transport) throw new Error("unexpected extra upstream admission");
+              admitted.push(transport);
+              return transport;
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    const progress = runtime.progressPeerTransport();
+    try {
+      await vi.waitFor(() => expect(oldTickStarted).toBe(true));
+
+      runtime.connect("ws://127.0.0.1:4200/apps/app-b/ws", "{}");
+      await waitForFakeWebSocketNegotiation();
+
+      expect(oldRawClosed).toBe(false);
+      expect(sockets).toHaveLength(1);
+      expect(admitted).toHaveLength(1);
+
+      oldTick.resolve(0);
+      await progress;
+      await vi.waitFor(() => expect(sockets).toHaveLength(2));
+      await runtime.waitForUpstreamServerConnection();
+
+      expect(oldRawClosed).toBe(true);
+      expect(sockets[1]!.url).toBe("ws://127.0.0.1:4200/apps/app-b/ws");
+      expect(admitted).toHaveLength(2);
+      expect(admitted[1]).toBe(nextTransport);
+    } finally {
+      oldTick.resolve(0);
+      await progress.catch(() => undefined);
+      await runtime.close();
+    }
+  });
+
+  it.each(["latest replacement", "disconnect"] as const)(
+    "supersedes a successor intent before predecessor retirement (%s)",
+    async (action) => {
+      const sockets: FakeWebSocket[] = [];
+      globalThis.WebSocket = class extends FakeWebSocket {
+        constructor(url: string) {
+          super(url);
+          sockets.push(this);
+        }
+      } as unknown as typeof WebSocket;
+      const oldTick = deferred<number>();
+      let oldTickStarted = false;
+      let oldRawClosed = false;
+      const oldTransport = new FakeTransport([]);
+      oldTransport.tick = (() => {
+        oldTickStarted = true;
+        return oldTick.promise;
+      }) as never;
+      oldTransport.close = () => {
+        oldRawClosed = true;
+        oldTransport.closed = true;
+        return true;
+      };
+      const replacementTransport = new FakeTransport([]);
+      const admitted: FakeTransport[] = [];
+      const transports = [oldTransport, replacementTransport];
+      const runtime = new NativeRuntimeAdapter(
+        {
+          openMemory: () =>
+            fakeDb({
+              connectUpstream: () => {
+                const transport = transports.shift();
+                if (!transport) throw new Error("unexpected extra upstream admission");
+                admitted.push(transport);
+                return transport;
+              },
+              tick: () => undefined,
+            }),
+          openBrowser: async () => {
+            throw new Error("not used");
+          },
+        } as never,
+        testSchema,
+        new Uint8Array(16),
+        TEST_RUNTIME_AUTHOR,
+        1,
+        true,
+      );
+
+      runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+      await runtime.waitForUpstreamServerConnection();
+      const progress = runtime.progressPeerTransport();
+      let disconnect: Promise<void> | undefined;
+      try {
+        await vi.waitFor(() => expect(oldTickStarted).toBe(true));
+
+        runtime.connect("ws://127.0.0.1:4200/apps/app-b/ws", "{}");
+        if (action === "latest replacement") {
+          runtime.connect("ws://127.0.0.1:4200/apps/app-c/ws", "{}");
+        } else {
+          disconnect = runtime.disconnect();
+        }
+        await waitForFakeWebSocketNegotiation();
+
+        expect(oldRawClosed).toBe(false);
+        expect(sockets).toHaveLength(1);
+        expect(admitted).toHaveLength(1);
+
+        oldTick.resolve(0);
+        await progress;
+        await disconnect;
+
+        expect(oldRawClosed).toBe(true);
+        if (action === "latest replacement") {
+          await vi.waitFor(() => expect(sockets).toHaveLength(2));
+          await runtime.waitForUpstreamServerConnection();
+          expect(sockets[1]!.url).toBe("ws://127.0.0.1:4200/apps/app-c/ws");
+          expect(admitted).toHaveLength(2);
+          expect(admitted[1]).toBe(replacementTransport);
+        } else {
+          expect(sockets).toHaveLength(1);
+          expect(admitted).toHaveLength(1);
+        }
+      } finally {
+        oldTick.resolve(0);
+        await progress.catch(() => undefined);
+        await disconnect?.catch(() => undefined);
+        await runtime.close();
+      }
+    },
+  );
+
+  it("reports predecessor retirement failure once without admitting its successor", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+    const oldTick = deferred<number>();
+    let oldTickStarted = false;
+    const retirementError = new Error("old transport retirement failed");
+    let closeCalls = 0;
+    const oldTransport = new FakeTransport([]);
+    oldTransport.tick = (() => {
+      oldTickStarted = true;
+      return oldTick.promise;
+    }) as never;
+    oldTransport.close = () => {
+      closeCalls += 1;
+      throw retirementError;
+    };
+    const nextTransport = new FakeTransport([]);
+    const admitted: FakeTransport[] = [];
+    const transports = [oldTransport, nextTransport];
+    const remoteSettlement = deferred<void>();
+    const write = {
+      ...fakeWrite(),
+      wait: (tier: string) => (tier === "local" ? Promise.resolve() : remoteSettlement.promise),
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            insert: () => write,
+            connectUpstream: () => {
+              const transport = transports.shift();
+              if (!transport) throw new Error("unexpected extra upstream admission");
+              admitted.push(transport);
+              return transport;
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const transportErrors: Error[] = [];
+    runtime.onServerTransportError((error) => transportErrors.push(error));
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    const txId = await committedTxId(
+      runtime.insert(
+        "todos",
+        { title: { type: "Text", value: "remote wait during retirement" } },
+        null,
+        "00000000-0000-0000-0000-000000000013",
+      ),
+    );
+    const remoteWait = runtime.waitForTransaction(txId, "edge");
+    const progress = runtime.progressPeerTransport();
+    try {
+      await vi.waitFor(() => expect(oldTickStarted).toBe(true));
+
+      runtime.connect("ws://127.0.0.1:4200/apps/app-b/ws", "{}");
+      oldTick.resolve(0);
+      await progress;
+
+      expect(closeCalls).toBe(1);
+      expect(transportErrors).toHaveLength(1);
+      expect(transportErrors[0]?.message).toContain("old transport retirement failed");
+      await expect(remoteWait).rejects.toThrow("old transport retirement failed");
+      await expect(runtime.waitForTransaction(txId, "local")).resolves.toBeUndefined();
+      expect(sockets).toHaveLength(1);
+      expect(admitted).toHaveLength(1);
+    } finally {
+      oldTick.resolve(0);
+      await progress.catch(() => undefined);
+      remoteSettlement.resolve();
+      await runtime.close();
+    }
+  });
+
   it.each([
     "none",
     "auth-refresh",

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -545,6 +545,155 @@ describe("NativeRuntimeAdapter server transport", () => {
     }
   });
 
+  it("explicit replacement joins retirement owned by network retry", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+    const oldTick = deferred<number>();
+    let oldTickStarted = false;
+    let oldRawClosed = false;
+    const oldTransport = new FakeTransport([]);
+    oldTransport.tick = (() => {
+      oldTickStarted = true;
+      return oldTick.promise;
+    }) as never;
+    oldTransport.close = () => {
+      oldRawClosed = true;
+      oldTransport.closed = true;
+      return true;
+    };
+    const nextTransport = new FakeTransport([]);
+    const admitted: FakeTransport[] = [];
+    const transports = [oldTransport, nextTransport];
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            connectUpstream: () => {
+              const transport = transports.shift();
+              if (!transport) throw new Error("unexpected extra upstream admission");
+              admitted.push(transport);
+              return transport;
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    const progress = runtime.progressPeerTransport();
+    try {
+      await vi.waitFor(() => expect(oldTickStarted).toBe(true));
+
+      sockets[0]!.emitServerClose();
+      runtime.connect("ws://127.0.0.1:4200/apps/app-b/ws", "{}");
+      await waitForServerPumpTimer();
+
+      expect(oldRawClosed).toBe(false);
+      expect(admitted).toHaveLength(1);
+      expect(sockets).toHaveLength(1);
+
+      oldTick.resolve(0);
+      await progress;
+      await vi.waitFor(() => expect(sockets).toHaveLength(2));
+      await runtime.waitForUpstreamServerConnection();
+
+      expect(oldRawClosed).toBe(true);
+      expect(sockets[1]!.url).toBe("ws://127.0.0.1:4200/apps/app-b/ws");
+      expect(admitted).toHaveLength(2);
+      expect(admitted[1]).toBe(nextTransport);
+    } finally {
+      oldTick.resolve(0);
+      await progress.catch(() => undefined);
+      await runtime.close();
+    }
+  });
+
+  it("retry retirement failure blocks successor admission", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+    const oldTick = deferred<number>();
+    let oldTickStarted = false;
+    let oldRawClosed = false;
+    const oldTransport = new FakeTransport([]);
+    oldTransport.tick = (() => {
+      oldTickStarted = true;
+      return oldTick.promise;
+    }) as never;
+    oldTransport.close = () => {
+      oldRawClosed = true;
+      oldTransport.closed = true;
+      throw new Error("predecessor retirement failure");
+    };
+    const nextTransport = new FakeTransport([]);
+    const admitted: FakeTransport[] = [];
+    const transports = [oldTransport, nextTransport];
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            connectUpstream: () => {
+              const transport = transports.shift();
+              if (!transport) throw new Error("unexpected extra upstream admission");
+              admitted.push(transport);
+              return transport;
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    const progress = runtime.progressPeerTransport();
+    try {
+      await vi.waitFor(() => expect(oldTickStarted).toBe(true));
+
+      sockets[0]!.emitServerClose();
+      runtime.connect("ws://127.0.0.1:4200/apps/app-b/ws", "{}");
+      await waitForFakeWebSocketNegotiation();
+
+      oldTick.resolve(0);
+      await progress;
+      await expect(runtime.waitForUpstreamServerConnection()).rejects.toThrow(
+        "predecessor retirement failure",
+      );
+      await waitForServerPumpTimer();
+      expect(oldRawClosed).toBe(true);
+      expect(admitted).toHaveLength(1);
+    } finally {
+      oldTick.resolve(0);
+      await progress.catch(() => undefined);
+      await runtime.close();
+    }
+  });
+
   it.each(["latest replacement", "disconnect"] as const)(
     "supersedes a successor intent before predecessor retirement (%s)",
     async (action) => {
@@ -710,6 +859,87 @@ describe("NativeRuntimeAdapter server transport", () => {
       expect(supersededTransport.closed).toBe(true);
       expect(replacementTransport.closed).toBe(false);
     } finally {
+      await runtime.close();
+    }
+  });
+
+  it("waits for unresolved superseded admission before successor", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+    const oldTransport = new FakeTransport([]);
+    const replacementTransport = new FakeTransport([]);
+    const supersededTransport = new FakeTransport([]);
+    const replacementAdmissionStarted = deferred<void>();
+    const admitted: FakeTransport[] = [];
+    let connectCalls = 0;
+    const replacementAdmission = deferred<Transport>();
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            connectUpstream: () => {
+              connectCalls += 1;
+              if (connectCalls === 1) {
+                admitted.push(oldTransport);
+                return oldTransport;
+              }
+              if (connectCalls === 2) {
+                replacementAdmissionStarted.resolve();
+                return replacementAdmission.promise.then((transport) => {
+                  admitted.push(transport as FakeTransport);
+                  return transport;
+                });
+              }
+              if (connectCalls === 3) {
+                admitted.push(replacementTransport);
+                return replacementTransport;
+              }
+              throw new Error("unexpected extra upstream admission");
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    runtime.connect("ws://127.0.0.1:4200/apps/app-b/ws", "{}");
+    await replacementAdmissionStarted.promise;
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-c/ws", "{}");
+    try {
+      await waitForServerPumpTimer();
+      expect(connectCalls).toBe(2);
+      expect(sockets).toHaveLength(2);
+      replacementAdmission.resolve(supersededTransport);
+      await runtime.waitForUpstreamServerConnection();
+
+      expect(sockets.map((socket) => socket.url)).toEqual([
+        "ws://127.0.0.1:4200/apps/app-a/ws",
+        "ws://127.0.0.1:4200/apps/app-b/ws",
+        "ws://127.0.0.1:4200/apps/app-c/ws",
+      ]);
+      expect(sockets[1]!.closed).toBe(true);
+      expect(sockets[2]!.closed).toBe(false);
+      expect(connectCalls).toBe(3);
+      expect(admitted).toEqual([oldTransport, supersededTransport, replacementTransport]);
+      expect(supersededTransport.closed).toBe(true);
+      expect(replacementTransport.closed).toBe(false);
+    } finally {
+      replacementAdmission.resolve(supersededTransport);
       await runtime.close();
     }
   });

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -636,6 +636,80 @@ describe("NativeRuntimeAdapter server transport", () => {
       }
     },
   );
+  it("consumes a newer replacement after superseding an active native admission", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+    const oldTransport = new FakeTransport([]);
+    const replacementTransport = new FakeTransport([]);
+    const supersededTransport = new FakeTransport([]);
+    const replacementAdmissionStarted = deferred<void>();
+    const admitted: FakeTransport[] = [];
+    let connectCalls = 0;
+    const replacementAdmission = deferred<Transport>();
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            connectUpstream: () => {
+              connectCalls += 1;
+              if (connectCalls === 1) {
+                admitted.push(oldTransport);
+                return oldTransport;
+              }
+              if (connectCalls === 2) {
+                replacementAdmissionStarted.resolve();
+                return replacementAdmission.promise.then((transport) => {
+                  admitted.push(transport as FakeTransport);
+                  return transport;
+                });
+              }
+              if (connectCalls === 3) {
+                admitted.push(replacementTransport);
+                return replacementTransport;
+              }
+              throw new Error("unexpected extra upstream admission");
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    runtime.connect("ws://127.0.0.1:4200/apps/app-b/ws", "{}");
+    await replacementAdmissionStarted.promise;
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-c/ws", "{}");
+    replacementAdmission.resolve(supersededTransport);
+
+    try {
+      await runtime.waitForUpstreamServerConnection();
+
+      expect(sockets.map((socket) => socket.url)).toEqual([
+        "ws://127.0.0.1:4200/apps/app-a/ws",
+        "ws://127.0.0.1:4200/apps/app-c/ws",
+      ]);
+      expect(connectCalls).toBe(3);
+      expect(admitted).toEqual([oldTransport, supersededTransport, replacementTransport]);
+      expect(supersededTransport.closed).toBe(true);
+      expect(replacementTransport.closed).toBe(false);
+    } finally {
+      await runtime.close();
+    }
+  });
 
   it("reports predecessor retirement failure once without admitting its successor", async () => {
     const sockets: FakeWebSocket[] = [];

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -714,6 +714,101 @@ describe("NativeRuntimeAdapter server transport", () => {
     }
   });
 
+  it("waits for an admitted predecessor retirement before admitting its successor", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+    const oldTransport = new FakeTransport([]);
+    const predecessorTransport = new FakeTransport([]);
+    const successorTransport = new FakeTransport([]);
+    const predecessorTick = deferred<number>();
+    let predecessorTickStarted = false;
+    predecessorTransport.tick = (() => {
+      predecessorTickStarted = true;
+      return predecessorTick.promise;
+    }) as never;
+    let successorScheduled = false;
+    const predecessorAdmission = deferred<void>();
+    const successorRequested = deferred<void>();
+    let runtime!: NativeRuntimeAdapter;
+    let progress: Promise<void> | undefined;
+    predecessorTransport.setAuxiliaryTraceEnabled = () => {
+      predecessorAdmission.resolve();
+      if (successorScheduled) return;
+      successorScheduled = true;
+      queueMicrotask(() => {
+        successorRequested.resolve();
+        runtime.connect("ws://127.0.0.1:4200/apps/app-c/ws", "{}");
+      });
+    };
+    const admitted: FakeTransport[] = [];
+    const transports = [oldTransport, predecessorTransport, successorTransport];
+    let connectCalls = 0;
+    runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            connectUpstream: () => {
+              connectCalls += 1;
+              const transport = transports.shift();
+              if (!transport) throw new Error("unexpected extra upstream admission");
+              admitted.push(transport);
+              if (connectCalls === 2) {
+                queueMicrotask(() => {
+                  progress = runtime.progressPeerTransport();
+                });
+              }
+              return transport;
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    runtime.connect("ws://127.0.0.1:4200/apps/app-b/ws", "{}");
+    await predecessorAdmission.promise;
+    await successorRequested.promise;
+    try {
+      await vi.waitFor(() => expect(predecessorTickStarted).toBe(true));
+      await waitForFakeWebSocketNegotiation();
+
+      expect(sockets).toHaveLength(2);
+      expect(admitted).toEqual([oldTransport, predecessorTransport]);
+      expect(predecessorTransport.closed).toBe(false);
+
+      predecessorTick.resolve(0);
+      await progress;
+      await runtime.waitForUpstreamServerConnection();
+
+      expect(sockets.map((socket) => socket.url)).toEqual([
+        "ws://127.0.0.1:4200/apps/app-a/ws",
+        "ws://127.0.0.1:4200/apps/app-b/ws",
+        "ws://127.0.0.1:4200/apps/app-c/ws",
+      ]);
+      expect(admitted).toEqual([oldTransport, predecessorTransport, successorTransport]);
+      expect(predecessorTransport.closed).toBe(true);
+      expect(successorTransport.closed).toBe(false);
+    } finally {
+      predecessorTick.resolve(0);
+      await progress?.catch(() => undefined);
+      await runtime.close();
+    }
+  });
+
   it("reports predecessor retirement failure once without admitting its successor", async () => {
     const sockets: FakeWebSocket[] = [];
     globalThis.WebSocket = class extends FakeWebSocket {

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -2205,6 +2205,8 @@ class FakeTransport implements Transport {
     return this.auxiliaryOutgoing.splice(0);
   }
 
+  setAuxiliaryTraceEnabled(_enabled: boolean): void {}
+
   tick(): number {
     this.tickCount += 1;
     return 0;

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -700,8 +700,11 @@ describe("NativeRuntimeAdapter server transport", () => {
 
       expect(sockets.map((socket) => socket.url)).toEqual([
         "ws://127.0.0.1:4200/apps/app-a/ws",
+        "ws://127.0.0.1:4200/apps/app-b/ws",
         "ws://127.0.0.1:4200/apps/app-c/ws",
       ]);
+      expect(sockets[1]!.closed).toBe(true);
+      expect(sockets[2]!.closed).toBe(false);
       expect(connectCalls).toBe(3);
       expect(admitted).toEqual([oldTransport, supersededTransport, replacementTransport]);
       expect(supersededTransport.closed).toBe(true);

--- a/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/native-runtime/runtime-transport.test.ts
@@ -1128,6 +1128,102 @@ describe("NativeRuntimeAdapter server transport", () => {
     }
   });
 
+  it("failed retirement continues to block later successors", async () => {
+    const sockets: FakeWebSocket[] = [];
+    globalThis.WebSocket = class extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+    const oldTick = deferred<number>();
+    let oldTickStarted = false;
+    const retirementError = new Error("old transport retirement failed");
+    let closeCalls = 0;
+    const oldTransport = new FakeTransport([]);
+    oldTransport.tick = (() => {
+      oldTickStarted = true;
+      return oldTick.promise;
+    }) as never;
+    oldTransport.close = () => {
+      closeCalls += 1;
+      throw retirementError;
+    };
+    const nextTransport = new FakeTransport([]);
+    const admitted: FakeTransport[] = [];
+    const transports = [oldTransport, nextTransport];
+    const remoteSettlement = deferred<void>();
+    const write = {
+      ...fakeWrite(),
+      wait: (tier: string) => (tier === "local" ? Promise.resolve() : remoteSettlement.promise),
+    };
+    const runtime = new NativeRuntimeAdapter(
+      {
+        openMemory: () =>
+          fakeDb({
+            insert: () => write,
+            connectUpstream: () => {
+              const transport = transports.shift();
+              if (!transport) throw new Error("unexpected extra upstream admission");
+              admitted.push(transport);
+              return transport;
+            },
+            tick: () => undefined,
+          }),
+        openBrowser: async () => {
+          throw new Error("not used");
+        },
+      } as never,
+      testSchema,
+      new Uint8Array(16),
+      TEST_RUNTIME_AUTHOR,
+      1,
+      true,
+    );
+    const transportErrors: Error[] = [];
+    runtime.onServerTransportError((error) => transportErrors.push(error));
+
+    runtime.connect("ws://127.0.0.1:4200/apps/app-a/ws", "{}");
+    await runtime.waitForUpstreamServerConnection();
+    const txId = await committedTxId(
+      runtime.insert(
+        "todos",
+        { title: { type: "Text", value: "remote wait during retirement" } },
+        null,
+        "00000000-0000-0000-0000-000000000013",
+      ),
+    );
+    const remoteWait = runtime.waitForTransaction(txId, "edge");
+    const progress = runtime.progressPeerTransport();
+    try {
+      await vi.waitFor(() => expect(oldTickStarted).toBe(true));
+
+      runtime.connect("ws://127.0.0.1:4200/apps/app-b/ws", "{}");
+      oldTick.resolve(0);
+      await progress;
+
+      expect(closeCalls).toBe(1);
+      expect(transportErrors).toHaveLength(1);
+      expect(transportErrors[0]?.message).toContain("old transport retirement failed");
+      await expect(remoteWait).rejects.toThrow("old transport retirement failed");
+      await expect(runtime.waitForTransaction(txId, "local")).resolves.toBeUndefined();
+      expect(sockets).toHaveLength(1);
+      expect(admitted).toHaveLength(1);
+      await runtime.waitForUpstreamServerConnection().catch(() => undefined);
+      runtime.connect("ws://127.0.0.1:4200/apps/app-c/ws", "{}");
+      await expect(runtime.waitForUpstreamServerConnection()).rejects.toThrow(
+        "old transport retirement failed",
+      );
+      expect(admitted).toHaveLength(1);
+      expect(transportErrors).toHaveLength(1);
+    } finally {
+      oldTick.resolve(0);
+      await progress.catch(() => undefined);
+      remoteSettlement.resolve();
+      await runtime.close();
+    }
+  });
+
   it.each([
     "none",
     "auth-refresh",


### PR DESCRIPTION
🤖 ## Summary
- Serialize native transport retirement before admitting replacements.
- Keep replacement runners alive through active supersession.
- Report predecessor retirement failures once.

## Before
A replacement transport could be admitted while its predecessor was still retiring, creating retirement races and duplicate failure handling.

## After
Successors wait for all live predecessor retirement to complete, and retirement failures are surfaced once without admitting an invalid successor.

## Test plan
- [x] Focused predecessor-retirement admission regression test
- [x] Focused retirement-failure deduplication regression test

## Integration status

Rebased into the stable-fixes stack on main. Independent review found and fixed three additional races: a superseded admission could finish after its successor started; an explicit connect could bypass retirement started by retry; and a later connect could forget an earlier failed retirement. All replacements now wait for outstanding retirement, and a failed retirement continues blocking admission rather than being forgotten. Regressions cover each case; the focused transport/auth suites pass. Full combined CI is green; user merge approval remains separate.
