### PR TITLE
perf: keep maintained event maps compact

### DIFF
--- a/crates/jazz/src/node/maintained_subscription_view.rs
+++ b/crates/jazz/src/node/maintained_subscription_view.rs
@@ -363,27 +363,31 @@ enum MaintainedTerminalKind {
     AggregateAppRows(AppRowSchema),
 }
 
+// Keep large result/proof carriers out of every version-event map slot. Box
+// comparison remains value-based; indirection must not change identity/order.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum EventIdentity {
-    Result(ResultMemberEntry),
+    Result(Box<ResultMemberEntry>),
     Version(ProgramSourceId, VersionIdentity),
     Replacement(ProgramSourceId, ReplacementKey, VersionIdentity),
-    ProgramFact(ProgramFactEntry),
+    ProgramFact(Box<ProgramFactEntry>),
     StructuredAppRow(RowUuid, Vec<u8>),
 }
 
 #[derive(Clone, Debug)]
 enum NetEvent {
-    Result(ResultMemberEntry, ResultMemberPayloadEntry),
+    Result(Box<(ResultMemberEntry, ResultMemberPayloadEntry)>),
     AggregateResult(
-        ResultMemberEntry,
-        ResultMemberPayloadEntry,
-        super::query_engine::SyntheticResultMembershipSchema,
-        Vec<String>,
+        Box<(
+            ResultMemberEntry,
+            ResultMemberPayloadEntry,
+            super::query_engine::SyntheticResultMembershipSchema,
+            Vec<String>,
+        )>,
     ),
     Version(ProgramSourceId, VersionIdentity, VersionRow),
     Replacement(ProgramSourceId, ReplacementKey, VersionIdentity, VersionRow),
-    ProgramFact(ProgramFactEntry),
+    ProgramFact(Box<ProgramFactEntry>),
     StructuredAppRow(RowUuid, OwnedRecord),
 }
 
