### PR TITLE
Fix nested EXISTS policy branch conversion

### DIFF
--- a/.changeset/nested-policy-exists.md
+++ b/.changeset/nested-policy-exists.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix deployment of policies with correlated `exists` clauses nested in boolean branches.

--- a/crates/jazz-testkit/tests/policies_integration/exists_rel_policies.rs
+++ b/crates/jazz-testkit/tests/policies_integration/exists_rel_policies.rs
@@ -1,5 +1,5 @@
 use jazz_server::JazzServer;
-use jazz_testkit::connect_ready_client;
+use jazz_testkit::{connect_ready_client, connect_ready_user};
 
 use super::*;
 
@@ -495,4 +495,61 @@ async fn uncorrelated_select_tracks_private_grants(policy: jazz::tools::PolicyEx
             server.shutdown().await;
         })
         .await;
+}
+
+/// Boolean clause order must not remove the owner check after an EXISTS-bearing OR.
+#[tokio::test]
+async fn exists_rel_disjunction_preserves_following_owner_predicate() {
+    tokio::task::LocalSet::new().run_until(async {
+        for owner_first in [false, true] {
+            let policies = permissions(|p| {
+                let owner = pe::eq("owner_id", pe::session(vec!["claims", "sub"]));
+                let alternative = pe::any_of([
+                    pe::eq("name", pe::literal("shortcut")),
+                    pe::exists(pe::table("admins").where_(pe::rel::all_of([
+                        pe::rel::eq_outer("id", "admin_id"),
+                        pe::rel::eq_session("user_id", vec!["claims", "sub"]),
+                    ]))),
+                ]);
+                p.allow_insert().where_(pe::all_of(if owner_first {
+                    [owner, alternative]
+                } else {
+                    [alternative, owner]
+                }));
+            });
+            let schema = SchemaBuilder::new()
+                .table(TableSchema::builder("admins")
+                    .column("user_id", ColumnType::Text)
+                    .policies(permissions(|p| p.allow_read().always())))
+                .table(TableSchema::builder("projects")
+                    .column("name", ColumnType::Text)
+                    .column("owner_id", ColumnType::Text)
+                    .fk_column("admin_id", "admins")
+                    .policies(policies))
+                .build();
+            let server = JazzServer::start_with_schema(schema.clone())
+                .await
+                .expect("start test server");
+            let backend = connect_ready_client(&server, &schema, "boolean-policy-seed", "projects", Duration::from_secs(30)).await;
+            let admin_id = backend.insert("admins", crate::row_input!("user_id" => super::ALICE_ID)).expect("seed admin").0;
+            let alice = connect_ready_user(&server, &schema, super::ALICE_ID, "projects", Duration::from_secs(30)).await;
+            for name in ["shortcut", "admin path"] {
+                for (owner, allowed) in [(super::ALICE_ID, true), (super::CAROL_ID, false)] {
+                    let result = alice.insert("projects", crate::row_input!("name" => name, "owner_id" => owner, "admin_id" => admin_id));
+                    match result {
+                        Ok((_, _, transaction)) => {
+                            let transaction = transaction.expect("write requires authority settlement");
+                            let settled = alice.wait_for_transaction(transaction, jazz::tools::DurabilityTier::EdgeServer).await;
+                            assert_eq!(settled.is_ok(), allowed, "owner_first={owner_first}, name={name}, owner={owner}: {settled:?}");
+                        }
+                        Err(error) if !allowed => assert_client_policy_denied(error, "projects", Operation::Insert),
+                        Err(error) => panic!("allowed write rejected: {error:?}"),
+                    }
+                }
+            }
+            alice.shutdown().await.expect("shutdown Alice");
+            backend.shutdown().await.expect("shutdown backend");
+            server.shutdown().await;
+        }
+    }).await;
 }

