### PR TITLE
Reuse retained prepared graphs when binding queries

### DIFF
--- a/crates/groove/src/ivm/graph.rs
+++ b/crates/groove/src/ivm/graph.rs
@@ -699,9 +699,17 @@ impl GraphBuilder {
     /// recursion. Runtime setup uses this for deeply nested valid query and
     /// policy graphs, which must not consume the owner thread's call stack.
     pub(crate) fn postorder(&self) -> Vec<&Self> {
+        self.postorder_skipping(|_| false)
+    }
+
+    /// Stop at already prepared fragments without walking their descendants.
+    pub(crate) fn postorder_skipping(&self, mut skip: impl FnMut(&Self) -> bool) -> Vec<&Self> {
         let mut pending = vec![(self, false)];
         let mut ordered = Vec::new();
         while let Some((graph, visited)) = pending.pop() {
+            if skip(graph) {
+                continue;
+            }
             if visited {
                 ordered.push(graph);
                 continue;

--- a/crates/groove/src/ivm/runtime/compilation.rs
+++ b/crates/groove/src/ivm/runtime/compilation.rs
@@ -1,5 +1,8 @@
 //! Hash-consed GraphBuilder compilation into executable IVM nodes.
 
+#[cfg(test)]
+thread_local! { pub(super) static BUILDER_COMPILATION_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) }; }
+
 use super::*;
 
 impl IvmRuntime {
@@ -27,19 +30,64 @@ impl IvmRuntime {
         &mut self,
         graph: &GraphBuilder,
     ) -> Result<CompiledNode, IvmRuntimeError> {
+        self.compile_graph_with_retained_input(graph, None)
+            .map(|(output, _)| output)
+    }
+
+    pub(super) fn add_prepared_graph(
+        &mut self,
+        graph: &GraphBuilder,
+    ) -> Result<(CompiledNode, CompiledNode), IvmRuntimeError> {
+        self.compile_graph_with_retained_input(graph, None)
+    }
+
+    pub(super) fn add_bound_graph(
+        &mut self,
+        graph: &GraphBuilder,
+        retained_builder: &GraphBuilder,
+        retained: &CompiledNode,
+    ) -> Result<CompiledNode, IvmRuntimeError> {
+        self.compile_graph_with_retained_input(graph, Some((retained_builder, retained)))
+            .map(|(output, _)| output)
+    }
+
+    fn compile_graph_with_retained_input(
+        &mut self,
+        graph: &GraphBuilder,
+        retained: Option<(&GraphBuilder, &CompiledNode)>,
+    ) -> Result<(CompiledNode, CompiledNode), IvmRuntimeError> {
         validate_collect_by_terminality(graph)?;
         let mut output_memo = HashMap::default();
-        // Precompute descriptors once for the complete graph. The postorder
-        // compiler below can then reuse those descriptors without repeatedly
-        // traversing a long policy graph from each parent.
-        self.infer_builder_output_cached(graph, &mut output_memo)?;
         let mut compiled_memo = HashMap::default();
-        for builder in graph.postorder() {
+        if let Some((builder, compiled)) = retained {
+            self.graph
+                .node(compiled.node)
+                .ok_or(IvmRuntimeError::GraphNodeNotFound(compiled.node))?;
+            let key = graph_builder_key(builder);
+            output_memo.insert(key, compiled.output);
+            compiled_memo.insert(key, compiled.clone());
+        }
+        self.infer_builder_output_cached(graph, &mut output_memo)?;
+        for builder in graph
+            .postorder_skipping(|builder| compiled_memo.contains_key(&graph_builder_key(builder)))
+        {
             self.add_dedup_graph_cached(builder, &mut output_memo, &mut compiled_memo)?;
         }
-        compiled_memo
-            .remove(&graph_builder_key(graph))
-            .ok_or(IvmRuntimeError::UnsupportedOperator)
+        let output = compiled_memo
+            .get(&graph_builder_key(graph))
+            .cloned()
+            .ok_or(IvmRuntimeError::UnsupportedOperator)?;
+        // A bound collector changes its terminal projection and routing. Its
+        // flat input remains reusable; ordinary terminals reuse their output.
+        let input = match graph {
+            GraphBuilder::CollectBy { input, .. } => input.as_ref(),
+            _ => graph,
+        };
+        let binding_input = compiled_memo
+            .get(&graph_builder_key(input))
+            .cloned()
+            .ok_or(IvmRuntimeError::UnsupportedOperator)?;
+        Ok((output, binding_input))
     }
 
     fn add_dedup_graph_cached(
@@ -52,6 +100,8 @@ impl IvmRuntime {
         if let Some(compiled) = compiled_memo.get(&key) {
             return Ok(compiled.clone());
         }
+        #[cfg(test)]
+        BUILDER_COMPILATION_COUNT.with(|count| count.set(count.get() + 1));
         let inferred_output = self.infer_builder_output_cached(graph, output_memo)?;
         let compiled = match graph {
             GraphBuilder::Table { .. }

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -3,6 +3,9 @@
 use super::evaluation_session::EvaluationInputs;
 use super::*;
 
+#[cfg(test)]
+thread_local! { pub(super) static BUILDER_INFERENCE_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) }; }
+
 fn resolved_record_value(
     record: BorrowedRecord<'_>,
     field: &str,
@@ -695,6 +698,7 @@ pub(super) struct RoutedMultisinkShapeState {
 pub(super) struct RoutedMultisinkTerminalState {
     pub(super) terminal: RoutedMultisinkTerminal,
     pub(super) output: CompiledNode,
+    pub(super) binding_input: CompiledNode,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -1424,7 +1428,7 @@ fn bound_routed_multisink_graph(
     terminal: &RoutedMultisinkTerminal,
     binding_values: &[Value],
     output: &RecordDescriptor,
-) -> Result<GraphBuilder, IvmRuntimeError> {
+) -> Result<(GraphBuilder, Arc<GraphBuilder>), IvmRuntimeError> {
     let predicates = terminal
         .route_fields
         .iter()
@@ -1452,17 +1456,34 @@ fn bound_routed_multisink_graph(
             .tuple_fields
             .retain(|field| terminal.public_fields.contains(&field.output_name));
         strip_bound_route_fields_from_collect(&mut collect, &terminal.route_fields);
+        let retained = Arc::clone(input);
         let input = predicate
-            .map(|predicate| input.as_ref().clone().filter(predicate))
-            .unwrap_or_else(|| input.as_ref().clone());
-        return Ok(GraphBuilder::CollectBy {
-            input: Arc::new(input),
-            collect: Box::new(collect),
-        });
+            .map(|predicate| {
+                Arc::new(GraphBuilder::Filter {
+                    input: Arc::clone(&retained),
+                    predicate,
+                    comparison: ValueComparison::Exact,
+                })
+            })
+            .unwrap_or_else(|| Arc::clone(&retained));
+        return Ok((
+            GraphBuilder::CollectBy {
+                input,
+                collect: Box::new(collect),
+            },
+            retained,
+        ));
     }
-    let graph = predicate
-        .map(|predicate| terminal.graph.clone().filter(predicate))
-        .unwrap_or_else(|| terminal.graph.clone());
+    let retained = Arc::new(terminal.graph.clone());
+    let input = predicate
+        .map(|predicate| {
+            Arc::new(GraphBuilder::Filter {
+                input: Arc::clone(&retained),
+                predicate,
+                comparison: ValueComparison::Exact,
+            })
+        })
+        .unwrap_or_else(|| Arc::clone(&retained));
     let fields = terminal
         .public_fields
         .iter()
@@ -1480,7 +1501,7 @@ fn bound_routed_multisink_graph(
             })
         })
         .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
-    Ok(graph.project_fields(fields))
+    Ok((GraphBuilder::Project { input, fields }, retained))
 }
 
 /// A routed terminal is compiled once but a bound subscription executes one
@@ -3304,7 +3325,7 @@ impl IvmRuntime {
         let runtime = install.runtime();
         let mut terminal_states = BTreeMap::new();
         for terminal in terminals {
-            let output = match runtime.add_dedup_graph(&terminal.graph) {
+            let (output, binding_input) = match runtime.add_prepared_graph(&terminal.graph) {
                 Ok(output) => output,
                 Err(error) => {
                     if inserted_source {
@@ -3317,7 +3338,11 @@ impl IvmRuntime {
             };
             terminal_states.insert(
                 terminal.sink.clone(),
-                RoutedMultisinkTerminalState { terminal, output },
+                RoutedMultisinkTerminalState {
+                    terminal,
+                    output,
+                    binding_input,
+                },
             );
         }
         // Publish retainers only after every terminal compiles, so the guard
@@ -3426,12 +3451,13 @@ impl IvmRuntime {
                 if let Some(fields) = public_fields.get(sink) {
                     terminal.public_fields = fields.clone();
                 }
-                let graph = bound_routed_multisink_graph(
+                let (graph, retained) = bound_routed_multisink_graph(
                     &terminal,
                     binding_values,
                     &prepared_terminal.output.output,
                 )?;
-                let output = runtime.add_dedup_graph(&graph)?;
+                let output =
+                    runtime.add_bound_graph(&graph, &retained, &prepared_terminal.binding_input)?;
                 outputs.insert(sink.clone(), output);
             }
             let binding_shape = runtime.binding_source_shape_name(shape_id)?;
@@ -3901,8 +3927,12 @@ impl IvmRuntime {
         // inheritance policy after its public result and routing projections
         // have been attached). Infer every child before its parent explicitly
         // so descriptor inference does not consume the server owner's stack.
-        for builder in graph.postorder() {
+        for builder in graph.postorder_skipping(|builder| {
+            output_memo.contains_key(&(builder as *const GraphBuilder as usize))
+        }) {
             let key = builder as *const GraphBuilder as usize;
+            // The traversal was collected before this loop. Shared fragments
+            // reached twice may have been inferred by an earlier iteration.
             if output_memo.contains_key(&key) {
                 continue;
             }
@@ -3920,6 +3950,8 @@ impl IvmRuntime {
         graph: &GraphBuilder,
         output_memo: &mut HashMap<usize, RecordDescriptor>,
     ) -> Result<RecordDescriptor, IvmRuntimeError> {
+        #[cfg(test)]
+        BUILDER_INFERENCE_COUNT.with(|count| count.set(count.get() + 1));
         match graph {
             GraphBuilder::Table {
                 table,

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -3246,3 +3246,91 @@ fn source_batch_prepares_one_descriptor_per_variant() {
         Err(IvmRuntimeError::UnknownTableVariant { version: 3, .. })
     ));
 }
+
+// Public results alone cannot expose recompilation of an already retained
+// policy graph. Pair the work bound with distinct route/output assertions.
+#[futures_test::test]
+async fn binding_reuses_prepared_graph_without_crossing_routes() {
+    let schema = albums_schema();
+    let albums = schema.table("albums").unwrap().record_schema();
+    let mut runtime = IvmRuntime::new(schema).unwrap();
+    let storage = Rc::new(MemoryStorage::new(&["albums"]).unwrap());
+    write_two_album_rows(&storage, &albums).await;
+    let mut graph = GraphBuilder::table("albums");
+    for _ in 0..40 {
+        graph = graph.project(["id", "title"]);
+    }
+    let terminals = (0..8)
+        .map(|index| {
+            let field = if index % 2 == 0 { "id" } else { "title" };
+            RoutedMultisinkTerminal::new(format!("rows{index}"), graph.clone(), ["id"], [field])
+        })
+        .collect::<Vec<_>>();
+    let prepared = runtime
+        .prepare(
+            terminals,
+            "reuse-work",
+            RecordDescriptor::new([("route", ValueType::U64)]),
+            storage.as_ref(),
+        )
+        .await
+        .unwrap();
+    let mut subscriptions = Vec::new();
+    for id in [1, 2] {
+        compilation::BUILDER_COMPILATION_COUNT.with(|count| count.set(0));
+        subscriptions::BUILDER_INFERENCE_COUNT.with(|count| count.set(0));
+        let subscription = runtime
+            .bind_shape(prepared.id(), &[Value::U64(id)], &storage)
+            .unwrap();
+        let compiled = compilation::BUILDER_COMPILATION_COUNT.with(|count| count.get());
+        let inferred = subscriptions::BUILDER_INFERENCE_COUNT.with(|count| count.get());
+        assert!(
+            inferred <= 24,
+            "binding re-inferred {inferred} retained nodes"
+        );
+        eprintln!("bind route={id}: compiled={compiled}, inferred={inferred}");
+        assert!(
+            compiled <= 24,
+            "binding recompiled {compiled} nodes from the retained graph"
+        );
+        runtime.drive_pending_incremental().await.unwrap();
+        let initial = subscription.try_recv().unwrap();
+        assert_eq!(initial.sinks.len(), 8);
+        for (sink, rows) in &initial.sinks {
+            let index = sink.strip_prefix("rows").unwrap().parse::<usize>().unwrap();
+            let expected = if index % 2 == 0 {
+                Value::U64(id)
+            } else {
+                Value::String(if id == 1 { "one" } else { "two" }.into())
+            };
+            assert_eq!(rows.to_values().unwrap(), vec![(vec![expected], 1)]);
+        }
+        subscriptions.push(subscription);
+    }
+    assert!(
+        subscriptions[0].try_recv().is_err(),
+        "second binding changed first route"
+    );
+}
+
+#[test]
+fn compilation_infers_each_shared_fragment_once() {
+    // This internal work invariant is invisible in the resulting descriptor.
+    let mut runtime = IvmRuntime::new(albums_schema()).unwrap();
+    let mut graph = GraphBuilder::table("albums");
+    for _ in 0..40 {
+        graph = graph.project(["id", "title"]);
+    }
+    let shared = Arc::new(graph);
+    let graph = GraphBuilder::Union {
+        inputs: vec![Arc::clone(&shared), shared],
+    };
+    subscriptions::BUILDER_INFERENCE_COUNT.with(|count| count.set(0));
+    let compiled = runtime.add_dedup_graph(&graph).unwrap();
+    assert_eq!(compiled.output.fields().len(), 2);
+    let inferred = subscriptions::BUILDER_INFERENCE_COUNT.with(|count| count.get());
+    assert!(
+        inferred <= 42,
+        "inferred {inferred} nodes for 42 distinct fragments"
+    );
+}


### PR DESCRIPTION
🤖 Binding a prepared query rebuilt descriptors and recompiled the retained policy/query graph before deduplication rediscovered the same nodes. Binding now reuses that compiled graph and compiles only the route filter and public output selection around it.

For example, an eight-sink shape with forty shared projection layers compiled 344 nodes on each bind. It now compiles and infers 16 binding-specific nodes. Binding routes 1 and 2 still produces only each route's rows, with each sink's requested output columns.

Collected results reuse the prepared collector's flat input, not the collector itself: route filtering and the collector's public fields/keys are still compiled for the bound result. Ordinary terminals reuse their prepared output. The shape's existing retainers keep those nodes alive. Pointer-keyed compilation memos remain scoped to this compilation call; there is no persistent pointer cache or new cross-query sharing policy. Deep-graph walks remain iterative and stop at the retained fragment.

This preserves prepared-shape routing and retention invariants (INV-SHAPE-3, 8, 15, 16). Binding values are still validated, collector terminality is still checked, and binding-specific outputs are still compiled. Storage, wire and query semantics are unchanged.

Validation: all 753 Groove tests passed (2 ignored), including deep graph and collected-result coverage. The focused test verifies separate bindings and eight distinct sink projections plus bounded compilation/inference. Disabling retained-input reuse makes it fail at 344 compiled nodes. A second work-bound check covers shared fragments within a DAG (42 distinct fragments must not be inferred 83 times). Optimized build passed. Clean native pair: cold settle 16.945s versus 17.030s on the parent, readiness 17.339s versus 17.424s; all 27,518 rows materialized. Todo update 253.547ms versus 250.525ms. **Discarded:** less than 1% end-to-end gain does not justify this additional machinery under the agreed threshold. No broader Jazz gates were run after the timing result. The branch is preserved for reference.
