### PR TITLE
bench: separate terminal and merge-head phase costs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,15 @@ a durable contract.
 
 ## Work style
 
+### Performance experiment preflight
+
+Before implementing a performance trial, read
+[`dev/benchmarks/rejected-experiments.md`](dev/benchmarks/rejected-experiments.md)
+and search preserved branches plus open/closed PR descriptions for the same
+mechanism. Record the changed premise before repeating a rejected experiment.
+Do not infer an end-to-end win from reduced allocation requests or a local
+phase alone; preserve comparable workload and source/binary receipts.
+
 ### Durable follow-up and WIP visibility
 
 GitHub Issues are the durable follow-up system. Before an orchestrator session

--- a/crates/jazz-sim/src/phase_attribution.rs
+++ b/crates/jazz-sim/src/phase_attribution.rs
@@ -11,7 +11,7 @@ use tracing::{
     span::{Attributes, Id, Record},
 };
 
-const PHASES: [&str; 24] = [
+const PHASES: [&str; 28] = [
     "core",
     "relay",
     "client",
@@ -36,6 +36,10 @@ const PHASES: [&str; 24] = [
     "query_prepare",
     "query_bind",
     "query_graph_compile",
+    "merge_heads_stage",
+    "merge_heads_rebuild",
+    "terminal_net",
+    "terminal_apply",
 ];
 const ROLES: [&str; 4] = ["outside_node_ticks", "core", "relay", "client"];
 #[derive(Clone, Copy, Default)]

--- a/crates/jazz/src/node/ingest/view_updates.rs
+++ b/crates/jazz/src/node/ingest/view_updates.rs
@@ -625,6 +625,7 @@ where
         Ok(None)
     }
 
+    #[cfg_attr(feature = "cold-settle-attribution", tracing::instrument(skip_all, name = "cold.phase.merge_heads_stage"))]
     pub(crate) async fn write_merge_heads_for_bulk_content_versions(
         &mut self,
         batch: &mut DatabaseBatch,
@@ -719,6 +720,7 @@ where
         Ok(())
     }
 
+    #[cfg_attr(feature = "cold-settle-attribution", tracing::instrument(skip_all, name = "cold.phase.merge_heads_rebuild"))]
     pub(crate) async fn rebuild_merge_heads_after_history_commit(
         &mut self,
         rows: &BTreeSet<(PhysicalTableId, String, BranchKey, RowUuid)>,

--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -699,6 +699,8 @@ impl MaintainedSubscriptionView {
     ) -> Result<ResultTransitions, super::Error> {
         // Decode into the net-change accumulator directly. No retained state
         // changes until the complete input has decoded successfully.
+        #[cfg(feature = "cold-settle-attribution")]
+        let net_span = tracing::trace_span!("cold.phase.terminal_net").entered();
         let mut net = BTreeMap::<EventIdentity, (NetEvent, i64)>::new();
         for row in rows {
             let (event, weight) = row?;
@@ -743,6 +745,10 @@ impl MaintainedSubscriptionView {
                 .or_insert((net_event, weight));
         }
 
+        #[cfg(feature = "cold-settle-attribution")]
+        drop(net_span);
+        #[cfg(feature = "cold-settle-attribution")]
+        let _apply_span = tracing::trace_span!("cold.phase.terminal_apply").entered();
         let mut transitions = ResultTransitions::default();
         for (_, (event, weight)) in net {
             if weight == 0 {

--- a/dev/benchmarks/rejected-experiments.md
+++ b/dev/benchmarks/rejected-experiments.md
@@ -1,0 +1,31 @@
+# Rejected performance experiments
+
+Read this before selecting another performance implementation. Also search
+existing local branches and open/closed PRs: the table is a navigation aid,
+not an exhaustive inventory. The linked PR descriptions hold the decision and
+measurement context. These are completed experiments, not a pending backlog.
+
+Each comparison is against that experiment's own parent. Different rows used
+different revisions; their absolute timings are not comparable to one another.
+Lower cumulative allocation requests are not proof of lower live memory or
+end-to-end latency. Revisit a rejected idea only with an explicit changed
+premise and a measurement that can test it.
+
+| Experiment                                                                                                                                                          | Decision / evidence                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#2828](https://github.com/garden-co/jazz/pull/2828): compose through total prepared projections                                                                    | Cold settle effectively unchanged (18.912s vs 18.866s). Extra compiler logic was not retained.                                                                                                                    |
+| [#2830](https://github.com/garden-co/jazz/pull/2830): direct supporting-witness metadata encoding                                                                   | 18.729s vs 18.866s, within observed baseline variation. Not retained.                                                                                                                                             |
+| [#2848](https://github.com/garden-co/jazz/pull/2848): universally share immutable `OwnedRecord` bytes                                                               | Cold load regressed about 4%; todo improved about 4%. Bookkeeping also affects short-lived records that are never cloned. Not retained.                                                                           |
+| [#2851](https://github.com/garden-co/jazz/pull/2851): render root projections from encoded fields                                                                   | About 0.5% cold / 2.8% todo improvement did not justify projection/arena machinery. Not retained.                                                                                                                 |
+| [#2853](https://github.com/garden-co/jazz/pull/2853): share compilation memos across query outputs                                                                  | About 1.1% cold improvement; todo regressed. Not retained.                                                                                                                                                        |
+| [#2861](https://github.com/garden-co/jazz/pull/2861): reuse retained prepared graphs during bind                                                                    | Less than 1% cold improvement, small todo regression. Not retained.                                                                                                                                               |
+| [#2869](https://github.com/garden-co/jazz/pull/2869) + [#2872](https://github.com/garden-co/jazz/pull/2872): compact private event enums and vector/sort coalescing | Combined warm comparison improved cold about 2.8% and todo about 1%; insufficient for the additional machinery. Both excluded.                                                                                    |
+| [#2884](https://github.com/garden-co/jazz/pull/2884): duplicate compact-event trial                                                                                 | Closed after identifying #2869. Terminal accumulation requested bytes fell about 65%, total requested bytes about 3%, but no clear cold-load win or peak-memory reduction. Does not reverse the earlier decision. |
+
+## Before building another trial
+
+1. Identify the actual allocation/copy/work site with a current profile and code walk.
+2. Search this ledger, preserved branches, and PR descriptions for the same mechanism.
+3. If it was rejected, state what changed before paying another build/test cycle.
+4. Preserve exact source/binary provenance and compare identical workloads.
+5. Record negative results as carefully as retained improvements.


### PR DESCRIPTION
🤖 Split the remaining cold-load bookkeeping into measurable phases before choosing another optimization. This adds opt-in benchmark spans only; normal builds, query results, storage, and wire behavior are unchanged.

The terminal pipeline now separates net-event accumulation from applying net events to retained state. Bulk ingest separately measures initial merge-head construction and the post-persistence rebuild. Existing nested phase accounting continues to subtract child spans; the new spans are absent without `cold-settle-attribution`.

## Measured bounds

Optimized native synthetic workload: seeded Core, empty relay/client, 27,518 visible rows and 39 subscriptions. The run completed all row assertions in 12.798s with phase instrumentation. This is diagnostic timing, not a clean before/after performance result.

- Initial merge-head construction across relay/client: 99ms.
- Post-persistence rebuild: 501ms inclusive, of which 340ms is exclusive rebuild work and 161ms is nested storage work. Do not add those numbers to one another.
- Terminal net accumulation across all node ticks: 584ms exclusive, excluding nested witness decoding.
- Applying net terminal events to retained state: 477ms.

These bound potential improvements; they do not establish that the work is removable. In particular, the first head pass consults incoming/staged ancestry and existing heads, whereas the second derives heads from all persisted row history and transaction fate. Eliminating either requires proving equivalence for partial history, out-of-order ancestry and previously resident versions.

## Validation

The optimized benchmark completed with 27,518 rows, no dropped timeline intervals, and exact exclusive-phase partition assertions. All three existing phase-attribution tests passed, including nested time accounting and pending-future scope restoration. The preceding implementation in #2882 passed the full Jazz/Groove library suites, canaries and bounded differential oracle; those results are not presented as a full canonical gate for this diagnostic follow-up.

Follows #2882; investigation remains tracked by #2746 and #2747. No new optimization or independent review is claimed.

## Experiment memory and current CI

The follow-up documentation records previously rejected experiments in `dev/benchmarks/rejected-experiments.md`, with an AGENTS preflight requiring historical checks before another trial. This prevents redoing universal record sharing or compact-event experiments without a changed premise. The duplicate #2884 trial was closed and is not part of this branch.

The original TypeScript CI job and one rerun both hit the existing #2655 BandChat guest-membership stall (owner memberships=2, guest=1). Both recurrences are recorded on that issue. Other correctness jobs passed; no harmless-timeout claim or assertion/timeout change is made.
