### PR TITLE
Borrow pending batch rows during delta computation

### DIFF
--- a/crates/groove/src/db/commit.rs
+++ b/crates/groove/src/db/commit.rs
@@ -122,11 +122,14 @@ impl Database {
             batch.notification_timing == NotificationTiming::AfterPersistence;
         // Later ordinary writes must not invalidate an ensure_exact result.
         let exact_keys = std::mem::take(&mut batch.exact_keys);
+        let borrowed_exact_keys = exact_keys
+            .iter()
+            .map(|((table, key), value)| ((table.as_str(), key.as_slice()), value))
+            .collect::<HashMap<_, _>>();
         let pending_writes = self.pending_writes_from_batch(batch)?;
         for write in &pending_writes {
-            if let Some(expected) =
-                exact_keys.get(&(write.table().to_owned(), write.key().to_vec()))
-                && write.stored_record().as_ref() != Some(expected)
+            if let Some(expected) = borrowed_exact_keys.get(&(write.table(), write.key()))
+                && write.stored_record().as_ref() != Some(*expected)
             {
                 return Err(Error::ImmutableBatchConflict);
             }
@@ -194,17 +197,22 @@ impl Database {
             }
         }
         let mut staged_operations = pending_writes
-            .iter()
+            .into_iter()
             .map(|write| match write {
-                PendingTableWrite::Set { key, .. } => OwnedWriteOperation::Set {
-                    cf: write.table().to_owned(),
-                    key: key.clone(),
-                    value: write.stored_record().expect("set has a stored record"),
+                PendingTableWrite::Set {
+                    table,
+                    key,
+                    variant_tag,
+                    record,
+                    ..
+                } => OwnedWriteOperation::Set {
+                    cf: table,
+                    key,
+                    value: encode_variant_record(variant_tag, &record),
                 },
-                PendingTableWrite::Delete { key, .. } => OwnedWriteOperation::Delete {
-                    cf: write.table().to_owned(),
-                    key: key.clone(),
-                },
+                PendingTableWrite::Delete { table, key, .. } => {
+                    OwnedWriteOperation::Delete { cf: table, key }
+                }
             })
             .collect::<Vec<_>>();
         for staged_id in accepted_large_values {

--- a/crates/groove/src/db/storage_helpers.rs
+++ b/crates/groove/src/db/storage_helpers.rs
@@ -918,7 +918,7 @@ where
     // instead of allocating a second table name and primary-key buffer for
     // every write merely to track same-batch visibility.
     let mut overlay =
-        HashMap::<(&str, &[u8]), Option<Vec<u8>>>::with_capacity(pending_writes.len());
+        HashMap::<(&str, &[u8]), Option<(u32, &[u8])>>::with_capacity(pending_writes.len());
     // Accumulate directly into the homogeneous groups consumed by IVM. The
     // previous path allocated a singleton TableDelta (and Vec) per old/new
     // record, then hashed every group and record again in a second pass.
@@ -929,8 +929,9 @@ where
 
     for (write, store) in pending_writes.iter().zip(stores) {
         let overlay_key = (write.table(), write.key());
+        let stored_current;
         let current = if let Some(record) = overlay.get(&overlay_key) {
-            record.clone()
+            *record
         } else if matches!(
             write,
             PendingTableWrite::Set {
@@ -940,7 +941,11 @@ where
         ) {
             None
         } else {
-            store.get_raw(write.key()).await?
+            stored_current = store.get_raw(write.key()).await?;
+            stored_current
+                .as_deref()
+                .map(split_variant_record)
+                .transpose()?
         };
         if matches!(
             write,
@@ -958,8 +963,7 @@ where
         let table_schema = schema
             .table(write.table())
             .ok_or_else(|| Error::TableNotFound(write.table().to_owned()))?;
-        if let Some(current) = current.as_deref() {
-            let (variant_tag, payload) = split_variant_record(current)?;
+        if let Some((variant_tag, payload)) = current {
             let descriptor_key = (write.table(), variant_tag);
             let descriptor = if let Some(descriptor) = old_descriptors.get(&descriptor_key) {
                 *descriptor
@@ -992,7 +996,14 @@ where
                 .entry(bytes::Bytes::copy_from_slice(record))
                 .or_default() += 1;
         }
-        let next = write.stored_record();
+        let next = match write {
+            PendingTableWrite::Set {
+                variant_tag,
+                record,
+                ..
+            } => Some((*variant_tag, record.as_slice())),
+            PendingTableWrite::Delete { .. } => None,
+        };
         overlay.insert(overlay_key, next);
     }
 


### PR DESCRIPTION
🤖 Applying a batch temporarily encoded every pending row into a same-batch lookup map, then encoded it again for storage. The map now borrows each pending row's variant and payload. Final storage operations take ownership of table names and keys instead of cloning them. Exact-match checks also use a borrowed-key index instead of allocating lookup coordinates per write.

For example, insert row 7 as “first”, then update it to “second” in one batch. Delta computation still sees the earlier pending write and emits only the final row. It now reads that earlier payload directly rather than building another encoded copy. Delete and reinsert sequences retain their same-batch visibility; immutable exact-match conflicts still reject the batch.

No persistence or wire encoding changes, and no durability/lifecycle changes. The borrowed data stays owned by the pending batch until delta computation finishes. Storage receives the same ordered owned operations as before.

Validation: all 750 Groove tests passed (2 ignored). Deliberately dropping prior-write visibility makes the existing repeated-key test fail by exposing both versions rather than only the final one. Clean native pair: 27,518-row cold settle 17.682s versus 18.006s on the parent runtime; dominant-query readiness 18.075s versus 18.398s. The 1,350-row todo update was 258.207ms versus 252.450ms. Treat this as modest/flat timing, not a demonstrated broad speedup. Jazz library: 2,007 passed, 2 ignored. All three incremental-delivery/work-scaling canaries passed, plus the two-seed maintained-vs-one-shot oracle at churn depths 10 and 1,000. These are focused checks, not the full CI-equivalent gate or browser acceptance.
