### PR TITLE
Make native benchmark allocator choice explicit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,6 +2072,9 @@ dependencies = [
 [[package]]
 name = "jazz-benchmark-guard"
 version = "0.1.0"
+dependencies = [
+ "mimalloc",
+]
 
 [[package]]
 name = "jazz-cli"

--- a/crates/benchmark-guard/Cargo.toml
+++ b/crates/benchmark-guard/Cargo.toml
@@ -7,3 +7,9 @@ description = "Shared precondition for trustworthy Jazz benchmark and receipt me
 
 [lib]
 path = "src/lib.rs"
+
+[features]
+mimalloc = ["dep:mimalloc"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+mimalloc = { version = "0.1", default-features = false, optional = true }

--- a/crates/benchmark-guard/src/lib.rs
+++ b/crates/benchmark-guard/src/lib.rs
@@ -1,5 +1,17 @@
 //! Refuse benchmark and receipt runs whose instrumentation changes the numbers.
 
+/// Explicit allocator for native benchmark leaves. Opt into `mimalloc` to
+/// match jazz-tools' Rust allocator; default System preserves older receipts.
+#[cfg(all(feature = "mimalloc", not(target_arch = "wasm32")))]
+pub use mimalloc::MiMalloc as Allocator;
+#[cfg(not(all(feature = "mimalloc", not(target_arch = "wasm32"))))]
+pub use std::alloc::System as Allocator;
+
+#[cfg(all(feature = "mimalloc", not(target_arch = "wasm32")))]
+pub const ALLOCATOR_NAME: &str = "mimalloc";
+#[cfg(not(all(feature = "mimalloc", not(target_arch = "wasm32"))))]
+pub const ALLOCATOR_NAME: &str = "system";
+
 /// An environment switch that changes the work performed by a measurement.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ContaminatingInstrumentation {

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -31,9 +31,14 @@ use jazz_sim::{emit_json_line, metadata_fields};
 use jazz_storage_rocksdb::{Durability, RocksDbStorage};
 use serde_json::{Value as JsonValue, json};
 
+#[cfg(not(any(feature = "bench-alloc-metrics", feature = "bench-alloc-sites")))]
+#[global_allocator]
+static ALLOCATOR: jazz_benchmark_guard::Allocator = jazz_benchmark_guard::Allocator;
+
 #[cfg(all(feature = "bench-alloc-metrics", not(feature = "bench-alloc-sites")))]
 mod alloc_metrics {
-    use std::alloc::{GlobalAlloc, Layout, System};
+    use jazz_benchmark_guard::Allocator;
+    use std::alloc::{GlobalAlloc, Layout};
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
     pub struct CountingAllocator;
@@ -42,17 +47,28 @@ mod alloc_metrics {
     static ALLOCS: AtomicU64 = AtomicU64::new(0);
     static BYTES: AtomicU64 = AtomicU64::new(0);
 
+    fn record_request(bytes: usize) {
+        if ACTIVE.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+        }
+    }
+
     unsafe impl GlobalAlloc for CountingAllocator {
         unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-            if ACTIVE.load(Ordering::Relaxed) {
-                ALLOCS.fetch_add(1, Ordering::Relaxed);
-                BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
-            }
-            unsafe { System.alloc(layout) }
+            record_request(layout.size());
+            unsafe { Allocator.alloc(layout) }
         }
-
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            record_request(layout.size());
+            unsafe { Allocator.alloc_zeroed(layout) }
+        }
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            record_request(new_size);
+            unsafe { Allocator.realloc(ptr, layout, new_size) }
+        }
         unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-            unsafe { System.dealloc(ptr, layout) }
+            unsafe { Allocator.dealloc(ptr, layout) }
         }
     }
 
