### PR TITLE
Estimate projection buffer size from output width

### DIFF
--- a/crates/groove/src/ivm/runtime/operator_updates.rs
+++ b/crates/groove/src/ivm/runtime/operator_updates.rs
@@ -594,6 +594,11 @@ impl NodeState {
                     }
                 )
             });
+        let input_bytes = input
+            .deltas
+            .iter()
+            .map(|delta| delta.record.len())
+            .sum::<usize>();
         let mut output = BytesMut::new();
         let mut spans = Vec::with_capacity(input.deltas.len());
         for (index, delta) in input.deltas.iter().enumerate() {
@@ -650,7 +655,10 @@ impl NodeState {
             if index == 0 {
                 // Estimate from output width: a projection can discard most
                 // of the input fields. Later outliers grow the buffer normally.
-                output.reserve(span.len().saturating_mul(input.deltas.len() - 1));
+                // One unusually wide first row must not amplify the reserve
+                // beyond the old input-sized bound.
+                let estimate = span.len().saturating_mul(input.deltas.len() - 1);
+                output.reserve(estimate.min(input_bytes.saturating_sub(output.len())));
             }
             spans.push((span, delta.weight));
         }

--- a/crates/groove/src/ivm/runtime/operator_updates.rs
+++ b/crates/groove/src/ivm/runtime/operator_updates.rs
@@ -594,14 +594,9 @@ impl NodeState {
                     }
                 )
             });
-        let estimated_output_bytes = input
-            .deltas
-            .iter()
-            .map(|delta| delta.record.len())
-            .sum::<usize>();
-        let mut output = BytesMut::with_capacity(estimated_output_bytes);
+        let mut output = BytesMut::new();
         let mut spans = Vec::with_capacity(input.deltas.len());
-        for delta in &input.deltas {
+        for (index, delta) in input.deltas.iter().enumerate() {
             let span = if let Some(fields) = raw_projection {
                 let start = output.len();
                 let result = output_desc.project_raw_fields_into(
@@ -652,6 +647,11 @@ impl NodeState {
                 output.extend_from_slice(&record);
                 start..output.len()
             };
+            if index == 0 {
+                // Estimate from output width: a projection can discard most
+                // of the input fields. Later outliers grow the buffer normally.
+                output.reserve(span.len().saturating_mul(input.deltas.len() - 1));
+            }
             spans.push((span, delta.weight));
         }
         #[cfg(feature = "cold-settle-attribution")]


### PR DESCRIPTION
🤖 Trial: size a newly encoded projection buffer using the first output row, rather than reserving the full input batch's byte size. Keep input bytes as an upper bound on that estimate: one unusually wide first row must not cause a multiplied allocation for otherwise narrow rows. Later variable-width rows grow the buffer normally. An omitted first row simply leaves ordinary geometric growth in place.

For example, selecting a UUID from wide records should reserve for UUID outputs, while a projection that expands records can still grow beyond the estimate. This changes allocation strategy only; encoded bytes, weights, omission behavior and query semantics are unchanged.

The preceding instrumentation found 1.68–1.97x capacity versus used bytes, about 586MB cumulative excess across the fixture. This is not peak live excess memory. The trial remains draft until clean cold-load/todo measurements establish whether it helps.

Groove library tests: 751 passed, 2 ignored. Clippy and formatting passed. Broader integration and independent review have not been run for this trial.

Clean trial result at `8955e1149b`: cold settle 12.477s versus 12.156s parent; todo batch phases 232.185ms versus 233.025ms. All 27,518 rows passed. Peak process RSS including seeding was 4,159,664,128 versus 4,316,057,600 bytes, about 3.6% lower. This does not justify retaining the estimate/bound machinery for this workload. Closing and preserving the branch; excluded from the retained stack.
