### PR TITLE
Attribute sampled allocation callers to node phases

### DIFF
--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -100,6 +100,7 @@ mod alloc_metrics {
         len: usize,
         count_sample: bool,
         byte_weight: u64,
+        phase: (&'static str, &'static str),
     }
 
     static ACTIVE: AtomicBool = AtomicBool::new(false);
@@ -201,6 +202,16 @@ mod alloc_metrics {
             len: 0,
             count_sample,
             byte_weight,
+            phase: {
+                #[cfg(feature = "cold-settle-attribution")]
+                {
+                    jazz_sim::phase_attribution::current_allocation_phase()
+                }
+                #[cfg(not(feature = "cold-settle-attribution"))]
+                {
+                    ("unscoped", "unscoped")
+                }
+            },
         };
         unsafe {
             backtrace::trace_unsynchronized(|frame| {
@@ -227,7 +238,13 @@ mod alloc_metrics {
             .clone();
         let sampled_stacks = samples.len();
         let mut counts: HashMap<Vec<usize>, (u64, u64)> = HashMap::new();
+        let mut phase_counts: HashMap<_, (u64, u64)> = HashMap::new();
         for sample in samples {
+            let totals = phase_counts
+                .entry((sample.phase, sample.frames[..sample.len].to_vec()))
+                .or_default();
+            totals.0 += u64::from(sample.count_sample);
+            totals.1 += sample.byte_weight;
             let totals = counts
                 .entry(sample.frames[..sample.len].to_vec())
                 .or_default();
@@ -289,6 +306,26 @@ mod alloc_metrics {
                     break;
                 }
             }
+        }
+        // Attribute every sampled stack exactly once, including unresolved
+        // callers, within the phase captured at allocation time.
+        let mut phase_callers: HashMap<_, (u64, u64)> = HashMap::new();
+        for ((phase, frames), totals) in phase_counts {
+            let caller = frames
+                .iter()
+                .find_map(|ip| resolved.get(ip).and_then(Option::as_deref))
+                .unwrap_or("unresolved");
+            let entry = phase_callers.entry((phase, caller.to_owned())).or_default();
+            entry.0 += totals.0;
+            entry.1 += totals.1;
+        }
+        let mut phase_callers = phase_callers.into_iter().collect::<Vec<_>>();
+        phase_callers.sort_by(|a, b| a.0.cmp(&b.0));
+        for (((role, phase), caller), (count, bytes)) in phase_callers {
+            eprintln!(
+                "ALLOC_PHASE_CALLER role={role} phase={phase} estimated_allocs={} estimated_bytes={bytes} caller={caller}",
+                count * sample_rate
+            );
         }
         let mut callers = callers.into_iter().collect::<Vec<_>>();
         for metric in ["count", "bytes"] {

--- a/crates/jazz-sim/src/phase_attribution.rs
+++ b/crates/jazz-sim/src/phase_attribution.rs
@@ -158,6 +158,16 @@ mod allocations {
             current.set(frame.map_or(UNSCOPED, |(role, phase)| role * PHASES.len() + phase))
         });
     }
+    /// Allocation-free identity of the innermost phase on this thread.
+    /// Sampled allocation stacks can retain these static labels after span exit.
+    pub fn current_allocation_phase() -> (&'static str, &'static str) {
+        let index = CURRENT.try_with(Cell::get).unwrap_or(UNSCOPED);
+        if index == UNSCOPED {
+            ("unscoped", "unscoped")
+        } else {
+            (ROLES[index / PHASES.len()], PHASES[index % PHASES.len()])
+        }
+    }
     pub fn record_allocation(bytes: usize) {
         let phase = CURRENT.try_with(Cell::get).unwrap_or(UNSCOPED);
         COUNTS[phase].fetch_add(1, Ordering::Relaxed);
@@ -190,7 +200,9 @@ mod allocations {
     }
 }
 #[cfg(feature = "bench-alloc-sites")]
-pub use allocations::{allocation_totals, record_allocation, reset_allocation_counts};
+pub use allocations::{
+    allocation_totals, current_allocation_phase, record_allocation, reset_allocation_counts,
+};
 
 /// Minimal subscriber: unrelated spans and events stay disabled.
 pub struct Collector;
@@ -365,6 +377,29 @@ mod tests {
         assert_eq!(find("core", "ingest")["requested_bytes"], 13);
         assert_eq!(find("relay", "relay")["requested_bytes"], 19);
         assert_eq!(find("unscoped", "unscoped")["requested_bytes"], 5);
+    }
+
+    #[cfg(feature = "bench-alloc-sites")]
+    #[test]
+    fn allocation_sample_labels_follow_thread_local_nested_spans() {
+        // Internal profiler contract: labels must survive exit and never leak
+        // onto a thread that did not enter the originating node's spans.
+        allocations::set_current(None);
+        assert_eq!(current_allocation_phase(), ("unscoped", "unscoped"));
+        let mut state = State::default();
+        state.enter(1, 0);
+        state.enter(4, 1);
+        let captured = current_allocation_phase();
+        assert_eq!(captured, ("relay", "ingest"));
+        assert_eq!(
+            std::thread::spawn(current_allocation_phase).join().unwrap(),
+            ("unscoped", "unscoped")
+        );
+        state.exit(4, 2);
+        assert_eq!(current_allocation_phase(), ("relay", "relay"));
+        state.exit(1, 3);
+        assert_eq!(current_allocation_phase(), ("unscoped", "unscoped"));
+        assert_eq!(captured, ("relay", "ingest"));
     }
 
     // Internal instrumentation invariants need deterministic clock values rather


### PR DESCRIPTION
🤖 This adds phase-specific allocation callers to the native cold-load profiler. We could already see that relay ingest allocated millions of times and that record clones were globally expensive, but could not reliably connect those observations.

Each sampled stack now captures the innermost node/phase labels at allocation time. Reporting groups callers within that phase, retaining an explicit unresolved bucket. For example, a clone in relay ingest is separate from the same clone in client persistence. Nested phases restore their parent label, and another thread does not inherit a node label.

This is diagnostic-only benchmark code, with no storage, wire or runtime semantics changes. Labels are static strings read without allocation; stack aggregation and symbol resolution happen after measurement stops. Counts are sampling estimates, while existing phase totals count all tracked allocations. Instrumented timings must not be treated as clean latency measurements.

Validation: all five phase-attribution tests passed; deliberately returning the unscoped label made the new nested/thread-isolation test fail. Optimized combined phase/allocation benchmark build passed. Full synthetic fixture capture passed: 27,518 rows, clean commit 900f71d786, 113,706,786 allocations and 28,521,853,022 requested bytes. The previous capture on the unchanged runtime counted 113,706,692 allocations and 28,521,779,518 bytes. Phase caller output identifies relay query setup as metadata-heavy and relay persistence as staged-write cloning plus physical-key construction. These are diagnostic totals, not clean timing claims.
