### PR TITLE
perf: shrink materialized value cells from 152 to 40 bytes

### DIFF
--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -489,7 +489,10 @@ async fn staged_large_value_is_consumed_atomically_with_its_referencing_row() {
     let mut batch = database.open_batch();
     batch.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(staged.value_ref.clone())],
+        vec![
+            Value::U64(1),
+            Value::Large(Box::new(staged.value_ref.clone())),
+        ],
     );
     batch.accept_large_value(staged.id);
     database.commit_batch(batch).await.unwrap();
@@ -497,7 +500,7 @@ async fn staged_large_value_is_consumed_atomically_with_its_referencing_row() {
     let mut replay = database.open_batch();
     replay.insert(
         "objects",
-        vec![Value::U64(2), Value::Large(staged.value_ref)],
+        vec![Value::U64(2), Value::Large(Box::new(staged.value_ref))],
     );
     replay.accept_large_value(staged.id);
     assert!(matches!(
@@ -581,7 +584,10 @@ async fn present_staged_receipt_has_no_implicit_ttl_and_is_accepted_atomically()
     let mut batch = database.open_batch();
     batch.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(staged.value_ref.clone())],
+        vec![
+            Value::U64(1),
+            Value::Large(Box::new(staged.value_ref.clone())),
+        ],
     );
     batch.accept_large_value(staged.id);
     database.commit_batch(batch).await.unwrap();
@@ -614,7 +620,7 @@ async fn resident_large_value_acceptance_blocks_stale_eviction_and_reclamation()
     let mut insert = database.open_batch();
     insert.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(staged.value_ref)],
+        vec![Value::U64(1), Value::Large(Box::new(staged.value_ref))],
     );
     insert.accept_large_value(staged.id);
     let applied = database.apply_batch(insert).await.unwrap();
@@ -671,7 +677,7 @@ async fn cross_receipt_eviction_defers_until_resident_publication_is_durable() {
     let mut insert = database.open_batch();
     insert.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(accepted.value_ref)],
+        vec![Value::U64(1), Value::Large(Box::new(accepted.value_ref))],
     );
     insert.accept_large_value(accepted.id);
     let applied = database.apply_batch(insert).await.unwrap();
@@ -748,7 +754,7 @@ async fn reclamation_uses_durable_zero_and_resident_references_as_a_veto() {
     let mut insert = database.open_batch();
     insert.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(value_ref.clone())],
+        vec![Value::U64(1), Value::Large(Box::new(value_ref.clone()))],
     );
     insert.accept_large_value(staged.id);
     database.commit_batch(insert).await.unwrap();
@@ -770,7 +776,7 @@ async fn reclamation_uses_durable_zero_and_resident_references_as_a_veto() {
     let mut first_activation = database.open_batch();
     first_activation.insert(
         "objects",
-        vec![Value::U64(2), Value::Large(value_ref.clone())],
+        vec![Value::U64(2), Value::Large(Box::new(value_ref.clone()))],
     );
     let first_activation = database.apply_batch(first_activation).await.unwrap();
     assert_eq!(
@@ -821,7 +827,7 @@ async fn reclamation_uses_durable_zero_and_resident_references_as_a_veto() {
     let mut second_activation = database.open_batch();
     second_activation.insert(
         "objects",
-        vec![Value::U64(3), Value::Large(value_ref.clone())],
+        vec![Value::U64(3), Value::Large(Box::new(value_ref.clone()))],
     );
     let second_activation = database.apply_batch(second_activation).await.unwrap();
     database
@@ -1556,7 +1562,7 @@ async fn finalized_upload_promotion_is_atomic_and_retry_returns_its_one_receipt(
     let mut accepted = reopened.open_batch();
     accepted.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(prepared.value_ref)],
+        vec![Value::U64(1), Value::Large(Box::new(prepared.value_ref))],
     );
     accepted.accept_large_value(receipt.id);
     reopened.commit_batch(accepted).await.unwrap();
@@ -2084,11 +2090,17 @@ async fn shared_durable_root_is_reclaimed_only_after_its_last_physical_record() 
     let mut insert = database.open_batch();
     insert.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(staged.value_ref.clone())],
+        vec![
+            Value::U64(1),
+            Value::Large(Box::new(staged.value_ref.clone())),
+        ],
     );
     insert.insert(
         "objects",
-        vec![Value::U64(2), Value::Large(staged.value_ref.clone())],
+        vec![
+            Value::U64(2),
+            Value::Large(Box::new(staged.value_ref.clone())),
+        ],
     );
     insert.accept_large_value(staged.id);
     database.commit_batch(insert).await.unwrap();
@@ -2498,7 +2510,10 @@ async fn pipelined_applied_batches_compose_large_value_root_references() {
     let mut first_batch = database.open_batch();
     first_batch.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(first_staged.value_ref.clone())],
+        vec![
+            Value::U64(1),
+            Value::Large(Box::new(first_staged.value_ref.clone())),
+        ],
     );
     first_batch.accept_large_value(first_staged.id);
     let first = database.apply_batch(first_batch).await.unwrap();
