### PR TITLE
Measure capacity versus used bytes in projection output buffers

### DIFF
--- a/crates/groove/src/cold_settle_attribution.rs
+++ b/crates/groove/src/cold_settle_attribution.rs
@@ -6,6 +6,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 const BUCKETS: usize = 2;
 
+static MAP_BUFFER_CAPACITY: AtomicU64 = AtomicU64::new(0);
+static MAP_BUFFER_USED: AtomicU64 = AtomicU64::new(0);
+
 static MAP_CALLS: [AtomicU64; BUCKETS] = [const { AtomicU64::new(0) }; BUCKETS];
 static MAP_INPUT_RECORDS: [AtomicU64; BUCKETS] = [const { AtomicU64::new(0) }; BUCKETS];
 static MAP_OUTPUT_RECORDS: [AtomicU64; BUCKETS] = [const { AtomicU64::new(0) }; BUCKETS];
@@ -16,6 +19,8 @@ static JOIN_OUTPUT_RECORDS: [AtomicU64; BUCKETS] = [const { AtomicU64::new(0) };
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Snapshot {
+    pub map_buffer_capacity: u64,
+    pub map_buffer_used: u64,
     pub map_calls: [u64; BUCKETS],
     pub map_input_records: [u64; BUCKETS],
     pub map_output_records: [u64; BUCKETS],
@@ -30,6 +35,8 @@ fn bucket(hydrate: bool) -> usize {
 }
 
 pub fn reset() {
+    MAP_BUFFER_CAPACITY.store(0, Ordering::Relaxed);
+    MAP_BUFFER_USED.store(0, Ordering::Relaxed);
     for counters in [
         &MAP_CALLS,
         &MAP_INPUT_RECORDS,
@@ -50,6 +57,8 @@ pub fn snapshot() -> Snapshot {
         std::array::from_fn(|index| counters[index].load(Ordering::Relaxed))
     }
     Snapshot {
+        map_buffer_capacity: MAP_BUFFER_CAPACITY.load(Ordering::Relaxed),
+        map_buffer_used: MAP_BUFFER_USED.load(Ordering::Relaxed),
         map_calls: load(&MAP_CALLS),
         map_input_records: load(&MAP_INPUT_RECORDS),
         map_output_records: load(&MAP_OUTPUT_RECORDS),
@@ -78,4 +87,11 @@ pub fn record_join(
     JOIN_LEFT_RECORDS[index].fetch_add(left_records as u64, Ordering::Relaxed);
     JOIN_RIGHT_RECORDS[index].fetch_add(right_records as u64, Ordering::Relaxed);
     JOIN_OUTPUT_RECORDS[index].fetch_add(output_records as u64, Ordering::Relaxed);
+}
+
+/// Sum completed newly encoded projection buffers, excluding byte-reuse paths.
+/// Capacity is retained allocation capacity, not cumulative realloc traffic.
+pub fn record_map_buffer(capacity: usize, used: usize) {
+    MAP_BUFFER_CAPACITY.fetch_add(capacity as u64, Ordering::Relaxed);
+    MAP_BUFFER_USED.fetch_add(used as u64, Ordering::Relaxed);
 }

--- a/crates/groove/src/ivm/runtime/operator_updates.rs
+++ b/crates/groove/src/ivm/runtime/operator_updates.rs
@@ -654,6 +654,8 @@ impl NodeState {
             };
             spans.push((span, delta.weight));
         }
+        #[cfg(feature = "cold-settle-attribution")]
+        crate::cold_settle_attribution::record_map_buffer(output.capacity(), output.len());
         let output = output.freeze();
         let deltas: Vec<_> = spans
             .into_iter()

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -825,6 +825,8 @@ struct AttributionSummary {
 
 #[derive(Clone, Default)]
 struct OperatorAttribution {
+    map_buffer_capacity: u64,
+    map_buffer_used: u64,
     map_calls: [u64; 2],
     map_input_records: [u64; 2],
     map_output_records: [u64; 2],
@@ -841,6 +843,8 @@ impl OperatorAttribution {
         before: jazz::groove::cold_settle_attribution::Snapshot,
         after: jazz::groove::cold_settle_attribution::Snapshot,
     ) {
+        self.map_buffer_capacity += after.map_buffer_capacity - before.map_buffer_capacity;
+        self.map_buffer_used += after.map_buffer_used - before.map_buffer_used;
         for index in 0..2 {
             self.map_calls[index] += after.map_calls[index] - before.map_calls[index];
             self.map_input_records[index] +=
@@ -2739,6 +2743,8 @@ fn emit_summary(config: &Config, phase: &str, summary: &RunSummary) {
         json!({
             "map_project": {
                 "calls": operators.map_calls,
+                "new_buffer_capacity_bytes": operators.map_buffer_capacity,
+                "new_buffer_used_bytes": operators.map_buffer_used,
                 "input_records": operators.map_input_records,
                 "output_records": operators.map_output_records,
             },


### PR DESCRIPTION
🤖 Add disabled-by-default counters for capacity and used bytes at the end of newly encoded MapProject output batches. The cold-load harness reports these by node alongside existing projection cardinalities. Byte-preserving reuse paths allocate no new output buffer and are excluded.

This measures a concrete question from the phase/allocation profile: projections currently reserve the complete input batch's byte size even when selecting fewer fields. Summed buffer capacities are not peak live heap, and neither these counters nor allocation-request counts measure actual physical memory consumption. No production allocation strategy changes here.

The attribution-enabled cold benchmark passes its focused compile check; Clippy and formatting pass. Full synthetic-fixture capture is pending. This remains draft instrumentation, not a performance improvement claim.

Full-fixture capture at `266f3bf7f3` returns all 27,518 rows. Summed new-buffer capacity versus used bytes: Core 403,491,708 / 232,537,569 (1.74x), relay 697,157,866 / 414,580,322 (1.68x), client 269,018,912 / 136,793,930 (1.97x). This establishes excess capacity but not a dominant explanation: about 586MB cumulative excess, not 586MB necessarily live at once. Instrumented settle is 15.121s; no clean timing claim is made for these counters.
