### PR TITLE
bench: compare memory-only cold-load topologies

### DIFF
--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -12,6 +12,9 @@ use jazz::db::{
     SubscriptionEvent, SubscriptionStream, Transport,
 };
 use jazz::groove::records::Value;
+use jazz::groove::storage::{
+    BoxedStorage, MemoryStorage, OrderedKvStorage, OwnedWriteOperation, ScanRequest, collect_scan,
+};
 use jazz::ids::{AuthorSubject, NodeUuid, RowUuid};
 use jazz::node::MergeableCommit;
 use jazz::protocol::{SubscriptionKey, SyncMessage};
@@ -573,6 +576,13 @@ fn main() {
         export_sql_fixture(&config, std::path::Path::new(&path));
         return;
     }
+    if storage_mode() != "rocks" {
+        assert_eq!(
+            config.phases,
+            vec!["cold"],
+            "memory modes currently measure cold loading only; set JAZZ_CUSTOMER_PHASES=cold"
+        );
+    }
     let schema = schema();
     let seeded = seed_core(&schema, &config);
     let expected = expected_visible_counts(&seeded, config.identity);
@@ -701,7 +711,7 @@ enum BenchIdentity {
 
 struct Seeded {
     _core_dir: Rc<tempfile::TempDir>,
-    core: Node<RocksDbStorage>,
+    core: Node<BoxedStorage>,
     ordinary_user: RowUuid,
     visible_groups: BTreeSet<RowUuid>,
     table_rows: BTreeMap<String, Vec<RowUuid>>,
@@ -890,12 +900,12 @@ struct SubscriptionTimeline {
 
 struct DbNode {
     _dir: Rc<tempfile::TempDir>,
-    db: Db<RocksDbStorage>,
+    db: Db<BoxedStorage>,
 }
 
 struct DbClient {
     _dir: Rc<tempfile::TempDir>,
-    db: Db<RocksDbStorage>,
+    db: Db<BoxedStorage>,
 }
 
 struct OpenSubscription {
@@ -1369,7 +1379,7 @@ fn seed_core(schema: &JazzSchema, config: &Config) -> Seeded {
         }
         fs::create_dir_all(&tmp_cache).expect("create temporary customer seed cache");
         {
-            let storage = open_storage(&tmp_cache, schema);
+            let storage = BoxedStorage::new(open_storage(&tmp_cache, schema));
             let state = block_on(jazz::node::NodeState::new_history_complete(
                 node(1),
                 schema.clone(),
@@ -1386,7 +1396,12 @@ fn seed_core(schema: &JazzSchema, config: &Config) -> Seeded {
 
     let core_dir = tempfile::tempdir().unwrap();
     copy_dir_contents(&cache_dir, core_dir.path()).expect("copy cached customer seed store");
-    let storage = open_storage(core_dir.path(), schema);
+    let rocks = open_storage(core_dir.path(), schema);
+    let storage = if storage_mode() == "all-memory" {
+        BoxedStorage::new(copy_seed_to_memory(&rocks))
+    } else {
+        BoxedStorage::new(rocks)
+    };
     let state = block_on(jazz::node::NodeState::new_history_complete(
         node(1),
         schema.clone(),
@@ -1648,7 +1663,7 @@ fn export_sql_fixture(config: &Config, path: &std::path::Path) {
     .unwrap();
 }
 
-fn write_seed_plan(core: &Node<RocksDbStorage>, plan: &SeedPlan) {
+fn write_seed_plan(core: &Node<BoxedStorage>, plan: &SeedPlan) {
     for write in &plan.writes {
         seed_db(core, &write.table, write.row, write.cells.clone());
     }
@@ -2386,7 +2401,7 @@ fn subscription_tables() -> Vec<String> {
     tables
 }
 
-fn seed_db(core: &Node<RocksDbStorage>, table: &str, row: RowUuid, cells: BTreeMap<String, Value>) {
+fn seed_db(core: &Node<BoxedStorage>, table: &str, row: RowUuid, cells: BTreeMap<String, Value>) {
     let node = core.node();
     let mut node = block_on(node.lock());
     let (tx_id, _) = jazz_sim::fixture::commit_mergeable_unit_settled(
@@ -2408,7 +2423,7 @@ fn open_db_node(
     dir: Option<Rc<tempfile::TempDir>>,
 ) -> DbNode {
     let dir = dir.unwrap_or_else(|| Rc::new(tempfile::tempdir().unwrap()));
-    let storage = open_storage(dir.path(), &schema);
+    let storage = open_receiver_storage(dir.path(), &schema);
     let db = block_on(Db::open(DbConfig {
         schema,
         storage,
@@ -2430,7 +2445,7 @@ fn open_client_db(
     dir: Option<Rc<tempfile::TempDir>>,
 ) -> DbClient {
     let dir = dir.unwrap_or_else(|| Rc::new(tempfile::tempdir().unwrap()));
-    let storage = open_storage(dir.path(), &schema);
+    let storage = open_receiver_storage(dir.path(), &schema);
     let db = block_on(Db::open(DbConfig {
         schema,
         storage,
@@ -2446,6 +2461,59 @@ fn open_client_db(
             .unwrap();
     }
     DbClient { _dir: dir, db }
+}
+
+fn storage_mode() -> String {
+    let mode = std::env::var("JAZZ_CUSTOMER_STORAGE").unwrap_or_else(|_| "rocks".to_owned());
+    assert!(
+        matches!(mode.as_str(), "rocks" | "memory-receivers" | "all-memory"),
+        "unknown storage mode {mode}"
+    );
+    mode
+}
+
+fn open_receiver_storage(path: &Path, schema: &JazzSchema) -> BoxedStorage {
+    if storage_mode() == "rocks" {
+        BoxedStorage::new(open_storage(path, schema))
+    } else {
+        let families = schema.column_families();
+        let names = families.iter().map(String::as_str).collect::<Vec<_>>();
+        BoxedStorage::new(MemoryStorage::new(&names).unwrap())
+    }
+}
+
+// Preload identical physical seed state, including aliases and acceptance
+// metadata. This is setup, not measured synchronization or reseeding work.
+fn copy_seed_to_memory(source: &RocksDbStorage) -> MemoryStorage {
+    let families = source
+        .column_family_names()
+        .expect("RocksDB enumerates families");
+    let names = families.iter().map(String::as_str).collect::<Vec<_>>();
+    let memory = MemoryStorage::new(&names).unwrap();
+    for family in families {
+        let entries = block_on(collect_scan(
+            block_on(source.scan(ScanRequest::prefix(family.clone(), Vec::new()))).unwrap(),
+        ))
+        .unwrap();
+        let operations = entries
+            .iter()
+            .map(|(key, value)| OwnedWriteOperation::Set {
+                cf: family.clone(),
+                key: key.clone(),
+                value: value.clone(),
+            })
+            .collect();
+        block_on(memory.write_many(operations)).unwrap();
+        let restored = block_on(collect_scan(
+            block_on(memory.scan(ScanRequest::prefix(family, Vec::new()))).unwrap(),
+        ))
+        .unwrap();
+        assert_eq!(
+            entries, restored,
+            "in-memory seed differs from persisted seed"
+        );
+    }
+    memory
 }
 
 fn open_storage(path: &std::path::Path, schema: &JazzSchema) -> RocksDbStorage {
@@ -2647,6 +2715,7 @@ fn pending_description(subscriptions: &[OpenSubscription]) -> String {
 
 fn emit_summary(config: &Config, phase: &str, summary: &RunSummary) {
     let mut fields = metadata_fields("customer_cold_start", "native", config.seed, "full");
+    fields.insert("storage_mode".to_owned(), json!(storage_mode()));
     fields.insert(
         "node_tick_wall_us_core_edge_client".to_owned(),
         json!(summary.tick_wall_us),

--- a/dev/benchmarks/sql-proxy/MEMORY.md
+++ b/dev/benchmarks/sql-proxy/MEMORY.md
@@ -1,0 +1,65 @@
+# Memory-only topology checkpoint
+
+This experiment changes only the native cold-load benchmark's storage adapter.
+The same Jazz/Groove query, authorization, synchronization and ingestion logic
+runs in all configurations; no production durability semantics change.
+
+## Results
+
+Three optimized native runs per configuration, rotated in execution order.
+Same synthetic seed, 39 subscriptions, 27,518 materialized rows. Setup and Core
+seed copying are outside the measured interval. These are cold receiver loads,
+not cold operating-system page-cache measurements.
+
+| Storage (Core / Edge / Client) | Median full load |           Range | Core tick time | Edge tick time | Client tick time |
+| ------------------------------ | ---------------: | --------------: | -------------: | -------------: | ---------------: |
+| RocksDB / RocksDB / RocksDB    |         12.652 s | 12.642–12.882 s |        2.766 s |        5.538 s |          2.646 s |
+| RocksDB / Memory / Memory      |         11.509 s | 11.496–11.643 s |        2.725 s |        4.775 s |          2.296 s |
+| Memory / Memory / Memory       |         11.213 s | 11.207–11.497 s |        2.613 s |        4.725 s |          2.212 s |
+
+Node columns are independently computed medians of time inside node ticks;
+they omit driver work and should not be added to reconstruct full load time.
+Memory receivers improve wall time by 9.0%; all-memory improves it by 11.4%.
+
+Every run ingested 46,740 unique bundles at Edge and 27,518 at Client, with
+68,015,375 raw payload bytes delivered to Client. An additional untimed
+all-memory capture matched the prior RocksDB capture's complete bundle
+multisets, including transaction bytes, version bytes, decoded fields and
+duplicate multiplicities: 47,437 deliveries Core→Edge and 28,137 Edge→Client.
+All existing expected-result and permission assertions passed.
+
+## Meaning and limits
+
+Most elapsed time survives removal of every persistent backend from the timed
+load. A recoverable receiver cache cannot achieve a large improvement merely
+by swapping RocksDB for the current MemoryStorage. It would need to reduce
+encoding, indexing, publication or other ingestion work that remains in this
+experiment. This is evidence for investigating those costs, not a measurement
+that assigns the entire remainder to any one of them.
+
+MemoryStorage itself uses mutex-protected ordered maps and owned byte buffers;
+it is not an ideal bulk in-memory representation. This comparison therefore
+is not an exact isolation of disk I/O cost. RocksDB already batches receiver
+bulk ingestion, and its existing WAL policy is unchanged. Browser IndexedDB
+may have a different storage cost; these are native results only.
+
+No checkpoint/restart performance, durable local outbox, crash recovery or
+production acknowledgment changes are evaluated here. Memory configurations
+reject phases other than `cold` rather than pretending to reopen persisted data.
+
+## Reproduction and provenance
+
+Build the `customer_cold_start` bench with profile `perf` and features
+`jazz/testing,jazz/transport-compression-zstd,jazz-benchmark-guard/mimalloc`.
+Run the same executable with `JAZZ_CUSTOMER_PHASES=cold` and
+`JAZZ_CUSTOMER_STORAGE=rocks`, `memory-receivers`, or `all-memory`.
+All configurations use BoxedStorage so the adapter boundary is shared.
+The all-memory Core is initialized from the same cached physical RocksDB seed;
+every column family's keys and values are compared exactly after copying.
+
+Measured source: parent `876fdd92d50d286d03630c6203348a3cee26e556` plus the
+benchmark-only change accompanying this report. Receipts report the parent
+SHA and dirty working tree because compilation preceded the experiment commit.
+Local raw receipts and executable path are preserved under
+`/home/ubuntu/jazz-debug-evidence/permissioned-profile/memory-topology/`.
+Capture timings are excluded from the table.


### PR DESCRIPTION
🤖 This benchmark compares the same native permissioned cold load with RocksDB everywhere, memory-only receivers, and memory on every node. It changes no production runtime or durability behavior.

Three rotated runs per configuration give median full-load times of **12.652 s**, **11.509 s**, and **11.213 s**, respectively. Removing persistent receiver storage saves about 9%; removing every persistent backend saves about 11%. Most of the cost remains in the existing in-memory engine and ingestion path; this does not yet test an alternative bulk cache representation.

The workload still materializes 27,518 rows. Core starts from identical physical seed state, verified key/value-for-key/value. An untimed all-memory wire capture matches the prior RocksDB capture's complete bundle multisets, including encoded transaction/version bytes and duplicate counts. All nine runs passed the benchmark's existing result and permission assertions.

The memory modes explicitly support cold load only. They do not simulate durable restart. MemoryStorage's ordered-map implementation is not an ideal RAM cache, so these numbers are not an exact disk-I/O attribution or a browser prediction.

Validation: optimized benchmark build; nine complete measured runs; exact capture comparison; formatting and commit gates. Details and reproduction: `dev/benchmarks/sql-proxy/MEMORY.md`.
