### PR TITLE
bench: compare engine work with slim encoded-memory reference

### DIFF
--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -1,3 +1,7 @@
+#[path = "customer_cold_start/slim_memory.rs"]
+mod slim_memory;
+#[path = "customer_cold_start/work_budget.rs"]
+mod work_budget;
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
@@ -568,6 +572,10 @@ fn main() {
         "phase attribution enabled: compare elapsed time only with the same instrumentation; disable this feature for absolute latency"
     );
     let config = Config::from_env();
+    if let Some(path) = std::env::var_os("JAZZ_CUSTOMER_SLIM_MEMORY") {
+        slim_memory::run(Path::new(&path));
+        return;
+    }
     if let Some(path) = std::env::var_os("JAZZ_CUSTOMER_DECODE_CAPTURE") {
         measure_capture_decode(Path::new(&path));
         return;
@@ -1402,6 +1410,7 @@ fn seed_core(schema: &JazzSchema, config: &Config) -> Seeded {
     } else {
         BoxedStorage::new(rocks)
     };
+    let storage = work_budget::wrap(storage, "core");
     let state = block_on(jazz::node::NodeState::new_history_complete(
         node(1),
         schema.clone(),
@@ -1881,6 +1890,7 @@ fn run_connect_and_subscribe(
         jazz::cold_settle_attribution::reset();
         jazz::groove::cold_settle_attribution::reset();
     }
+    work_budget::start();
     alloc_metrics::reset_and_start();
     #[cfg(feature = "bench-perf-control")]
     let mut perf_control = PerfControl::start();
@@ -2058,6 +2068,10 @@ fn run_connect_and_subscribe(
     // Match the readiness boundary: later one-shot verification and storage
     // sizing are diagnostics, not work needed to make subscriptions usable.
     let alloc_snapshot = alloc_metrics::stop();
+    let budget = work_budget::stop();
+    if let Some(path) = std::env::var_os("JAZZ_CUSTOMER_WORK_BUDGET") {
+        fs::write(path, serde_json::to_vec_pretty(&budget).unwrap()).unwrap();
+    }
     #[cfg(feature = "cold-settle-attribution")]
     let projection_nodes_at_readiness = jazz::groove::cold_settle_attribution::map_node_work();
     #[cfg(feature = "cold-settle-attribution")]
@@ -2423,7 +2437,7 @@ fn open_db_node(
     dir: Option<Rc<tempfile::TempDir>>,
 ) -> DbNode {
     let dir = dir.unwrap_or_else(|| Rc::new(tempfile::tempdir().unwrap()));
-    let storage = open_receiver_storage(dir.path(), &schema);
+    let storage = work_budget::wrap(open_receiver_storage(dir.path(), &schema), "edge");
     let db = block_on(Db::open(DbConfig {
         schema,
         storage,
@@ -2445,7 +2459,7 @@ fn open_client_db(
     dir: Option<Rc<tempfile::TempDir>>,
 ) -> DbClient {
     let dir = dir.unwrap_or_else(|| Rc::new(tempfile::tempdir().unwrap()));
-    let storage = open_receiver_storage(dir.path(), &schema);
+    let storage = work_budget::wrap(open_receiver_storage(dir.path(), &schema), "client");
     let db = block_on(Db::open(DbConfig {
         schema,
         storage,

--- a/crates/jazz-sim/benches/customer_cold_start/slim_memory.rs
+++ b/crates/jazz-sim/benches/customer_cold_start/slim_memory.rs
@@ -1,0 +1,322 @@
+//! Workload-specific reference, not an alternative Jazz implementation.
+use super::*;
+use std::io::BufRead;
+use uuid::Uuid;
+
+type Encoded = Vec<(Vec<u8>, Vec<u8>)>;
+struct Store {
+    rows: Vec<jazz::protocol::VersionRecord>,
+    tables: BTreeMap<String, Vec<usize>>,
+    keys: BTreeMap<(String, Uuid), usize>,
+    transactions: Vec<Vec<u8>>,
+}
+fn hex(value: &JsonValue) -> Vec<u8> {
+    value
+        .as_str()
+        .unwrap()
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|p| u8::from_str_radix(std::str::from_utf8(p).unwrap(), 16).unwrap())
+        .collect()
+}
+fn read(path: &Path) -> Encoded {
+    let mut result = Vec::new();
+    for line in std::io::BufReader::new(fs::File::open(path).unwrap()).lines() {
+        let frame: JsonValue = serde_json::from_str(&line.unwrap()).unwrap();
+        for b in frame["bundles"].as_array().unwrap() {
+            assert_eq!(b["scope"], "CompleteTransaction");
+            assert_eq!(b["fate"], "Accepted");
+            assert_eq!(b["versions"].as_array().unwrap().len(), 1);
+            assert_eq!(b["versions"][0]["parents"], json!([]));
+            result.push((hex(&b["tx_hex"]), hex(&b["versions"][0]["wire_hex"])));
+        }
+    }
+    result
+}
+impl Store {
+    fn ingest(input: &Encoded) -> Self {
+        let mut s = Self {
+            rows: Vec::new(),
+            tables: BTreeMap::new(),
+            keys: BTreeMap::new(),
+            transactions: Vec::new(),
+        };
+        for (tx, bytes) in input {
+            let _: jazz::tx::Transaction = postcard::from_bytes(tx).unwrap();
+            let row: jazz::protocol::VersionRecord = postcard::from_bytes(bytes).unwrap();
+            let key = (row.table().to_owned(), row.row_uuid().0);
+            if let Some(&i) = s.keys.get(&key) {
+                assert_eq!(s.rows[i], row);
+                assert_eq!(s.transactions[i], *tx);
+            } else {
+                let i = s.rows.len();
+                s.tables.entry(key.0.clone()).or_default().push(i);
+                s.keys.insert(key, i);
+                s.rows.push(row);
+                s.transactions.push(tx.clone());
+            }
+        }
+        s
+    }
+    fn table(&self, name: &str) -> &[usize] {
+        self.tables.get(name).map(Vec::as_slice).unwrap_or(&[])
+    }
+}
+struct Plan {
+    columns: BTreeMap<String, BTreeMap<String, usize>>,
+    resources: Vec<(String, String, Option<String>)>,
+    expected: BTreeMap<String, BTreeSet<Uuid>>,
+    account: Uuid,
+}
+impl Plan {
+    fn new(fixture: &JsonValue) -> Self {
+        Self {
+            columns: schema()
+                .tables
+                .iter()
+                .map(|t| {
+                    (
+                        t.name.clone(),
+                        t.columns
+                            .iter()
+                            .enumerate()
+                            .map(|(i, c)| (c.name().to_owned(), i))
+                            .collect(),
+                    )
+                })
+                .collect(),
+            resources: fixture["resources"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|r| {
+                    (
+                        r["table"].as_str().unwrap().to_owned(),
+                        r["access"].as_str().unwrap().to_owned(),
+                        r["child"].as_str().map(str::to_owned),
+                    )
+                })
+                .collect(),
+            expected: fixture["expected"]
+                .as_object()
+                .unwrap()
+                .iter()
+                .map(|(t, ids)| {
+                    (
+                        t.clone(),
+                        ids.as_array()
+                            .unwrap()
+                            .iter()
+                            .map(|id| Uuid::parse_str(id.as_str().unwrap()).unwrap())
+                            .collect(),
+                    )
+                })
+                .collect(),
+            account: Uuid::parse_str(fixture["account"].as_str().unwrap()).unwrap(),
+        }
+    }
+    fn cell(&self, s: &Store, i: usize, name: &str) -> Value {
+        let r = &s.rows[i];
+        r.cell_at(self.columns[r.table()][name]).unwrap()
+    }
+    fn id(&self, s: &Store, i: usize, name: &str) -> Uuid {
+        match self.cell(s, i, name) {
+            Value::Uuid(id) => id,
+            v => panic!("unexpected ID {v:?}"),
+        }
+    }
+    fn flag(&self, s: &Store, i: usize, name: &str) -> bool {
+        match self.cell(s, i, name) {
+            Value::Bool(v) => v,
+            v => panic!("unexpected flag {v:?}"),
+        }
+    }
+    // Deliberately recompute permissions per query, like the SQL reference.
+    // The bounded traversal preserves depth; it never assumes a flat group graph.
+    fn query(&self, s: &Store, table: &str) -> (Vec<usize>, BTreeSet<usize>, usize) {
+        let resource = self
+            .resources
+            .iter()
+            .find(|(t, _, c)| t == table || c.as_deref() == Some(table));
+        let Some((parent, access, child)) = resource else {
+            return (
+                s.table(table).to_vec(),
+                s.table(table).iter().copied().collect(),
+                s.table(table).len(),
+            );
+        };
+        let mut visits = 0;
+        let mut reached = BTreeSet::new();
+        let mut frontier = BTreeSet::new();
+        let mut support = BTreeSet::new();
+        for &i in s.table("group_access_edges") {
+            visits += 1;
+            if self.id(s, i, "user_id") == self.account {
+                frontier.insert(self.id(s, i, "group_id"));
+                support.insert(i);
+            }
+        }
+        reached.extend(&frontier);
+        for _ in 0..8 {
+            let mut next = BTreeSet::new();
+            for &i in s.table("group_entry") {
+                visits += 1;
+                if !self.flag(s, i, "administrator")
+                    && frontier.contains(&self.id(s, i, "member_id"))
+                {
+                    let target = self.id(s, i, "target_id");
+                    if s.keys.contains_key(&("group".to_owned(), target)) {
+                        next.insert(target);
+                        support.insert(i);
+                    }
+                }
+            }
+            reached.extend(&next);
+            frontier = next;
+            if frontier.is_empty() {
+                break;
+            }
+        }
+        for id in &reached {
+            if let Some(&i) = s.keys.get(&("group".to_owned(), *id)) {
+                support.insert(i);
+            }
+        }
+        let mut allowed = BTreeMap::<Uuid, Vec<usize>>::new();
+        for &i in s.table(access) {
+            visits += 1;
+            if !self.flag(s, i, "administrator") && reached.contains(&self.id(s, i, "team")) {
+                allowed
+                    .entry(self.id(s, i, "resource"))
+                    .or_default()
+                    .push(i);
+            }
+        }
+        let is_child = child.as_deref() == Some(table);
+        let mut output = Vec::new();
+        for &i in s.table(table) {
+            visits += 1;
+            let id = if is_child {
+                self.id(s, i, "parent_id")
+            } else {
+                s.rows[i].row_uuid().0
+            };
+            if let Some(grants) = allowed.get(&id) {
+                output.push(i);
+                support.insert(i);
+                support.extend(grants);
+                if is_child {
+                    support.insert(*s.keys.get(&(parent.clone(), id)).expect("parent witness"));
+                }
+            }
+        }
+        (output, support, visits)
+    }
+    fn evaluate(&self, s: &Store) -> (BTreeMap<String, Vec<usize>>, usize, usize, usize) {
+        let mut outputs = BTreeMap::new();
+        let mut witnesses = 0;
+        let mut visits = 0;
+        let mut fields = 0;
+        for table in self.expected.keys() {
+            let (rows, support, n) = self.query(s, table);
+            visits += n;
+            witnesses += support.len();
+            // Materialize all application fields, rather than count-only results.
+            let rendered = rows
+                .iter()
+                .map(|&i| {
+                    let r = &s.rows[i];
+                    (0..self.columns[table].len())
+                        .map(|c| r.cell_at(c).unwrap())
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+            fields += rendered.iter().map(Vec::len).sum::<usize>();
+            std::hint::black_box(rendered);
+            outputs.insert(table.clone(), rows);
+        }
+        (outputs, witnesses, visits, fields)
+    }
+    fn verify(&self, s: &Store, outputs: &BTreeMap<String, Vec<usize>>, fixture: &JsonValue) {
+        for (table, rows) in outputs {
+            assert_eq!(
+                rows.iter()
+                    .map(|&i| s.rows[i].row_uuid().0)
+                    .collect::<BTreeSet<_>>(),
+                self.expected[table],
+                "{table}"
+            );
+        }
+        let writes = fixture["writes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|w| ((w["table"].as_str().unwrap(), w["id"].as_str().unwrap()), w))
+            .collect::<BTreeMap<_, _>>();
+        for rows in outputs.values() {
+            for &i in rows {
+                let r = &s.rows[i];
+                let id = r.row_uuid().0.to_string();
+                let w = writes[&(r.table(), id.as_str())];
+                for (name, &position) in &self.columns[r.table()] {
+                    assert_eq!(
+                        serde_json::to_value(r.cell_at(position).unwrap()).unwrap(),
+                        w["cells"][name]
+                    );
+                }
+            }
+        }
+    }
+}
+pub fn run(root: &Path) {
+    let fixture: JsonValue =
+        serde_json::from_reader(fs::File::open(root.join("fixture.json")).unwrap()).unwrap();
+    let plan = Plan::new(&fixture);
+    let ce = read(&root.join("core-edge.jsonl"));
+    let ec = read(&root.join("edge-client.jsonl"));
+    let core = Store::ingest(&ce); // preexisting Core state, outside load timing
+    // Sensitivity: a principal with no membership must not receive protected
+    // resource or child outputs. This would fail if the permission filter were
+    // removed, while ordinary unprotected tables may remain readable.
+    let mut denied = Plan::new(&fixture);
+    denied.account = Uuid::nil();
+    let mut protected_rows = 0;
+    for (table, _, child) in &denied.resources {
+        for name in std::iter::once(table).chain(child.iter()) {
+            protected_rows += plan.expected[name].len();
+            assert!(
+                denied.query(&core, name).0.is_empty(),
+                "unlinked identity sees {name}"
+            );
+        }
+    }
+    assert!(protected_rows > 0);
+    for round in 0..3 {
+        alloc_metrics::reset_and_start();
+        let total = Instant::now();
+        let t = Instant::now();
+        let core_result = plan.evaluate(&core);
+        let core_ms = t.elapsed().as_secs_f64() * 1000.;
+        let t = Instant::now();
+        let edge = Store::ingest(&ce);
+        let edge_ingest_ms = t.elapsed().as_secs_f64() * 1000.;
+        let t = Instant::now();
+        let edge_result = plan.evaluate(&edge);
+        let edge_query_ms = t.elapsed().as_secs_f64() * 1000.;
+        let t = Instant::now();
+        let client = Store::ingest(&ec);
+        let client_ingest_ms = t.elapsed().as_secs_f64() * 1000.;
+        let t = Instant::now();
+        let client_result = plan.evaluate(&client);
+        let client_query_ms = t.elapsed().as_secs_f64() * 1000.;
+        let total_ms = total.elapsed().as_secs_f64() * 1000.;
+        let allocations = alloc_metrics::stop();
+        plan.verify(&core, &core_result.0, &fixture);
+        plan.verify(&edge, &edge_result.0, &fixture);
+        plan.verify(&client, &client_result.0, &fixture);
+        println!(
+            "{}",
+            json!({"round":round,"allocation_requests":allocations.allocs,"allocation_bytes":allocations.bytes,"total_ms":total_ms,"core_query_ms":core_ms,"edge_ingest_ms":edge_ingest_ms,"edge_query_ms":edge_query_ms,"client_ingest_ms":client_ingest_ms,"client_query_ms":client_query_ms,"unique_rows":[core.rows.len(),edge.rows.len(),client.rows.len()],"operator_row_visits":[core_result.2,edge_result.2,client_result.2],"support_memberships":[core_result.1,edge_result.1,client_result.1],"output_fields":[core_result.3,edge_result.3,client_result.3]})
+        );
+    }
+}

--- a/crates/jazz-sim/benches/customer_cold_start/work_budget.rs
+++ b/crates/jazz-sim/benches/customer_cold_start/work_budget.rs
@@ -1,0 +1,238 @@
+//! Diagnostic storage boundary counts; never use instrumented timing as baseline.
+use jazz::groove::storage::*;
+use std::cell::{Cell, RefCell};
+use std::collections::BTreeMap;
+thread_local! {
+ static ACTIVE: Cell<bool> = const { Cell::new(false) };
+ static COUNTS: RefCell<BTreeMap<String, usize>> = const { RefCell::new(BTreeMap::new()) };
+}
+pub fn start() {
+    COUNTS.with(|c| c.borrow_mut().clear());
+    ACTIVE.with(|v| v.set(true));
+}
+pub fn stop() -> serde_json::Value {
+    ACTIVE.with(|v| v.set(false));
+    COUNTS.with(|c| serde_json::json!(*c.borrow()))
+}
+fn add(role: &str, cf: &str, name: &str, count: usize) {
+    if ACTIVE.with(Cell::get) {
+        COUNTS.with(|c| {
+            *c.borrow_mut()
+                .entry(format!("{role}/{cf}/{name}"))
+                .or_default() += count
+        });
+    }
+}
+fn count_writes(role: &str, operations: &[OwnedWriteOperation]) {
+    add(role, "*", "write_batches", 1);
+    for operation in operations {
+        match operation {
+            OwnedWriteOperation::Set { cf, key, value } => {
+                add(role, cf, "write_entries", 1);
+                add(role, cf, "write_key_bytes", key.len());
+                add(role, cf, "write_value_bytes", value.len());
+            }
+            OwnedWriteOperation::Delete { cf, key } => {
+                add(role, cf, "delete_entries", 1);
+                add(role, cf, "write_key_bytes", key.len());
+            }
+        }
+    }
+}
+struct Cursor<'a> {
+    inner: StorageScan<'a>,
+    role: &'static str,
+    cf: String,
+}
+impl StorageCursor for Cursor<'_> {
+    fn next_batch(&mut self) -> StorageFuture<'_, Result<Option<Vec<KeyValue>>, Error>> {
+        Box::pin(async move {
+            let batch = self.inner.next_batch().await?;
+            if let Some(rows) = &batch {
+                add(self.role, &self.cf, "scan_rows", rows.len());
+                add(
+                    self.role,
+                    &self.cf,
+                    "read_key_bytes",
+                    rows.iter().map(|r| r.0.len()).sum(),
+                );
+                add(
+                    self.role,
+                    &self.cf,
+                    "read_value_bytes",
+                    rows.iter().map(|r| r.1.len()).sum(),
+                );
+            }
+            Ok(batch)
+        })
+    }
+}
+pub struct BudgetStorage {
+    inner: BoxedStorage,
+    role: &'static str,
+}
+pub fn wrap(inner: BoxedStorage, role: &'static str) -> BoxedStorage {
+    if std::env::var_os("JAZZ_CUSTOMER_WORK_BUDGET").is_some() {
+        BoxedStorage::new(BudgetStorage { inner, role })
+    } else {
+        inner
+    }
+}
+impl OrderedKvStorage for BudgetStorage {
+    fn compare_value(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> StorageFuture<'_, Result<ValueComparison, Error>> {
+        add(self.role, &cf, "compare_value_calls", 1);
+        add(self.role, &cf, "comparison_bytes", expected.len());
+        self.inner.compare_value(cf, key, expected)
+    }
+
+    fn scan(&self, request: ScanRequest) -> StorageFuture<'_, Result<StorageScan<'_>, Error>> {
+        let cf = request.cf.clone();
+        add(self.role, &cf, "scan_calls", 1);
+        Box::pin(async move {
+            let inner = self.inner.scan(request).await?;
+            Ok(Box::new(Cursor {
+                inner,
+                role: self.role,
+                cf,
+            }) as StorageScan<'_>)
+        })
+    }
+
+    fn get(&self, cf: String, key: Vec<u8>) -> StorageFuture<'_, Result<Option<Value>, Error>> {
+        add(self.role, &cf, "get_calls", 1);
+        add(self.role, &cf, "lookup_key_bytes", key.len());
+        Box::pin(async move {
+            let result = self.inner.get(cf.clone(), key).await?;
+            if let Some(value) = &result {
+                add(self.role, &cf, "read_value_bytes", value.len());
+            }
+            Ok(result)
+        })
+    }
+
+    fn put_if_absent(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        value: Vec<u8>,
+    ) -> StorageFuture<'_, Result<Option<Value>, Error>> {
+        add(self.role, &cf, "put_if_absent_calls", 1);
+        self.inner.put_if_absent(cf, key, value)
+    }
+
+    fn compare_and_delete(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        expected: Vec<u8>,
+    ) -> StorageFuture<'_, Result<bool, Error>> {
+        add(self.role, &cf, "compare_and_delete_calls", 1);
+        self.inner.compare_and_delete(cf, key, expected)
+    }
+
+    fn set(
+        &self,
+        cf: String,
+        key: Vec<u8>,
+        value: Vec<u8>,
+    ) -> StorageFuture<'_, Result<(), Error>> {
+        add(self.role, &cf, "set_calls", 1);
+        add(self.role, &cf, "write_entries", 1);
+        add(self.role, &cf, "write_key_bytes", key.len());
+        add(self.role, &cf, "write_value_bytes", value.len());
+        self.inner.set(cf, key, value)
+    }
+
+    fn delete(&self, cf: String, key: Vec<u8>) -> StorageFuture<'_, Result<(), Error>> {
+        add(self.role, &cf, "delete_calls", 1);
+        self.inner.delete(cf, key)
+    }
+
+    fn close(&self) -> StorageFuture<'_, Result<(), Error>> {
+        self.inner.close()
+    }
+
+    fn set_write_flush_cadence(&self, every: usize) -> StorageFuture<'_, Result<(), Error>> {
+        self.inner.set_write_flush_cadence(every)
+    }
+
+    fn flush_write_boundary(&self) -> StorageFuture<'_, Result<(), Error>> {
+        self.inner.flush_write_boundary()
+    }
+
+    fn approximate_class_bytes(&self, cf: String) -> StorageFuture<'_, Result<Option<u64>, Error>> {
+        self.inner.approximate_class_bytes(cf)
+    }
+
+    fn last_with_prefix(
+        &self,
+        cf: String,
+        prefix: Vec<u8>,
+    ) -> StorageFuture<'_, Result<Option<KeyValue>, Error>> {
+        add(self.role, &cf, "last_with_prefix_calls", 1);
+        Box::pin(async move {
+            let result = self.inner.last_with_prefix(cf.clone(), prefix).await?;
+            if let Some((key, value)) = &result {
+                add(self.role, &cf, "read_key_bytes", key.len());
+                add(self.role, &cf, "read_value_bytes", value.len());
+            }
+            Ok(result)
+        })
+    }
+
+    fn last_with_prefix_before_or_at(
+        &self,
+        cf: String,
+        prefix: Vec<u8>,
+        upper: Vec<u8>,
+    ) -> StorageFuture<'_, Result<Option<KeyValue>, Error>> {
+        add(self.role, &cf, "last_with_prefix_before_or_at_calls", 1);
+        Box::pin(async move {
+            let result = self
+                .inner
+                .last_with_prefix_before_or_at(cf.clone(), prefix, upper)
+                .await?;
+            if let Some((key, value)) = &result {
+                add(self.role, &cf, "read_key_bytes", key.len());
+                add(self.role, &cf, "read_value_bytes", value.len());
+            }
+            Ok(result)
+        })
+    }
+
+    fn write_many(
+        &self,
+        operations: Vec<OwnedWriteOperation>,
+    ) -> StorageFuture<'_, Result<(), Error>> {
+        count_writes(self.role, &operations);
+        self.inner.write_many(operations)
+    }
+
+    fn write_many_outcome(
+        &self,
+        operations: Vec<OwnedWriteOperation>,
+    ) -> StorageFuture<'_, WriteManyOutcome> {
+        count_writes(self.role, &operations);
+        self.inner.write_many_outcome(operations)
+    }
+
+    fn column_family_names(&self) -> Option<Vec<String>> {
+        self.inner.column_family_names()
+    }
+}
+
+impl ReopenableStorage for BudgetStorage {
+    fn reopen(self, column_families: Vec<String>) -> StorageFuture<'static, Result<Self, Error>> {
+        Box::pin(async move {
+            Ok(Self {
+                inner: self.inner.reopen(column_families).await?,
+                role: self.role,
+            })
+        })
+    }
+}

