### PR TITLE
perf: prune unused columns from query joins

### DIFF
--- a/crates/groove/SPEC/3_queries_operators.md
+++ b/crates/groove/SPEC/3_queries_operators.md
@@ -147,6 +147,22 @@ _Further invariants._ `INV-QUERY-5` — `MapProject` copies only configured fiel
 and preserves the input weight. `INV-QUERY-6` — `UnwrapNullable` preserves the
 original delta weight.
 
+### Consumer-local column pruning
+
+After resolving field references against the original descriptors, compilation
+may narrow a semi/anti join's right input to its matching fields. Projection
+preserves weights; it is not DISTINCT. Multiple rows sharing a key retain their
+combined multiplicity, including simultaneous insertion and retraction.
+
+For a projection over an inner join, each join input may retain only fields
+required by the output expressions and matching keys. Expressions are rebound
+to the narrowed descriptor by resolved position; logical field labels must not
+be reinterpreted after dropping columns. Comparison modes and exact value types
+remain unchanged. These are consumer-local graphs: independently used sources,
+projections and arrangements remain intact. Pruning does not cross upstream
+filters, winner/window selection, recursive boundaries or fallible expressions;
+it must not suppress errors or change which rows qualify or their ordering.
+
 ### 3.4 Joins
 
 Joins combine or suppress rows by key. groove executes the **inner equi-join**

--- a/crates/groove/src/db/tests/graphs/joins.rs
+++ b/crates/groove/src/db/tests/graphs/joins.rs
@@ -1431,3 +1431,109 @@ async fn anti_join_resubscribe_hydrates_from_storage_after_unretained_changes() 
         .unwrap();
     assert!(subscription.recv().unwrap().is_empty());
 }
