### PR TITLE
Preserve live result edits across evaluation continuations

### DIFF
--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -880,6 +880,9 @@ impl IncrementalEvaluation<'_> {
                 }
                 Poll::Pending => {
                     self.work_queue.requeue_yielded(node);
+                    self.terminal_deltas = std::mem::take(&mut evaluator.terminal_deltas);
+                    self.root_ordering_windows =
+                        std::mem::take(&mut evaluator.root_ordering_windows);
                     drop(evaluator);
                     cx.waker().wake_by_ref();
                     return Poll::Pending;
@@ -902,6 +905,8 @@ impl IncrementalEvaluation<'_> {
             // Resident requests completed synchronously. Install their results
             // and resume the queue within this same public poll so resident
             // writes retain their same-tick visibility contract.
+            self.terminal_deltas = std::mem::take(&mut evaluator.terminal_deltas);
+            self.root_ordering_windows = std::mem::take(&mut evaluator.root_ordering_windows);
             drop(evaluator);
             return self.poll(runtime, cx);
         }


### PR DESCRIPTION
🤖 An incremental evaluation can finish one query’s result edits and then pause to hydrate data for another query. Two continuation paths moved those pending edits into a temporary evaluator and dropped them before resuming. This preserves terminal edits and root ordering windows on both paths.

For example, an empty database with several live queries ingests accepted rows in one batch. The group query should deliver its 38 new rows. In the synthetic performance fixture, seven subscriptions did so, but opening an eighth permissioned query made the group result remain empty even though its supporting rows arrived. With this change, all 39 subscriptions return their exact expected results for both 46,740- and 27,518-transaction captures.

This changes evaluation continuation bookkeeping, not storage or wire formats. The row bytes were present in the failing case; subsequent one-shot reads could find them.

**Draft:** the before/after failure is captured by the companion experimental harness. Three repeated full runs pass with this change. A focused public-API regression and broader verification are still required before this is ready; no independent review is claimed. See #2892. Based on #2891’s performance stack.