@@ -706,14 +710,16 @@ impl MaintainedSubscriptionView {
             let (event, weight) = row?;
             let net_event = match event {
                 DecodedMaintainedEvent::ResultCurrent { member, payload } => {
-                    NetEvent::Result(member, payload)
+                    NetEvent::Result(Box::new((member, payload)))
                 }
                 DecodedMaintainedEvent::AggregateResult {
                     member,
                     payload,
                     synthetic,
                     value_fields,
-                } => NetEvent::AggregateResult(member, payload, synthetic, value_fields),
+                } => {
+                    NetEvent::AggregateResult(Box::new((member, payload, synthetic, value_fields)))
+                }
                 DecodedMaintainedEvent::VersionContent { source, row }
                 | DecodedMaintainedEvent::VersionDeletion { source, row } => {
                     let identity = VersionIdentity::for_row(&row);
@@ -729,11 +735,11 @@ impl MaintainedSubscriptionView {
                     let key = ReplacementKey::for_row(&row, VersionLayer::Deletion);
                     NetEvent::Replacement(source, key, identity, row)
                 }
-                DecodedMaintainedEvent::ProgramSourceCoverage(coverage) => {
-                    NetEvent::ProgramFact(ProgramFactEntry::ProgramSourceCoverage(coverage))
-                }
+                DecodedMaintainedEvent::ProgramSourceCoverage(coverage) => NetEvent::ProgramFact(
+                    Box::new(ProgramFactEntry::ProgramSourceCoverage(coverage)),
+                ),
                 DecodedMaintainedEvent::RelationEdge(edge) => {
-                    NetEvent::ProgramFact(ProgramFactEntry::RelationEdge(edge))
+                    NetEvent::ProgramFact(Box::new(ProgramFactEntry::RelationEdge(edge)))
                 }
                 DecodedMaintainedEvent::StructuredAppRow { root, record } => {
                     NetEvent::StructuredAppRow(root, record)
@@ -760,10 +766,12 @@ impl MaintainedSubscriptionView {
                 );
             }
             match event {
-                NetEvent::Result(entry, payload) => {
+                NetEvent::Result(result) => {
+                    let (entry, payload) = *result;
                     self.apply_result_delta(entry, payload, weight, &mut transitions);
                 }
-                NetEvent::AggregateResult(member, payload, synthetic, value_fields) => {
+                NetEvent::AggregateResult(result) => {
+                    let (member, payload, synthetic, value_fields) = *result;
                     self.apply_aggregate_result_delta(
                         member,
                         payload,
@@ -808,6 +816,7 @@ impl MaintainedSubscriptionView {
                     }
                 }
                 NetEvent::ProgramFact(fact) => {
+                    let fact = *fact;
                     if let Some(is_present) = self.apply_source_fact_delta(
                         SourceFactOrigin::ProgramFact,
                         fact.clone(),
@@ -3284,8 +3293,8 @@ impl ReplacementKey {
 impl NetEvent {
     fn identity(&self) -> EventIdentity {
         match self {
-            Self::Result(entry, _) => EventIdentity::Result(entry.clone()),
-            Self::AggregateResult(member, ..) => EventIdentity::Result(member.clone()),
+            Self::Result(result) => EventIdentity::Result(Box::new(result.0.clone())),
+            Self::AggregateResult(result) => EventIdentity::Result(Box::new(result.0.clone())),
             Self::Version(source, identity, _) => {
                 EventIdentity::Version(source.clone(), identity.clone())
             }
@@ -5136,4 +5145,16 @@ mod terminal_role_hash_tests {
 #[cfg(test)]
 std::thread_local! {
     pub(crate) static SOURCE_CLOSURE_TRAVERSALS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+// This internal allocation budget is not observable through query equality:
+// rare proof/aggregate variants must not inflate every cold-load map entry.
+#[cfg(test)]
+#[test]
+fn maintained_event_map_entries_remain_compact() {
+    let identity = std::mem::size_of::<EventIdentity>();
+    let event = std::mem::size_of::<NetEvent>();
+    println!("LAYOUT EventIdentity {identity} NetEvent {event}");
+    assert!(identity <= 128, "event identity occupies {identity} bytes");
+    assert!(event <= 192, "net event occupies {event} bytes");
 }


### PR DESCRIPTION
🤖 Cold-load terminal accumulation used map keys of 968 bytes and event values of 1,080 bytes, even for ordinary immutable-version events. The size came from much larger result/proof variants sharing the same private enums. This keeps those larger variants behind owning pointers, reducing identity/value sizes to 96/160 bytes on the measured native target.

Only private `EventIdentity` and `NetEvent` representations change. Version/replacement events remain inline. Result/aggregate/proof payloads retain ownership behind `Box`; comparisons still compare values and preserve variant order. The decode-before-state-mutation boundary, weight coalescing, exact raw-version identity, and transition ordering remain unchanged. No public API, protocol type, storage encoding, or wire encoding changes.

For example, a version witness no longer reserves room for a full aggregate payload in every tree slot. A result event still owns its complete member/payload, and an equal result key still combines weights regardless of pointer address. A late decoding error still drops the complete temporary accumulator before retained state changes.

## Measurements

Same optimized native 27,518-row / 39-subscription workload. Allocation instrumentation measures cumulative requests, not live memory:

- Terminal accumulation requested bytes: 1.278GB → 0.452GB (about 65% less).
- Whole measured allocation scope: 27.533GB → 26.707GB (about 3% less).
- Allocation count: 108.597M → 108.805M; large variants add allocations.
- Peak RSS remains around 3.9–4.0GB. No peak-memory improvement is claimed.

Clean ABBA cold-settle runs were base13.745s, candidate11.802s, candidate11.161s, base11.474s. The first base was slow; excluding that outlier, the candidate average is essentially equal to the remaining base. **There is no clear overall cold-load speedup in this sample.** The 1,500-row native todo batch phase sums were base239.7/247.9ms and candidate230.1/231.4ms; this small sample suggests improvement but is not a confidence interval.

## Validation

All 2,010 Jazz library tests passed (2 ignored), including the new internal footprint budget. The pre-change measured sizes exceed that budget; the new layout fits it. Existing behavioral checks exercise coalescing, replacement, exact witnesses, aggregates and failure atomicity. All three incremental-delivery scaling canaries and the two-seed differential oracle at churn depths 10/1000 passed.

Draft experiment, with a measured allocation reduction rather than a claimed large latency win. No independent review is claimed; root-only work as requested. Follows #2883; related to #2746/#2747.
