### PR TITLE
bench: compare captured sync ingestion across SQL topologies

### DIFF
--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -565,6 +565,10 @@ fn main() {
         "phase attribution enabled: compare elapsed time only with the same instrumentation; disable this feature for absolute latency"
     );
     let config = Config::from_env();
+    if let Some(path) = std::env::var_os("JAZZ_CUSTOMER_DECODE_CAPTURE") {
+        measure_capture_decode(Path::new(&path));
+        return;
+    }
     if let Some(path) = std::env::var_os("JAZZ_CUSTOMER_EXPORT_SQL") {
         export_sql_fixture(&config, std::path::Path::new(&path));
         return;
@@ -724,6 +728,7 @@ struct SeedWrite {
 
 struct RunSummary {
     wall_ms: u128,
+    tick_wall_us: [u128; 3],
     connect_ms: u128,
     subscribe_ms: u128,
     settle_ms: u128,
@@ -905,6 +910,7 @@ struct OpenSubscription {
 
 #[derive(Default)]
 struct TransportMetrics {
+    capture: RefCell<Option<SyncCapture>>,
     messages: Cell<u64>,
     view_updates: Cell<u64>,
     bytes: Cell<u64>,
@@ -915,6 +921,109 @@ struct TransportMetrics {
     #[cfg(feature = "cold-settle-attribution")]
     attribution: RefCell<ProbeAttribution>,
     view_updates_by_subscription: RefCell<BTreeMap<SubscriptionKey, ViewUpdateSummary>>,
+}
+
+// Diagnostic capture is intentionally outside clean timing receipts. The SQL
+// replay persists the actual immutable bytes, not a smaller synthetic payload.
+struct SyncCapture {
+    writer: std::io::BufWriter<fs::File>,
+    schema: JazzSchema,
+}
+
+impl SyncCapture {
+    fn record(&mut self, message: &SyncMessage) {
+        use std::io::Write;
+        let (carriers, supporting) = match message {
+            SyncMessage::ViewUpdate(view) | SyncMessage::AuthorizationScopeView { view, .. } => {
+                (&view.version_carriers, view.supporting_rows.len())
+            }
+            SyncMessage::CurrentRowsReceipt(receipt) => (&receipt.version_carriers, 0),
+            SyncMessage::CommitUnit { .. } | SyncMessage::AuthorityPublication(_) => panic!(
+                "extend SQL capture for non-view version delivery before comparing this fixture"
+            ),
+            _ => return,
+        };
+        let bundles = version_bundle_refs(carriers).map(|bundle| {
+            let versions = bundle.versions.iter().map(|version| {
+                let table = self.schema.tables.iter().find(|t| t.name == version.table()).unwrap();
+                let cells = table.columns.iter().enumerate().map(|(position, column)|
+                    (column.name().to_owned(), version.cell_at(position).expect("fixture cell present")))
+                    .collect::<BTreeMap<_, _>>();
+                json!({"table": version.table(), "row": version.row_uuid().0.to_string(),
+                    "schema": version.schema_version(), "branch": version.branch_key(),
+                    "parents": version.parents(), "cells": cells,
+                    "wire_hex": capture_hex(&postcard::to_allocvec(version).unwrap())})
+            }).collect::<Vec<_>>();
+            json!({"tx": bundle.tx, "tx_hex": capture_hex(&postcard::to_allocvec(bundle.tx).unwrap()),
+                "scope": bundle.scope, "fate": bundle.fate, "global_time": bundle.global_time,
+                "durability": bundle.durability, "versions": versions})
+        }).collect::<Vec<_>>();
+        serde_json::to_writer(
+            &mut self.writer,
+            &json!({"supporting_count": supporting, "bundles": bundles}),
+        )
+        .unwrap();
+        writeln!(&mut self.writer).unwrap();
+    }
+}
+
+fn measure_capture_decode(path: &Path) {
+    use std::io::BufRead;
+    let decode_hex = |value: &JsonValue| {
+        value
+            .as_str()
+            .unwrap()
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| u8::from_str_radix(std::str::from_utf8(pair).unwrap(), 16).unwrap())
+            .collect::<Vec<_>>()
+    };
+    let mut encoded = Vec::new();
+    for line in std::io::BufReader::new(fs::File::open(path).unwrap()).lines() {
+        let frame: JsonValue = serde_json::from_str(&line.unwrap()).unwrap();
+        for bundle in frame["bundles"].as_array().unwrap() {
+            assert_eq!(bundle["versions"].as_array().unwrap().len(), 1);
+            encoded.push((
+                decode_hex(&bundle["tx_hex"]),
+                decode_hex(&bundle["versions"][0]["wire_hex"]),
+            ));
+        }
+    }
+    let schema = schema();
+    for round in 0..3 {
+        let started = Instant::now();
+        let mut decoded = Vec::with_capacity(encoded.len());
+        for (tx, version) in &encoded {
+            let tx: jazz::tx::Transaction = postcard::from_bytes(tx).unwrap();
+            let version: jazz::protocol::VersionRecord = postcard::from_bytes(version).unwrap();
+            let table = schema
+                .tables
+                .iter()
+                .find(|table| table.name == version.table())
+                .unwrap();
+            let cells = (0..table.columns.len())
+                .map(|index| version.cell_at(index).unwrap())
+                .collect::<Vec<_>>();
+            decoded.push((tx, version, cells));
+        }
+        let elapsed = started.elapsed();
+        std::hint::black_box(&decoded);
+        println!(
+            "{}",
+            json!({"round": round, "bundles": decoded.len(), "decode_and_extract_ms": elapsed.as_secs_f64()*1000.0,
+            "encoded_bytes": encoded.iter().map(|(tx, row)| tx.len()+row.len()).sum::<usize>()})
+        );
+    }
+}
+
+fn capture_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 15) as usize] as char);
+    }
+    output
 }
 
 #[cfg(feature = "cold-settle-attribution")]
