### PR TITLE
Fix permissions publication after missing schema lineage

### DIFF
--- a/.changeset/permissions-lineage-recovery.md
+++ b/.changeset/permissions-lineage-recovery.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Recover permissions publication when a schema migration is already durable but missing from the running server. Reject missing or ambiguous lineage before advancing the permissions head, so publication can be retried safely.

--- a/crates/jazz-server/src/server/catalogue.rs
+++ b/crates/jazz-server/src/server/catalogue.rs
@@ -102,6 +102,7 @@ pub struct ServerCatalogue;
 pub(crate) trait CatalogueStore {
     fn known_schema_hashes(&self) -> Result<Vec<SchemaHash>, CatalogueError>;
     fn known_schema(&self, schema_hash: &SchemaHash) -> Result<Option<Schema>, CatalogueError>;
+    fn known_lenses(&self) -> Result<Vec<Lens>, CatalogueError>;
     fn schema_published_at(&self, schema_hash: &SchemaHash) -> Result<Option<u64>, CatalogueError>;
     fn are_schema_hashes_connected(
         &self,
@@ -273,6 +274,7 @@ struct CatalogueIndex {
     schemas: HashMap<SchemaHash, Schema>,
     schema_published_at: HashMap<SchemaHash, u64>,
     lens_edges: HashSet<(SchemaHash, SchemaHash)>,
+    lenses: HashMap<(SchemaHash, SchemaHash), Lens>,
     permissions_head: Option<PermissionsHeadSummary>,
     permissions_bundles: HashMap<ObjectId, CurrentPermissionsSummary>,
 }
@@ -478,6 +480,7 @@ impl CatalogueIndex {
                 }
                 if !lens.is_draft() {
                     self.lens_edges.insert((source, target));
+                    self.lenses.insert((source, target), lens);
                 }
             }
             Some(kind) if kind == ObjectType::CataloguePermissionsBundle.as_str() => {
@@ -612,6 +615,11 @@ impl CatalogueStore for StoredCatalogue {
     fn known_schema(&self, schema_hash: &SchemaHash) -> Result<Option<Schema>, CatalogueError> {
         let index = self.index.lock().map_err(|_| CatalogueError::LockError)?;
         Ok(index.schemas.get(schema_hash).cloned())
+    }
+
+    fn known_lenses(&self) -> Result<Vec<Lens>, CatalogueError> {
+        let index = self.index.lock().map_err(|_| CatalogueError::LockError)?;
+        Ok(index.lenses.values().cloned().collect())
     }
 
     fn schema_published_at(&self, schema_hash: &SchemaHash) -> Result<Option<u64>, CatalogueError> {
@@ -770,6 +778,13 @@ impl ServerCatalogue {
         schema_hash: &SchemaHash,
     ) -> Result<Option<Schema>, CatalogueError> {
         store.known_schema(schema_hash)
+    }
+
+    pub(crate) fn known_lenses(
+        &self,
+        store: &impl CatalogueStore,
+    ) -> Result<Vec<Lens>, CatalogueError> {
+        store.known_lenses()
     }
 
     pub(crate) fn schema_published_at(

--- a/crates/jazz-server/src/server/routes/http.rs
+++ b/crates/jazz-server/src/server/routes/http.rs
@@ -1178,50 +1178,43 @@ pub(super) async fn publish_permissions_handler(
             .into_response();
     }
 
-    match state.catalogue.publish_permissions_bundle(
-        &state.catalogue_store,
+    match crate::server::runtime_catalogue::publish_permissions_and_runtime(
+        &state,
         schema_hash,
         permissions,
         expected_parent_bundle_object_id,
-    ) {
-        Ok(_) => match state
-            .catalogue
-            .current_permissions_head(&state.catalogue_store)
-        {
-            Ok(head) => {
-                if let Err(err) =
-                    crate::server::runtime_catalogue::publish_runtime_catalogue(&state, &[], &[])
-                        .await
-                {
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ErrorResponse::internal(format!(
-                            "failed to bridge permissions head into server shell: {err}"
-                        ))),
-                    )
-                        .into_response();
-                }
-                let head = head.map(permissions_head_view);
-                (StatusCode::CREATED, Json(PermissionsHeadResponse { head })).into_response()
-            }
-            Err(err) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::internal(format!(
-                    "failed to read published permissions head: {err}"
-                ))),
-            )
-                .into_response(),
-        },
-        Err(crate::server::catalogue::CatalogueError::WriteError(message))
-            if message.starts_with("stale permissions parent") =>
-        {
-            (
-                StatusCode::CONFLICT,
-                Json(ErrorResponse::bad_request(message)),
-            )
-                .into_response()
-        }
-        Err(err) => (
+    )
+    .await
+    {
+        Ok(head) => (
+            StatusCode::CREATED,
+            Json(PermissionsHeadResponse {
+                head: Some(permissions_head_view(head)),
+            }),
+        )
+            .into_response(),
+        Err(crate::server::runtime_catalogue::PermissionsPublicationError::Catalogue(
+            crate::server::catalogue::CatalogueError::WriteError(message),
+        )) if message.starts_with("stale permissions parent") => (
+            StatusCode::CONFLICT,
+            Json(ErrorResponse::bad_request(message)),
+        )
+            .into_response(),
+        Err(crate::server::runtime_catalogue::PermissionsPublicationError::LineageUnavailable(
+            message,
+        )) => (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::bad_request(message)),
+        )
+            .into_response(),
+        Err(crate::server::runtime_catalogue::PermissionsPublicationError::Bridge(message)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::internal(format!(
+                "failed to bridge permissions head into server shell: {message}"
+            ))),
+        )
+            .into_response(),
+        Err(crate::server::runtime_catalogue::PermissionsPublicationError::Catalogue(err)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse::internal(format!(
                 "failed to publish permissions catalogue: {err}"

--- a/crates/jazz-server/src/server/routes/mod.rs
+++ b/crates/jazz-server/src/server/routes/mod.rs
@@ -147,20 +147,13 @@ mod tests {
     use axum::response::Json;
 
     use jazz::tools::AppId;
-    use jazz::tools::public_schema::{SchemaHash, TableName};
+    use jazz::tools::public_schema::{
+        ColumnType, PolicyExpr, Schema, SchemaBuilder, SchemaHash, TableName, TablePolicies,
+        TableSchema,
+    };
     use jazz::tools::schema_lens::LensOp;
     use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-    use crate::server::catalogue::ConnectionSchemaDiagnostics;
-    use axum::body;
-    use axum::routing::{get, post};
-    use futures::{SinkExt as _, StreamExt as _};
-    use jazz::ids::AuthorSubject;
-    use jazz::tools::public_schema::{
-        ColumnType, PolicyExpr, Schema, SchemaBuilder, TablePolicies, TableSchema,
-    };
-    use serde_json::Value;
     use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
     use tower::ServiceExt;
 
@@ -173,6 +166,13 @@ mod tests {
         FEATURE_STRUCTURED_ERRORS, FEATURE_SYNC_MESSAGE_PAYLOAD, WireFrame, WireHello,
         WirePeerRole, decode_frame, encode_frame,
     };
+
+    use crate::server::catalogue::ConnectionSchemaDiagnostics;
+    use axum::body;
+    use axum::routing::{get, post};
+    use futures::{SinkExt as _, StreamExt as _};
+    use jazz::ids::AuthorSubject;
+    use serde_json::Value;
 
     #[tokio::test]
     async fn backend_admission_requires_exact_service_secret_and_application() {

--- a/crates/jazz-server/src/server/routes/websocket.rs
+++ b/crates/jazz-server/src/server/routes/websocket.rs
@@ -3537,6 +3537,122 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn permissions_publication_reconciles_durable_lineage_after_runtime_bridge_failure() {
+        use jazz::tools::public_schema::SchemaHash;
+        use jazz::tools::schema_lens::{Lens, LensOp, LensTransform};
+
+        let v1 = SchemaBuilder::new()
+            .table(
+                PublicTableSchema::builder("todos")
+                    .column("old_title", ColumnType::Text)
+                    .column("done", ColumnType::Boolean),
+            )
+            .build();
+        let v2 = SchemaBuilder::new()
+            .table(
+                PublicTableSchema::builder("todos")
+                    .column("title", ColumnType::Text)
+                    .column("done", ColumnType::Boolean),
+            )
+            .build();
+        let v1_hash = SchemaHash::compute(&v1);
+        let v2_hash = SchemaHash::compute(&v2);
+        let state = ServerBuilder::new(AppId::random())
+            .with_auth_config(AuthConfig {
+                admin_secret: Some("admin-secret".to_owned()),
+                backend_secret: Some("backend-secret".to_owned()),
+                ..Default::default()
+            })
+            .with_storage(StorageBackend::InMemory)
+            .with_schema(v1)
+            .build()
+            .await
+            .expect("build lineage retry server")
+            .state;
+
+        // Internal fault setup is necessary because the public admin routes
+        // persist and bridge together: they cannot deterministically stop
+        // between those operations. Simulate that failed bridge here, but
+        // observe recovery only through HTTP and real websocket Db clients.
+        state
+            .catalogue
+            .publish_schema(&state.catalogue_store, v2)
+            .expect("persist target schema");
+        let mut transform = LensTransform::new();
+        transform.push(
+            LensOp::RenameColumn {
+                table: "todos".to_owned(),
+                old_name: "old_title".to_owned(),
+                new_name: "title".to_owned(),
+            },
+            false,
+        );
+        state
+            .catalogue
+            .publish_lens(
+                &state.catalogue_store,
+                &Lens::new(v1_hash, v2_hash, transform),
+            )
+            .expect("persist target lineage");
+
+        let addr = start_ws_test_server(state.clone()).await;
+        let policies = public_table_policies().with_select(PolicyExpr::eq_session(
+            "title",
+            vec![
+                "user".to_owned(),
+                "identity".to_owned(),
+                "subject".to_owned(),
+            ],
+        ));
+        let response = reqwest::Client::new()
+            .post(format!(
+                "http://{addr}/apps/{}/admin/permissions",
+                state.app_id
+            ))
+            .header("X-Jazz-Admin-Secret", "admin-secret")
+            .header("Content-Type", "application/json")
+            .body(
+                serde_json::json!({
+                    "schemaHash": v2_hash.to_string(),
+                    "permissions": { "todos": policies },
+                })
+                .to_string(),
+            )
+            .send()
+            .await
+            .expect("publish permissions through admin route");
+        let status = response.status();
+        let body = response.text().await.expect("permissions response body");
+        assert_eq!(status, reqwest::StatusCode::CREATED, "{body}");
+
+        let reader_identity = AuthorSubject::for_test_bytes([0xb2; 16]);
+        let (_, visible_title) = issuer_and_subject(reader_identity);
+        let writer = TestClient::new(ws_public_schema_convert(), 0xa1, 0xa100).await;
+        let mut writer_ws =
+            open_negotiated_ws(addr, &state, AuthorSubject::for_test_bytes([0xa1; 16])).await;
+        let (_, writer_attachment) = settle_ws_todos_query(&writer, &mut writer_ws).await;
+        for title in [visible_title.as_str(), "hidden"] {
+            let write = writer.write_todo(title);
+            assert_eq!(
+                settle_ws_write(&writer, &mut writer_ws, &write).await.fate,
+                Fate::Accepted,
+                "the authority must accept the fixture row before the reader queries"
+            );
+        }
+        writer.detach_query(writer_attachment);
+
+        let reader = TestClient::new(ws_public_schema_convert(), 0xb2, 0xb200).await;
+        let mut reader_ws = open_negotiated_ws_session(addr, &state, reader_identity).await;
+        let (query, attachment) = settle_ws_todos_query(&reader, &mut reader_ws).await;
+        assert_eq!(
+            reader.edge_todo_titles(&query).await,
+            vec![visible_title],
+            "the recovered permissions must expose the allowed row and hide the other row"
+        );
+        reader.detach_query(attachment);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn ws_reader_query_covered_empty_when_existing_row_hidden_by_read_policy() {
         let schema = ws_private_docs_schema_convert();
         let state = ServerBuilder::new(AppId::random())

--- a/crates/jazz-server/src/server/runtime_catalogue.rs
+++ b/crates/jazz-server/src/server/runtime_catalogue.rs
@@ -1,6 +1,6 @@
 //! Bridge the administrative catalogue into the WebSocket-serving core shell.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use jazz::groove::records::Value as CoreValue;
 use jazz::protocol::{LensOp as CoreLensOp, MigrationLens, TableLens};
@@ -8,6 +8,8 @@ use jazz::schema::JazzSchema;
 
 use jazz::tools::public_schema::{Schema, SchemaHash, TableName, Value};
 use jazz::tools::schema_lens::{Lens, LensOp};
+
+use super::catalogue::{CatalogueError, PermissionsHeadSummary};
 
 use super::{ServerRuntimeHandle, ServerState};
 
@@ -29,6 +31,72 @@ pub(crate) async fn publish_runtime_catalogue(
     // otherwise a later head can install first and then be overwritten by this
     // older bridge.
     let _publication = state.runtime_catalogue_publication.lock().await;
+    publish_runtime_catalogue_locked(state, schemas, lenses).await
+}
+
+pub(crate) enum PermissionsPublicationError {
+    Catalogue(CatalogueError),
+    LineageUnavailable(String),
+    Bridge(String),
+}
+
+pub(crate) async fn publish_permissions_and_runtime(
+    state: &ServerState,
+    schema_hash: SchemaHash,
+    permissions: HashMap<TableName, jazz::tools::public_schema::TablePolicies>,
+    expected_parent_bundle_object_id: Option<jazz::tools::ObjectId>,
+) -> Result<PermissionsHeadSummary, PermissionsPublicationError> {
+    #[cfg(test)]
+    state.run_runtime_catalogue_before_publication_hook_for_test();
+    let _publication = state.runtime_catalogue_publication.lock().await;
+
+    let runtime_enabled =
+        state.runtime().is_some() || state.core_server_shell_storage_config.is_some();
+    let mut shell = state.runtime();
+    if runtime_enabled {
+        ensure_structural_lineage_locked(state, schema_hash, &HashMap::new(), &[], &mut shell)
+            .await
+            .map_err(|error| match error {
+                StructuralLineageError::Unavailable(message) => {
+                    PermissionsPublicationError::LineageUnavailable(message)
+                }
+                StructuralLineageError::Bridge(message) => {
+                    PermissionsPublicationError::Bridge(message)
+                }
+            })?;
+    }
+
+    state
+        .catalogue
+        .publish_permissions_bundle(
+            &state.catalogue_store,
+            schema_hash,
+            permissions,
+            expected_parent_bundle_object_id,
+        )
+        .map_err(PermissionsPublicationError::Catalogue)?;
+    let head = state
+        .catalogue
+        .current_permissions(&state.catalogue_store)
+        .map_err(PermissionsPublicationError::Catalogue)?
+        .ok_or_else(|| {
+            PermissionsPublicationError::Bridge(
+                "published permissions head is missing from the catalogue".to_owned(),
+            )
+        })?
+        .head;
+
+    publish_runtime_catalogue_locked(state, &[], &[])
+        .await
+        .map_err(PermissionsPublicationError::Bridge)?;
+    Ok(head)
+}
+
+async fn publish_runtime_catalogue_locked(
+    state: &ServerState,
+    schemas: &[Schema],
+    lenses: &[Lens],
+) -> Result<(), String> {
     if state.runtime().is_none() && state.core_server_shell_storage_config.is_none() {
         return Ok(());
     }
@@ -46,36 +114,7 @@ pub(crate) async fn publish_runtime_catalogue(
     }
 
     for lens in lenses {
-        let source_schema = known_schema(state, &supplied_schemas, lens.source_hash)?;
-        let target_schema = known_schema(state, &supplied_schemas, lens.target_hash)?;
-        let runtime_lens = convert_lens(lens, &source_schema, &target_schema)?;
-        let new_tables = lens
-            .forward
-            .ops
-            .iter()
-            .filter_map(|op| match op {
-                LensOp::AddTable { table, .. } => Some(table.as_str().to_owned()),
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-        let dropped_tables = lens
-            .forward
-            .ops
-            .iter()
-            .filter_map(|op| match op {
-                LensOp::RemoveTable { table, .. } => Some(table.as_str().to_owned()),
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-        let initial_schema = JazzSchema::new(&source_schema)
-            .map_err(|error| format!("convert lens source schema for runtime: {error}"))?;
-        let target_runtime = JazzSchema::new(&target_schema)
-            .map_err(|error| format!("convert lens target schema: {error}"))?;
-        let runtime_shell = runtime_shell(state, &mut shell, initial_schema)?;
-        runtime_shell
-            .publish_schema_with_lens(target_runtime, runtime_lens, new_tables, dropped_tables)
-            .await
-            .map_err(|error| format!("publish schema lineage to runtime shell: {error}"))?;
+        publish_runtime_lens(state, &mut shell, lens, &supplied_schemas).await?;
     }
 
     let permissions = state
@@ -87,6 +126,16 @@ pub(crate) async fn publish_runtime_catalogue(
     let Some(permissions) = permissions else {
         return Ok(());
     };
+    ensure_structural_lineage_locked(
+        state,
+        permissions.head.schema_hash,
+        &supplied_schemas,
+        lenses,
+        &mut shell,
+    )
+    .await
+    .map_err(StructuralLineageError::into_string)?;
+
     let mut schema = known_schema(state, &supplied_schemas, permissions.head.schema_hash)?;
     let structural_runtime = JazzSchema::new(&schema)
         .map_err(|error| format!("convert permissions lineage source schema: {error}"))?;
@@ -109,6 +158,204 @@ pub(crate) async fn publish_runtime_catalogue(
     Ok(())
 }
 
+async fn publish_runtime_lens(
+    state: &ServerState,
+    shell: &mut Option<ServerRuntimeHandle>,
+    lens: &Lens,
+    supplied_schemas: &HashMap<SchemaHash, Schema>,
+) -> Result<(), String> {
+    let source_schema = known_schema(state, supplied_schemas, lens.source_hash)?;
+    let target_schema = known_schema(state, supplied_schemas, lens.target_hash)?;
+    let runtime_lens = convert_lens(lens, &source_schema, &target_schema)?;
+    let new_tables = lens
+        .forward
+        .ops
+        .iter()
+        .filter_map(|op| match op {
+            LensOp::AddTable { table, .. } => Some(table.as_str().to_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let dropped_tables = lens
+        .forward
+        .ops
+        .iter()
+        .filter_map(|op| match op {
+            LensOp::RemoveTable { table, .. } => Some(table.as_str().to_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let initial_schema = JazzSchema::new(&source_schema)
+        .map_err(|error| format!("convert lens source schema for runtime: {error}"))?;
+    let target_runtime = JazzSchema::new(&target_schema)
+        .map_err(|error| format!("convert lens target schema: {error}"))?;
+    let runtime_shell = runtime_shell(state, shell, initial_schema)?;
+    runtime_shell
+        .publish_schema_with_lens(target_runtime, runtime_lens, new_tables, dropped_tables)
+        .await
+        .map_err(|error| format!("publish schema lineage to runtime shell: {error}"))?;
+    Ok(())
+}
+
+#[derive(Debug)]
+enum StructuralLineageError {
+    Unavailable(String),
+    Bridge(String),
+}
+
+impl StructuralLineageError {
+    fn into_string(self) -> String {
+        match self {
+            Self::Unavailable(message) | Self::Bridge(message) => message,
+        }
+    }
+}
+
+async fn ensure_structural_lineage_locked(
+    state: &ServerState,
+    target_hash: SchemaHash,
+    supplied_schemas: &HashMap<SchemaHash, Schema>,
+    supplied_lenses: &[Lens],
+    shell: &mut Option<ServerRuntimeHandle>,
+) -> Result<(), StructuralLineageError> {
+    let target_schema = known_schema(state, supplied_schemas, target_hash)
+        .map_err(StructuralLineageError::Bridge)?;
+    let target_runtime = JazzSchema::new(&target_schema)
+        .map_err(|error| StructuralLineageError::Bridge(error.to_string()))?;
+
+    let Some(runtime) = shell.clone() else {
+        runtime_shell(state, shell, target_runtime)
+            .map(|_| ())
+            .map_err(StructuralLineageError::Bridge)?;
+        return Ok(());
+    };
+    let target_runtime_id = target_runtime.version_id();
+    if runtime
+        .runtime_catalogue_contains_schema(target_runtime_id)
+        .await
+        .map_err(StructuralLineageError::Bridge)?
+    {
+        return Ok(());
+    }
+
+    let mut lenses_by_edge = HashMap::new();
+    let durable_lenses = state
+        .catalogue
+        .known_lenses(&state.catalogue_store)
+        .map_err(|error| {
+            StructuralLineageError::Bridge(format!("read catalogue lenses: {error}"))
+        })?;
+    for lens in durable_lenses {
+        lenses_by_edge.insert((lens.source_hash, lens.target_hash), lens);
+    }
+    for lens in supplied_lenses.iter().filter(|lens| !lens.is_draft()) {
+        lenses_by_edge.insert((lens.source_hash, lens.target_hash), lens.clone());
+    }
+    let mut lenses = lenses_by_edge.into_values().collect::<Vec<_>>();
+    lenses.sort_by(|left, right| {
+        left.source_hash
+            .as_bytes()
+            .cmp(right.source_hash.as_bytes())
+            .then_with(|| {
+                left.target_hash
+                    .as_bytes()
+                    .cmp(right.target_hash.as_bytes())
+            })
+    });
+
+    let mut schemas_by_hash = HashMap::from([(target_hash, target_schema)]);
+    let mut valid_lenses = Vec::new();
+    for lens in lenses {
+        let Some(source_schema) =
+            known_schema_if_present(state, supplied_schemas, lens.source_hash)
+                .map_err(StructuralLineageError::Bridge)?
+        else {
+            continue;
+        };
+        let Some(target_schema) =
+            known_schema_if_present(state, supplied_schemas, lens.target_hash)
+                .map_err(StructuralLineageError::Bridge)?
+        else {
+            continue;
+        };
+        schemas_by_hash.insert(lens.source_hash, source_schema);
+        schemas_by_hash.insert(lens.target_hash, target_schema);
+        valid_lenses.push(lens);
+    }
+
+    let mut runtime_known = HashSet::new();
+    for (&hash, schema) in &schemas_by_hash {
+        let runtime_schema = JazzSchema::new(schema).map_err(|error| {
+            StructuralLineageError::Bridge(format!("convert catalogue schema {hash}: {error}"))
+        })?;
+        if runtime
+            .runtime_catalogue_contains_schema(runtime_schema.version_id())
+            .await
+            .map_err(StructuralLineageError::Bridge)?
+        {
+            runtime_known.insert(hash);
+        }
+    }
+
+    let mut incoming = HashMap::<SchemaHash, Vec<Lens>>::new();
+    // Grouping preserves the deterministic order established above.
+    for lens in valid_lenses {
+        incoming.entry(lens.target_hash).or_default().push(lens);
+    }
+    let mut visiting = HashSet::new();
+    let path = match find_lineage_path(target_hash, &incoming, &runtime_known, &mut visiting) {
+        LineagePath::Unique(path) => path,
+        LineagePath::None | LineagePath::Ambiguous => {
+            return Err(StructuralLineageError::Unavailable(format!(
+                "permissions target schema {target_hash} has no unique published lineage in the server shell; publish a migration first"
+            )));
+        }
+    };
+    for lens in path {
+        publish_runtime_lens(state, shell, &lens, supplied_schemas)
+            .await
+            .map_err(StructuralLineageError::Bridge)?;
+    }
+    Ok(())
+}
+
+enum LineagePath {
+    None,
+    Unique(Vec<Lens>),
+    Ambiguous,
+}
+
+fn find_lineage_path(
+    current: SchemaHash,
+    incoming: &HashMap<SchemaHash, Vec<Lens>>,
+    runtime_known: &HashSet<SchemaHash>,
+    visiting: &mut HashSet<SchemaHash>,
+) -> LineagePath {
+    if runtime_known.contains(&current) {
+        return LineagePath::Unique(Vec::new());
+    }
+    if !visiting.insert(current) {
+        return LineagePath::None;
+    }
+
+    let mut found = None;
+    for lens in incoming.get(&current).into_iter().flatten() {
+        match find_lineage_path(lens.source_hash, incoming, runtime_known, visiting) {
+            LineagePath::None => {}
+            LineagePath::Ambiguous => return LineagePath::Ambiguous,
+            LineagePath::Unique(mut path) => {
+                path.push(lens.clone());
+                if found.is_some() {
+                    return LineagePath::Ambiguous;
+                }
+                found = Some(path);
+            }
+        }
+    }
+    visiting.remove(&current);
+    found.map_or(LineagePath::None, LineagePath::Unique)
+}
+
 fn runtime_shell(
     state: &ServerState,
     shell: &mut Option<ServerRuntimeHandle>,
@@ -127,21 +374,30 @@ fn known_schema(
     supplied_schemas: &HashMap<SchemaHash, Schema>,
     hash: SchemaHash,
 ) -> Result<Schema, String> {
+    known_schema_if_present(state, supplied_schemas, hash)?
+        .ok_or_else(|| format!("catalogue schema {hash} is missing"))
+}
+
+fn known_schema_if_present(
+    state: &ServerState,
+    supplied_schemas: &HashMap<SchemaHash, Schema>,
+    hash: SchemaHash,
+) -> Result<Option<Schema>, String> {
     if let Some(schema) = state
         .catalogue
         .known_schema(&state.catalogue_store, &hash)
         .map_err(|error| format!("read catalogue schema {hash}: {error}"))?
         .or_else(|| supplied_schemas.get(&hash).cloned())
     {
-        return Ok(schema);
+        return Ok(Some(schema));
     }
 
     let empty_schema = Schema::new();
     if hash == SchemaHash::compute(&empty_schema) {
-        return Ok(empty_schema);
+        return Ok(Some(empty_schema));
     }
 
-    Err(format!("catalogue schema {hash} is missing"))
+    Ok(None)
 }
 
 fn convert_lens(lens: &Lens, source: &Schema, target: &Schema) -> Result<MigrationLens, String> {

--- a/crates/jazz/src/serving/mod.rs
+++ b/crates/jazz/src/serving/mod.rs
@@ -1043,6 +1043,10 @@ impl InMemoryServerShell {
         )
     }
 
+    pub(crate) fn runtime_catalogue_contains_schema(&self, schema: SchemaVersionId) -> bool {
+        self.db.catalogue_schema(schema).is_some()
+    }
+
     fn bootstrap_runtime_schema(&mut self, schema: JazzSchema) -> ShellResult<()> {
         let schema_id = schema.version_id();
         let current = self.db.current_write_schema()?;

--- a/crates/jazz/src/serving/server_runtime.rs
+++ b/crates/jazz/src/serving/server_runtime.rs
@@ -734,6 +734,15 @@ impl ServerRuntimeHandle {
             .await
     }
 
+    #[doc(hidden)]
+    pub async fn runtime_catalogue_contains_schema(
+        &self,
+        schema: SchemaVersionId,
+    ) -> Result<bool, String> {
+        self.run(move |shell| Ok(shell.runtime_catalogue_contains_schema(schema)))
+            .await
+    }
+
     /// Start a core runtime over the selected storage configuration.
     pub fn start_with_storage(
         schema: JazzSchema,


### PR DESCRIPTION
🤖 ## Summary
- Reconcile durable structural schema lineage into the running server before
  advancing the permissions head.
- Serialise lineage reconciliation, permissions publication and runtime
  application under the existing publication lock.
- Verify recovery through HTTP and real WebSocket clients.
- Consolidate deterministic lens ordering in runtime reconciliation.

Closes #2847.

## Before
An earlier failed catalogue bridge could leave a schema and migration persisted
while the running server still knew only the source schema. Publishing
permissions for the target could then persist a new head and return HTTP 500
because its runtime lineage source was missing.

## After
When a unique published lineage connects the running server to the target,
the server installs that lineage before publishing and applying permissions.

For example, if an old_title → title migration is durable but absent from the
runtime, retrying permissions publication installs the migration and succeeds.
An authenticated client then receives only rows allowed by the published policy.

Missing or ambiguous lineage returns a recoverable HTTP 400 before advancing
the permissions head. Stale permissions parents still return HTTP 409.
This does not infer migrations, choose an arbitrary structural parent, or change
wire or storage formats.

## Test plan
- [x] Run `cargo test -p jazz-server --lib`: 244 passed.
- [x] Verify HTTP publication followed by client-visible allowed/hidden rows.
- [x] Confirm the regression fails when its policy incorrectly permits all rows,
      then restore the intended policy.
- [ ] Exercise the original invalid-string-identity → corrected-UUID deploy
      sequence end to end; automated coverage injects the underlying
      catalogue/runtime divergence instead.

## Integration status

Rebased into the stable-fixes stack on main, with independent review corrections included. The focused HTTP/WebSocket lineage regression was rerun successfully during integration. Combined CI passed. The existing missing/ambiguous-lineage and original invalid-identity-sequence coverage limitations remain explicit. Full combined CI is green.

Coverage follow-up: #2911 tracks the original rejected-deploy sequence and missing/ambiguous-lineage failure paths.
