### PR TITLE
bench: attribute projection work to graph nodes

### DIFF
--- a/crates/groove/src/cold_settle_attribution.rs
+++ b/crates/groove/src/cold_settle_attribution.rs
@@ -2,6 +2,8 @@
 
 #![allow(missing_docs)]
 
+use std::collections::BTreeMap;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 const BUCKETS: usize = 2;
@@ -35,6 +37,7 @@ fn bucket(hydrate: bool) -> usize {
 }
 
 pub fn reset() {
+    MAP_NODES.lock().unwrap().clear();
     MAP_BUFFER_CAPACITY.store(0, Ordering::Relaxed);
     MAP_BUFFER_USED.store(0, Ordering::Relaxed);
     for counters in [
@@ -94,4 +97,43 @@ pub fn record_join(
 pub fn record_map_buffer(capacity: usize, used: usize) {
     MAP_BUFFER_CAPACITY.fetch_add(capacity as u64, Ordering::Relaxed);
     MAP_BUFFER_USED.fetch_add(used as u64, Ordering::Relaxed);
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MapNodeWork {
+    pub node: u64,
+    pub hydrate: bool,
+    pub calls: u64,
+    pub input_records: u64,
+    pub output_records: u64,
+    /// Projection preparation and execution only, excluding upstream evaluation.
+    pub elapsed_ns: u64,
+    pub plan: String,
+}
+
+static MAP_NODES: Mutex<BTreeMap<(u64, bool), MapNodeWork>> = Mutex::new(BTreeMap::new());
+
+pub fn record_map_node(
+    node: u64,
+    hydrate: bool,
+    input_records: usize,
+    output_records: usize,
+    elapsed_ns: u64,
+    plan: impl FnOnce() -> String,
+) {
+    let mut nodes = MAP_NODES.lock().unwrap();
+    let entry = nodes.entry((node, hydrate)).or_insert_with(|| MapNodeWork {
+        node,
+        hydrate,
+        plan: plan(),
+        ..MapNodeWork::default()
+    });
+    entry.calls += 1;
+    entry.input_records += input_records as u64;
+    entry.output_records += output_records as u64;
+    entry.elapsed_ns += elapsed_ns;
+}
+
+pub fn map_node_work() -> Vec<MapNodeWork> {
+    MAP_NODES.lock().unwrap().values().cloned().collect()
 }

--- a/crates/groove/src/ivm/runtime/evaluator.rs
+++ b/crates/groove/src/ivm/runtime/evaluator.rs
@@ -1168,6 +1168,8 @@ impl TickEvaluator<'_> {
                 }
                 OpType::MapProject(project) => {
                     let input = self.update_unary_input(graph_node, node).await?;
+                    #[cfg(feature = "cold-settle-attribution")]
+                    let projection_started = std::time::Instant::now();
                     let raw_projection =
                         self.raw_projection_fields(node, project, &input.descriptor, output_desc)?;
                     let result = NodeState::update_map_project(
@@ -1179,6 +1181,19 @@ impl TickEvaluator<'_> {
                     );
                     #[cfg(feature = "cold-settle-attribution")]
                     if let Ok(output) = &result {
+                        crate::cold_settle_attribution::record_map_node(
+                            node.0,
+                            self.context.eval_mode == EvalMode::Hydrate,
+                            input.deltas.len(),
+                            output.deltas.len(),
+                            projection_started.elapsed().as_nanos() as u64,
+                            || {
+                                format!(
+                                    "inputs={:?} projection={project:?}",
+                                    graph_node.descriptor.inputs
+                                )
+                            },
+                        );
                         crate::cold_settle_attribution::record_map(
                             self.context.eval_mode == EvalMode::Hydrate,
                             input.deltas.len(),

--- a/crates/groove/src/ivm/runtime/recursion.rs
+++ b/crates/groove/src/ivm/runtime/recursion.rs
@@ -1677,6 +1677,8 @@ impl HydrationEvaluator<'_> {
                 }
                 OpType::MapProject(project) => {
                     let input = self.eval_unary_input(graph_node, node).await?;
+                    #[cfg(feature = "cold-settle-attribution")]
+                    let projection_started = std::time::Instant::now();
                     let fields = raw_projection_fields(project, &input.descriptor, output_desc)?;
                     let result = NodeState::update_map_project(
                         project,
@@ -1687,6 +1689,19 @@ impl HydrationEvaluator<'_> {
                     );
                     #[cfg(feature = "cold-settle-attribution")]
                     if let Ok(output) = &result {
+                        crate::cold_settle_attribution::record_map_node(
+                            node.0,
+                            true,
+                            input.deltas.len(),
+                            output.deltas.len(),
+                            projection_started.elapsed().as_nanos() as u64,
+                            || {
+                                format!(
+                                    "inputs={:?} projection={project:?}",
+                                    graph_node.descriptor.inputs
+                                )
+                            },
+                        );
                         crate::cold_settle_attribution::record_map(
                             true,
                             input.deltas.len(),

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -1841,6 +1841,8 @@ fn run_connect_and_subscribe(
     // sizing are diagnostics, not work needed to make subscriptions usable.
     let alloc_snapshot = alloc_metrics::stop();
     #[cfg(feature = "cold-settle-attribution")]
+    let projection_nodes_at_readiness = jazz::groove::cold_settle_attribution::map_node_work();
+    #[cfg(feature = "cold-settle-attribution")]
     {
         attribution.phase_timing = jazz_sim::phase_attribution::snapshot();
         if let Some(mut path) = std::env::var_os("JAZZ_PHASE_TIMELINE") {
@@ -1989,6 +1991,20 @@ fn run_connect_and_subscribe(
         attribution.probe_core_to_relay_total_ns = core_to_relay_probe.total_ns;
         attribution.probe_relay_to_client_calls = relay_to_client_probe.calls;
         attribution.probe_relay_to_client_total_ns = relay_to_client_probe.total_ns;
+        for node in projection_nodes_at_readiness {
+            eprintln!(
+                "PROJECT_NODE {}",
+                json!({
+                    "node": node.node,
+                    "hydrate": node.hydrate,
+                    "calls": node.calls,
+                    "input_records": node.input_records,
+                    "output_records": node.output_records,
+                    "elapsed_ns": node.elapsed_ns,
+                    "plan": node.plan,
+                })
+            );
+        }
         let counters = jazz::cold_settle_attribution::snapshot();
         attribution.preflight_payload_encodes = counters.preflight_payload_encodes;
         attribution.preflight_payload_encode_ns = counters.preflight_payload_encode_ns;


### PR DESCRIPTION
🤖 Add opt-in per-node projection attribution to the existing cold-settle benchmark feature. Each node records its evaluation mode, input/output row visits, preparation/execution duration and plan shape. Upstream input evaluation is outside the timer, and reporting occurs after the readiness boundary; final verification queries are excluded.

This answers whether millions of intermediate row visits imply projection is still a dominant cost. In the synthetic 27,518-row fixture, 4,659 node/mode entries account for exactly 1,892,708 input/output visits, matching the existing aggregate counters. Projection preparation/execution totals 309ms in an instrumented 13.278s cold settle. The busiest nodes repeatedly transform the 43,000-candidate child table into app-row and version/replacement witness forms, including upstream-node work. This is not a unique-row count or a clean latency baseline.

Normal builds collect none of this information. The detailed diagnostic aggregates equal node IDs across node roles; it does not claim per-role timings. Timings cover successful synchronous projection preparation/execution, not upstream evaluation or memo lookup. Plan text is generated once per node/mode and emitted only by the benchmark after readiness.

Validation: optimized feature-enabled build and complete fixed fixture passed; per-node row totals match aggregate counters exactly. Feature-enabled Groove Clippy and formatting passed. This is benchmark instrumentation, not a production optimization. Independent review and full canonical acceptance are not claimed.