@@ -1024,6 +1133,9 @@ impl Transport for DuplexTransport {
         tracing::instrument(skip_all, name = "cold.phase.benchmark_transport")
     )]
     fn send(&mut self, message: SyncMessage) -> Result<(), TransportError> {
+        if let Some(capture) = self.metrics.capture.borrow_mut().as_mut() {
+            capture.record(&message);
+        }
         self.metrics.messages.set(self.metrics.messages.get() + 1);
         if let SyncMessage::ViewUpdate(jazz::protocol::ViewUpdatePayload {
             subscription,
@@ -1760,6 +1872,27 @@ fn run_connect_and_subscribe(
     let start = Instant::now();
     let relay_core = duplex_counted();
     let client_relay = duplex_counted();
+    if let Some(root) = std::env::var_os("JAZZ_CUSTOMER_CAPTURE_SYNC") {
+        assert_eq!(label, "cold", "capture requires only the cold phase");
+        eprintln!("SQL sync capture enabled: discard this run's timing");
+        fs::create_dir_all(&root).unwrap();
+        for (name, metrics) in [
+            ("core-edge", &relay_core.right_to_left),
+            ("edge-client", &client_relay.right_to_left),
+        ] {
+            let path = Path::new(&root).join(format!("{name}.jsonl"));
+            *metrics.capture.borrow_mut() = Some(SyncCapture {
+                writer: std::io::BufWriter::new(
+                    fs::OpenOptions::new()
+                        .write(true)
+                        .create_new(true)
+                        .open(path)
+                        .unwrap(),
+                ),
+                schema: schema(),
+            });
+        }
+    }
     let _relay_upstream = block_on(relay.db.connect_upstream(relay_core.left_transport));
     let _core_sub = seeded
         .core
@@ -1798,6 +1931,7 @@ fn run_connect_and_subscribe(
 
     let settle_start = Instant::now();
     let mut ticks = 0_usize;
+    let mut tick_wall_us = [0_u128; 3];
     #[allow(unused_mut)]
     let mut attribution = AttributionSummary::default();
     while !subscriptions
@@ -1825,7 +1959,6 @@ fn run_connect_and_subscribe(
         let before_core_to_relay = relay_core.right_to_left.messages.get();
         #[cfg(feature = "cold-settle-attribution")]
         let core_operators_before = jazz::groove::cold_settle_attribution::snapshot();
-        #[cfg(feature = "cold-settle-attribution")]
         let core_tick_start = Instant::now();
         #[cfg(feature = "cold-settle-attribution")]
         tracing::trace_span!("cold.phase.core")
@@ -1833,6 +1966,7 @@ fn run_connect_and_subscribe(
             .unwrap();
         #[cfg(not(feature = "cold-settle-attribution"))]
         block_on(seeded.core.tick()).unwrap();
+        tick_wall_us[0] += core_tick_start.elapsed().as_micros();
         #[cfg(feature = "cold-settle-attribution")]
         {
             attribution.core_tick_ns += core_tick_start.elapsed().as_nanos() as u64;
@@ -1848,7 +1982,6 @@ fn run_connect_and_subscribe(
         let relay_to_client_before = client_relay.right_to_left.messages.get();
         #[cfg(feature = "cold-settle-attribution")]
         let relay_operators_before = jazz::groove::cold_settle_attribution::snapshot();
-        #[cfg(feature = "cold-settle-attribution")]
         let relay_tick_start = Instant::now();
         #[cfg(feature = "cold-settle-attribution")]
         tracing::trace_span!("cold.phase.relay")
@@ -1856,6 +1989,7 @@ fn run_connect_and_subscribe(
             .unwrap();
         #[cfg(not(feature = "cold-settle-attribution"))]
         block_on(relay.db.tick()).unwrap();
+        tick_wall_us[1] += relay_tick_start.elapsed().as_micros();
         #[cfg(feature = "cold-settle-attribution")]
         {
             attribution.relay_tick_ns += relay_tick_start.elapsed().as_nanos() as u64;
@@ -1871,7 +2005,6 @@ fn run_connect_and_subscribe(
         let client_to_relay_before = client_relay.left_to_right.messages.get();
         #[cfg(feature = "cold-settle-attribution")]
         let client_operators_before = jazz::groove::cold_settle_attribution::snapshot();
-        #[cfg(feature = "cold-settle-attribution")]
         let client_tick_start = Instant::now();
         #[cfg(feature = "cold-settle-attribution")]
         tracing::trace_span!("cold.phase.client")
@@ -1879,6 +2012,7 @@ fn run_connect_and_subscribe(
             .unwrap();
         #[cfg(not(feature = "cold-settle-attribution"))]
         block_on(client.db.tick()).unwrap();
+        tick_wall_us[2] += client_tick_start.elapsed().as_micros();
         #[cfg(feature = "cold-settle-attribution")]
         {
             attribution.client_tick_ns += client_tick_start.elapsed().as_nanos() as u64;
@@ -2091,6 +2225,7 @@ fn run_connect_and_subscribe(
         attribution.selected_payload_bytes = counters.selected_payload_bytes;
     }
     RunSummary {
+        tick_wall_us,
         wall_ms: start.elapsed().as_millis(),
         connect_ms,
         subscribe_ms,
@@ -2512,6 +2647,14 @@ fn pending_description(subscriptions: &[OpenSubscription]) -> String {
 
 fn emit_summary(config: &Config, phase: &str, summary: &RunSummary) {
     let mut fields = metadata_fields("customer_cold_start", "native", config.seed, "full");
+    fields.insert(
+        "node_tick_wall_us_core_edge_client".to_owned(),
+        json!(summary.tick_wall_us),
+    );
+    fields.insert(
+        "sync_capture_enabled".to_owned(),
+        json!(std::env::var_os("JAZZ_CUSTOMER_CAPTURE_SYNC").is_some()),
+    );
     fields.insert(
         "allocation_instrumented".to_owned(),
         json!(cfg!(any(

--- a/dev/benchmarks/sql-proxy/SYNC.md
+++ b/dev/benchmarks/sql-proxy/SYNC.md
@@ -1,0 +1,118 @@
+# Captured synchronization and SQL ingestion
+
+`ingest.py` extends the read-only reference to separate SQL stores representing
+Core, Edge and Client. All material comes from the existing synthetic benchmark.
+It is a static initial-load experiment, not a replacement sync implementation.
+
+## Actual traffic, not an invented write set
+
+Run the optimized Rust benchmark with `JAZZ_CUSTOMER_PHASES=cold` and
+`JAZZ_CUSTOMER_CAPTURE_SYNC=/tmp/new-capture-directory`. Capture refuses to
+replace existing files. Discard the capture run's timing: it serializes diagnostic
+JSON and writes large files. `sync_capture_enabled` labels new receipts.
+
+The two JSONL files retain full postcard transaction bytes, full postcard/JVRR
+version envelopes, scope/fate/global-time/durability state, exact coordinates,
+and fields decoded by Jazz itself. Loading the capture checks every field
+against the fixture export and rejects other transaction kinds, non-root
+branches, missing cells, unaccepted fates or nonempty predecessor lists.
+
+This initial load delivers:
+
+| Link          | Bundle deliveries | Distinct versions | Repeated deliveries |
+| ------------- | ----------------: | ----------------: | ------------------: |
+| Core → Edge   |            47,437 |            46,740 |                 697 |
+| Edge → Client |            28,137 |            27,518 |                 619 |
+
+The native receipt reports **one receiver bulk-ingest commit per node**. SQL
+therefore also uses one data-ingest transaction. ANALYZE performs additional
+engine bookkeeping/transaction work; its time is included separately. The topology replay reproduces
+the captured ordering and duplicates after fetching rows from the source DB.
+Source fetches are real SQL reads; no in-memory fixture substitutes for them.
+
+## Receiver responsibilities
+
+Each node has separate persistent storage (a SQLite file, or its own PostgreSQL
+database in the isolated test cluster). Static tables/indexes are initialized
+before timing, as the native benchmark opens its empty stores before its timer.
+The timed receiver operation:
+
+1. Coalesces duplicate immutable versions, checking exact equality.
+2. Bulk loads staging tables (`executemany` or PostgreSQL `COPY`).
+3. Checks existing transaction/version bytes for conflicts, then inserts missing
+   records in one atomic SQL transaction.
+4. Maintains transaction and row/version lookup indexes plus the relationship
+   indexes used by permission queries.
+5. Commits with the configured durability, then refreshes planner statistics.
+   Statistics work is measured and reported separately, not free setup.
+
+The store keeps **complete captured wire envelopes verbatim**, plus typed fields
+for queries. This is deliberately storage-heavy: it does not intern repeated
+wire descriptors as Jazz's native storage does. It provides a conservative SQL
+reference, not a storage-layout equivalence claim.
+
+History views check accepted transactions and absence of accepted successor
+versions. The permission query is the same bounded recursive query as the first
+experiment. Every result field, persisted transaction/envelope byte and duplicate
+outcome is verified. Conflicting version bytes must roll back. Fresh connections
+verify persisted results after close/reopen; this is not a power-cut test.
+
+## Timed comparisons
+
+- Captured Edge → Client delivery into an empty SQL receiver, followed by reads.
+- Identical delivery into the populated receiver (idempotent replay).
+- Core → Client, including Core permissions, ingestion and local reads.
+- Core → Edge → Client: Core serves the trusted Edge all fixture rows; Edge
+  evaluates user permissions; Client persists them and evaluates locally.
+
+The two-hop total is a directly measured serial wall time, including source
+query/fetch, packet ordering, each ingestion and Client reads. Assertions,
+hashing, fixture parsing, initial Core seeding and node teardown are outside it.
+The initial-load stores are fresh, but source data is cache-warm. It is not an
+OS-cache-cold read test. Streaming readiness and overlapping node execution are
+not modeled; these totals should not be extrapolated to a WAN.
+
+SQLite uses WAL with synchronous NORMAL (relaxed) or FULL (durable), with
+checkpointing deferred beyond commit. PostgreSQL uses synchronous_commit off
+or on with the cluster's fsync enabled. Commit latency is included. Relaxed
+means recent ingest is recoverable by resynchronization; durable means waiting
+for the engine's synchronous commit, not a tested hardware survival guarantee.
+
+Per-ingest counters include client CPU, backend CPU (Linux scheduler ticks),
+backend physical write/read bytes and PostgreSQL WAL insertion bytes. PostgreSQL
+background writers are not included in backend `/proc` I/O. SQLite file + WAL
+size and PostgreSQL database size have different meanings; do not equate them.
+
+## Codec and semantic boundary
+
+SQL receives predecoded typed fields as well as full wire bytes. Native transport
+also passes logical SyncMessages in-process, but its receiver's field access and
+transport accounting differ. To bound that omission separately, run the same
+Rust executable with `JAZZ_CUSTOMER_DECODE_CAPTURE=<capture JSONL>`: it times the
+real postcard/JVRR decoder and field extraction while retaining the decoded
+batch. JSON/hex capture parsing is excluded. Do not silently add these diagnostic
+codec timings to a SQL wall-time receipt and call it a measured end-to-end run.
+The SQL topology does not serialize a real Jazz network connection.
+
+The experiment preserves the data and permission outcomes of this initial
+shallow-history fixture. It omits ongoing IVM maintenance, authority receipt
+bookkeeping, cancellation, reconnect reconciliation, branching, exclusive
+transactions and other behaviors not exercised by the captured load. A ratio
+to Jazz is evidence of remaining work to explain, not proof that all omitted
+machinery is removable overhead.
+
+## Run
+
+```sh
+python3 dev/benchmarks/sql-proxy/ingest.py /tmp/sql-fixture.json /tmp/capture \
+  --rounds 3 --durability relaxed --out /tmp/sqlite-sync.json
+# psycopg 3 required; use an isolated cluster. The harness creates and deletes
+# only uniquely named sql_sync_* databases that it owns.
+python3 dev/benchmarks/sql-proxy/ingest.py /tmp/sql-fixture.json /tmp/capture \
+  --postgres 'host=/tmp port=55439 dbname=postgres user=ubuntu' \
+  --rounds 3 --durability durable --out /tmp/postgres-sync.json
+```
+
+Temporary SQL databases are removed after successful validation (or on error);
+keep JSON receipts. The captured data is public synthetic material, but is large
+and should remain a local evidence artifact rather than enter Git history.

--- a/dev/benchmarks/sql-proxy/SYNC_RESULTS.md
+++ b/dev/benchmarks/sql-proxy/SYNC_RESULTS.md
@@ -1,0 +1,98 @@
+# First synchronization comparison
+
+Three fresh-store rounds per engine/durability setting. All timings are wall-time
+medians; source data is cache-warm. Initial source seeding and empty-store schema
+creation are outside the timer. Receiver planner-statistics refresh is inside.
+
+| Work                                          | SQLite relaxed | SQLite synchronous | PostgreSQL relaxed | PostgreSQL synchronous |
+| --------------------------------------------- | -------------: | -----------------: | -----------------: | ---------------------: |
+| Replay actual Client bundles into empty store |        0.497 s |            0.823 s |            1.493 s |                1.527 s |
+| Core → Client → local results                 |        0.914 s |            1.238 s |            1.892 s |                1.949 s |
+| Core → Edge → Client → local results          |        1.969 s |            2.840 s |            4.808 s |                4.837 s |
+| Replay identical bundles into populated store |        0.514 s |            0.520 s |            1.330 s |                1.333 s |
+
+The last row includes staging/byte comparison and statistics work. It does not
+simulate reconnect negotiation that avoids resending known bytes. Durable
+version rows remain unchanged, but staging and statistics can still write.
+
+## Two-hop work distribution, relaxed setting
+
+| Stage                                    | SQLite | PostgreSQL |
+| ---------------------------------------- | -----: | ---------: |
+| Core query and complete envelope fetch   | 233 ms |     440 ms |
+| Edge ingestion including statistics      | 790 ms |   2,444 ms |
+| Edge permission query and envelope fetch | 274 ms |     328 ms |
+| Client ingestion including statistics    | 452 ms |   1,464 ms |
+| Client local permissioned reads          | 131 ms |      75 ms |
+
+These component medians are descriptive, not an additive reconstruction of the
+measured median total. Totals also include packet grouping/order work and small
+counter-collection overhead. PostgreSQL client/backend CPU overlap and must not
+be summed as wall time.
+
+## What this demonstrates
+
+The SQL read-only reference took about 31 ms. Making the load populate two
+indexed stores raises that to seconds. **Synchronization is a materially larger
+job than a request/response read**, even for shallow histories. The receivers
+dominate these SQL topology runs.
+
+This does not establish an intrinsic lower bound. The proxy writes full captured
+wire envelopes, including repeated descriptors, and additionally stages them
+before exact-match insertion. For example, Client traffic contains 64.65 MB of
+uncompressed per-bundle transaction/version encodings including duplicates;
+Jazz's captured Client physical-class estimate is about 19.16 MB. SQL's conservative
+representation does more storage work. It also omits maintained IVM state and
+other runtime protocol machinery; see SYNC.md before interpreting ratios.
+
+PostgreSQL also showed that preparing a newly populated query engine matters:
+without refreshing statistics, a trial Client query pass took about 1.62 s.
+With the refresh charged to ingestion (about 0.19–0.22 s), reads took about
+0.075 s. This is an observed trial contrast, not an isolated multi-round A/B.
+
+## Fresh Jazz checkpoint
+
+Three optimized native runs with only lightweight tick-boundary timers took
+13.277, 13.267 and 12.775 seconds total (median **13.267 s**). Per-node tick
+medians were **Core 2.729 s, Edge 5.620 s, Client 2.892 s**. Remaining time is
+mostly connect/subscription setup and final accounting. Component medians do
+not reconstruct a single run's total; raw receipts retain exact per-run values.
+
+The roughly 8.5 s in receiver nodes is **not pure storage time**: it includes
+query execution, maintained runtime initialization, publication and protocol
+processing. Likewise Core's 2.7 s includes serving/runtime work despite its
+application rows already being present. This prevents attributing the entire
+gap to the inherent necessity of writing replicated rows. The SQL reference
+shows the expanded task can be substantially cheaper, even with its oversized
+persistent envelopes, but a finer Jazz node split is needed to locate the
+remaining work.
+
+## Decoder boundary
+
+The real Jazz postcard/JVRR decoder plus field extraction, retaining the decoded
+batch, took three-run medians of **111 ms for Core → Edge** and **65 ms for
+Edge → Client**. Capture JSON/hex parsing was outside those timers. These are
+separate diagnostic timings, not part of the SQL total, and should not be added
+and relabeled as a measured full-network result. They make the predecoded-input
+omission explicit and quantify this particular decoder's scale.
+
+## Validation and provenance
+
+All four configurations verify every visible field, every persisted transaction
+and version-envelope byte, captured duplicate order/counts, rejection and rollback
+of conflicting bytes, and equality after close/reopen. The 39 queries return
+27,518 rows. The Edge holds 46,740 distinct versions and Client 27,518, matching
+the actual Jazz receiver counts. There is one data-ingest transaction per node;
+ANALYZE has its own engine bookkeeping/transaction cost, included in the timer.
+
+SQLite 3.45.1 WAL uses NORMAL or FULL synchronous mode. PostgreSQL 17.10 runs
+with fsync and full_page_writes enabled, and synchronous_commit off/on. All SQL
+nodes have separate stores on one host; PostgreSQL databases share an isolated
+cluster/WAL writer. No owned compilation or other benchmark overlapped these
+measurement rounds. This is not a WAN or power-failure acceptance test.
+
+Raw receipts are preserved locally under
+`/home/ubuntu/jazz-debug-evidence/permissioned-profile/sql-sync/`, including the
+four `<engine>-<durability>.json` results, the original captures, and the two
+`decode-<hop>.jsonl` diagnostics. Captures are large synthetic artifacts and are
+not committed.

--- a/dev/benchmarks/sql-proxy/ingest.py
+++ b/dev/benchmarks/sql-proxy/ingest.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Replay actual synthetic Jazz bundles into indexed SQL stores, then forward them."""
+
+import argparse
+from collections import defaultdict
+import hashlib
+import json
+import os
+from pathlib import Path
+import sqlite3
+import tempfile
+import time
+import uuid
+
+from run import scalar, quoted, reference_query
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def load_capture(path, fixture, columns):
+    expected = {
+        (w["table"], w["id"]): {k: scalar(v) for k, v in w["cells"].items()}
+        for w in fixture["writes"]
+    }
+    packets = []
+    for line in path.open():
+        frame = json.loads(line)
+        for bundle in frame["bundles"]:
+            assert (
+                bundle["fate"] == "Accepted"
+                and bundle["scope"] == "CompleteTransaction"
+            )
+            assert (
+                bundle["tx"]["kind"] == "Mergeable"
+                and bundle["tx"]["n_total_writes"] == 1
+            )
+            assert len(bundle["versions"]) == 1
+            version = bundle["versions"][0]
+            assert not version["parents"] and version["branch"] == {"values": []}
+            cells = {k: scalar(v) for k, v in version["cells"].items()}
+            assert cells == expected[(version["table"], version["row"])]
+            tx = canonical(bundle["tx"]["tx_id"])
+            meta = canonical(
+                {k: bundle[k] for k in ["fate", "scope", "global_time", "durability"]}
+            )
+            # Complete postcard/JVRR envelope remains byte-identical in storage.
+            packets.append(
+                (
+                    version["table"],
+                    version["row"],
+                    tx,
+                    bytes.fromhex(bundle["tx_hex"]),
+                    meta,
+                    bytes.fromhex(version["wire_hex"]),
+                    *[cells[c] for c in columns[version["table"]]],
+                )
+            )
+    return packets
+
+
+class Store:
+    def __init__(self, args, fixture, columns, name):
+        self.pg = bool(args.postgres)
+        self.columns = columns
+        self.fixture = fixture
+        self.args = args
+        self.temp = tempfile.TemporaryDirectory(prefix="jazz-sql-sync-")
+        self.name = "sql_sync_" + uuid.uuid4().hex
+        if self.pg:
+            import psycopg
+
+            self.admin = psycopg.connect(args.postgres, autocommit=True)
+            self.admin.execute("CREATE DATABASE " + quoted(self.name))
+            self.db = psycopg.connect(args.postgres, dbname=self.name, autocommit=True)
+            self.db.execute("SET client_encoding TO UTF8")
+            self.db.execute(
+                "SET synchronous_commit TO "
+                + ("on" if args.durability == "durable" else "off")
+            )
+            self.db.execute("SET jit TO off")
+            self.server_pid = self.db.execute("SELECT pg_backend_pid()").fetchone()[0]
+        else:
+            self.path = Path(self.temp.name) / "node.sqlite"
+            self.db = sqlite3.connect(self.path, isolation_level=None)
+            self.db.execute("PRAGMA journal_mode=WAL")
+            self.db.execute(
+                "PRAGMA synchronous="
+                + ("FULL" if args.durability == "durable" else "NORMAL")
+            )
+            self.db.execute("PRAGMA wal_autocheckpoint=0")
+        blob = "BYTEA" if self.pg else "BLOB"
+        self.db.execute(
+            f"CREATE TABLE transactions(tx TEXT PRIMARY KEY, accepted INTEGER NOT NULL, payload {blob}, meta TEXT)"
+        )
+        self.db.execute(
+            f"CREATE TEMP TABLE tx_stage(tx TEXT, payload {blob}, meta TEXT)"
+        )
+        self.db.execute(
+            "CREATE TABLE parents(child TEXT, parent TEXT, PRIMARY KEY(child,parent))"
+        )
+        self.db.execute("CREATE INDEX parent_lookup ON parents(parent)")
+        samples = {}
+        for w in fixture["writes"]:
+            samples.setdefault(
+                w["table"], {k: scalar(v) for k, v in w["cells"].items()}
+            )
+        for t, cols in columns.items():
+            decl = "".join(
+                f", {quoted(c)} "
+                + (
+                    "DOUBLE PRECISION"
+                    if isinstance(samples[t][c], float)
+                    else "BIGINT"
+                    if isinstance(samples[t][c], int)
+                    else "TEXT"
+                )
+                for c in cols
+            )
+            self.db.execute(
+                f"CREATE TABLE {quoted('h_' + t)}(id TEXT, version TEXT PRIMARY KEY, tx TEXT NOT NULL, wire {blob}{decl})"
+            )
+            self.db.execute(
+                f"CREATE TEMP TABLE {quoted('stage_' + t)}(id TEXT, version TEXT, tx TEXT, wire {blob}{decl})"
+            )
+            self.db.execute(
+                f"CREATE INDEX {quoted('id_' + t)} ON {quoted('h_' + t)}(id)"
+            )
+            for c in cols:
+                if c in {
+                    "parent_id",
+                    "resource",
+                    "team",
+                    "member_id",
+                    "target_id",
+                    "user_id",
+                    "group_id",
+                }:
+                    self.db.execute(
+                        f"CREATE INDEX {quoted('idx_' + t + '_' + c)} ON {quoted('h_' + t)}({quoted(c)})"
+                    )
+            self.db.execute(f"""CREATE VIEW {quoted("v_" + t)} AS SELECT h.* FROM {quoted("h_" + t)} h
+                JOIN transactions t ON t.tx=h.tx AND t.accepted=1 WHERE NOT EXISTS
+                (SELECT 1 FROM parents p JOIN transactions successor ON successor.tx=p.child AND successor.accepted=1 WHERE p.parent=h.version)""")
+
+    def backend_counters(self):
+        pid = self.server_pid if self.pg else os.getpid()
+        stat = Path(f"/proc/{pid}/stat").read_text().split()
+        io = {
+            k: int(v)
+            for k, v in (
+                line.split(":")
+                for line in Path(f"/proc/{pid}/io").read_text().splitlines()
+            )
+        }
+        out = {
+            "backend_cpu_ms": (int(stat[13]) + int(stat[14]))
+            * 1000
+            / os.sysconf("SC_CLK_TCK"),
+            "backend_write_bytes": io["write_bytes"],
+            "backend_read_bytes": io["read_bytes"],
+        }
+        if self.pg:
+            lsn = self.db.execute("SELECT pg_current_wal_insert_lsn()").fetchone()[0]
+            high, low = lsn.split("/")
+            out["wal_bytes"] = int(high, 16) * 2**32 + int(low, 16)
+        return out
+
+    def reopen(self):
+        self.db.close()
+        if self.pg:
+            import psycopg
+
+            self.db = psycopg.connect(
+                self.args.postgres, dbname=self.name, autocommit=True
+            )
+            self.db.execute("SET client_encoding TO UTF8")
+        else:
+            self.db = sqlite3.connect(self.path, isolation_level=None)
+
+    def load_stage(self, name, rows, width):
+        if self.pg:
+            with self.db.cursor() as cur:
+                with cur.copy("COPY " + quoted(name) + " FROM STDIN") as copy:
+                    for row in rows:
+                        copy.write_row(row)
+        else:
+            self.db.executemany(
+                "INSERT INTO "
+                + quoted(name)
+                + " VALUES ("
+                + ",".join(["?"] * width)
+                + ")",
+                rows,
+            )
+
+    def ingest(self, packets):
+        counters = self.backend_counters()
+        start = time.perf_counter_ns()
+        cpu = time.process_time_ns()
+        unique = {}
+        transactions = {}
+        grouped = defaultdict(list)
+        for packet in packets:
+            table, row, tx, payload, meta, wire, *cells = packet
+            key = (table, tx)
+            if key in unique and unique[key] != packet:
+                raise ValueError("conflicting incoming immutable version")
+            unique[key] = packet
+            if tx in transactions and transactions[tx] != (tx, payload, meta):
+                raise ValueError("conflicting incoming transaction")
+            transactions[tx] = (tx, payload, meta)
+        for table, row, tx, payload, meta, wire, *cells in unique.values():
+            grouped[table].append((row, tx, tx, wire, *cells))
+        self.db.execute("BEGIN")
+        try:
+            self.db.execute("DELETE FROM tx_stage")
+            self.load_stage("tx_stage", transactions.values(), 3)
+            if self.db.execute(
+                "SELECT 1 FROM tx_stage s JOIN transactions t ON t.tx=s.tx WHERE t.payload<>s.payload OR t.meta<>s.meta LIMIT 1"
+            ).fetchone():
+                raise ValueError("conflicting persisted transaction")
+            self.db.execute(
+                "INSERT INTO transactions SELECT tx,1,payload,meta FROM tx_stage WHERE true ON CONFLICT(tx) DO NOTHING"
+            )
+            for table, rows in grouped.items():
+                stage = quoted("stage_" + table)
+                history = quoted("h_" + table)
+                self.db.execute("DELETE FROM " + stage)
+                self.load_stage("stage_" + table, rows, 4 + len(self.columns[table]))
+                if self.db.execute(
+                    f"SELECT 1 FROM {stage} s JOIN {history} h ON h.version=s.version WHERE h.wire<>s.wire OR h.id<>s.id LIMIT 1"
+                ).fetchone():
+                    raise ValueError("conflicting persisted version")
+                self.db.execute(
+                    f"INSERT INTO {history} SELECT * FROM {stage} WHERE true ON CONFLICT(version) DO NOTHING"
+                )
+            self.db.execute("COMMIT")
+        except Exception:
+            self.db.execute("ROLLBACK")
+            raise
+        commit_ms = (time.perf_counter_ns() - start) / 1e6
+        analyze_start = time.perf_counter_ns()
+        if self.args.analyze:
+            self.db.execute("ANALYZE")
+        analyze_ms = (time.perf_counter_ns() - analyze_start) / 1e6
+        elapsed = (time.perf_counter_ns() - start) / 1e6
+        cpu_ms = (time.process_time_ns() - cpu) / 1e6
+        delta = {k: v - counters[k] for k, v in self.backend_counters().items()}
+        return {
+            "wall_ms": elapsed,
+            "commit_ms": commit_ms,
+            "analyze_ms": analyze_ms,
+            "client_cpu_ms": cpu_ms,
+            **delta,
+            "incoming": len(packets),
+            "unique": len(unique),
+            "duplicates": len(packets) - len(unique),
+            "commits": 1,
+        }
+
+    def serve(self, trusted):
+        start = time.perf_counter_ns()
+        output = []
+        for table, cols in self.columns.items():
+            selected = (
+                ""
+                if trusted
+                else " JOIN ("
+                + reference_query(self.fixture, self.columns, table, True, False)
+                + ") selected ON selected.id=h.id"
+            )
+            fields = "".join(",h." + quoted(c) for c in cols)
+            sql = (
+                f"SELECT h.id,h.tx,t.payload,t.meta,h.wire{fields} FROM {quoted('v_' + table)} h JOIN transactions t ON t.tx=h.tx"
+                + selected
+            )
+            for row in self.db.execute(sql).fetchall():
+                output.append((table, *row))
+        return output, (time.perf_counter_ns() - start) / 1e6
+
+    def local_read(self):
+        start = time.perf_counter_ns()
+        results = {}
+        for table in self.columns:
+            results[table] = self.db.execute(
+                reference_query(self.fixture, self.columns, table, True, False)
+            ).fetchall()
+        return results, (time.perf_counter_ns() - start) / 1e6
+
+    def size(self):
+        if self.pg:
+            return self.db.execute(
+                "SELECT pg_database_size(current_database())"
+            ).fetchone()[0]
+        return sum(
+            p.stat().st_size for p in Path(self.temp.name).iterdir() if p.is_file()
+        )
+
+    def close(self):
+        self.db.close()
+        if self.pg:
+            self.admin.execute("DROP DATABASE " + quoted(self.name))
+            self.admin.close()
+        self.temp.cleanup()
+
+
+def packet_digest(packets):
+    digest = hashlib.sha256()
+    for p in sorted(set(packets), key=lambda p: (p[0], p[1], p[2])):
+        for value in p:
+            data = value if isinstance(value, bytes) else canonical(value).encode()
+            digest.update(len(data).to_bytes(8, "big"))
+            digest.update(data)
+    return digest.hexdigest()
+
+
+def trace_order(packets, captured):
+    by_key = {(p[0], p[1], p[2]): p for p in packets}
+    return [by_key[(p[0], p[1], p[2])] for p in captured]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("fixture", type=Path)
+    ap.add_argument("capture", type=Path)
+    ap.add_argument("--analyze", action=argparse.BooleanOptionalAction, default=True)
+    ap.add_argument("--postgres")
+    ap.add_argument("--durability", choices=["relaxed", "durable"], default="relaxed")
+    ap.add_argument("--rounds", type=int, default=3)
+    ap.add_argument("--out", type=Path, required=True)
+    args = ap.parse_args()
+    fixture = json.loads(args.fixture.read_text())
+    columns = {t: [] for t in fixture["expected"]}
+    for w in fixture["writes"]:
+        columns[w["table"]] = list(w["cells"])
+    captured = {
+        hop: load_capture(args.capture / (hop + ".jsonl"), fixture, columns)
+        for hop in ["core-edge", "edge-client"]
+    }
+    digests = {hop: packet_digest(packets) for hop, packets in captured.items()}
+    expected = {t: {} for t in columns}
+    visible = {t: set(ids) for t, ids in fixture["expected"].items()}
+    for w in fixture["writes"]:
+        if w["id"] in visible[w["table"]]:
+            expected[w["table"]][w["id"]] = (
+                w["id"],
+                *[scalar(w["cells"][c]) for c in columns[w["table"]]],
+            )
+    receipts = []
+    for iteration in range(args.rounds):
+        stores = []
+        try:
+
+            def create(name):
+                store = Store(args, fixture, columns, name)
+                stores.append(store)
+                return store
+
+            # Direct replay measures actual wire delivery, including duplicates.
+            replay = create("replay")
+            replay_stats = replay.ingest(captured["edge-client"])
+            results, read_ms = replay.local_read()
+            assert all(
+                {r[0]: r for r in rows} == expected[t] for t, rows in results.items()
+            )
+            duplicate_stats = replay.ingest(captured["edge-client"])
+            served, _ = replay.serve(True)
+            assert packet_digest(served) == digests["edge-client"]
+            # Conflicting bytes must reject without changing the durable result.
+            bad = list(captured["edge-client"][0])
+            bad[5] = bad[5] + b"bad"
+            try:
+                replay.ingest([tuple(bad)])
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("conflicting version accepted")
+            served, _ = replay.serve(True)
+            assert packet_digest(served) == digests["edge-client"]
+            replay_size = replay.size()
+            replay.reopen()
+            served, _ = replay.serve(True)
+            assert packet_digest(served) == digests["edge-client"]
+            replay.close()
+            stores.remove(replay)
+            # Seed Core outside the measured downstream load, as in Jazz.
+            core = create("core")
+            core.ingest(captured["core-edge"])
+            core.db.execute("ANALYZE")
+            direct = create("direct")
+            direct_start = time.perf_counter_ns()
+            direct_packets, direct_query_ms = core.serve(False)
+            direct_packets = trace_order(direct_packets, captured["edge-client"])
+            direct_stats = direct.ingest(direct_packets)
+            direct_results, direct_read_ms = direct.local_read()
+            direct_total_ms = (time.perf_counter_ns() - direct_start) / 1e6
+            assert packet_digest(direct_packets) == digests["edge-client"]
+            assert all(
+                {r[0]: r for r in rows} == expected[t]
+                for t, rows in direct_results.items()
+            )
+            direct.close()
+            stores.remove(direct)
+            edge = create("edge")
+            client = create("client")
+            # Timed serial topology has separate persistent stores and includes
+            # query, driver transfer, ingestion, index work and final local reads.
+            total_start = time.perf_counter_ns()
+            to_edge, core_query_ms = core.serve(True)
+            to_edge = trace_order(to_edge, captured["core-edge"])
+            edge_stats = edge.ingest(to_edge)
+            to_client, edge_query_ms = edge.serve(False)
+            to_client = trace_order(to_client, captured["edge-client"])
+            client_stats = client.ingest(to_client)
+            results, client_read_ms = client.local_read()
+            total_ms = (time.perf_counter_ns() - total_start) / 1e6
+            assert packet_digest(to_edge) == digests["core-edge"]
+            assert packet_digest(to_client) == digests["edge-client"]
+            assert all(
+                {r[0]: r for r in rows} == expected[t] for t, rows in results.items()
+            )
+            receipt = {
+                "round": iteration,
+                "engine": "postgres" if args.postgres else "sqlite",
+                "durability": args.durability,
+                "analyze": args.analyze,
+                "replay": replay_stats,
+                "replay_local_read_ms": read_ms,
+                "duplicate_replay": duplicate_stats,
+                "replay_size_bytes": replay_size,
+                "direct_total_ms": direct_total_ms,
+                "direct_query_ms": direct_query_ms,
+                "direct_ingest": direct_stats,
+                "direct_read_ms": direct_read_ms,
+                "topology_total_ms": total_ms,
+                "core_query_fetch_ms": core_query_ms,
+                "edge_ingest": edge_stats,
+                "edge_query_fetch_ms": edge_query_ms,
+                "client_ingest": client_stats,
+                "client_local_read_ms": client_read_ms,
+                "edge_size_bytes": edge.size(),
+                "client_size_bytes": client.size(),
+            }
+            client.reopen()
+            served, _ = client.serve(True)
+            assert packet_digest(served) == digests["edge-client"]
+            receipts.append(receipt)
+            print(json.dumps(receipt), flush=True)
+        finally:
+            for store in reversed(stores):
+                store.close()
+    args.out.write_text(
+        json.dumps(
+            {
+                "receipts": receipts,
+                "capture_digests": digests,
+                "capture_counts": {k: len(v) for k, v in captured.items()},
+                "checks": "full cells, full wire+transaction bytes, duplicate replay, conflicting version rollback, reopen",
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/benchmarks/sql-proxy/run.py
+++ b/dev/benchmarks/sql-proxy/run.py
@@ -20,6 +20,40 @@ def quoted(name):
     return '"' + name.replace('"', '""') + '"'
 
 
+def reference_query(data, columns, table, history, witnesses):
+    resources = {r["table"]: r for r in data["resources"]}
+    children = {r["child"]: r for r in data["resources"] if r["child"]}
+    prefix = 'v_' if history else 'c_'
+    q = lambda t: quoted(prefix+t)
+    resource = resources.get(table) or children.get(table)
+    if not resource:
+        if witnesses:
+            return f'SELECT b.* FROM {q(table)} r JOIN bundles b ON b.version=r.version'
+        return f'SELECT id{"," if columns[table] else ""}{",".join(map(quoted,columns[table]))} FROM {q(table)}'
+    # Gather is bounded at depth 8 and deduplicates reached group IDs.
+    # UNION(id,depth) deliberately retains depth to honor the bound, then DISTINCT id.
+    cte = f'''WITH RECURSIVE reach(id,depth) AS (
+        SELECT group_id,0 FROM {q('group_access_edges')} WHERE user_id='{data['account']}'
+        UNION SELECT e.target_id,r.depth+1 FROM reach r JOIN {q('group_entry')} e ON e.member_id=r.id
+            JOIN {q('group')} g ON g.id=e.target_id WHERE e.administrator=0 AND r.depth<8
+    ), reached AS (SELECT DISTINCT id FROM reach),
+    allowed AS (SELECT DISTINCT a.resource FROM {q(resource['access'])} a JOIN reached g ON g.id=a.team WHERE a.administrator=0),
+    output AS (SELECT r.* FROM {q(table)} r WHERE EXISTS (
+        SELECT 1 FROM allowed a WHERE a.resource=r.{"parent_id" if table in children else "id"}))'''
+    if not witnesses:
+        return cte + f' SELECT id,{",".join(map(quoted,columns[table]))} FROM output'
+    # Conservative, readable supporting set: output, parent, matching grants,
+    # and the reachable permission graph. Not a claim of Jazz-identical provenance.
+    parent_select = f"SELECT p.version FROM {q(resource['table'])} p JOIN output o ON o.parent_id=p.id" if table in children else 'SELECT version FROM output'
+    parent_ids = 'SELECT DISTINCT parent_id FROM output' if table in children else 'SELECT id FROM output'
+    return cte + f''', needed(version) AS (
+        SELECT version FROM output UNION {parent_select}
+        UNION SELECT a.version FROM {q(resource['access'])} a JOIN reached g ON a.team=g.id WHERE a.administrator=0 AND a.resource IN ({parent_ids})
+        UNION SELECT s.version FROM {q('group_access_edges')} s WHERE s.user_id='{data['account']}'
+        UNION SELECT e.version FROM {q('group_entry')} e JOIN reach r ON e.member_id=r.id WHERE e.administrator=0 AND r.depth<8
+        UNION SELECT g.version FROM {q('group')} g JOIN reached r ON r.id=g.id
+    ) SELECT b.* FROM needed n JOIN bundles b ON b.version=n.version'''
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('fixture', type=Path)
@@ -83,36 +117,7 @@ def main():
     resources = {r['table']: r for r in data['resources']}
     children = {r['child']: r for r in data['resources'] if r['child']}
     def query(table, history, witnesses):
-        prefix = 'v_' if history else 'c_'
-        q = lambda t: quoted(prefix+t)
-        resource = resources.get(table) or children.get(table)
-        if not resource:
-            if witnesses:
-                return f'SELECT b.* FROM {q(table)} r JOIN bundles b ON b.version=r.version'
-            return f'SELECT id{"," if columns[table] else ""}{",".join(map(quoted,columns[table]))} FROM {q(table)}'
-        # Gather is bounded at depth 8 and deduplicates reached group IDs.
-        # UNION(id,depth) deliberately retains depth to honor the bound, then DISTINCT id.
-        cte = f'''WITH RECURSIVE reach(id,depth) AS (
-            SELECT group_id,0 FROM {q('group_access_edges')} WHERE user_id='{data['account']}'
-            UNION SELECT e.target_id,r.depth+1 FROM reach r JOIN {q('group_entry')} e ON e.member_id=r.id
-                JOIN {q('group')} g ON g.id=e.target_id WHERE e.administrator=0 AND r.depth<8
-        ), reached AS (SELECT DISTINCT id FROM reach),
-        allowed AS (SELECT DISTINCT a.resource FROM {q(resource['access'])} a JOIN reached g ON g.id=a.team WHERE a.administrator=0),
-        output AS (SELECT r.* FROM {q(table)} r WHERE EXISTS (
-            SELECT 1 FROM allowed a WHERE a.resource=r.{"parent_id" if table in children else "id"}))'''
-        if not witnesses:
-            return cte + f' SELECT id,{",".join(map(quoted,columns[table]))} FROM output'
-        # Conservative, readable supporting set: output, parent, matching grants,
-        # and the reachable permission graph. Not a claim of Jazz-identical provenance.
-        parent_select = f"SELECT p.version FROM {q(resource['table'])} p JOIN output o ON o.parent_id=p.id" if table in children else 'SELECT version FROM output'
-        parent_ids = 'SELECT DISTINCT parent_id FROM output' if table in children else 'SELECT id FROM output'
-        return cte + f''', needed(version) AS (
-            SELECT version FROM output UNION {parent_select}
-            UNION SELECT a.version FROM {q(resource['access'])} a JOIN reached g ON a.team=g.id WHERE a.administrator=0 AND a.resource IN ({parent_ids})
-            UNION SELECT s.version FROM {q('group_access_edges')} s WHERE s.user_id='{data['account']}'
-            UNION SELECT e.version FROM {q('group_entry')} e JOIN reach r ON e.member_id=r.id WHERE e.administrator=0 AND r.depth<8
-            UNION SELECT g.version FROM {q('group')} g JOIN reached r ON r.id=g.id
-        ) SELECT b.* FROM needed n JOIN bundles b ON b.version=n.version'''
+        return reference_query(data, columns, table, history, witnesses)
     receipts=[]
     expected_ids = {t: set(ids) for t,ids in data['expected'].items()}
     expected = {t: {i: tuple([i]+[c[k] for k in columns[t]]) for i,v,c in rows if i in expected_ids[t]} for t,rows in tables.items()}


### PR DESCRIPTION
🤖 Extends #2888's read-only SQL reference to captured transaction ingestion and separate persistent Core → Edge → Client stores. This is a research harness; Jazz runtime/storage/wire semantics are unchanged.

The opt-in native capture retains the actual transaction and version-envelope bytes and decoded fields. SQL verifies those fields against the fixture, persists complete envelopes, maintains query indexes, checks exact-match replay/conflicts, and evaluates permissions locally. Source forwarding reads from SQL, then follows the captured order and duplicates. One data-ingest transaction per node matches Jazz's observed bulk receiver commits; statistics-refresh work is also measured.

Three fresh-store rounds, median total including source queries/fetch, receiver ingestion/statistics and local reads:

| Engine / commit mode | Core → Client | Core → Edge → Client |
| --- | ---: | ---: |
| SQLite relaxed | 0.914 s | 1.969 s |
| SQLite synchronous | 1.238 s | 2.840 s |
| PostgreSQL relaxed | 1.892 s | 4.808 s |
| PostgreSQL synchronous | 1.949 s | 4.837 s |

Captured Client ingestion alone takes 0.497 s in relaxed SQLite and 1.493 s in relaxed PostgreSQL. The real Jazz decoder/field-extraction diagnostic adds a separately measured 111 ms for Core → Edge and 65 ms for Edge → Client; these are not silently included in the SQL wall-time receipts.

Fresh lightweight Jazz timers give median total 13.267 s, with tick medians Core 2.729 s / Edge 5.620 s / Client 2.892 s. Receiver-node time includes runtime and publication work, not only storage. The result supports synchronization being a much larger task than a read, while leaving substantial work to explain inside Jazz's nodes.

Validation: all four SQL configurations pass full-field/full-envelope equality, duplicate delivery, conflicting-version rollback and close/reopen checks. Edge/Client distinct versions match Jazz at 46,740 / 27,518. Optimized native capture, decoder and three clean tick-timed runs pass. Formatter, Clippy and sensitive-data checks pass. No full CI-equivalent or independent review claim.

Boundaries: static shallow-history fixture only; no maintained IVM state, full authority/reconnect protocol or real network serialization. SQL stores redundant complete envelopes and staging copies, so it is deliberately storage-heavy. Separate PostgreSQL databases share one isolated cluster/WAL writer. Results do not establish an intrinsic sync lower bound or an exact speedup for a production replacement.

Reproduction and limitations: `dev/benchmarks/sql-proxy/SYNC.md`. Results and interpretation: `SYNC_RESULTS.md`. Raw synthetic captures remain local rather than adding hundreds of MB to Git. Draft on #2888, no product changes.