--- a/dev/benchmarks/sql-proxy/SLIM_MEMORY.md
+++ b/dev/benchmarks/sql-proxy/SLIM_MEMORY.md
@@ -1,0 +1,156 @@
+# Slim encoded-memory reference and engine work budget
+
+This is a workload-specific executable reference, not a proposed production
+engine. It asks whether handling the actual encoded records is inherently slow.
+It accompanies the unchanged-engine storage comparison in MEMORY.md.
+
+## Reference contract
+
+`JAZZ_CUSTOMER_SLIM_MEMORY=/path/to/inputs` runs the reference inside the
+`customer_cold_start` native benchmark. Inputs are `fixture.json` from the SQL
+fixture exporter plus `core-edge.jsonl` and `edge-client.jsonl` from the actual
+sync capture. Capture JSON parsing and hexadecimal conversion are setup.
+
+The Core is prepopulated before timing. During the measured interval:
+
+1. Evaluate the 39 fixture queries and collect supporting rows at Core.
+2. Decode and install the actual Core→Edge captured transactions and versions.
+3. Evaluate the queries and collect supporting rows at Edge.
+4. Decode and install the actual Edge→Client captured transactions and versions.
+5. Evaluate the queries and collect supporting rows at Client.
+
+Each receiver owns decoded VersionRecords (which retain native encoded record
+bytes), raw transaction bytes, an ordered table/row identity index and table
+vectors of row indices. Exact duplicate rows are checked. Queries read predicate
+fields through VersionRecord APIs and materialize every application field of
+all outputs. No synthetic smaller payload substitutes for the encoded records.
+
+Permissions are independently implemented from the fixture relationships:
+account→group membership, bounded eight-step non-administrator group traversal,
+non-administrator resource grants, and inherited child access. Reachability is
+recomputed per query. Supporting sets include outputs, parent rows, matching
+grants and readable reachable permission-graph rows. This is the conservative
+SQL-reference supporting-set definition, not a claim of identical Jazz witnesses.
+After timing, every output ID and application field is checked against the
+independently exported fixture at all three nodes.
+
+## Deliberate differences from full Jazz
+
+The captured deliveries are replayed, not generated from the reference's
+supporting sets. This charges the real payload volume (including duplicate
+deliveries), but omits subscription scope construction, query compilation,
+transport serialization/compression and maintained incremental operator state.
+The fixture has one accepted version per row; the reference stores that version
+and transaction bytes but implements no general history, concurrency, branch,
+fate-transition, revocation or crash-recovery machinery. Its timing is an
+achievable workload-specific reference, not an equivalent end-to-end DB result.
+
+## Work budget
+
+`JAZZ_CUSTOMER_WORK_BUDGET=/path/to/counts.json` wraps the benchmark's storage
+adapters. Counting begins at connect/subscribe and stops at readiness, before
+one-shot verification and size inspection. Keys include role and column family.
+It counts requested point/compare/reverse reads, scan calls and returned rows,
+returned byte volumes, and submitted batch entries/bytes. These are storage
+boundary volumes, not a claim to count every internal memcpy or backend copy.
+The wrapper delegates the same adapter operations rather than replacing its
+batch/cursor behavior. Counted timings are diagnostic only.
+
+Combine this with feature `cold-settle-attribution` for existing projection,
+join and phase attribution. Projection input counts mean record visits, not
+unique rows; projection buffer bytes count newly produced buffers. Trace span
+entries can include async polls and must not be interpreted as logical commits.
+
+## Measured results
+
+Three final optimized native reference rounds: 271.742, 270.055 and 270.739 ms.
+Independent phase medians: Core queries 30.911 ms; Edge decode/install
+113.580 ms; Edge queries 30.377 ms; Client decode/install 67.195 ms; Client
+queries 29.344 ms. The initial checkpoint was 267.215 ms; the final run includes
+the complete duplicate-version equality check and passed permission sensitivity. Do not compare instrumented diagnostic wall time with these
+clean timings. The previous unchanged all-memory Jazz median was 11.213 s;
+the reference deliberately omits the machinery listed above.
+
+All three nodes render 135,254 application fields and collect 33,104 supporting
+memberships across the 39 queries. Reference query-loop visits are 55,922 at
+Core, 55,922 at Edge and 36,700 at Client; this counter excludes ingest/index
+work, container-internal comparisons and output field reads.
+
+Storage-boundary work through readiness:
+
+| Role   | Unique fixture rows present | Point get requests | Scan requests | Scan rows returned | KV set entries submitted |
+| ------ | --------------------------: | -----------------: | ------------: | -----------------: | -----------------------: |
+| Core   |                      46,740 |             47,439 |           132 |            293,588 |                        0 |
+| Edge   |                      46,740 |            402,063 |       187,271 |            373,401 |                  565,566 |
+| Client |                      27,518 |            220,148 |       110,270 |             82,555 |                  334,739 |
+
+Client receives roughly eight point reads, four scans and twelve KV writes per
+unique row. Its set entries include 141,175 index entries, 111,010 metadata
+entries, and 27,518 each in history, global-current and changes families.
+Edge has a similar write amplification. Both receivers submit 83 backend
+batches through readiness, but the large received-bundle ingest is one bulk
+commit per receiver; batch count is not a count of per-row commits.
+
+Existing operator instrumentation reports:
+
+| Role   | Projection input visits | New projection bytes | Join left visits | Join right visits |
+| ------ | ----------------------: | -------------------: | ---------------: | ----------------: |
+| Core   |                 616,745 |          252,613,514 |          191,444 |            97,983 |
+| Edge   |               1,024,313 |          397,796,811 |          598,757 |           139,545 |
+| Client |                 451,302 |          148,634,823 |          141,470 |         1,132,578 |
+
+The 799 MB of newly produced projection bytes is cumulative, not peak memory.
+Projection capacity totals 1.390 GB; neither measure counts every allocation or
+copy in the engine. Join counters are operator-specific record visits, not a
+count of successful pair matches. Reference and engine visit counters describe
+different operations; their ratio is not a normalized throughput measurement.
+
+## Code-walk interpretation
+
+The bulk receive path groups transactions, deduplicates versions, completes
+parents, translates wire rows into storage records, stages transactions,
+history, current-row records and merge heads, then applies one engine batch.
+After that batch it also rebuilds merge heads from persisted history.
+See `ingest_reset_view_bundle_refs_in_bulk` in Jazz's
+`node/ingest/commit_bundles.rs` and the two bulk merge-head helpers in
+`node/ingest/view_updates.rs`. Even shallow histories pay for several forms of
+the same logical row; the post-commit rebuild rereads each row's history and
+transaction fate. Removing it safely would require proving why both passes
+exist across all supported cases, not assuming the fixture covers them.
+
+Groove's `compute_table_deltas` constructs old/new record deltas, performs
+storage lookups except on proven-fresh inserts, and copies payloads into grouped
+weighted records. Query execution then processes many intermediate records and
+terminal/publication representations. These measured volumes support a thesis
+of amplification across representations and passes. They do not assign all
+remaining time to encoding or prove that a single fast path removes it.
+
+The next useful design question is how to install a large immutable batch and
+initialize maintained query state from it without repeatedly expanding the same
+records through the generic mutation/event machinery. No production change is
+part of this experiment.
+
+## Allocation budget (separate instrumented runs)
+
+With only allocation counting enabled, no phase tracing and no storage-budget
+wrapper, the all-memory engine requests **108,924,168 allocations/reallocations**
+and **27,676,205,024 bytes** through readiness. The reference requests a median
+**2,530,439 allocations/reallocations** and **362,597,278 bytes** for its measured
+Core query + two receiver ingest/query sequence. Both use the benchmark's
+mimalloc adapter underneath the counting wrapper.
+
+These are cumulative requested bytes (a reallocation charges its full requested
+new size), not resident memory, leaked memory, bytes necessarily copied, or an
+exact explanation of elapsed time. The reference omits engine responsibilities
+listed above. Nevertheless, cheap record access is compatible with a much
+smaller allocation workload on the same encoded data. Even this deliberately
+simple reference performs millions of allocations; it is not an optimized
+zero-allocation target.
+
+Verification also checks that an identity without membership receives no
+protected resource/child rows. Reproduction receipts, exact executable paths
+and logs are preserved locally under
+`/home/ubuntu/jazz-debug-evidence/permissioned-profile/slim-memory/`.
+Benchmark-only source is based on #2890 (`c4189ddba1`); measurements precede the
+experiment commit, so emitted Git metadata identifies that parent and a dirty
+tree. Instrumentation modes have separate executables and receipt files.


