### PR TITLE
perf: share immutable record bytes across clones

### DIFF
--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -1798,10 +1798,10 @@ pub struct Record<'a> {
     descriptor: &'a RecordDescriptor,
 }
 
-/// Owned encoded record tied to an owned descriptor.
+/// Immutable encoded record tied to an owned descriptor. Clones share bytes.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct OwnedRecord {
-    raw: Vec<u8>,
+    raw: bytes::Bytes,
     descriptor: RecordDescriptor,
 }
 
@@ -1982,7 +1982,10 @@ fn read_canonical_u32_varint(input: &[u8]) -> Result<(u32, usize), Error> {
 
 impl OwnedRecord {
     pub fn new(raw: Vec<u8>, descriptor: RecordDescriptor) -> Self {
-        Self { raw, descriptor }
+        Self {
+            raw: raw.into(),
+            descriptor,
+        }
     }
 
     pub fn descriptor(&self) -> &RecordDescriptor {
@@ -1994,7 +1997,7 @@ impl OwnedRecord {
     }
 
     pub fn into_raw(self) -> Vec<u8> {
-        self.raw
+        self.raw.into()
     }
 
     pub fn borrowed(&self) -> BorrowedRecord<'_> {

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -2769,3 +2769,21 @@ fn compact_large_value_preserves_native_and_serde_encodings() {
         serde_json::json!({"Large": reference})
     );
 }
+
+// Internal ownership guard: byte sharing is not observable through query results,
+// but copying every immutable record clone is a material allocation regression.
+#[test]
+fn immutable_record_clones_share_bytes_and_owned_extraction_stays_independent() {
+    let d = descriptor([ValueType::U64, ValueType::String]);
+    let values = [Value::U64(42), Value::String("shared payload".repeat(100))];
+    let original = OwnedRecord::new(d.create(&values).unwrap(), d);
+    let clone = original.clone();
+    assert_eq!(original.raw().as_ptr(), clone.raw().as_ptr());
+    let mut extracted = clone.into_raw();
+    extracted[0] ^= 1;
+    assert_eq!(original.to_values().unwrap(), values);
+    let pointer = original.raw().as_ptr();
+    let extracted = original.into_raw();
+    assert_eq!(pointer, extracted.as_ptr());
+    assert_eq!(d.bind(&extracted).to_values().unwrap(), values);
+}


### PR DESCRIPTION
🤖 Make cloning an immutable `OwnedRecord` share its encoded payload instead of allocating and copying the entire byte vector. Profiling identified record/version cloning as a frequent allocation source across query delivery and ingestion.

For example, retaining the same encoded row in several immutable version records now shares its bytes. Reading fields, comparison, hashing and serialization retain their existing behavior. `into_raw()` still returns a mutable owned vector: when another record retains the bytes it copies, so changing that vector cannot change the retained record; with exclusive ownership it recovers the original buffer. Constructor and accessor signatures remain unchanged. Existing explicit native and serde encodings are untouched.

The runtime change is confined to OwnedRecord's private buffer and its two ownership conversions. Groove's library suite passes (750 passed, 2 ignored). A new internal ownership test fails on the original copying implementation and passes with sharing; it also checks extraction isolation and unique-owner buffer recovery. Existing codec and record tests pass unchanged.

Discarded experiment on #2846. Two sequential, reversed-order comparisons consistently regress permissioned cold settle: candidate 18.311s/18.337s versus parent 17.570s/17.656s (about 4% slower), all 27,518 rows. Todo improves to 255.519ms/254.996ms versus 268.109ms/264.909ms (about 4%). The cold-load target governs, so this change is not retained. Shared-buffer conversion adds bookkeeping for short-lived records that are never cloned; the experiment does not justify applying shared ownership universally. Broader gates were not run after the regression was confirmed. Branch and measurements are preserved.
