### PR TITLE
perf: skip duplicate rendering of newly inserted roots

### DIFF
--- a/crates/groove/src/ivm/runtime/windows.rs
+++ b/crates/groove/src/ivm/runtime/windows.rs
@@ -790,6 +790,11 @@ fn update_collect_by_root_terminal_state(
     }
 
     for (root_key, before_record) in before {
+        // A new root already emitted its Insert above. With no previous row,
+        // this pass cannot emit an Update, so do not render it a second time.
+        let Some(before_record) = before_record else {
+            continue;
+        };
         // `groups` can retain a root-collector maintenance group before it
         // has ever been presented to this terminal consumer. Without a prior
         // Insert, an Update would address no facade occurrence.
@@ -803,19 +808,16 @@ fn update_collect_by_root_terminal_state(
                 .collect::<Vec<_>>();
             collect_by_root_from_records(input_desc, output_desc, collect_by, &records)
         })?;
+        // Removed roots were retracted before inserts/moves above.
+        let Some(after_record) = after_record else {
+            continue;
+        };
         if before_record == after_record {
             continue;
         }
-        let edit = match (before_record, after_record) {
-            // New roots were inserted above in final collector order.
-            (None, Some(_)) => continue,
-            (Some(_), Some(record)) => TerminalEdit::Update {
-                key: root_key.clone(),
-                value: record.to_vec(),
-            },
-            // Removed roots were retracted before inserts/moves above.
-            (Some(_), None) => continue,
-            (None, None) => continue,
+        let edit = TerminalEdit::Update {
+            key: root_key.clone(),
+            value: after_record.to_vec(),
         };
         operations.push(TerminalOperation {
             root_descriptor: output_desc,
@@ -1506,6 +1508,43 @@ mod root_terminal_tests {
                 }
             }
         }
+    }
+
+    // Internal work bound: the public Insert/Update stream cannot reveal a
+    // discarded second rendering of every newly inserted root.
+    #[test]
+    fn newly_inserted_roots_are_encoded_only_once() {
+        let input = record_descriptor();
+        let collect_by = collector();
+        let mut state = CollectByIncrementalState::default();
+        let deltas = (1..=100)
+            .map(|id| delta(id, id, "new", 1))
+            .collect::<Vec<_>>();
+        crate::records::RECORD_ENCODE_COUNT.with(|count| count.set(0));
+        let operations = update_unbounded_collect_by_terminal_state(
+            input,
+            input,
+            &collect_by,
+            None,
+            &mut state,
+            &deltas,
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            crate::records::RECORD_ENCODE_COUNT.with(|count| count.get()),
+            100
+        );
+        assert_eq!(operations.len(), 100);
+        assert!(
+            operations
+                .iter()
+                .all(|op| matches!(op.edit, TerminalEdit::Insert { .. }))
+        );
+        let mut roots = Vec::new();
+        apply_root_operations(&mut roots, &operations);
+        assert_eq!(roots.len(), 100);
+        assert!(roots.iter().all(|(_, rank)| rank == "new"));
     }
 
     #[test]

--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -140,7 +140,7 @@ pub struct RecordDescriptor(Intern<RecordDescriptorData>);
 
 #[cfg(test)]
 thread_local! {
-    static RECORD_ENCODE_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    pub(crate) static RECORD_ENCODE_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 impl RecordDescriptor {


### PR DESCRIPTION
🤖 Avoid rendering every newly inserted root twice. Root collection first renders a row to publish its Insert, then later visits touched roots to publish Updates. Previously that second pass rendered the new row again before noticing that it had no previous row and discarding the work.

For example, opening a subscription with 100 new roots produced 100 Inserts but encoded 200 root records. The Update pass now skips roots without a previous record before looking up or rendering their current record, reducing this to 100 encodings. Existing-row Updates still compare before/after records; removals, ordering and inserts retain the same behavior. No storage or wire change.

The new internal work-bound test observes 200 encodings on the original implementation and 100 after the fix, while asserting the exact Insert count and materialized rows. Groove's library suite passes (750 passed, 2 ignored). The test-only encode counter is exposed within the crate; production carries no new instrumentation.

Draft on #2846. The shared-buffer experiment #2848 was discarded after a repeatable cold-load regression and is not in this branch. Clean native comparison: cold settle 17.693s versus parent 17.651s, readiness 18.089s versus 18.044s, all 27,518 rows. Todo is 278.362ms versus 272.087ms in this single pair; no improvement is claimed. Retained as removal of proven redundant work with simpler control flow, not a latency win. Jazz library tests pass (2,007 passed, 2 ignored); all three scaling canaries and the two-seed maintained/one-shot oracle at depths 10 and 1,000 pass. No independent review or full release gate is claimed.