### PR DESCRIPTION
🤖 Adds two diagnostic tools to the native permissioned cold-load benchmark: storage work counters and a slim reference that retains the actual encoded versions, indexes row references, evaluates the fixture's permission graph and materializes every output field.

The final clean reference takes ~271 ms for Core queries plus actual captured payload decode/install and queries at Edge and Client. The unchanged all-memory Jazz comparison was 11.213 s. This is deliberately a workload-specific reference, not a protocol-equivalent replacement: it replays captured delivery sets and omits maintained subscriptions, transport encoding/compression, general history and runtime coordination. Full output IDs and fields match the independently exported fixture at all three nodes. An identity without membership produces no protected outputs.

The engine work budget is the main finding:
- Client's 27,518 rows cause 220,148 point reads, 110,270 scan requests and 334,739 KV set entries.
- Projection operators visit 2.09 million records across the topology and produce 799 MB of new encoded buffers.
- A separate run with allocation counting only (no tracing or storage wrapper) requests 109 million allocations/reallocations and 27.7 GB cumulatively. The reference requests 2.53 million and 363 MB. These are requested allocation volumes, not peak memory or memcpy totals.

The code walk connects this to multiple physical row forms/indexes, merge-head staging followed by persisted-history rebuilding, and repeated intermediate query/publication records. It does not yet establish which production simplification safely eliminates that work.

Production runtime behavior is unchanged. Full method, limits, tables and reproduction commands are in `dev/benchmarks/sql-proxy/SLIM_MEMORY.md`. Validation includes optimized reference runs, exact result/field assertions, permission sensitivity, complete all-memory diagnostic runs, benchmark compile smoke and formatting. No production optimization is proposed in this PR.