@@ -2506,7 +2521,10 @@ async fn pipelined_applied_batches_compose_large_value_root_references() {
     let mut second_batch = database.open_batch();
     second_batch.insert(
         "objects",
-        vec![Value::U64(2), Value::Large(second_staged.value_ref.clone())],
+        vec![
+            Value::U64(2),
+            Value::Large(Box::new(second_staged.value_ref.clone())),
+        ],
     );
     second_batch.accept_large_value(second_staged.id);
     let second = database.apply_batch(second_batch).await.unwrap();
@@ -2574,7 +2592,10 @@ async fn last_root_publication_blocks_descendant_install_until_its_refcount_writ
     let mut insert = database.open_batch();
     insert.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(staged.value_ref.clone())],
+        vec![
+            Value::U64(1),
+            Value::Large(Box::new(staged.value_ref.clone())),
+        ],
     );
     insert.accept_large_value(staged.id);
     database.commit_batch(insert).await.unwrap();
@@ -2677,7 +2698,10 @@ async fn corrupt_large_value_root_does_not_leave_a_publication_hole() {
     let mut insert = database.open_batch();
     insert.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(staged.value_ref.clone())],
+        vec![
+            Value::U64(1),
+            Value::Large(Box::new(staged.value_ref.clone())),
+        ],
     );
     insert.accept_large_value(staged.id);
     database.commit_batch(insert).await.unwrap();
@@ -2739,7 +2763,7 @@ async fn cancelled_lifecycle_wait_does_not_leave_a_publication_hole() {
     let mut insert = database.open_batch();
     insert.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(staged.value_ref)],
+        vec![Value::U64(1), Value::Large(Box::new(staged.value_ref))],
     );
     insert.accept_large_value(staged.id);
     database.commit_batch(insert).await.unwrap();
@@ -2807,7 +2831,10 @@ async fn queued_resolver_before_last_root_delete_does_not_leak_child_reference()
     let mut insert = database.open_batch();
     insert.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(staged.value_ref.clone())],
+        vec![
+            Value::U64(1),
+            Value::Large(Box::new(staged.value_ref.clone())),
+        ],
     );
     insert.accept_large_value(staged.id);
     database.commit_batch(insert).await.unwrap();
@@ -2943,7 +2970,7 @@ async fn missing_chunk_observer_completes_during_tick_before_lifecycle_lock() {
     let mut insert = database.open_batch();
     insert.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(staged.value_ref)],
+        vec![Value::U64(1), Value::Large(Box::new(staged.value_ref))],
     );
     insert.accept_large_value(staged.id);
     let applied = database.apply_batch(insert).await.unwrap();
@@ -3020,7 +3047,10 @@ async fn sequential_cold_large_value_publications_do_not_deadlock_observer() {
     let mut first = database.open_batch();
     first.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(first_staged.value_ref)],
+        vec![
+            Value::U64(1),
+            Value::Large(Box::new(first_staged.value_ref)),
+        ],
     );
     first.accept_large_value(first_staged.id);
     let first = database.apply_batch(first).await.unwrap();
@@ -3040,7 +3070,10 @@ async fn sequential_cold_large_value_publications_do_not_deadlock_observer() {
     let mut second = database.open_batch();
     second.insert(
         "objects",
-        vec![Value::U64(2), Value::Large(second_staged.value_ref)],
+        vec![
+            Value::U64(2),
+            Value::Large(Box::new(second_staged.value_ref)),
+        ],
     );
     second.accept_large_value(second_staged.id);
     let mut second_application = Box::pin(database.apply_batch(second));
@@ -3128,7 +3161,7 @@ async fn first_cold_publication_persists_before_resolver_without_deadlock() {
     let mut insert = database.open_batch();
     insert.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(staged.value_ref)],
+        vec![Value::U64(1), Value::Large(Box::new(staged.value_ref))],
     );
     insert.accept_large_value(staged.id);
     let applied = database.apply_batch(insert).await.unwrap();