@@ -82,7 +98,8 @@ mod alloc_metrics {
 
 #[cfg(feature = "bench-alloc-sites")]
 mod alloc_metrics {
-    use std::alloc::{GlobalAlloc, Layout, System};
+    use jazz_benchmark_guard::Allocator;
+    use std::alloc::{GlobalAlloc, Layout};
     use std::collections::HashMap;
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -111,35 +128,46 @@ mod alloc_metrics {
     static MAX_SAMPLES: AtomicU64 = AtomicU64::new(DEFAULT_MAX_SAMPLES as u64);
     static SAMPLES: Mutex<Vec<StackSample>> = Mutex::new(Vec::new());
 
+    fn record_request(bytes: usize) {
+        if ACTIVE.load(Ordering::Relaxed) {
+            let alloc_index = ALLOCS.fetch_add(1, Ordering::Relaxed) + 1;
+            let size = bytes as u64;
+            #[cfg(feature = "cold-settle-attribution")]
+            jazz_sim::phase_attribution::record_allocation(bytes);
+            let before_bytes = BYTES.fetch_add(size, Ordering::Relaxed);
+            let byte_sample =
+                before_bytes / BYTE_SAMPLE_INTERVAL != (before_bytes + size) / BYTE_SAMPLE_INTERVAL;
+            let sample_rate = SAMPLE_RATE.load(Ordering::Relaxed).max(1);
+            let count_sample = alloc_index.is_multiple_of(sample_rate);
+            if (count_sample || byte_sample) && !IN_SAMPLE.swap(true, Ordering::Relaxed) {
+                sample_stack(
+                    count_sample,
+                    if byte_sample {
+                        size.max(BYTE_SAMPLE_INTERVAL)
+                    } else {
+                        0
+                    },
+                );
+                IN_SAMPLE.store(false, Ordering::Relaxed);
+            }
+        }
+    }
+
     unsafe impl GlobalAlloc for SiteAllocator {
         unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-            if ACTIVE.load(Ordering::Relaxed) {
-                let alloc_index = ALLOCS.fetch_add(1, Ordering::Relaxed) + 1;
-                let size = layout.size() as u64;
-                #[cfg(feature = "cold-settle-attribution")]
-                jazz_sim::phase_attribution::record_allocation(layout.size());
-                let before_bytes = BYTES.fetch_add(size, Ordering::Relaxed);
-                let byte_sample = before_bytes / BYTE_SAMPLE_INTERVAL
-                    != (before_bytes + size) / BYTE_SAMPLE_INTERVAL;
-                let sample_rate = SAMPLE_RATE.load(Ordering::Relaxed).max(1);
-                let count_sample = alloc_index.is_multiple_of(sample_rate);
-                if (count_sample || byte_sample) && !IN_SAMPLE.swap(true, Ordering::Relaxed) {
-                    sample_stack(
-                        count_sample,
-                        if byte_sample {
-                            size.max(BYTE_SAMPLE_INTERVAL)
-                        } else {
-                            0
-                        },
-                    );
-                    IN_SAMPLE.store(false, Ordering::Relaxed);
-                }
-            }
-            unsafe { System.alloc(layout) }
+            record_request(layout.size());
+            unsafe { Allocator.alloc(layout) }
         }
-
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            record_request(layout.size());
+            unsafe { Allocator.alloc_zeroed(layout) }
+        }
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            record_request(new_size);
+            unsafe { Allocator.realloc(ptr, layout, new_size) }
+        }
         unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-            unsafe { System.dealloc(ptr, layout) }
+            unsafe { Allocator.dealloc(ptr, layout) }
         }
     }
 
@@ -2588,6 +2616,14 @@ fn emit_summary(config: &Config, phase: &str, summary: &RunSummary) {
         "allocation_scope".to_owned(),
         json!("connect_subscribe_settle"),
     );
+    fields.insert(
+        "rust_allocator".to_owned(),
+        json!(jazz_benchmark_guard::ALLOCATOR_NAME),
+    );
+    fields.insert(
+        "allocator_preload".to_owned(),
+        json!(std::env::var_os("LD_PRELOAD").is_some()),
+    );
     fields.insert("peak_rss_bytes".to_owned(), json!(summary.peak_rss_bytes));
     fields.insert(
         "core_encoded_storage_bytes".to_owned(),
@@ -2880,15 +2916,19 @@ fn env_f64(name: &str, default: f64) -> f64 {
 }
 
 fn peak_rss_bytes() -> u64 {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     unsafe {
         let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
         if libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) == 0 {
-            return usage.assume_init().ru_maxrss as u64;
+            let peak = usage.assume_init().ru_maxrss as u64;
+            #[cfg(target_os = "linux")]
+            return peak.saturating_mul(1024);
+            #[cfg(target_os = "macos")]
+            return peak;
         }
         0
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
         0
     }

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -202,5 +202,6 @@ required-features = ["testing"]
 
 [[bench]]
 name = "local_batch_phases"
+path = "benches/local_batch_phases_entry.rs"
 harness = false
 required-features = ["testing"]

--- a/crates/jazz/benches/local_batch_phases.rs
+++ b/crates/jazz/benches/local_batch_phases.rs
@@ -2,6 +2,8 @@
 //! Direct nodes intentionally expose phase boundaries that the public Db owner
 //! loop combines. This excludes JS, IndexedDB, scheduling and auth bootstrap.
 use std::{collections::BTreeMap, time::Instant};
+#[global_allocator]
+static ALLOCATOR: jazz_benchmark_guard::Allocator = jazz_benchmark_guard::Allocator;
 #[path = "support/perf_control.rs"]
 mod perf_control;
 mod schema_fixture;
@@ -52,7 +54,7 @@ fn phase<T>(backend: &str, count: usize, name: &str, f: impl FnOnce() -> T) -> T
     drop(profile);
     println!(
         "{}",
-        json!({"backend":backend,"rows":count,"phase":name,"wall_us":elapsed.as_micros(),"start_ns":start_ns,"end_ns":end_ns,"cpu_profiled":cpu_profiled})
+        json!({"rust_allocator":jazz_benchmark_guard::ALLOCATOR_NAME,"allocator_preload":std::env::var_os("LD_PRELOAD").is_some(),"backend":backend,"rows":count,"phase":name,"wall_us":elapsed.as_micros(),"start_ns":start_ns,"end_ns":end_ns,"cpu_profiled":cpu_profiled})
     );
     result
 }

