### PR TITLE
perf: use the latest-write index for staged scans

### DIFF
--- a/crates/groove/src/storage/mod.rs
+++ b/crates/groove/src/storage/mod.rs
@@ -1670,20 +1670,61 @@ impl StagedWriteState {
                     });
             }
 
-            let mut latest_by_cf_key: BTreeMap<String, BTreeMap<Vec<u8>, usize>> = BTreeMap::new();
-            for (index, operation) in self.operations.iter().enumerate() {
-                latest_by_cf_key
-                    .entry(operation.cf().to_owned())
-                    .or_default()
-                    .insert(operation.key().to_vec(), index);
-            }
-            self.latest_by_cf_key = Some(latest_by_cf_key);
+            self.ensure_key_index();
         }
 
         self.latest_by_cf_key
             .as_ref()
             .and_then(|latest_by_cf_key| latest_by_cf_key.get(cf))
             .and_then(|latest_by_key| latest_by_key.get(key).copied())
+    }
+
+    fn ensure_key_index(&mut self) {
+        if self.latest_by_cf_key.is_some() {
+            return;
+        }
+        let mut latest_by_cf_key: BTreeMap<String, BTreeMap<Vec<u8>, usize>> = BTreeMap::new();
+        for (index, operation) in self.operations.iter().enumerate() {
+            latest_by_cf_key
+                .entry(operation.cf().to_owned())
+                .or_default()
+                .insert(operation.key().to_vec(), index);
+        }
+        self.latest_by_cf_key = Some(latest_by_cf_key);
+    }
+
+    fn scan_snapshot(
+        &mut self,
+        cf: &str,
+        bounds: &ScanBounds,
+    ) -> VecDeque<(Vec<u8>, Option<Value>)> {
+        use std::ops::Bound::{Excluded, Included, Unbounded};
+        if self.operations.is_empty() || bounds.is_empty_range() {
+            return VecDeque::new();
+        }
+        self.ensure_key_index();
+        let Some(by_key) = self
+            .latest_by_cf_key
+            .as_ref()
+            .and_then(|by_cf| by_cf.get(cf))
+        else {
+            return VecDeque::new();
+        };
+        let (start, end) = match bounds {
+            ScanBounds::Prefix(prefix) => (prefix.as_slice(), prefix_successor(prefix)),
+            ScanBounds::Range { start, end } => (start.as_slice(), Some(end.clone())),
+        };
+        let upper = end.as_deref().map_or(Unbounded, Excluded);
+        by_key
+            .range::<[u8], _>((Included(start), upper))
+            .map(|(key, index)| {
+                let value = match &self.operations[*index] {
+                    OwnedWriteOperation::Set { value, .. } => Some(value.clone()),
+                    OwnedWriteOperation::Delete { .. } => None,
+                };
+                (key.clone(), value)
+            })
+            .collect()
     }
 
     pub(crate) fn contains_key(&mut self, cf: &ColumnFamilyName, key: &Key) -> bool {
@@ -1782,47 +1823,15 @@ impl<'a, S: ?Sized> StagedWriteOverlay<'a, S> {
     }
 }
 
-fn overlay_point_value(
-    mut value: Option<Value>,
-    operations: &[OwnedWriteOperation],
-    cf: &str,
-    key: &[u8],
-) -> Result<Option<Value>, Error> {
-    for operation in operations {
-        if operation.cf() != cf || operation.key() != key {
-            continue;
-        }
-        match operation {
-            OwnedWriteOperation::Set { value: set, .. } => value = Some(set.clone()),
-            OwnedWriteOperation::Delete { .. } => value = None,
-        }
-    }
-    Ok(value)
-}
-
-fn snapshot_staged_operations(
-    staged_writes: &RefCell<StagedWriteState>,
-    include: impl Fn(&OwnedWriteOperation) -> bool,
-) -> Vec<OwnedWriteOperation> {
-    staged_writes
-        .borrow()
-        .operations
-        .iter()
-        .filter(|operation| include(operation))
-        .cloned()
-        .collect()
-}
-
 /// Ordered cursor which merges the durable base with the staged transaction
 /// writes as the caller asks for batches.  It intentionally owns only the
 /// in-range staged keys; its base cursor remains lazy, so a logical limit does
 /// not turn a sparse staged overlay into a full base-prefix materialization.
 struct OverlayScanCursor<'a> {
     base: StorageScan<'a>,