+
+#[futures_test::test]
+async fn existence_join_narrowing_keeps_duplicate_key_counts_across_retractions() {
+    for anti in [false, true] {
+        let storage = MemoryStorage::new(&["albums", "artists"]).unwrap();
+        let mut database = Database::new(albums_artists_schema(), storage)
+            .await
+            .unwrap();
+        let left = GraphBuilder::table("albums");
+        let right = GraphBuilder::table("artists");
+        let graph = if anti {
+            GraphBuilder::anti_join(left, right, ["title"], ["name"])
+        } else {
+            GraphBuilder::semi_join(left, right, ["title"], ["name"])
+        };
+        let subscription = database.subscribe_one_sink(graph.clone()).await.unwrap();
+        assert!(subscription.recv().unwrap().is_empty());
+        let album = vec![Value::U64(7), Value::U64(11), Value::String("same".into())];
+        let mut batch = database.open_batch();
+        batch.insert("albums", album.clone());
+        batch.insert(
+            "artists",
+            vec![Value::U64(11), Value::String("same".into())],
+        );
+        batch.insert(
+            "artists",
+            vec![Value::U64(12), Value::String("same".into())],
+        );
+        database.commit_batch(batch).await.unwrap();
+        if anti {
+            assert!(subscription.try_recv().is_err());
+        } else {
+            assert_eq!(expect_recv_vals(&subscription), [(album.clone(), 1)]);
+        }
+        // The rows differ only in a field discarded by the existence input.
+        // Removing one must not act as if their common key disappeared.
+        let mut batch = database.open_batch();
+        batch.delete("artists", PrimaryKeyValue::U64(11));
+        database.commit_batch(batch).await.unwrap();
+        assert!(subscription.try_recv().is_err());
+        // Replace the last matching row in one tick: still no threshold crossing.
+        let mut batch = database.open_batch();
+        batch.delete("artists", PrimaryKeyValue::U64(12));
+        batch.insert(
+            "artists",
+            vec![Value::U64(13), Value::String("same".into())],
+        );
+        database.commit_batch(batch).await.unwrap();
+        assert!(subscription.try_recv().is_err());
+        let mut batch = database.open_batch();
+        batch.delete("artists", PrimaryKeyValue::U64(13));
+        database.commit_batch(batch).await.unwrap();
+        assert_eq!(
+            expect_recv_vals(&subscription),
+            [(album, if anti { 1 } else { -1 })]
+        );
+    }
+}
+
+#[futures_test::test]
+async fn projected_join_preserves_values_with_unnamed_input_slots() {
+    use crate::records::{DescriptorField, FieldIdentity, RecordDescriptor, ValueType};
+    let descriptor = RecordDescriptor::new_with_fields([
+        DescriptorField {
+            name: None,
+            identity: Some(FieldIdentity::Slot(42)),
+            value_type: ValueType::U64,
+        },
+        DescriptorField::new("id", ValueType::U64),
+        DescriptorField::new("label", ValueType::String),
+    ]);
+    let side = |label: &str| {
+        GraphBuilder::values(
+            descriptor,
+            [vec![
+                Value::U64(999),
+                Value::U64(1),
+                Value::String(label.into()),
+            ]],
+        )
+        .unwrap()
+    };
+    let graph = GraphBuilder::join(side("left value"), side("right value"), ["id"], ["id"])
+        .project_fields([
+            ProjectField::renamed("left.label", "left_label"),
+            ProjectField::renamed("right.label", "right_label"),
+        ]);
+    let mut database = Database::new(DatabaseSchema::new([]), MemoryStorage::new(&[]).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(
+        database
+            .query_graph(graph)
+            .await
+            .unwrap()
+            .to_values()
+            .unwrap(),
+        [(
+            vec![
+                Value::String("left value".into()),
+                Value::String("right value".into())
+            ],
+            1
+        )]
+    );
+}

--- a/crates/groove/src/ivm/runtime/compilation.rs
+++ b/crates/groove/src/ivm/runtime/compilation.rs
@@ -23,6 +23,236 @@ impl IvmRuntime {
         node
     }
 
+    /// Consumer-local column pruning. Keep the source graph intact for other
+    /// consumers and for all of its fallible computations and ordering rules.
+    fn compile_selected_columns(
+        &mut self,
+        input: CompiledNode,
+        selected: &[usize],
+    ) -> Result<CompiledNode, IvmRuntimeError> {
+        if selected.len() == input.output.fields().len() {
+            return Ok(input);
+        }
+        let names = selected
+            .iter()
+            .map(|index| format!("__narrow_field_{index}"))
+            .collect::<Vec<_>>();
+        let output = RecordDescriptor::new(selected.iter().zip(&names).map(|(index, name)| {
+            (
+                name.clone(),
+                input.output.fields()[*index].value_type.clone(),
+            )
+        }));
+        let expressions = selected
+            .iter()
+            .zip(&names)
+            .map(|(index, name)| ProjectionExpr {
+                expression: ProjectExpr::Field(FieldRef::Resolved(*index)),
+                output_name: Some(name.clone()),
+                output_identity: crate::records::FieldIdentity::Name(name.clone()),
+            })
+            .collect();
+        let mapping = selected.iter().map(|index| (0, *index)).collect();
+        let node = self.graph.dedup_node(
+            NodeDescriptor::new(
+                OpType::MapProject(MapProjectOp {
+                    expressions,
+                    mapping,
+                }),
+                [input.node],
+                output,
+            ),
+            NodeDurability::Ephemeral,
+        );
+        self.initialize_node_runtime(node);
+        Ok(CompiledNode {
+            output,
+            node,
+            root_ordering_node: input.root_ordering_node,
+        })
+    }
+
+    /// Semi/anti joins observe right-key multiplicities, not right payloads.
+    fn compile_existence_input(
+        &mut self,
+        input: CompiledNode,
+        keys: &[FieldRef],
+    ) -> Result<(CompiledNode, Vec<PlanExpr>), IvmRuntimeError> {
+        let indices = keys
+            .iter()
+            .map(|key| resolve_field_ref(&input.output, key))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut selected = indices.clone();
+        selected.sort_unstable();
+        selected.dedup();
+        let input = self.compile_selected_columns(input, &selected)?;
+        let keys = indices
+            .iter()
+            .map(|index| {
+                let index = selected.binary_search(index).expect("selected key");
+                field_ref_name(&input.output, &FieldRef::Resolved(index)).map(PlanExpr::field)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok((input, keys))
+    }
+
+    /// Project(Join) needs only consumer fields plus matching keys on each
+    /// input. Bind expressions against the original descriptor first, so
+    /// dropping or renaming columns cannot redirect a logical field reference.
+    fn narrow_projected_join(
+        &mut self,
+        input: NodeId,
+        expressions: &mut [ProjectionExpr],
+    ) -> Result<NodeId, IvmRuntimeError> {
+        let descriptor = &self
+            .graph
+            .node(input)
+            .ok_or(IvmRuntimeError::GraphNodeNotFound(input))?
+            .descriptor;
+        let OpType::Join(join) = &descriptor.operator else {
+            return Ok(input);
+        };
+        if join.residual_predicate.is_some() || !matches!(join.kind, JoinOpKind::Inner) {
+            return Ok(input);
+        }
+        let descriptor = descriptor.clone();
+        let OpType::Join(join) = &descriptor.operator else {
+            unreachable!()
+        };
+        let original = descriptor.output.records();
+        let left_len = join.left_descriptor.fields().len();
+        let input_mapping = super::join::join_output_mapping(
+            &join.left_descriptor,
+            &join.right_descriptor,
+            &original,
+        )?;
+        let mut demanded = Vec::new();
+        for expression in expressions.iter() {
+            if let Some(field) = projection_source_ref(&expression.expression) {
+                demanded.push(input_mapping[resolve_field_ref(&original, field)?]);
+            }
+        }
+        let mut left_fields = demanded
+            .iter()
+            .copied()
+            .filter_map(|(side, index)| (side == 0).then_some(index))
+            .collect::<Vec<_>>();
+        let mut right_fields = demanded
+            .iter()
+            .copied()
+            .filter_map(|(side, index)| (side == 1).then_some(index))
+            .collect::<Vec<_>>();
+        let left_keys = plan_expr_names(&join.left_key)
+            .iter()
+            .map(|name| resolve_field_ref(&join.left_descriptor, &FieldRef::name(name)))
+            .collect::<Result<Vec<_>, _>>()?;
+        let right_keys = plan_expr_names(&join.right_key)
+            .iter()
+            .map(|name| resolve_field_ref(&join.right_descriptor, &FieldRef::name(name)))
+            .collect::<Result<Vec<_>, _>>()?;
+        left_fields.extend(&left_keys);
+        right_fields.extend(&right_keys);
+        left_fields.sort_unstable();
+        left_fields.dedup();
+        right_fields.sort_unstable();
+        right_fields.dedup();
+        if left_fields.len() == left_len
+            && right_fields.len() == join.right_descriptor.fields().len()
+        {
+            return Ok(input);
+        }
+        // The compiled Join inputs are arrangements. Prune their record inputs,
+        // then construct consumer-specific arrangements; never mutate a shared one.
+        let mut compile_side = |arrangement: NodeId,
+                                output: RecordDescriptor,
+                                fields: &[usize],
+                                keys: &[usize]|
+         -> Result<_, IvmRuntimeError> {
+            let source = self
+                .graph
+                .node(arrangement)
+                .ok_or(IvmRuntimeError::GraphNodeNotFound(arrangement))?
+                .descriptor
+                .inputs[0];
+            let compiled = self.compile_selected_columns(
+                CompiledNode {
+                    node: source,
+                    output,
+                    root_ordering_node: None,
+                },
+                fields,
+            )?;
+            let key = keys
+                .iter()
+                .map(|index| {
+                    field_ref_name(
+                        &compiled.output,
+                        &FieldRef::Resolved(
+                            fields.binary_search(index).expect("join key retained"),
+                        ),
+                    )
+                    .map(PlanExpr::field)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let arrangement = self.add_arrangement_node(
+                compiled.node,
+                compiled.output,
+                plan_expr_names(&key),
+                join.comparison,
+            );
+            Ok((compiled.output, arrangement, key))
+        };
+        let (left_descriptor, left, left_key) = compile_side(
+            descriptor.inputs[0],
+            join.left_descriptor,
+            &left_fields,
+            &left_keys,
+        )?;
+        let (right_descriptor, right, right_key) = compile_side(
+            descriptor.inputs[1],
+            join.right_descriptor,
+            &right_fields,
+            &right_keys,
+        )?;
+        let output = join_descriptor(&left_descriptor, &right_descriptor);
+        let output_positions =
+            super::join::join_output_mapping(&left_descriptor, &right_descriptor, &output)?
+                .into_iter()
+                .enumerate()
+                .map(|(position, source)| (source, position))
+                .collect::<HashMap<_, _>>();
+        for expression in expressions {
+            if let Some(field) = projection_source_ref_mut(&mut expression.expression) {
+                let (side, old) = input_mapping[resolve_field_ref(&original, field)?];
+                let retained = if side == 0 {
+                    &left_fields
+                } else {
+                    &right_fields
+                };
+                let physical = retained
+                    .binary_search(&old)
+                    .expect("consumer field retained");
+                *field = FieldRef::Resolved(output_positions[&(side, physical)]);
+            }
+        }
+        let node = self.graph.dedup_node(
+            NodeDescriptor::new(
+                OpType::Join(JoinOp {
+                    left_descriptor,
+                    right_descriptor,
+                    left_key,
+                    right_key,
+                    ..join.clone()
+                }),
+                [left, right],
+                output,
+            ),
+            NodeDurability::Ephemeral,
+        );
+        self.initialize_node_runtime(node);
+        Ok(node)
+    }
+
     #[cfg_attr(
         feature = "cold-settle-attribution",
         tracing::instrument(skip_all, name = "cold.phase.query_graph_compile")
@@ -793,6 +1023,7 @@ impl IvmRuntime {
                     }
                     input_node = parent.descriptor.inputs[0];
                 }
+                input_node = self.narrow_projected_join(input_node, &mut expressions)?;
                 let source_output = self
                     .graph
                     .node(input_node)
@@ -1065,6 +1296,8 @@ impl IvmRuntime {
                     self.add_dedup_graph_cached(left, output_memo, compiled_memo)?;
                 let compiled_right =
                     self.add_dedup_graph_cached(right, output_memo, compiled_memo)?;
+                let (compiled_right, right_key) =
+                    self.compile_existence_input(compiled_right, right_on)?;
                 let output = inferred_output;
                 let left_descriptor = compiled_left.output;
                 let right_descriptor = compiled_right.output;
@@ -1072,10 +1305,7 @@ impl IvmRuntime {
                     .iter()
                     .map(|field| field_ref_name(&left_descriptor, field).map(PlanExpr::field))
                     .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
-                let right_key = right_on
-                    .iter()
-                    .map(|field| field_ref_name(&right_descriptor, field).map(PlanExpr::field))
-                    .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
+
                 let left_arrangement = self.add_arrangement_node(
                     compiled_left.node,
                     left_descriptor,
@@ -1124,6 +1354,8 @@ impl IvmRuntime {
                     self.add_dedup_graph_cached(left, output_memo, compiled_memo)?;
                 let compiled_right =
                     self.add_dedup_graph_cached(right, output_memo, compiled_memo)?;
+                let (compiled_right, right_key) =
+                    self.compile_existence_input(compiled_right, right_on)?;
                 let output = inferred_output;
                 let left_descriptor = compiled_left.output;
                 let right_descriptor = compiled_right.output;
@@ -1131,10 +1363,7 @@ impl IvmRuntime {
                     .iter()
                     .map(|field| field_ref_name(&left_descriptor, field).map(PlanExpr::field))
                     .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
-                let right_key = right_on
-                    .iter()
-                    .map(|field| field_ref_name(&right_descriptor, field).map(PlanExpr::field))
-                    .collect::<Result<Vec<_>, IvmRuntimeError>>()?;
+
                 let left_arrangement = self.add_arrangement_node(
                     compiled_left.node,
                     left_descriptor,
@@ -1634,4 +1863,29 @@ fn arg_by_comparison_field_indices(
         .chain(order_field_indices)
         .copied()
         .collect()
+}
+
+fn projection_source_ref(expression: &ProjectExpr) -> Option<&FieldRef> {
+    match expression {
+        ProjectExpr::Field(field)
+        | ProjectExpr::Nullable(field)
+        | ProjectExpr::NullableFlat(field)
+        | ProjectExpr::RecordField { source: field, .. }
+        | ProjectExpr::EnumTagRemap { source: field, .. }
+        | ProjectExpr::EnumRemap { source: field, .. }
+        | ProjectExpr::RecursiveEnumRemap { source: field, .. } => Some(field),
+        ProjectExpr::Literal(_) | ProjectExpr::TypedLiteral { .. } | ProjectExpr::Null(_) => None,
+    }
+}
+fn projection_source_ref_mut(expression: &mut ProjectExpr) -> Option<&mut FieldRef> {
+    match expression {
+        ProjectExpr::Field(field)
+        | ProjectExpr::Nullable(field)
+        | ProjectExpr::NullableFlat(field)
+        | ProjectExpr::RecordField { source: field, .. }
+        | ProjectExpr::EnumTagRemap { source: field, .. }
+        | ProjectExpr::EnumRemap { source: field, .. }
+        | ProjectExpr::RecursiveEnumRemap { source: field, .. } => Some(field),
+        ProjectExpr::Literal(_) | ProjectExpr::TypedLiteral { .. } | ProjectExpr::Null(_) => None,
+    }
 }

--- a/crates/groove/src/ivm/runtime/tests.rs
+++ b/crates/groove/src/ivm/runtime/tests.rs
@@ -3246,3 +3246,83 @@ fn source_batch_prepares_one_descriptor_per_variant() {
         Err(IvmRuntimeError::UnknownTableVariant { version: 3, .. })
     ));
 }
+
+// Internal mechanism test: result equality alone cannot show whether a join
+// retains unused payload, or whether pruning damaged an independent consumer.
+#[test]
+fn join_consumers_retain_only_required_columns_without_mutating_shared_sources() {
+    let mut runtime = IvmRuntime::new(albums_schema()).unwrap();
+    let source = GraphBuilder::table("albums");
+    let full = runtime.add_dedup_graph(&source).unwrap();
+    for anti in [false, true] {
+        let graph = if anti {
+            GraphBuilder::anti_join(source.clone(), source.clone(), ["id"], ["id"])
+        } else {
+            GraphBuilder::semi_join(source.clone(), source.clone(), ["id"], ["id"])
+        };
+        let compiled = runtime.add_dedup_graph(&graph).unwrap();
+        let operator = &runtime
+            .graph
+            .node(compiled.node)
+            .unwrap()
+            .descriptor
+            .operator;
+        let (OpType::SemiJoin(join) | OpType::AntiJoin(join)) = operator else {
+            panic!("selection join")
+        };
+        assert_eq!(join.left_descriptor, full.output);
+        assert_eq!(join.right_descriptor.fields().len(), 1);
+        assert_eq!(compiled.output, full.output);
+    }
+    let joined = GraphBuilder::join(source.clone(), source, ["id"], ["id"]);
+    let full_join = runtime.add_dedup_graph(&joined).unwrap();
+    let projected = runtime
+        .add_dedup_graph(&joined.project_fields([ProjectField::renamed("left.title", "label")]))
+        .unwrap();
+    let project = runtime.graph.node(projected.node).unwrap();
+    let pruned = runtime.graph.node(project.descriptor.inputs[0]).unwrap();
+    let OpType::Join(join) = &pruned.descriptor.operator else {
+        panic!("pruned join")
+    };
+    assert_eq!(join.left_descriptor.fields().len(), 2); // matching key + result
+    assert_eq!(join.right_descriptor.fields().len(), 1); // matching key only
+    assert_eq!(
+        runtime
+            .graph
+            .node(full_join.node)
+            .unwrap()
+            .descriptor
+            .output
+            .records()
+            .fields()
+            .len(),
+        4
+    );
+    assert_eq!(
+        runtime
+            .graph
+            .node(full.node)
+            .unwrap()
+            .descriptor
+            .output
+            .records(),
+        full.output
+    );
+    let OpType::MapProject(op) = &project.descriptor.operator else {
+        panic!("projection")
+    };
+    let input = pruned.descriptor.output.records();
+    let raw = input
+        .create(&[
+            Value::U64(7),
+            Value::String("retained".into()),
+            Value::U64(7),
+        ])
+        .unwrap();
+    let bytes =
+        project_record(&op.expressions, &op.mapping, projected.output, &input, &raw).unwrap();
+    assert_eq!(
+        projected.output.bind(&bytes).get_idx(0).unwrap(),
+        Value::String("retained".into())
+    );
+}

--- a/crates/jazz/SPEC/6_queries.md
+++ b/crates/jazz/SPEC/6_queries.md
@@ -19,6 +19,16 @@ materialize a Groove source by launching another Jazz query. In particular,
 policy preparation, source resolution, and schema projection MUST NOT call the
 ordinary one-shot query pipeline to obtain an input relation.
 
+Jazz specifies exact row/version identities and policy/binding dependencies before
+requesting immutable supporting or replacement witnesses. The witness carrier
+is constructed after selection against the authorized visible relation. A routed
+selection retains its binding fields and multiplicity; narrowing must not allow
+one route or version to borrow another's visibility. This ordering changes only
+intermediate computation, not the witness's wire or storage representation.
+General column pruning belongs to Groove's resolved graph compiler: Jazz need
+not encode unused payload into existence-check inputs or prescribe a physical
+arrangement layout. This does not imply a second storage lookup.
+
 Lowering itself is synchronous and pure. The implementation separates any
 currently necessary asynchronous source preparation from
 `lower_resolved_query_program`: preparation produces owned declarative source

--- a/crates/jazz/src/node/query_engine/lowering/terminals.rs
+++ b/crates/jazz/src/node/query_engine/lowering/terminals.rs
@@ -3130,43 +3130,73 @@ fn content_version_witness_graph_from_visible_graph(
             inline_version_witness_fields_for_tagged_rows(source, event_kind)?,
         ),
     };
-    let witness_names = witness_fields
-        .iter()
-        .map(|field| field.output_name.clone())
-        .collect::<Vec<_>>();
-    let witnesses = witness_source.project_fields(witness_fields);
-    let version = version_witness_fields(&source.row_shape)?;
-    if routing_param_fields.is_empty() {
-        return Ok(GraphBuilder::semi_join(
-            witnesses,
-            visible_graph,
-            ["row_uuid", "tx_time", "tx_node_id"],
-            [
-                source.row_shape.row_uuid_field.clone(),
-                version.tx_time_field.clone(),
-                version.tx_node_field.clone(),
-            ],
-        ));
-    }
-    let mut fields = witness_names
-        .into_iter()
-        .map(|field| ProjectField::renamed(format!("right.{field}"), field))
-        .collect::<Vec<_>>();
-    fields.extend(
-        routing_param_fields
+    // Resolve selection against the raw carrier before expanding it into a
+    // terminal witness (which duplicates metadata and wraps authored cells).
+    let witness_keys = ["row_uuid", "tx_time", "tx_node_id"].map(|name| {
+        let field = witness_fields
             .iter()
-            .map(|field| ProjectField::renamed(format!("left.{field}"), field.clone())),
-    );
-    Ok(GraphBuilder::join(
-        visible_graph,
-        witnesses,
-        [
-            source.row_shape.row_uuid_field.clone(),
-            version.tx_time_field.clone(),
-            version.tx_node_field.clone(),
-        ],
-        ["row_uuid", "tx_time", "tx_node_id"],
-    )
+            .find(|field| field.output_name == name)
+            .expect("witness projection declares its exact version key");
+        let groove::ivm::ProjectExpr::Field(source) = &field.expression else {
+            unreachable!("witness identity is a source field")
+        };
+        source.clone()
+    });
+    let version = version_witness_fields(&source.row_shape)?;
+    let visible_keys = vec![
+        FieldRef::name(source.row_shape.row_uuid_field.clone()),
+        FieldRef::name(version.tx_time_field),
+        FieldRef::name(version.tx_node_field),
+    ];
+    if routing_param_fields.is_empty() {
+        return Ok(GraphBuilder::SemiJoin {
+            left: std::sync::Arc::new(witness_source),
+            right: std::sync::Arc::new(visible_graph),
+            left_on: witness_keys.into(),
+            right_on: visible_keys,
+            comparison: groove::ivm::ValueComparison::Exact,
+        }
+        .project_fields(witness_fields));
+    }
+
+    // A routed publication keeps the visibility relation's bag multiplicity
+    // and binding values. Groove prunes unused join input columns after
+    // binding the exact keys and the projection's field dependencies.
+    let mut fields = witness_fields;
+    for field in &mut fields {
+        use groove::ivm::ProjectExpr;
+        let key = match &mut field.expression {
+            ProjectExpr::Field(key)
+            | ProjectExpr::Nullable(key)
+            | ProjectExpr::NullableFlat(key)
+            | ProjectExpr::RecordField { source: key, .. }
+            | ProjectExpr::EnumTagRemap { source: key, .. }
+            | ProjectExpr::EnumRemap { source: key, .. }
+            | ProjectExpr::RecursiveEnumRemap { source: key, .. } => key,
+            ProjectExpr::Literal(_) | ProjectExpr::TypedLiteral { .. } | ProjectExpr::Null(_) => {
+                continue;
+            }
+        };
+        match key {
+            FieldRef::Name(name) | FieldRef::StoredName(name) => {
+                *key = FieldRef::stored_name(format!("right.{name}"));
+            }
+            FieldRef::Resolved(_) => unreachable!("witness carriers are bound by name"),
+        }
+    }
+    fields.extend(routing_param_fields.iter().map(|field| {
+        let mut projected = ProjectField::named(field);
+        projected.expression =
+            groove::ivm::ProjectExpr::Field(FieldRef::stored_name(format!("left.{field}")));
+        projected
+    }));
+    Ok(GraphBuilder::Join {
+        left: std::sync::Arc::new(visible_graph),
+        right: std::sync::Arc::new(witness_source),
+        left_on: visible_keys,
+        right_on: witness_keys.into(),
+        comparison: groove::ivm::ValueComparison::Exact,
+    }
     .project_fields(fields))
 }
 

--- a/crates/jazz/src/node/query_engine/tests/terminals.rs
+++ b/crates/jazz/src/node/query_engine/tests/terminals.rs
@@ -1478,3 +1478,33 @@ fn policy_context_carries_alpha_enforcement_mode() {
 
     assert_ne!(permissive, enforcing);
 }
+
+// Internal compiler-contract test: equal public rows cannot prove whether
+// wide witness encoding happens before or after exact-version selection.
+#[test]
+fn immutable_witness_encoding_follows_exact_version_selection() {
+    for fact in [
+        ProgramFactKey::VersionWitnesses,
+        ProgramFactKey::ReplacementWitnesses,
+    ] {
+        let request = QueryProgramRequest {
+            authorization_mode: QueryAuthorizationMode::TrustedServing,
+            reads: QueryReadSet::primary(current_read_view()),
+            policy: system_policy_context(),
+            input: row_set_input(0x31),
+            output: RowSetOutputRequest {
+                app_rows: None,
+                facts: BTreeSet::from([fact]),
+            },
+        };
+        let program = lower_query_program(request, &mut FakeSourceResolver::default()).unwrap();
+        assert!(program.lowered.terminals.iter().any(|terminal| graph_any(&terminal.graph, &|graph| {
+            let GraphBuilder::Project { input, fields } = graph else { return false };
+            fields.iter().any(|field| field.output_name == "event_kind")
+                && fields.iter().any(|field| field.output_name == "parents")
+                && matches!(input.as_ref(), GraphBuilder::SemiJoin { left, left_on, right_on, .. }
+                    if matches!(left.as_ref(), GraphBuilder::Table { table, .. } if table.ends_with("_content_versions"))
+                    && left_on.len() == 3 && right_on.len() == 3)
+        })));
+    }
+}


### PR DESCRIPTION
🤖 Query execution can retain and index complete records even when a join only needs their matching fields. This draft implements consumer-local column pruning in Groove and defers Jazz witness construction until after exact-version selection.

## Division of responsibility

Jazz keeps the semantic decision: an immutable content/replacement witness must match the authorized visible row **and its exact transaction identity**. It now performs that match against the raw source before constructing the wide witness carrier. Routed publication preserves binding fields and bag multiplicity. Deletion witnesses already selected the authorized exact deletion before encoding and retain that contract.

Groove makes the general physical decision after resolving field identities:

- Semi/anti joins retain only matching columns on their right side, preserving weights rather than applying DISTINCT.
- A projection over an inner join retains only consumer columns plus matching columns in each join input. Output expressions are rebound by resolved position, preserving their declared output identities and types.
- Narrow consumers get their own deduplicated projections/arrangements. Other consumers can continue using the complete source or join.
- The transformation preserves comparison modes and does not cross filters, ordering/winner selection, recursive boundaries, or fallible upstream expressions. Joins with residual predicates or non-inner kinds are not rewritten by the projected-join transformation.

This introduces no second storage lookup, public API change, or wire/storage encoding change.

## Worked cases

For a task-existence query whose child records contain a large body, the existence arrangement needs the matching key and its multiplicity, not the body. If two children match, removing one keeps the task visible; removing the last child changes the result. Replacing the last child with another matching child in the same commit does not produce a spurious disappearance.

For a join that returns a task title and only uses the related row for matching, the related input keeps its key while dropping its unused payload. A separate query requesting the complete related row still sees the complete source. Join output positions are mapped through the existing physical input mapping, including unnamed input slots that do not appear in the join output. A new behavioral regression failed with the initial concatenated-position assumption and passes with the corrected mapping. Nullable, nested-record and enum projection expressions retain their source-field dependencies; their conversions remain after the join.

For two versions of the same row, visibility of the older version cannot authorize the newer one: row ID, transaction time and transaction node remain the match keys within the already selected source/branch. Routed publication retains its binding fields, preventing narrowing from mixing authorization contexts.

## Measurements

Optimized native synthetic cold load: 27,518 visible rows / 39 subscriptions, seeded Core and empty relay/client. Clean candidate repeats were 11.358s and 11.512s, versus a final base repeat of 11.612s (an earlier base repeat was a 13.275s outlier). An initial independent pair was 11.698s base / 11.390s candidate. The defensible conclusion is roughly 1–3% lower total latency, not a large improvement; peak RSS stayed around 3.9GB.

The 1,500-row todo batch phase sums were 230/235ms on base and 238/246ms on candidate: a slight regression in this sample. These native receipts are not browser IndexedDB reopen timings. The measured candidate precedes the final unnamed-slot mapping correction; no timing gain is attributed to that correctness correction.

The symbolized, phase-instrumented comparison shows settle-only exclusive IVM time falling from 2.307s to 1.769s (about 23%), with join output records falling from 848,427 to 691,929. Cumulative projection output bytes increase slightly, from 783.9MB to 799.0MB, because key projections are added. This metric excludes join output bytes. The driver executes Core, relay and client sequentially; both timelines have nine nonoverlapping node ticks. IVM saves 538ms, other exclusive phases add a net 148ms, and total node-tick time falls 390ms (13.488s to 13.098s). Thus overlap is not hiding the gain in this benchmark. Witness decoding/publication counts remain unchanged, and total latency improves only modestly. This is not evidence that join width accounts for most of the remaining cold-load cost.

## Validation and status

2,009 Jazz library tests and 755 Groove library tests passed (2 ignored in each); all three incremental-delivery canaries, the two-seed differential oracle at churn depths 10/1000, Clippy and formatting passed. New checks cover compiled input width/shared-consumer preservation, duplicate-key retractions and same-tick replacement, and witness encoding after exact-version selection. Temporarily clamping maintained multiplicities to presence/absence makes the new behavioral regression fail; the mutation was restored.

An existing microsecond wall-clock subscription-install test failed during concurrent compilation, then passed alone and in the quiet full Groove suite. Its query has no join/projection, and no threshold was changed.

Draft: no independent review or full canonical acceptance is claimed. The coordinator performed this work without subagents as requested. Related to #2746 and #2747; follows #2878.
