### PR TITLE
Separate lowering preparation and binding in cold-load profiles

### DIFF
--- a/crates/groove/src/ivm/runtime/compilation.rs
+++ b/crates/groove/src/ivm/runtime/compilation.rs
@@ -23,6 +23,10 @@ impl IvmRuntime {
         node
     }
 
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.query_graph_compile")
+    )]
     pub(super) fn add_dedup_graph(
         &mut self,
         graph: &GraphBuilder,

--- a/crates/groove/src/ivm/runtime/subscriptions.rs
+++ b/crates/groove/src/ivm/runtime/subscriptions.rs
@@ -3223,6 +3223,10 @@ impl IvmRuntime {
         })
     }
 
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.query_prepare")
+    )]
     pub async fn prepare<I, S>(
         &mut self,
         terminals: I,
@@ -3394,6 +3398,10 @@ impl IvmRuntime {
         Ok(subscription)
     }
 
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.query_bind")
+    )]
     fn bind_shape_with_public_fields_staged<S>(
         &mut self,
         shape_id: PreparedShapeId,

--- a/crates/jazz-sim/src/phase_attribution.rs
+++ b/crates/jazz-sim/src/phase_attribution.rs
@@ -11,7 +11,7 @@ use tracing::{
     span::{Attributes, Id, Record},
 };
 
-const PHASES: [&str; 20] = [
+const PHASES: [&str; 24] = [
     "core",
     "relay",
     "client",
@@ -32,6 +32,10 @@ const PHASES: [&str; 20] = [
     "decode_version_witness",
     "rebind_terminal_output",
     "canonical_supporting_version",
+    "query_lowering",
+    "query_prepare",
+    "query_bind",
+    "query_graph_compile",
 ];
 const ROLES: [&str; 4] = ["outside_node_ticks", "core", "relay", "client"];
 #[derive(Clone, Copy, Default)]

--- a/crates/jazz/src/node/query_eval/lowering.rs
+++ b/crates/jazz/src/node/query_eval/lowering.rs
@@ -559,6 +559,10 @@ where
         .await
     }
 
+    #[cfg_attr(
+        feature = "cold-settle-attribution",
+        tracing::instrument(skip_all, name = "cold.phase.query_lowering")
+    )]
     async fn compile_query_program_request_with_inline_sources_and_access_paths_inner(
         &mut self,
         request: QueryProgramRequest,


### PR DESCRIPTION
🤖 The native cold-load profiler previously grouped query lowering, preparation and binding into one query-setup bucket. That could identify setup as expensive but could not tell us which stage an optimization would affect.

Add opt-in spans for Jazz program lowering, Groove shape preparation, bound subscription setup and graph compilation. The existing reporter gives inclusive timing for each stage and exclusive timing/allocation totals without double-counting nested work. Sampled callers retain the finer phase label. No query data or parameters are included in the spans.

These annotations are gated behind `cold-settle-attribution`; ordinary runtime, wire and storage behavior is unchanged. All five phase-accounting tests and the optimized combined phase/allocation benchmark build passed. Full synthetic fixture passed on clean ea66214f87: 27,518 rows, 109,953,630 allocations and 28,251,620,915 requested bytes. Graph compilation accounted for approximately 586ms across roles; relay binding was 218ms inclusive, of which 186ms was nested compilation. The larger query-setup spans include nested row execution and must not be interpreted as compiler time. Instrumented timing is diagnostic, not a clean latency claim.