--- a/crates/jazz/src/tools/public_schema_convert.rs
+++ b/crates/jazz/src/tools/public_schema_convert.rs
@@ -1074,6 +1074,33 @@ fn append_policy_clause(
     expr: &PolicyExpr,
     native_select_inherits: bool,
 ) -> Result<Query, SchemaConversionError> {
+    // A clause conjoins the entire policy accumulated so far, including every
+    // alternative created by an earlier OR. Appending only to the false base
+    // would let those alternatives bypass this clause.
+    if !query.policy_branches.is_empty() {
+        let alternatives = PolicyBranch::alternatives_from_query(query);
+        let mut combined = Query::from(table.as_str()).filter(Predicate::Any(Vec::new()));
+        for alternative in alternatives {
+            let mut branch = Query::from(table.as_str());
+            branch.filters = alternative.filters;
+            branch.joins = alternative.joins;
+            branch.reachable = alternative.reachable;
+            branch.inherits = alternative.inherits;
+            let branch = append_policy_clause(
+                schema,
+                table_schema,
+                table,
+                path,
+                branch,
+                expr,
+                native_select_inherits,
+            )?;
+            for alternative in PolicyBranch::alternatives_from_query(branch) {
+                combined = combined.policy_branch(alternative);
+            }
+        }
+        return Ok(combined);
+    }
     match expr {
         PolicyExpr::And(exprs) => {
             let mut query = query;
@@ -1124,6 +1151,52 @@ fn append_policy_clause(
             condition,
         } => append_exists_policy_clause(schema, table, path, query, exists_table, condition),
         PolicyExpr::ExistsRel { rel } => append_exists_rel_policy_clause(table, path, query, rel),
+        PolicyExpr::Or(exprs) if exprs.iter().any(policy_requires_branch) => {
+            let existing_branches = PolicyBranch::alternatives_from_query(query);
+            let mut query = Query::from(table.as_str()).filter(Predicate::Any(Vec::new()));
+
+            for (index, expr) in exprs.iter().enumerate() {
+                let branch_query = convert_policy_with_native_select_inherits(
+                    schema,
+                    table_schema,
+                    table,
+                    &format!("{path}.Or[{index}]"),
+                    expr,
+                    native_select_inherits,
+                )?;
+                for branch in PolicyBranch::alternatives_from_query(branch_query) {
+                    for existing in &existing_branches {
+                        query = query.policy_branch(PolicyBranch {
+                            filters: existing
+                                .filters
+                                .iter()
+                                .chain(branch.filters.iter())
+                                .cloned()
+                                .collect(),
+                            joins: existing
+                                .joins
+                                .iter()
+                                .chain(branch.joins.iter())
+                                .cloned()
+                                .collect(),
+                            reachable: existing
+                                .reachable
+                                .iter()
+                                .chain(branch.reachable.iter())
+                                .cloned()
+                                .collect(),
+                            inherits: existing
+                                .inherits
+                                .iter()
+                                .chain(branch.inherits.iter())
+                                .cloned()
+                                .collect(),
+                        });
+                    }
+                }
+            }
+            Ok(query)
+        }
         _ => Ok(append_predicate_filters(
             query,
             predicate_filters_for_expr(table, path, expr)?,
@@ -4419,6 +4492,101 @@ mod tests {
         assert_eq!(join.table, "chatMembers");
         assert_eq!(join.on_column, "chatId");
         assert_eq!(join.source_column.as_deref(), Some("chatId"));
+    }
+
+    #[test]
+    fn converts_nested_or_with_correlated_exists_under_and_to_policy_branches() {
+        let schema = SchemaBuilder::new()
+            .table(TableSchemaBuilder::new("rooms").column("archived", ColumnType::Boolean))
+            .table(
+                TableSchemaBuilder::new("roomParticipants")
+                    .fk_column("room_id", "rooms")
+                    .column("session_user_id", ColumnType::Text),
+            )
+            .table(
+                TableSchemaBuilder::new("roomMetadata")
+                    .fk_column("room_id", "rooms")
+                    .column("owner_id", ColumnType::Text)
+                    .column("is_admin", ColumnType::Boolean)
+                    .policies(TablePolicies::new().with_update(
+                        Some(PolicyExpr::And(vec![
+                            PolicyExpr::Cmp {
+                                column: "owner_id".to_owned(),
+                                op: CmpOp::Eq,
+                                value: PolicyValue::SessionRef(vec![
+                                    "claims".to_owned(),
+                                    "sub".to_owned(),
+                                ]),
+                            },
+                            PolicyExpr::And(vec![
+                                PolicyExpr::Exists {
+                                    table: "rooms".to_owned(),
+                                    condition: Box::new(PolicyExpr::And(vec![
+                                        PolicyExpr::Cmp {
+                                            column: "id".to_owned(),
+                                            op: CmpOp::Eq,
+                                            value: PolicyValue::SessionRef(vec![
+                                                "__jazz_outer_row".to_owned(),
+                                                "room_id".to_owned(),
+                                            ]),
+                                        },
+                                        PolicyExpr::Cmp {
+                                            column: "archived".to_owned(),
+                                            op: CmpOp::Eq,
+                                            value: PolicyValue::Literal(Value::Boolean(false)),
+                                        },
+                                    ])),
+                                },
+                                PolicyExpr::Or(vec![
+                                    PolicyExpr::Cmp {
+                                        column: "is_admin".to_owned(),
+                                        op: CmpOp::Eq,
+                                        value: PolicyValue::Literal(Value::Boolean(true)),
+                                    },
+                                    PolicyExpr::Exists {
+                                        table: "roomParticipants".to_owned(),
+                                        condition: Box::new(PolicyExpr::And(vec![
+                                            PolicyExpr::Cmp {
+                                                column: "room_id".to_owned(),
+                                                op: CmpOp::Eq,
+                                                value: PolicyValue::SessionRef(vec![
+                                                    "__jazz_outer_row".to_owned(),
+                                                    "room_id".to_owned(),
+                                                ]),
+                                            },
+                                            PolicyExpr::Cmp {
+                                                column: "session_user_id".to_owned(),
+                                                op: CmpOp::Eq,
+                                                value: PolicyValue::SessionRef(vec![
+                                                    "claims".to_owned(),
+                                                    "sub".to_owned(),
+                                                ]),
+                                            },
+                                        ])),
+                                    },
+                                ]),
+                            ]),
+                        ])),
+                        PolicyExpr::True,
+                    )),
+            )
+            .build();
+
+        let converted = convert_public_schema(&schema).unwrap();
+        let metadata = converted
+            .tables
+            .iter()
+            .find(|table| table.name == "roomMetadata")
+            .unwrap();
+        let policy = metadata.write_policies.update_using.as_ref().unwrap();
+
+        assert_eq!(policy.filters, vec![Predicate::Any(Vec::new())]);
+        assert_eq!(policy.policy_branches.len(), 2);
+        assert_eq!(policy.policy_branches[0].joins.len(), 1);
+        assert_eq!(policy.policy_branches[0].joins[0].table, "rooms");
+        assert_eq!(policy.policy_branches[1].joins.len(), 2);
+        assert_eq!(policy.policy_branches[1].joins[0].table, "rooms");
+        assert_eq!(policy.policy_branches[1].joins[1].table, "roomParticipants");
     }
 
     #[test]


### PR DESCRIPTION
🤖 ## Summary

- Lower branch-bearing `Or` expressions nested inside `And` policy clauses.
- Preserve existing filters and joins in every generated policy alternative.
- Add a regression test matching the reported deployment failure.
- Add a `jazz-tools` patch Changeset.

This addresses the nested boolean-composition case from #1759. Broader EXISTS/ExistsRel coverage and execution remain tracked there.

## Testing

- `cargo test -p jazz --lib --features testing tools::public_schema_convert::tests::converts_nested_or_with_correlated_exists_under_and_to_policy_branches -- --exact`
- `cargo test -p jazz --lib --features testing tools::public_schema_convert::tests::` — 54 passed

## Integration status

Rebased into the stable-fixes stack on main, with independent review corrections included. Review found that a restriction after an OR could be dropped from alternatives. For example, `(is_admin OR has_grant) AND owner = current_user` must apply the owner check to both branches. The integrated version distributes every conjunct and tests both orderings; removing the correction permits a wrong-owner write and fails the regression. Full combined CI is green.
