### PR TITLE
Build fresh join indexes without staging an overlay

### DIFF
--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -64,6 +64,7 @@ impl JoinBucket {
         self.iter().next().is_none()
     }
 
+    #[cfg(test)]
     fn commit_overlay(&mut self) {
         if self.overlay.is_empty() {
             return;
@@ -766,27 +767,23 @@ fn append_join_deltas(
     Ok(())
 }
 
-fn apply_join_delta_to_index(index: &mut JoinIndex, deltas: &[KeyedRecordDelta<'_>]) {
+fn build_join_delta_index(deltas: &[KeyedRecordDelta<'_>]) -> JoinIndex {
+    // This index is fresh and has no snapshots. Populate its base directly;
+    // the overlay is only needed when updating an existing shared bucket.
+    let mut index = JoinIndex::default();
     for delta in deltas {
         let bucket = index.entry(delta.key.clone()).or_default();
+        let base = Rc::make_mut(&mut bucket.base);
         let next_weight =
-            bucket.get(&delta.delta.record).copied().unwrap_or_default() + delta.delta.weight;
+            base.get(&delta.delta.record).copied().unwrap_or_default() + delta.delta.weight;
         if next_weight == 0 {
-            bucket.set(delta.delta.record.clone(), 0);
-            if bucket.is_empty() {
+            base.remove(&delta.delta.record);
+            if base.is_empty() {
                 index.remove(&delta.key);
             }
         } else {
-            bucket.set(delta.delta.record.clone(), next_weight);
+            base.insert(delta.delta.record.clone(), next_weight);
         }
-    }
-}
-
-fn build_join_delta_index(deltas: &[KeyedRecordDelta<'_>]) -> JoinIndex {
-    let mut index = HashMap::default();
-    apply_join_delta_to_index(&mut index, deltas);
-    for bucket in index.values_mut() {
-        bucket.commit_overlay();
     }
     index
 }


### PR DESCRIPTION
🤖 Fresh join indexes currently allocate per-key change overlays, populate them, then transfer their entries into base maps. These indexes have no preexisting snapshot to preserve. Populate the base directly instead, keeping the overlay path for updates to shared arrangements.

For example, two occurrences of the same row still add their signed weights; cancellation removes the row, and removes an empty key bucket. Negative weights remain supported. No query semantics, storage or wire formats change. The old bucket-fold helper remains test-only for the existing snapshot-isolation test.

This is a measured trial, not ready for merge. Groove library tests pass: 751 passed, 2 ignored. Clippy and formatting pass. Clean full-fixture and todo comparisons are pending; the phase-attributed CPU capture put fresh join-index construction at about 5% of sampled cycles, so the expected overall benefit is bounded. Broader integration and independent review are not yet claimed.

Trial result: direct construction settled in 12.404s versus 12.212s for the preserved parent binary, with all 27,518 rows in both. Todo batch phases were 229.824ms versus 237.586ms. This is flat overall and does not establish a useful end-to-end improvement. Closing the trial and preserving its branch; it is not part of the retained stack.
