### PR TITLE
Validate direct-store keys without constructing records

### DIFF
--- a/crates/groove/src/db/storage_helpers.rs
+++ b/crates/groove/src/db/storage_helpers.rs
@@ -181,16 +181,9 @@ impl DirectRecordStore<'_> {
             }
             .into());
         }
-        let prefix_descriptor =
-            RecordDescriptor::new(self.key.fields().iter().take(values.len()).map(|field| {
-                (
-                    field.name.clone().expect("direct store fields are named"),
-                    field.value_type.clone(),
-                )
-            }));
-        let _ = prefix_descriptor.create(values)?;
         let mut bytes = Vec::new();
-        for value in values {
+        for (value, field) in values.iter().zip(self.key.fields()) {
+            records::ensure_value_type(value, &field.value_type)?;
             encode_primary_key_part(&mut bytes, value)?;
         }
         Ok(bytes)

--- a/crates/groove/src/db/tests/batches.rs
+++ b/crates/groove/src/db/tests/batches.rs
@@ -5895,3 +5895,67 @@ async fn old_row_delta_descriptors_are_prepared_once_per_batch_variant() {
         Err(Error::UnknownTableVariant { version: 3, .. })
     ));
 }
+
+#[futures_test::test]
+async fn direct_store_key_reads_validate_without_encoding_throwaway_records() {
+    let schema = DatabaseSchema::new([]).with_direct_record_store(DirectRecordStoreSchema::new(
+        "checked_keys",
+        RecordDescriptor::new([
+            ("scope", ValueType::String),
+            (
+                "coordinate",
+                ValueType::Tuple(vec![ValueType::U16, ValueType::Bool]),
+            ),
+        ]),
+        RecordDescriptor::new([("value", ValueType::U64)]),
+    ));
+    let storage = MemoryStorage::new(&schema.column_families()).unwrap();
+    let db = Database::new(schema, storage).await.unwrap();
+    let store = db.direct_record_store("checked_keys").unwrap();
+    let key = [
+        "scope".into(),
+        Value::Tuple(vec![Value::U16(3), Value::Bool(true)]),
+    ];
+    store.set(&key, &[Value::U64(42)]).await.unwrap();
+    // Internal work counter supplements public behavior: key validation must
+    // not reconstruct a record just to discard its bytes.
+    crate::records::RECORD_ENCODE_COUNT.with(|count| count.set(0));
+    assert_eq!(
+        store
+            .get(&key)
+            .await
+            .unwrap()
+            .unwrap()
+            .get("value")
+            .unwrap(),
+        Value::U64(42)
+    );
+    assert_eq!(store.prefix(&key[..1]).await.unwrap().len(), 1);
+    assert_eq!(store.prefix(&[]).await.unwrap().len(), 1);
+    assert_eq!(
+        crate::records::RECORD_ENCODE_COUNT.with(|count| count.get()),
+        0
+    );
+    for invalid in [
+        vec![Value::U64(3)],
+        vec![
+            "scope".into(),
+            Value::Tuple(vec![Value::Bool(true), Value::U16(3)]),
+        ],
+        vec!["scope".into(), Value::Tuple(vec![Value::U16(3)])],
+        vec!["scope".into(), key[1].clone(), Value::U8(0)],
+    ] {
+        assert!(store.prefix(&invalid).await.is_err());
+    }
+    assert!(store.get(&key[..1]).await.is_err());
+    assert_eq!(
+        store
+            .get(&key)
+            .await
+            .unwrap()
+            .unwrap()
+            .get("value")
+            .unwrap(),
+        Value::U64(42)
+    );
+}

--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -98,6 +98,7 @@ use thiserror::Error;
 
 pub use macros::{FieldKind, RecordField, assert_record_field_layout};
 pub use values::collect_by_ordered_scalar;
+pub(crate) use values::ensure_value_type;
 pub use values::{
     EnumCase, EnumSchema, EnumValue, ScalarEnumSchema, SystemVariantRegistry, Value, ValueType,
     VariantRegistry, decode_persisted_record_descriptor, decode_record_descriptor,
@@ -111,7 +112,7 @@ pub use values::{
 pub const MAX_VARIANT_TAG_LEN: usize = 5;
 
 use values::{
-    checked_add, decode_value, encode_fixed_value, encode_value, ensure_value_type, usize_to_u32,
+    checked_add, decode_value, encode_fixed_value, encode_value, usize_to_u32,
     validate_schema_value_type, write_u32,
 };
 

--- a/crates/groove/src/records/values.rs
+++ b/crates/groove/src/records/values.rs
@@ -2201,7 +2201,7 @@ fn decode_array(bytes: &[u8], element_type: &ValueType) -> Result<Value, Error> 
     Ok(Value::Array(values))
 }
 
-pub(super) fn ensure_value_type(value: &Value, value_type: &ValueType) -> Result<(), Error> {
+pub(crate) fn ensure_value_type(value: &Value, value_type: &ValueType) -> Result<(), Error> {
     match (value, value_type) {
         (Value::U8(_), ValueType::U8)
         | (Value::U16(_), ValueType::U16)


### PR DESCRIPTION
🤖 Direct-store key validation built a new prefix schema and encoded a temporary record on every read, write and range lookup, then discarded those bytes and separately encoded the actual key. It now calls the same existing value/type checker against the store's declared key fields and encodes only the ordered key.

A prefix such as `["scope"]` still selects the same records, and complete keys retain their exact stored encoding. Wrong scalar types, malformed tuple members, and excessive prefix arity still fail. No serializer, storage layout, wire format or durability change is involved.

Validation: 751 Groove tests passed (2 ignored), including existing ordered tuple-key/reopen coverage. The new public read/prefix test also checks that key validation creates zero throwaway records; restoring the old path fails with 3 encodings. Independently removing type validation makes its invalid-key assertion fail. Optimized benchmark build passed. Clean native pair: 27,518-row cold settle 17.332s versus 17.276s on the parent; readiness 17.727s versus 17.672s. The 1,350-row todo update was 264.164ms versus 255.937ms. Timing is flat; this is retained as a small code/work simplification, not a measured broad speedup. Jazz library: 2,007 passed, 2 ignored. All three incremental work/delivery canaries and the two-seed differential oracle (depths 10 and 1,000) passed. This is focused validation, not full CI-equivalent or browser acceptance.
