### PR TITLE
perf: reuse graph compilation across query outputs

### DIFF
--- a/crates/groove/src/ivm/runtime/compilation.rs
+++ b/crates/groove/src/ivm/runtime/compilation.rs
@@ -2,6 +2,11 @@
 
 use super::*;
 
+#[cfg(test)]
+thread_local! {
+    pub(super) static BUILDER_COMPILATION_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 impl IvmRuntime {
     fn add_arrangement_node(
         &mut self,
@@ -27,18 +32,26 @@ impl IvmRuntime {
         &mut self,
         graph: &GraphBuilder,
     ) -> Result<CompiledNode, IvmRuntimeError> {
+        self.add_dedup_graph_with_memos(graph, &mut HashMap::default(), &mut HashMap::default())
+    }
+
+    /// Reuse planning within one operation over stable borrowed graphs. The
+    /// caller must keep every graph in place until both pointer-keyed memos
+    /// are discarded; never retain these memos across operations.
+    pub(super) fn add_dedup_graph_with_memos(
+        &mut self,
+        graph: &GraphBuilder,
+        output_memo: &mut HashMap<usize, RecordDescriptor>,
+        compiled_memo: &mut HashMap<usize, CompiledNode>,
+    ) -> Result<CompiledNode, IvmRuntimeError> {
         validate_collect_by_terminality(graph)?;
-        let mut output_memo = HashMap::default();
-        // Precompute descriptors once for the complete graph. The postorder
-        // compiler below can then reuse those descriptors without repeatedly
-        // traversing a long policy graph from each parent.
-        self.infer_builder_output_cached(graph, &mut output_memo)?;
-        let mut compiled_memo = HashMap::default();
+        self.infer_builder_output_cached(graph, output_memo)?;
         for builder in graph.postorder() {
-            self.add_dedup_graph_cached(builder, &mut output_memo, &mut compiled_memo)?;
+            self.add_dedup_graph_cached(builder, output_memo, compiled_memo)?;
         }
         compiled_memo
-            .remove(&graph_builder_key(graph))
+            .get(&graph_builder_key(graph))
+            .cloned()
             .ok_or(IvmRuntimeError::UnsupportedOperator)
     }
 
@@ -52,6 +65,8 @@ impl IvmRuntime {
         if let Some(compiled) = compiled_memo.get(&key) {
             return Ok(compiled.clone());
         }
+        #[cfg(test)]
+        BUILDER_COMPILATION_COUNT.with(|count| count.set(count.get() + 1));
         let inferred_output = self.infer_builder_output_cached(graph, output_memo)?;
         let compiled = match graph {
             GraphBuilder::Table { .. }

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -1,5 +1,10 @@
 //! Prepared shapes, routed bindings, and subscription delivery state.
 
+#[cfg(test)]
+thread_local! {
+    pub(super) static BUILDER_INFERENCE_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 use super::evaluation_session::EvaluationInputs;
 use super::*;
 
@@ -3240,6 +3245,7 @@ impl IvmRuntime {
             return Err(IvmRuntimeError::EmptyMultisinkSubscription);
         }
         let mut sink_names = HashSet::new();
+        let mut output_memo = HashMap::default();
         for terminal in &terminals {
             if !sink_names.insert(terminal.sink.clone()) {
                 return Err(IvmRuntimeError::DuplicateMultisinkSink(
@@ -3267,7 +3273,7 @@ impl IvmRuntime {
             {
                 return Err(IvmRuntimeError::GraphFieldIndexOutOfBounds(*index));
             }
-            let output = self.infer_builder_output(&terminal.graph)?;
+            let output = self.infer_builder_output_cached(&terminal.graph, &mut output_memo)?;
             for field in &terminal.route_fields {
                 if output.field_index(field).is_none() {
                     return Err(IvmRuntimeError::GraphFieldNotFound(field.clone()));
@@ -3302,24 +3308,42 @@ impl IvmRuntime {
         };
         let mut install = super::graph_lifecycle::EphemeralGraphInstall::new(self);
         let runtime = install.runtime();
-        let mut terminal_states = BTreeMap::new();
-        for terminal in terminals {
-            let output = match runtime.add_dedup_graph(&terminal.graph) {
-                Ok(output) => output,
-                Err(error) => {
-                    if inserted_source {
-                        runtime
-                            .binding_sources
-                            .remove(&BindingSourceKey::prepared(shape));
-                    }
-                    return Err(error);
+        let mut compiled_memo = HashMap::default();
+        // Borrow the stable terminal vector through validation and compilation.
+        // Moving each graph before compilation could recycle a memoized address.
+        let outputs = terminals
+            .iter()
+            .map(|terminal| {
+                runtime.add_dedup_graph_with_memos(
+                    &terminal.graph,
+                    &mut output_memo,
+                    &mut compiled_memo,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>();
+        let outputs = match outputs {
+            Ok(outputs) => outputs,
+            Err(error) => {
+                if inserted_source {
+                    runtime
+                        .binding_sources
+                        .remove(&BindingSourceKey::prepared(shape));
                 }
-            };
-            terminal_states.insert(
-                terminal.sink.clone(),
-                RoutedMultisinkTerminalState { terminal, output },
-            );
-        }
+                return Err(error);
+            }
+        };
+        drop(output_memo);
+        drop(compiled_memo);
+        let terminal_states = terminals
+            .into_iter()
+            .zip(outputs)
+            .map(|(terminal, output)| {
+                (
+                    terminal.sink.clone(),
+                    RoutedMultisinkTerminalState { terminal, output },
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
         // Publish retainers only after every terminal compiles, so the guard
         // can collect failed additions without disturbing existing shapes.
         for terminal in terminal_states.values() {
@@ -3420,18 +3444,32 @@ impl IvmRuntime {
                 .values()
                 .map(|terminal| count_builder_nodes(&terminal.terminal.graph) + 2)
                 .sum::<usize>() as u64;
+            // Construct all bound wrappers first so memo keys stay stable.
+            let graphs = shape
+                .terminals
+                .iter()
+                .map(|(sink, prepared_terminal)| {
+                    let mut terminal = prepared_terminal.terminal.clone();
+                    if let Some(fields) = public_fields.get(sink) {
+                        terminal.public_fields = fields.clone();
+                    }
+                    let graph = bound_routed_multisink_graph(
+                        &terminal,
+                        binding_values,
+                        &prepared_terminal.output.output,
+                    )?;
+                    Ok::<_, IvmRuntimeError>((sink.clone(), graph))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let mut output_memo = HashMap::default();
+            let mut compiled_memo = HashMap::default();
             let mut outputs = BTreeMap::new();
-            for (sink, prepared_terminal) in &shape.terminals {
-                let mut terminal = prepared_terminal.terminal.clone();
-                if let Some(fields) = public_fields.get(sink) {
-                    terminal.public_fields = fields.clone();
-                }
-                let graph = bound_routed_multisink_graph(
-                    &terminal,
-                    binding_values,
-                    &prepared_terminal.output.output,
+            for (sink, graph) in &graphs {
+                let output = runtime.add_dedup_graph_with_memos(
+                    graph,
+                    &mut output_memo,
+                    &mut compiled_memo,
                 )?;
-                let output = runtime.add_dedup_graph(&graph)?;
                 outputs.insert(sink.clone(), output);
             }
             let binding_shape = runtime.binding_source_shape_name(shape_id)?;
@@ -3920,6 +3958,8 @@ impl IvmRuntime {
         graph: &GraphBuilder,
         output_memo: &mut HashMap<usize, RecordDescriptor>,
     ) -> Result<RecordDescriptor, IvmRuntimeError> {
+        #[cfg(test)]
+        BUILDER_INFERENCE_COUNT.with(|count| count.set(count.get() + 1));
         match graph {
             GraphBuilder::Table {
                 table,

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -3246,3 +3246,82 @@ fn source_batch_prepares_one_descriptor_per_variant() {
         Err(IvmRuntimeError::UnknownTableVariant { version: 3, .. })
     ));
 }
+
+// Internal work bound: identical query results cannot expose repeated planning
+// of a shared graph independently for every sink of one prepare/bind operation.
+#[futures_test::test]
+async fn multisink_prepare_and_bind_infer_shared_graphs_once() {
+    let schema = albums_schema();
+    let albums = schema.table("albums").unwrap().record_schema();
+    let mut runtime = IvmRuntime::new(schema).unwrap();
+    let storage = Rc::new(MemoryStorage::new(&["albums"]).unwrap());
+    write_two_album_rows(&storage, &albums).await;
+    let mut graph = GraphBuilder::table("albums");
+    for _ in 0..20 {
+        graph = graph.project(["id", "title"]);
+    }
+    let terminals = (0..8)
+        .map(|index| {
+            let field = if index % 2 == 0 { "id" } else { "title" };
+            RoutedMultisinkTerminal::new(
+                format!("rows{index}"),
+                graph.clone().project([field]),
+                Vec::<String>::new(),
+                [field],
+            )
+        })
+        .collect::<Vec<_>>();
+    subscriptions::BUILDER_INFERENCE_COUNT.with(|count| count.set(0));
+    compilation::BUILDER_COMPILATION_COUNT.with(|count| count.set(0));
+    let prepared = runtime
+        .prepare(
+            terminals,
+            "shared-work",
+            RecordDescriptor::default(),
+            storage.as_ref(),
+        )
+        .await
+        .unwrap();
+    let prepare_count = subscriptions::BUILDER_INFERENCE_COUNT.with(|count| count.get());
+    let prepare_compiles = compilation::BUILDER_COMPILATION_COUNT.with(|count| count.get());
+    assert!(
+        prepare_compiles <= 80,
+        "prepare compiled {prepare_compiles} shared nodes"
+    );
+    assert!(
+        prepare_count <= 80,
+        "prepare inferred {prepare_count} nodes for shared graphs"
+    );
+    subscriptions::BUILDER_INFERENCE_COUNT.with(|count| count.set(0));
+    compilation::BUILDER_COMPILATION_COUNT.with(|count| count.set(0));
+    let subscription = runtime.bind_shape(prepared.id(), &[], &storage).unwrap();
+    let bind_count = subscriptions::BUILDER_INFERENCE_COUNT.with(|count| count.get());
+    let bind_compiles = compilation::BUILDER_COMPILATION_COUNT.with(|count| count.get());
+    assert!(
+        bind_compiles <= 80,
+        "bind compiled {bind_compiles} shared nodes"
+    );
+    eprintln!(
+        "prepare inferred={prepare_count} compiled={prepare_compiles}; bind inferred={bind_count} compiled={bind_compiles}"
+    );
+    assert!(
+        bind_count <= 80,
+        "bind inferred {bind_count} nodes for shared graphs"
+    );
+    runtime.drive_pending_incremental().await.unwrap();
+    let initial = subscription.try_recv().unwrap();
+    assert_eq!(initial.sinks.len(), 8);
+    for (sink, rows) in &initial.sinks {
+        let values = rows.to_values().unwrap();
+        assert_eq!(values.len(), 2);
+        assert!(values.iter().all(|(_, weight)| *weight == 1));
+        let expected = if sink.strip_prefix("rows").unwrap().parse::<usize>().unwrap() % 2 == 0 {
+            [Value::U64(1), Value::U64(2)]
+        } else {
+            [Value::String("one".into()), Value::String("two".into())]
+        };
+        for value in expected {
+            assert!(values.contains(&(vec![value], 1)));
+        }
+    }
+}


### PR DESCRIPTION
🤖 Reuse descriptor inference and graph compilation across all outputs of one prepared/bound query. Previously each terminal created fresh memos, so shared graph portions were inferred and compiled again for every sink, and prepare discarded its validation inference before compilation.

For example, eight sinks over a shared 20-step graph needed 352 descriptor inferences during prepare. The operation-scoped memos reduce this to 36 inferences and 36 compilations; binding performs 44 of each while preserving different requested columns for different sinks.

Prepare keeps the terminal vector stationary through validation and compilation, then discards the pointer-keyed memos before moving terminals into retained state. Bind constructs all bound wrappers first and borrows that stable vector during compilation. No memo survives the operation or crosses a schema/authentication transition. Existing graph-install rollback and retainer publication remain in place; no persistent or wire format changes.

Discarded experiment on #2849. The encoded-root projection experiment #2851 was discarded and is not in this branch. The new internal work-bound test fails on the original preparation path and asserts each sink's visible rows and columns. Groove library tests pass (751 passed, 2 ignored). Disabling compilation-memo reuse makes the new test fail at 176 compilations rather than 36; exact restoration passes. Clean native comparison materializes all 27,518 rows: cold settle 17.807s versus parent 18.014s (1.1%), readiness 18.198s versus 18.406s, todo 265.583ms versus 257.063ms. An allocation capture reports 109,870,578 allocations and 28,058,810,559 requested bytes; the earlier compact-value capture before this and the duplicate-render removal reported 115,597,486 and 28,848,569,899, so this combined difference must not be attributed solely to this PR. The end-to-end payoff does not justify retaining the extra memo plumbing. Branch and evidence are preserved; broader gates were not pursued.