@@ -3229,7 +3262,7 @@ async fn suspended_resident_chunk_install_joins_assigned_publication() {
     let mut first_batch = database.open_batch();
     first_batch.insert(
         "objects",
-        vec![Value::U64(1), Value::Large(first.value_ref)],
+        vec![Value::U64(1), Value::Large(Box::new(first.value_ref))],
     );
     first_batch.accept_large_value(first.id);
     let first = database.apply_batch(first_batch).await.unwrap();
@@ -3245,7 +3278,7 @@ async fn suspended_resident_chunk_install_joins_assigned_publication() {
     let mut second_batch = database.open_batch();
     second_batch.insert(
         "objects",
-        vec![Value::U64(2), Value::Large(second.value_ref)],
+        vec![Value::U64(2), Value::Large(Box::new(second.value_ref))],
     );
     second_batch.accept_large_value(second.id);
     let second = database.apply_batch(second_batch).await.unwrap();
@@ -3364,7 +3397,7 @@ async fn late_publication_metadata_write_failure_is_fatal_and_observable() {
     let mut second = database.open_batch();
     second.insert(
         "objects",
-        vec![Value::U64(2), Value::Large(staged.value_ref)],
+        vec![Value::U64(2), Value::Large(Box::new(staged.value_ref))],
     );
     second.accept_large_value(staged.id);
     let second = database.apply_batch(second).await.unwrap();
@@ -3468,7 +3501,7 @@ async fn external_chunk_backend_error_cannot_forge_publication_durability_failur
     let mut second = database.open_batch();
     second.insert(
         "objects",
-        vec![Value::U64(2), Value::Large(staged.value_ref)],
+        vec![Value::U64(2), Value::Large(Box::new(staged.value_ref))],
     );
     second.accept_large_value(staged.id);
     let second = database.apply_batch(second).await.unwrap();

--- a/crates/groove/src/db/tests/subscriptions/mod.rs
+++ b/crates/groove/src/db/tests/subscriptions/mod.rs
@@ -2510,7 +2510,10 @@ async fn pending_incremental_checksum_survives_last_subscription_gc() {
                 descriptor: objects.clone(),
                 deltas: vec![RecordDelta {
                     record: objects
-                        .create(&[Value::U64(1), Value::Large(prepared.value_ref.clone())])
+                        .create(&[
+                            Value::U64(1),
+                            Value::Large(Box::new(prepared.value_ref.clone())),
+                        ])
                         .unwrap()
                         .into(),
                     weight: 1,

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -2922,7 +2922,7 @@ impl TickEvaluator<'_> {
                 Value::Large(value) => {
                     if pending.current.is_none() {
                         pending.current = Some(crate::large_values::StreamingChecksum::new(
-                            value.clone(),
+                            value.as_ref().clone(),
                             checksum.window_bytes,
                             checksum.max_bytes_per_turn,
                         )?);

--- a/crates/groove/src/large_values.rs
+++ b/crates/groove/src/large_values.rs
@@ -8178,7 +8178,7 @@ mod tests {
                 0,
                 "inline nested scalars must remain encoded"
             );
-            let indirect = encode(Value::Large(prepared.value_ref.clone()));
+            let indirect = encode(Value::Large(Box::new(prepared.value_ref.clone())));
             assert!(matches!(
                 materialize_record_attempt(&descriptor, &indirect, &mut inputs),
                 Err(IvmRuntimeError::EvaluationBlocked)
@@ -8212,7 +8212,7 @@ mod tests {
         let raw = descriptor
             .create(&[
                 Value::String("inline".to_owned()),
-                Value::Large(prepared.value_ref),
+                Value::Large(Box::new(prepared.value_ref)),
             ])
             .unwrap();
         let mut inputs = EvaluationInputs::default();
@@ -8858,7 +8858,7 @@ mod tests {
         .value_ref;
         let text_cell =
             RecordDescriptor::new([("cell", physical_storage_value_type(LargeValueKind::String))]);
-        assert!(text_cell.create(&[Value::Large(json)]).is_err());
+        assert!(text_cell.create(&[Value::Large(Box::new(json))]).is_err());
     }
 
     #[test]

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -2116,12 +2116,12 @@ fn indirect_string_uses_the_same_logical_value_type_with_an_explicit_physical_ar
     )
     .unwrap();
     let record = descriptor
-        .create(&[Value::Large(prepared.value_ref.clone())])
+        .create(&[Value::Large(Box::new(prepared.value_ref.clone()))])
         .unwrap();
 
     assert_eq!(
         descriptor.get_idx(&record, 0).unwrap(),
-        Value::Large(prepared.value_ref)
+        Value::Large(Box::new(prepared.value_ref))
     );
     assert_eq!(
         descriptor.bind(&record).get_str(0).unwrap_err(),
@@ -2471,7 +2471,11 @@ fn embedded_record_admission_matches_legacy_roundtrip_corpus() {
     ] {
         let prepared = crate::large_values::prepare(kind, logical).unwrap();
         let d = descriptor([ValueType::stored_scalar(kind)]);
-        cases.push((d, d.create(&[Value::Large(prepared.value_ref)]).unwrap()));
+        cases.push((
+            d,
+            d.create(&[Value::Large(Box::new(prepared.value_ref))])
+                .unwrap(),
+        ));
     }
     let composite = descriptor([
         ValueType::Record(Box::new(child)),
@@ -2604,7 +2608,9 @@ fn indirect_reference_visitor_preserves_nested_multiplicity_and_early_stop() {
         .value_ref;
     let nested = descriptor([ValueType::String]);
     let child = OwnedRecord::new(
-        nested.create(&[Value::Large(reference.clone())]).unwrap(),
+        nested
+            .create(&[Value::Large(Box::new(reference.clone()))])
+            .unwrap(),
         nested,
     );
     let d = descriptor([
@@ -2617,9 +2623,9 @@ fn indirect_reference_visitor_preserves_nested_multiplicity_and_early_stop() {
             Value::String("inline contents".repeat(100)),
             Value::Array(vec![
                 Value::Nullable(None),
-                Value::Nullable(Some(Box::new(Value::Large(reference.clone())))),
+                Value::Nullable(Some(Box::new(Value::Large(Box::new(reference.clone()))))),
                 Value::Nullable(Some(Box::new(Value::String("inline".into())))),
-                Value::Nullable(Some(Box::new(Value::Large(reference.clone())))),
+                Value::Nullable(Some(Box::new(Value::Large(Box::new(reference.clone()))))),
             ]),
             Value::Record(child),
         ])
@@ -2719,4 +2725,47 @@ fn variable_field_failure_preserves_preexisting_output() {
     let mut output = vec![91, 92, 93];
     assert!(d.encode_field_into(0, &value, &mut output).is_err());
     assert_eq!(output, [91, 92, 93]);
+}
+
+// An internal representation budget: every ordinary scalar in a materialized
+// row pays Value's inline width, even when no indirect large value is present.
+#[test]
+fn materialized_value_cells_have_a_small_inline_representation() {
+    assert!(
+        std::mem::size_of::<Value>() <= 64,
+        "Value occupies {} bytes; uncommon payloads must not inflate every cell",
+        std::mem::size_of::<Value>()
+    );
+}
+
+// Boxing changes Rust ownership only. Pin both the native scalar carrier and
+// the existing serde enum discriminant/payload independently of Value's layout.
+#[test]
+fn compact_large_value_preserves_native_and_serde_encodings() {
+    use crate::large_values::{LargeValueKind, StoredScalar, encode_stored_scalar, prepare};
+    let reference = prepare(LargeValueKind::Bytes, b"same payload")
+        .unwrap()
+        .value_ref;
+    let value = Value::Large(reference.clone().into());
+    let descriptor = descriptor([ValueType::Bytes]);
+    let stored = descriptor.create(std::slice::from_ref(&value)).unwrap();
+    assert_eq!(
+        stored,
+        encode_stored_scalar(
+            LargeValueKind::Bytes,
+            &StoredScalar::Chunked(reference.clone())
+        )
+        .unwrap()
+    );
+    assert_eq!(descriptor.bind(&stored).get_idx(0).unwrap(), value);
+    // Large remains enum variant 8 in the existing generic Value carrier.
+    let mut expected = vec![8];
+    expected.extend(postcard::to_allocvec(&reference).unwrap());
+    let encoded = postcard::to_allocvec(&value).unwrap();
+    assert_eq!(encoded, expected);
+    assert_eq!(postcard::from_bytes::<Value>(&encoded).unwrap(), value);
+    assert_eq!(
+        serde_json::to_value(&value).unwrap(),
+        serde_json::json!({"Large": reference})
+    );
 }

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -37,8 +37,9 @@ pub enum Value {
     String(String),
     Bytes(Vec<u8>),
     /// Engine-owned indirect physical arm. Public result boundaries
-    /// materialize this back into the declared logical scalar type.
-    Large(crate::large_values::LargeValueRef),
+    /// materialize this back into the declared logical scalar type. Box the
+    /// uncommon reference so every ordinary materialized cell stays compact.
+    Large(Box<crate::large_values::LargeValueRef>),
     Uuid(uuid::Uuid),
     EnumTag(u8),
     Tuple(Vec<Value>),
@@ -1624,14 +1625,14 @@ pub(super) fn encode_value_into(
             ValueType::Internal(InternalValueType(InternalValueTypeRepr::StoredScalar(kind))),
         ) if value.kind == *kind => bytes.extend(crate::large_values::encode_stored_scalar(
             *kind,
-            &crate::large_values::StoredScalar::Chunked(value.clone()),
+            &crate::large_values::StoredScalar::Chunked(value.as_ref().clone()),
         )?),
         (Value::Large(value), ValueType::String)
             if value.kind == crate::large_values::LargeValueKind::String =>
         {
             bytes.extend(crate::large_values::encode_stored_scalar(
                 crate::large_values::LargeValueKind::String,
-                &crate::large_values::StoredScalar::Chunked(value.clone()),
+                &crate::large_values::StoredScalar::Chunked(value.as_ref().clone()),
             )?)
         }
         (Value::Large(value), ValueType::Bytes)
@@ -1639,7 +1640,7 @@ pub(super) fn encode_value_into(
         {
             bytes.extend(crate::large_values::encode_stored_scalar(
                 crate::large_values::LargeValueKind::Bytes,
-                &crate::large_values::StoredScalar::Chunked(value.clone()),
+                &crate::large_values::StoredScalar::Chunked(value.as_ref().clone()),
             )?)
         }
         (Value::Uuid(value), ValueType::Uuid) => bytes.extend_from_slice(value.as_bytes()),
@@ -1758,7 +1759,7 @@ pub(super) fn decode_value(bytes: &[u8], value_type: &ValueType) -> Result<Value
             crate::large_values::StoredScalar::Chunked(value)
                 if value.kind == crate::large_values::LargeValueKind::String =>
             {
-                Ok(Value::Large(value))
+                Ok(Value::Large(Box::new(value)))
             }
             crate::large_values::StoredScalar::Chunked(_) => Err(Error::TypeMismatch {
                 expected: value_type.clone(),
@@ -1772,7 +1773,7 @@ pub(super) fn decode_value(bytes: &[u8], value_type: &ValueType) -> Result<Value
             crate::large_values::StoredScalar::Chunked(value)
                 if value.kind == crate::large_values::LargeValueKind::Bytes =>
             {
-                Ok(Value::Large(value))
+                Ok(Value::Large(Box::new(value)))
             }
             crate::large_values::StoredScalar::Chunked(_) => Err(Error::TypeMismatch {
                 expected: value_type.clone(),
@@ -1796,7 +1797,7 @@ pub(super) fn decode_value(bytes: &[u8], value_type: &ValueType) -> Result<Value
                         .map_err(|_| Error::InvalidUtf8),
                 },
                 crate::large_values::StoredScalar::Chunked(value) if value.kind == *kind => {
-                    Ok(Value::Large(value))
+                    Ok(Value::Large(Box::new(value)))
                 }
                 crate::large_values::StoredScalar::Chunked(_) => Err(Error::TypeMismatch {
                     expected: value_type.clone(),

--- a/crates/groove/tests/large_value_query.rs
+++ b/crates/groove/tests/large_value_query.rs
@@ -45,8 +45,8 @@ async fn count_star_does_not_fetch_an_unused_indirect_column() {
     let source = GraphBuilder::values(
         descriptor,
         [
-            vec![Value::Large(prepared.value_ref.clone())],
-            vec![Value::Large(prepared.value_ref)],
+            vec![Value::Large(Box::new(prepared.value_ref.clone()))],
+            vec![Value::Large(Box::new(prepared.value_ref))],
         ],
     )
     .unwrap();
@@ -100,7 +100,10 @@ async fn projection_does_not_fetch_an_unselected_indirect_column() {
     let descriptor = RecordDescriptor::new([("id", ValueType::U64), ("body", ValueType::Bytes)]);
     let graph = GraphBuilder::values(
         descriptor,
-        [vec![Value::U64(7), Value::Large(prepared.value_ref)]],
+        [vec![
+            Value::U64(7),
+            Value::Large(Box::new(prepared.value_ref)),
+        ]],
     )
     .unwrap()
     .project(["id"]);
@@ -143,7 +146,10 @@ async fn filter_does_not_fetch_an_indirect_column_the_predicate_does_not_referen
     let descriptor = RecordDescriptor::new([("id", ValueType::U64), ("body", ValueType::Bytes)]);
     let graph = GraphBuilder::values(
         descriptor,
-        [vec![Value::U64(7), Value::Large(prepared.value_ref)]],
+        [vec![
+            Value::U64(7),
+            Value::Large(Box::new(prepared.value_ref)),
+        ]],
     )
     .unwrap()
     .filter(PredicateExpr::eq("id", Value::U64(7)))
@@ -186,7 +192,10 @@ async fn join_fetches_only_key_and_selected_large_fields() {
     database.set_chunk_provider(Rc::new(provider));
     let left = GraphBuilder::values(
         RecordDescriptor::new([("id", ValueType::U64), ("body", ValueType::String)]),
-        [vec![Value::U64(7), Value::Large(prepared.value_ref)]],
+        [vec![
+            Value::U64(7),
+            Value::Large(Box::new(prepared.value_ref)),
+        ]],
     )
     .unwrap();
     let right = GraphBuilder::values(
@@ -260,7 +269,10 @@ async fn subscription_materializes_large_insert_and_update_deltas_atomically() {
     assert!(subscription.recv().unwrap().is_empty());
 
     let mut batch = database.open_batch();
-    batch.insert("docs", vec![Value::U64(1), Value::Large(first.value_ref)]);
+    batch.insert(
+        "docs",
+        vec![Value::U64(1), Value::Large(Box::new(first.value_ref))],
+    );
     let publication = database.apply_batch(batch).await.unwrap();
     database
         .finish_persistence(publication.persist().await)
@@ -274,7 +286,10 @@ async fn subscription_materializes_large_insert_and_update_deltas_atomically() {
     assert_eq!(inserted[0].1, 1);
 
     let mut batch = database.open_batch();
-    batch.update("docs", vec![Value::U64(1), Value::Large(second.value_ref)]);
+    batch.update(
+        "docs",
+        vec![Value::U64(1), Value::Large(Box::new(second.value_ref))],
+    );
     let publication = database.apply_batch(batch).await.unwrap();
     database
         .finish_persistence(publication.persist().await)
@@ -342,7 +357,10 @@ async fn streaming_checksum_subscription_retracts_old_source_and_installs_new_so
     assert!(subscription.recv().unwrap().is_empty());
 
     let mut batch = database.open_batch();
-    batch.insert("files", vec![Value::U64(1), Value::Large(first.value_ref)]);
+    batch.insert(
+        "files",
+        vec![Value::U64(1), Value::Large(Box::new(first.value_ref))],
+    );
     let publication = database.apply_batch(batch).await.unwrap();
     database
         .finish_persistence(publication.persist().await)
@@ -359,7 +377,10 @@ async fn streaming_checksum_subscription_retracts_old_source_and_installs_new_so
     );
 
     let mut batch = database.open_batch();
-    batch.update("files", vec![Value::U64(1), Value::Large(second.value_ref)]);
+    batch.update(
+        "files",
+        vec![Value::U64(1), Value::Large(Box::new(second.value_ref))],
+    );
     let publication = database.apply_batch(batch).await.unwrap();
     database
         .finish_persistence(publication.persist().await)
@@ -408,7 +429,11 @@ async fn indirect_string_materializes_as_the_ordinary_logical_query_value() {
     .unwrap();
     database.set_chunk_provider(Rc::new(provider));
     let descriptor = RecordDescriptor::new([("body", ValueType::String)]);
-    let graph = GraphBuilder::values(descriptor, [vec![Value::Large(prepared.value_ref)]]).unwrap();
+    let graph = GraphBuilder::values(
+        descriptor,
+        [vec![Value::Large(Box::new(prepared.value_ref))]],
+    )
+    .unwrap();
 
     let rows = database
         .query_graph(graph)
@@ -452,8 +477,11 @@ fn query_future_stays_pending_while_required_chunks_are_paused() {
         .unwrap();
         database.set_chunk_provider(Rc::new(provider));
         let descriptor = RecordDescriptor::new([("body", ValueType::String)]);
-        let graph =
-            GraphBuilder::values(descriptor, [vec![Value::Large(prepared.value_ref)]]).unwrap();
+        let graph = GraphBuilder::values(
+            descriptor,
+            [vec![Value::Large(Box::new(prepared.value_ref))]],
+        )
+        .unwrap();
         let mut query = Box::pin(database.query_graph(graph));
         let waker = noop_waker();
         let mut context = Context::from_waker(&waker);
@@ -497,7 +525,11 @@ async fn chunk_failure_is_reported_without_publishing_a_partial_result() {
     .unwrap();
     database.set_chunk_provider(Rc::new(provider));
     let descriptor = RecordDescriptor::new([("body", ValueType::String)]);
-    let graph = GraphBuilder::values(descriptor, [vec![Value::Large(prepared.value_ref)]]).unwrap();
+    let graph = GraphBuilder::values(
+        descriptor,
+        [vec![Value::Large(Box::new(prepared.value_ref))]],
+    )
+    .unwrap();
 
     let error = database.query_graph(graph).await.unwrap_err();
 
@@ -536,7 +568,7 @@ async fn indirect_scalars_materialize_inside_composite_values() {
     let graph = GraphBuilder::values(
         descriptor,
         [vec![Value::Array(vec![Value::Nullable(Some(Box::new(
-            Value::Large(prepared.value_ref),
+            Value::Large(Box::new(prepared.value_ref)),
         )))])]],
     )
     .unwrap();
@@ -585,9 +617,12 @@ async fn predicates_compare_indirect_strings_by_logical_value() {
     .unwrap();
     database.set_chunk_provider(Rc::new(provider));
     let descriptor = RecordDescriptor::new([("body", ValueType::String)]);
-    let graph = GraphBuilder::values(descriptor, [vec![Value::Large(prepared.value_ref)]])
-        .unwrap()
-        .filter(PredicateExpr::eq("body", Value::String(logical.clone())));
+    let graph = GraphBuilder::values(
+        descriptor,
+        [vec![Value::Large(Box::new(prepared.value_ref))]],
+    )
+    .unwrap()
+    .filter(PredicateExpr::eq("body", Value::String(logical.clone())));
 
     let rows = database
         .query_graph(graph)
@@ -625,7 +660,7 @@ async fn predicates_compare_present_nullable_indirect_strings_logically() {
     let graph = GraphBuilder::values(
         descriptor,
         [vec![Value::Nullable(Some(Box::new(Value::Large(
-            prepared.value_ref,
+            Box::new(prepared.value_ref),
         ))))]],
     )
     .unwrap()
@@ -674,7 +709,7 @@ async fn lexical_predicate_stops_chunk_requests_after_decisive_prefix_mismatch()
     database.set_chunk_provider(Rc::new(provider));
     let graph = GraphBuilder::values(
         RecordDescriptor::new([("body", ValueType::String)]),
-        [vec![Value::Large(prepared.value_ref)]],
+        [vec![Value::Large(Box::new(prepared.value_ref))]],
     )
     .unwrap()
     .filter(PredicateExpr::gt("body", Value::String(literal)));
@@ -1254,7 +1289,10 @@ async fn graph_streaming_checksum_yields_and_publishes_one_complete_row() {
     let descriptor = RecordDescriptor::new([("id", ValueType::U64), ("body", ValueType::Bytes)]);
     let graph = GraphBuilder::values(
         descriptor,
-        [vec![Value::U64(7), Value::Large(prepared.value_ref)]],
+        [vec![
+            Value::U64(7),
+            Value::Large(Box::new(prepared.value_ref)),
+        ]],
     )
     .unwrap()
     .streaming_checksum("body", "body_checksum", 16 * 1024, 32 * 1024);
@@ -1306,9 +1344,12 @@ async fn graph_streaming_checksum_failure_publishes_nothing_and_can_retry() {
     let owned = OwnedChunkProvider::new_with_budget(Rc::new(provider), 128 * 1024);
     database.set_owned_chunk_provider(owned.clone());
     let descriptor = RecordDescriptor::new([("body", ValueType::Bytes)]);
-    let graph = GraphBuilder::values(descriptor, [vec![Value::Large(prepared.value_ref)]])
-        .unwrap()
-        .streaming_checksum("body", "checksum", 16 * 1024, 32 * 1024);
+    let graph = GraphBuilder::values(
+        descriptor,
+        [vec![Value::Large(Box::new(prepared.value_ref))]],
+    )
+    .unwrap()
+    .streaming_checksum("body", "checksum", 16 * 1024, 32 * 1024);
 
     control.fail_next(ChunkError::Backend("injected".to_owned()));
     assert!(database.query_graph(graph.clone()).await.is_err());

--- a/crates/jazz/src/db/mutations.rs
+++ b/crates/jazz/src/db/mutations.rs
@@ -786,7 +786,7 @@ where
                     .node
                     .lock()
                     .await
-                    .append_and_stage_large_value(value_ref, bytes)
+                    .append_and_stage_large_value(*value_ref, bytes)
                     .await?;
                 self.write_staged_large_value_update(table, row, column, staged, nullable)
                     .await
@@ -846,7 +846,7 @@ where
                     .node
                     .lock()
                     .await
-                    .edit_and_stage_large_value(value_ref, offset, delete_length, insert)
+                    .edit_and_stage_large_value(*value_ref, offset, delete_length, insert)
                     .await?;
                 self.write_staged_large_value_update(table, row, column, staged, nullable)
                     .await
@@ -1040,7 +1040,7 @@ where
                 "partial splice requires a bytes or string column",
             ));
         }
-        let Value::Large(mut current) = value else {
+        let Value::Large(current) = value else {
             return Ok((
                 apply_inline_splices(
                     preserve_nullable(value, nullable),
@@ -1052,6 +1052,7 @@ where
                 Vec::new(),
             ));
         };
+        let mut current = *current;
         if current.kind != expected_kind {
             return Err(Error::new(
                 ErrorCode::Schema,
@@ -1192,7 +1193,7 @@ where
                 .ok_or_else(|| Error::new(ErrorCode::Query, "splice page length overflows"))?;
         }
         Ok((
-            preserve_nullable(Value::Large(current), nullable),
+            preserve_nullable(Value::Large(Box::new(current)), nullable),
             final_staged,
             prior_claims,
         ))
@@ -1263,10 +1264,10 @@ where
             .node
             .lock()
             .await
-            .edit_and_stage_large_value(large.clone(), 0, large.byte_length, replacement)
+            .edit_and_stage_large_value(large.as_ref().clone(), 0, large.byte_length, replacement)
             .await?;
         Ok((
-            preserve_nullable(Value::Large(staged.value_ref.clone()), nullable),
+            preserve_nullable(Value::Large(Box::new(staged.value_ref.clone())), nullable),
             Some(staged),
             Vec::new(),
         ))
@@ -1324,7 +1325,7 @@ where
                 })?;
             cells.insert(
                 column.to_owned(),
-                preserve_nullable(Value::Large(staged.value_ref.clone()), nullable),
+                preserve_nullable(Value::Large(Box::new(staged.value_ref.clone())), nullable),
             );
             let parents = node
                 .local_content_winner_tx_id_in_schema(self.schema_version_id, table, row)

--- a/crates/jazz/src/db/peer_connection.rs
+++ b/crates/jazz/src/db/peer_connection.rs
@@ -885,7 +885,7 @@ fn collect_large_value_refs(value: &Value, refs: &mut Vec<groove::large_values::
     match value {
         Value::Large(value_ref) => {
             if !refs.contains(value_ref) {
-                refs.push(value_ref.clone());
+                refs.push(value_ref.as_ref().clone());
             }
         }
         Value::Tuple(values) | Value::Array(values) => {

--- a/crates/jazz/src/node/mod.rs
+++ b/crates/jazz/src/node/mod.rs
@@ -2429,7 +2429,7 @@ impl MergeableCommit {
         nullable: bool,
     ) -> Self {
         let column = column.into();
-        let value = Value::Large(staged.value_ref);
+        let value = Value::Large(Box::new(staged.value_ref));
         self.cells.insert(
             column.clone(),
             if nullable {
@@ -2532,7 +2532,7 @@ fn collect_indirect_descriptors(
     match value {
         Value::Large(value_ref) => {
             if !descriptors.contains(value_ref) {
-                descriptors.push(value_ref.clone());
+                descriptors.push(value_ref.as_ref().clone());
             }
         }
         Value::Tuple(values) | Value::Array(values) => {

--- a/crates/jazz/src/node/physical/tests.rs
+++ b/crates/jazz/src/node/physical/tests.rs
@@ -1185,16 +1185,16 @@ mod variant_case_tests {
         .unwrap();
         let json_root = json_prepared.value_ref.clone();
         assert!(
-            json_cell.create(&[Value::Large(json_root.clone())]).is_ok(),
+            json_cell.create(&[Value::Large(Box::new(json_root.clone()))]).is_ok(),
             "the JSON physical descriptor accepts its schema-derived large value"
         );
         assert!(
-            text_cell.create(&[Value::Large(json_root.clone())]).is_err(),
+            text_cell.create(&[Value::Large(Box::new(json_root.clone()))]).is_err(),
             "a JSON descriptor must not enter text physical storage"
         );
 
         let json_record = json_cell
-            .create(&[Value::Large(json_root.clone())])
+            .create(&[Value::Large(Box::new(json_root.clone()))])
             .expect("encode JSON physical cell");
         let replayed_values = text_cell.bind(&json_record).to_values().unwrap();
         let [Value::Large(replayed)] = replayed_values.as_slice() else {

--- a/crates/jazz/src/node/state/commit.rs
+++ b/crates/jazz/src/node/state/commit.rs
@@ -780,7 +780,7 @@ where
             .prepare_and_stage_large_value(kind, &bytes)
             .await?;
         self.enforce_large_value_staging_policy(&staged).await?;
-        let descriptor = Value::Large(staged.value_ref.clone());
+        let descriptor = Value::Large(Box::new(staged.value_ref.clone()));
         *value = if nullable {
             Value::Nullable(Some(Box::new(descriptor)))
         } else {

--- a/crates/jazz/src/node/state/lifecycle.rs
+++ b/crates/jazz/src/node/state/lifecycle.rs
@@ -1285,7 +1285,7 @@ where
         let column = column.into();
         commit
             .cells
-            .insert(column.clone(), Value::Large(staged.value_ref.clone()));
+            .insert(column.clone(), Value::Large(Box::new(staged.value_ref.clone())));
         commit.prepared_large_columns.insert(column);
         commit.staged_large_values.push(staged.id);
         Ok((commit, staged.value_ref))

--- a/crates/jazz/src/node/tests/general.rs
+++ b/crates/jazz/src/node/tests/general.rs
@@ -1265,7 +1265,7 @@ fn handcrafted_large_descriptor_is_rejected_but_node_staged_preparation_can_publ
     .unwrap();
     let forged = MergeableCommit::new("todos", row(0x75), 10).cells(BTreeMap::from([
         ("title".to_owned(), Value::String("title".to_owned())),
-        ("body".to_owned(), Value::Large(prepared.value_ref.clone())),
+        ("body".to_owned(), Value::Large(Box::new(prepared.value_ref.clone()))),
     ]));
     assert!(matches!(
         node.commit_mergeable_settled(forged),

--- a/crates/jazz/src/node/tests/native_storage_corpus.rs
+++ b/crates/jazz/src/node/tests/native_storage_corpus.rs
@@ -1098,7 +1098,7 @@ where
         .expect("fixture root finalizes through the normal node admission path");
     first_commit
         .cells
-        .insert("attachment".to_owned(), Value::Large(staged.value_ref));
+        .insert("attachment".to_owned(), Value::Large(Box::new(staged.value_ref)));
     first_commit
         .prepared_large_columns
         .insert("attachment".to_owned());

--- a/crates/jazz/src/protocol.rs
+++ b/crates/jazz/src/protocol.rs
@@ -5773,7 +5773,7 @@ fn put_value(bytes: &mut Vec<u8>, value: &Value) {
             bytes.push(15);
             let encoded = groove::large_values::encode_stored_scalar(
                 value.kind,
-                &groove::large_values::StoredScalar::Chunked(value.clone()),
+                &groove::large_values::StoredScalar::Chunked(value.as_ref().clone()),
             )
             .expect("admitted large descriptor has canonical encoding");
             put_bytes(bytes, &encoded);
@@ -6428,7 +6428,7 @@ mod tests {
         for value in [
             Value::Record(record),
             Value::Enum(enum_value),
-            Value::Large(large),
+            Value::Large(Box::new(large)),
         ] {
             assert!(
                 MigrationLens::new(

--- a/crates/jazz/tests/large_json_wire.rs
+++ b/crates/jazz/tests/large_json_wire.rs
@@ -55,7 +55,7 @@ fn json_version_records_freeze_inline_and_indirect_semantics() {
     let prepared =
         prepare_with_fixture_locators(LargeValueKind::Json, json.as_bytes(), b"jazz-json-wire-v1")
             .unwrap();
-    let indirect_value = Value::Large(prepared.value_ref);
+    let indirect_value = Value::Large(Box::new(prepared.value_ref));
     let indirect = make(indirect_value.clone());
     let legacy_descriptor =
         RecordDescriptor::new(inline.record().descriptor().fields().iter().map(|field| {


### PR DESCRIPTION
🤖 Shrink each materialized `Value` from 152 to 40 bytes on x86-64 by boxing the uncommon indirect large-value reference. Previously a boolean, integer or null paid the same inline width as the 152-byte large-value reference. A vector of 1,000 ordinary cells now needs 40 KB of cell storage instead of 152 KB, excluding its existing child allocations.

The change affects Rust ownership only. Native record encodings, existing serde variant tags and payloads, permissions and sync semantics remain unchanged. Large strings/bytes still use the same reference and materialization path; only that uncommon variant adds a box allocation. The splice loop unboxes once and keeps its working reference inline between edits. Rust callers constructing `Value::Large` now pass a boxed reference.

All Rust workspace target classes compile with CI's required features. Groove's library suite passes (749 passed, 2 ignored). A representation-budget test fails on the original 152-byte implementation, and a new compatibility test pins native scalar bytes plus the existing postcard/JSON carrier representations. Existing large-value tests retain their assertions; their constructors are updated mechanically.

Draft experiment on #2843. Clean native comparison against preserved parent binaries: cold settle 18.031s versus 18.353s, readiness 18.426s versus 18.754s, all 27,518 rows; the 1,500-row todo batch is 269.058ms versus 269.362ms. Treat this as latency-flat, not a substantial speedup. The 74% smaller inline cell representation is verified from compiler layout constants. Jazz library tests pass (2,007 passed, 2 ignored), along with all 24 large-value query tests, the unchanged large-JSON wire fixture, all three scaling canaries and the two-seed maintained/one-shot oracle at depths 10 and 1,000. Allocation capture over connect/subscribe/settle materialized all 27,518 rows: requested bytes fell from 32,651,257,883 to 28,848,569,899 (11.6%), while allocation count was effectively unchanged (115,600,178 versus 115,597,486). This explains why smaller cells did not materially reduce elapsed time. Retained as a small ownership/memory improvement, not a claimed latency win. No independent review or full release gate is claimed.