-    staged: VecDeque<(Vec<u8>, Vec<OwnedWriteOperation>)>,
+    staged: VecDeque<(Vec<u8>, Option<Value>)>,
     base_entries: VecDeque<KeyValue>,
     base_done: bool,
-    cf: String,
     direction: ScanDirection,
     remaining: Option<usize>,
 }
@@ -1857,11 +1866,8 @@ impl OverlayScanCursor<'_> {
                 let staged_entry = choice.1.then(|| self.staged.pop_front()).flatten();
 
                 match staged_entry {
-                    Some((key, operations)) => {
-                        let base_value = base_entry.map(|(_, value)| value);
-                        if let Some(value) =
-                            overlay_point_value(base_value, &operations, &self.cf, &key)?
-                        {
+                    Some((key, value)) => {
+                        if let Some(value) = value {
                             return Ok(Some((key, value)));
                         }
                     }
@@ -1909,38 +1915,19 @@ fn overlay_scan<'a, S>(
 where
     S: OrderedKvStorage + ?Sized,
 {
-    let cf = request.cf.clone();
-    let bounds = request.bounds.clone();
-    let operations = snapshot_staged_operations(staged_writes, |operation| {
-        operation.cf() == cf
-            && match &bounds {
-                ScanBounds::Prefix(prefix) => operation.key().starts_with(prefix),
-                ScanBounds::Range { start, end } => {
-                    operation.key() >= start.as_slice() && operation.key() < end.as_slice()
-                }
-            }
-    });
+    // Capture only the final value per key at scan creation. Later staged
+    // writes must not change this cursor's overlay snapshot.
+    let mut staged = staged_writes
+        .borrow_mut()
+        .scan_snapshot(&request.cf, &request.bounds);
     Box::pin(async move {
-        let mut staged = BTreeMap::<Vec<u8>, Vec<OwnedWriteOperation>>::new();
-        for operation in operations {
-            staged
-                .entry(operation.key().to_vec())
-                .or_default()
-                .push(operation);
-        }
-
         // A base limit of only the logical result size is unsound: every
         // staged key whose final operation can remove it may consume one of
         // those physical entries without producing a logical result. A
         // Thus `limit + removals` is both a hard physical ceiling and enough base entries to fill the
         // requested logical result when they exist.
         let physical_max_items = request.max_items.map(|limit| {
-            let final_removals = staged
-                .values()
-                .filter(|operations| {
-                    matches!(operations.last(), Some(OwnedWriteOperation::Delete { .. }))
-                })
-                .count();
+            let final_removals = staged.iter().filter(|(_, value)| value.is_none()).count();
             limit.saturating_add(final_removals)
         });
         let base = base
@@ -1949,7 +1936,6 @@ where
                 ..request.clone()
             })
             .await?;
-        let mut staged = staged.into_iter().collect::<VecDeque<_>>();
         if request.direction == ScanDirection::Reverse {
             staged.make_contiguous().reverse();
         }
@@ -1958,7 +1944,6 @@ where
             staged,
             base_entries: VecDeque::new(),
             base_done: false,
-            cf: request.cf,
             direction: request.direction,
             remaining: request.max_items,
         }) as StorageScan<'a>)
@@ -3946,6 +3931,73 @@ mod tests {
             vec![(b"row:298".to_vec(), b"reverse-override".to_vec())]
         );
         assert_eq!(storage.take_scan_entries_materialized(), 2);
+    }
+
+    #[futures_test::test]
+    async fn staged_scan_keeps_final_values_and_its_open_snapshot() {
+        let storage = MemoryStorage::new(&["records", "other"]).unwrap();
+        let transaction = StorageTransaction::new(&storage);
+        transaction.stage_owned_operations(vec![
+            OwnedWriteOperation::set("records", b"a", b"old"),
+            OwnedWriteOperation::set("records", b"a", b"new"),
+            OwnedWriteOperation::set("records", b"b", b"removed"),
+            OwnedWriteOperation::delete("records", b"b"),
+            OwnedWriteOperation::delete("records", b"c"),
+            OwnedWriteOperation::set("records", b"c", b"restored"),
+            OwnedWriteOperation::set("other", b"a", b"other-family"),
+            OwnedWriteOperation::set("records", &[255, 0], b"high"),
+        ]);
+        let open = transaction
+            .scan(ScanRequest::range(
+                "records".into(),
+                b"a".to_vec(),
+                b"d".to_vec(),
+            ))
+            .await
+            .unwrap();
+        transaction.stage_owned_operations(vec![
+            OwnedWriteOperation::set("records", b"a", b"later"),
+            OwnedWriteOperation::set("records", b"b", b"revived"),
+            OwnedWriteOperation::set("records", b"d", b"outside-range"),
+        ]);
+        assert_eq!(
+            collect_scan(open).await.unwrap(),
+            vec![
+                (b"a".to_vec(), b"new".to_vec()),
+                (b"c".to_vec(), b"restored".to_vec()),
+            ]
+        );
+        let current = transaction
+            .scan(ScanRequest::range("records".into(), b"a".to_vec(), b"d".to_vec()).reversed())
+            .await
+            .unwrap();
+        assert_eq!(
+            collect_scan(current).await.unwrap(),
+            vec![
+                (b"c".to_vec(), b"restored".to_vec()),
+                (b"b".to_vec(), b"revived".to_vec()),
+                (b"a".to_vec(), b"later".to_vec()),
+            ]
+        );
+        let high = transaction
+            .scan(ScanRequest::prefix("records".into(), vec![255]))
+            .await
+            .unwrap();
+        assert_eq!(
+            collect_scan(high).await.unwrap(),
+            vec![(vec![255, 0], b"high".to_vec())]
+        );
+        for (start, end) in [(b"d", b"a"), (b"a", b"a")] {
+            let empty = transaction
+                .scan(ScanRequest::range(
+                    "records".into(),
+                    start.to_vec(),
+                    end.to_vec(),
+                ))
+                .await
+                .unwrap();
+            assert!(collect_scan(empty).await.unwrap().is_empty());
+        }
     }
 
     // Internal receipt: the regression is work performed inside the storage overlay and is not


### PR DESCRIPTION
🤖 Scanning a transaction's staged writes currently walks every operation, clones all matching set/delete operations, groups them into per-key lists, and replays those lists into cloned output values. This change reuses the existing ordered latest-write index and snapshots one final value or deletion per in-range key.

For example, `set(a, old), set(a, new), set(b, value), delete(b)` becomes the scan overlay `a → new, b → absent`. Earlier operations remain in the commit log; only the scan snapshot is simplified. A scan opened before another `set(a, later)` keeps its original staged snapshot. A newly opened scan sees `later` through the updated index.

The first indexed access builds the key index once; subsequent staged writes maintain it. Narrow scans then seek directly to their column-family/key interval. The base storage cursor stays lazy, reverse scans stay reversed, and the physical base limit still allows for staged deletions that hide durable rows. Empty/reversed intervals and prefixes without a finite successor remain supported. No storage or wire bytes change.

Validation: all 752 Groove tests and 2,008 Jazz library tests passed (2 ignored in each). The new storage API test covers last-write-wins, delete/restore, scan-open snapshot isolation, cross-family isolation, reverse ordering, range exclusion and an all-0xff prefix. Changing index construction to first-write-wins makes its exact-value assertion fail; mutation restored. All three incremental canaries, the two-seed differential oracle at churn depths 10/1000, Clippy and formatting passed.

Synthetic native cold load: 11.672s and 11.570s versus parent 11.753s, all 27,518 rows present. This is about 1%, not a substantial cold-load improvement. Todo phase sum was 234.236ms versus 250.390ms in one preliminary pair. The main rationale is removing full-list filtering and redundant operation histories while preserving the storage contract. No independent review or full canonical acceptance is claimed.
