### PR TITLE
perf: share immutable version index key bytes

### DIFF
--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::mem;
+use std::sync::Arc;
 
 use groove::ivm::{
     MultisinkDeltas, RecordDeltas, TerminalEdit, TerminalOperation, TerminalPathSegment,
@@ -246,7 +247,7 @@ struct ReplacementIndex {
 struct VersionIdentity {
     table: groove::Intern<String>,
     layer: VersionLayer,
-    raw_record: Vec<u8>,
+    raw_record: Arc<[u8]>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -254,7 +255,7 @@ struct VersionSortKey {
     table: groove::Intern<String>,
     row_uuid: RowUuid,
     layer: VersionLayer,
-    raw_record: Vec<u8>,
+    raw_record: Arc<[u8]>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -3014,7 +3015,7 @@ impl WeightedVersionIndex {
         let tx_id = version_tx_id_from_aliases(&row, node_aliases).ok_or(
             super::Error::InvalidStoredValue("history tx node alias must exist"),
         )?;
-        let sort_key = VersionSortKey::for_row(&row);
+        let sort_key = VersionSortKey::for_row(&row, &identity);
         let new = old + weight;
 
         if old <= 0 && new > 0 {
@@ -3098,10 +3099,11 @@ impl ReplacementIndex {
             let tx_id = version_tx_id_from_aliases(&row, node_aliases).ok_or(
                 super::Error::InvalidStoredValue("history tx node alias must exist"),
             )?;
+            let sort_key = VersionSortKey::for_row(&row, &identity);
             row_versions.insert(
                 identity,
                 WeightedVersion {
-                    sort_key: VersionSortKey::for_row(&row),
+                    sort_key,
                     row,
                     tx_id,
                     weight: new,
@@ -3221,15 +3223,11 @@ fn result_member_payload_entry_bytes(payload: &ResultMemberPayloadEntry) -> usiz
 }
 
 fn version_identity_bytes(identity: &VersionIdentity) -> usize {
-    mem::size_of_val(identity)
-        + intern_string_bytes(&identity.table)
-        + vec_bytes(&identity.raw_record)
+    mem::size_of_val(identity) + intern_string_bytes(&identity.table) + identity.raw_record.len()
 }
 
 fn version_sort_key_bytes(sort_key: &VersionSortKey) -> usize {
-    mem::size_of_val(sort_key)
-        + intern_string_bytes(&sort_key.table)
-        + vec_bytes(&sort_key.raw_record)
+    mem::size_of_val(sort_key) + intern_string_bytes(&sort_key.table) + sort_key.raw_record.len()
 }
 
 fn replacement_key_bytes(key: &ReplacementKey) -> usize {
@@ -3251,18 +3249,18 @@ impl VersionIdentity {
         Self {
             table: row.table,
             layer: row.layer(),
-            raw_record: row.record.raw().to_vec(),
+            raw_record: Arc::from(row.record.raw()),
         }
     }
 }
 
 impl VersionSortKey {
-    fn for_row(row: &VersionRow) -> Self {
+    fn for_row(row: &VersionRow, identity: &VersionIdentity) -> Self {
         Self {
             table: row.table,
             row_uuid: row.row_uuid(),
             layer: row.layer(),
-            raw_record: row.record.raw().to_vec(),
+            raw_record: Arc::clone(&identity.raw_record),
         }
     }
 }


### PR DESCRIPTION
🤖 Maintained version indexes currently copy an encoded row into its identity key, copy it again into the secondary ordering key, and clone those buffers when inserting into additional indexes. This change shares immutable bytes between those private keys. Keys still compare their full byte contents; no hashes or pointer identity replace exact equality.

For example, a version appearing in both the primary identity index and its transaction index now shares one key buffer. Retracting that exact version still removes its transaction entry, while other versions remain independently addressable. The public owned record, storage bytes and wire protocol are unchanged.

The synthetic 27,518-row cold-load fixture passed in 11.806s and 11.870s versus 11.988s for the parent: effectively flat latency. Peak RSS, including seeding, fell from 4.262GB to 3.949–3.960GB (about 7%). The todo phase sum was 224.581ms versus 249.017ms in one pair; this is preliminary, not a robust 10% speedup claim. Measurements use the optimized perf profile with explicit mimalloc. This is a small ownership change retained primarily for lower memory use.

Validation: 2,008 Jazz library tests passed (2 ignored), all three incremental-delivery canaries and the two-seed differential oracle at churn depths 10/1000 passed; formatting and Clippy passed. Existing exact-version ordering, retraction and replacement tests cover behavior. No independent review or full canonical acceptance is claimed. Footprint diagnostics conservatively count referenced bytes per index entry and are not a deduplicated heap measurement.
