### PR TITLE
perf: avoid repeated client occurrence scans

### DIFF
--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -5445,9 +5445,7 @@ fn apply_terminal_operations_to_subscription_snapshot(
     let before = affected
         .iter()
         .filter_map(|occurrence_id| {
-            let index = occurrences
-                .iter()
-                .position(|current| current == occurrence_id)?;
+            let index = *snapshot_index.roots.get(occurrence_id)?;
             Some((occurrence_id.clone(), (index, snapshot.rows[index].clone())))
         })
         .collect::<BTreeMap<_, _>>();
@@ -5492,13 +5490,17 @@ fn apply_terminal_operations_to_subscription_snapshot(
         }
     }
 
+    // Membership remains valid across positional edits; positions do not.
+    // Avoid searching the growing vector for a provably fresh insertion.
+    let mut present = occurrences.iter().cloned().collect::<BTreeSet<_>>();
     for (occurrence_id, operation) in root_operations {
         match operation.edit {
             groove::ivm::TerminalEdit::Insert { index, value, .. } => {
-                if let Some(existing) = occurrences
-                    .iter()
-                    .position(|current| current == &occurrence_id)
-                {
+                if !present.insert(occurrence_id.clone()) {
+                    let existing = occurrences
+                        .iter()
+                        .position(|current| current == &occurrence_id)
+                        .expect("present occurrence has a snapshot position");
                     occurrences.remove(existing);
                     snapshot.rows.remove(existing);
                     snapshot.root_count -= 1;
@@ -5547,6 +5549,7 @@ fn apply_terminal_operations_to_subscription_snapshot(
                         "terminal root removal addressed a missing result",
                     ));
                 };
+                present.remove(&occurrence_id);
                 occurrences.remove(index);
                 snapshot.rows.remove(index);
                 snapshot.root_count -= 1;
@@ -5599,10 +5602,10 @@ fn apply_terminal_operations_to_subscription_snapshot(
     let mut removed = Vec::new();
     for occurrence_id in affected {
         let previous = before.get(&occurrence_id);
-        let current = occurrences
-            .iter()
-            .position(|current| current == &occurrence_id)
-            .map(|index| (index, &snapshot.rows[index]));
+        let current = snapshot_index
+            .roots
+            .get(&occurrence_id)
+            .map(|&index| (index, &snapshot.rows[index]));
         match (previous, current) {
             (None, Some((index, row))) => added.push(SubscriptionOutputRow {
                 occurrence_id,


### PR DESCRIPTION
🤖 The client subscription facade searches its growing result vector before each insertion and again while reporting each affected row. A fresh 23,831-row batch implies roughly 568 million comparisons across these loops.

Use occurrence membership to skip searches for fresh inserts, and the existing pre/post-frame position indexes when producing changes. Membership is updated on removal. Existing occurrences still follow the ordered replacement/move logic: inserting B at the front of [A,B,C] gives [B,A,C], not a duplicate B. Removed indices still refer to the pre-frame snapshot; output identities remain occurrence identities, not application row IDs. No public semantics, wire or storage changes.

The native cache profile attributed 19.6% of L1 misses but only ~2.4% of sampled cycles to the complete client delivery phase. Initial optimized native ABBA cold receipts: base 12.243s (first-run outlier), candidate 11.146s, candidate 11.279s, base 11.204s. This does not yet demonstrate a total latency improvement. Todo batch sums: base 242.2/241.4ms, candidate 240.8/234.1ms. All 27,518 expected rows were verified. These are native three-node cold-sync measurements, not browser reopen timings.

22 focused subscription tests passed, including ordered insert/move, pre-frame removal indices, and nested results. Clippy/formatting passed. Draft: broader checks are in progress; no independent review claimed (root-only work as requested). Follows #2883 and retains #2882. Related to #2746/#2747.