--- a/crates/jazz/benches/local_batch_phases.rs
+++ b/crates/jazz/benches/local_batch_phases.rs
@@ -2,8 +2,6 @@
 //! Direct nodes intentionally expose phase boundaries that the public Db owner
 //! loop combines. This excludes JS, IndexedDB, scheduling and auth bootstrap.
 use std::{collections::BTreeMap, time::Instant};
-#[global_allocator]
-static ALLOCATOR: jazz_benchmark_guard::Allocator = jazz_benchmark_guard::Allocator;
 #[path = "support/perf_control.rs"]
 mod perf_control;
 mod schema_fixture;
@@ -367,7 +365,7 @@ pub(crate) fn correctness_smoke() {
     run_fixture(10, 50);
 }
 
-fn main() {
+pub(crate) fn main() {
     if std::env::var_os("JAZZ_PERF_PHASE").is_some() {
         eprintln!("scoped CPU attribution run: timings are not clean latency receipts");
     } else {

--- a/crates/jazz/benches/local_batch_phases_entry.rs
+++ b/crates/jazz/benches/local_batch_phases_entry.rs
@@ -1,0 +1,11 @@
+// Keep the allocator at the executable boundary: the scenario is also
+// included in a combined correctness-test executable with its own allocator.
+#[path = "local_batch_phases.rs"]
+mod scenario;
+
+#[global_allocator]
+static ALLOCATOR: jazz_benchmark_guard::Allocator = jazz_benchmark_guard::Allocator;
+
+fn main() {
+    scenario::main();
+}


### PR DESCRIPTION
🤖 Native benchmark receipts did not identify their Rust allocator. They used System even when being compared with jazz-tools, which explicitly uses mimalloc. Add an opt-in `jazz-benchmark-guard/mimalloc` mode to the two active native perf targets, keeping System as the default so older receipts remain comparable. Each receipt now records `rust_allocator` and whether `LD_PRELOAD` is present.

The cold-load allocation wrappers now forward `alloc_zeroed` and `realloc` to the selected allocator while recording the request. Previously the trait defaults replaced those operations with allocation/zeroing or allocation/copy/free. Clean uninstrumented measurements were unaffected; instrumented allocation reports count allocation requests, including requested realloc sizes, rather than physical heap growth.

Linux cold-load receipts now report peak RSS in bytes (Linux getrusage reports KiB); previously this field returned zero outside macOS. No product allocator, query, storage or wire behavior changes.

Build example: `cargo build -p jazz -p jazz-sim --bench local_batch_phases --bench customer_cold_start --profile perf --features jazz/testing,jazz/transport-compression-zstd,jazz-benchmark-guard/mimalloc`. Omit the final feature for System. NAPI uses a separate mimalloc fork, and browser/WASM timing remains a separate measurement.

Validation at `37993fcda6`: benchmark-guard tests pass (2); optimized System, mimalloc and combined allocation-site/phase targets compile; the allocation-metrics variant also passes cargo check. Both clean full-fixture runs return all 27,518 rows.

| Native measurement | System | mimalloc |
| --- | ---: | ---: |
| Cold settle | 16.877s | 12.619s |
| Dominant child ready | 17.268s | 12.913s |
| Todo batch phases (1,500 rows) | 243.437ms | 228.264ms |
| Peak process RSS, including seeding | 3.73GiB | 3.96GiB |

This corrects the benchmark configuration when comparing with the CLI; it is not a newly delivered product speedup. Both clean runs have no allocator preload. The combined mimalloc phase/allocation capture also returns all 27,518 rows: 15.209s instrumented settle, 109,953,857 allocation requests and 28,251,885,251 requested bytes. Instrumented timing is not the clean latency baseline. Browser and end-to-end acceptance remain separate.

CI exposed an executable-composition case missed by the standalone checks: `legacy_benchmark_smoke` includes the todo scenario alongside another benchmark with its own global allocator. Fixed at `3f22a94680` by moving the todo allocator into a small executable entry file; the reusable scenario module no longer selects an allocator. The combined correctness target now passes all 6 tests, and the standalone mimalloc benchmark passes its compile check. Fresh CI passed after rerunning the known BandChat guest-invitation failure tracked in #2655; the allocator compile failure is fixed.
