### PR TITLE
Measure isolated history installation and active-query costs

### DIFF
--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -1,3 +1,5 @@
+#[path = "customer_cold_start/history_cost.rs"]
+mod history_cost;
 #[path = "customer_cold_start/slim_memory.rs"]
 mod slim_memory;
 #[path = "customer_cold_start/work_budget.rs"]
@@ -572,6 +574,10 @@ fn main() {
         "phase attribution enabled: compare elapsed time only with the same instrumentation; disable this feature for absolute latency"
     );
     let config = Config::from_env();
+    if let Some(path) = std::env::var_os("JAZZ_CUSTOMER_HISTORY_COST") {
+        history_cost::run(Path::new(&path));
+        return;
+    }
     if let Some(path) = std::env::var_os("JAZZ_CUSTOMER_SLIM_MEMORY") {
         slim_memory::run(Path::new(&path));
         return;

--- a/crates/jazz-sim/benches/customer_cold_start/history_cost.rs
+++ b/crates/jazz-sim/benches/customer_cold_start/history_cost.rs
@@ -1,0 +1,351 @@
+//! Isolate the real receiver bulk installer from subscription/query work.
+use super::*;
+use jazz::protocol::VersionBundle;
+use std::io::BufRead;
+
+fn hex(v: &JsonValue) -> Vec<u8> {
+    v.as_str()
+        .unwrap()
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|p| u8::from_str_radix(std::str::from_utf8(p).unwrap(), 16).unwrap())
+        .collect()
+}
+fn read(path: &Path) -> Vec<VersionBundle> {
+    let mut out = Vec::new();
+    for line in std::io::BufReader::new(fs::File::open(path).unwrap()).lines() {
+        let frame: JsonValue = serde_json::from_str(&line.unwrap()).unwrap();
+        for b in frame["bundles"].as_array().unwrap() {
+            out.push(VersionBundle {
+                tx: postcard::from_bytes(&hex(&b["tx_hex"])).unwrap(),
+                versions: b["versions"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|v| postcard::from_bytes(&hex(&v["wire_hex"])).unwrap())
+                    .collect(),
+                scope: serde_json::from_value(b["scope"].clone()).unwrap(),
+                fate: serde_json::from_value(b["fate"].clone()).unwrap(),
+                global_time: serde_json::from_value(b["global_time"].clone()).unwrap(),
+                durability: serde_json::from_value(b["durability"].clone()).unwrap(),
+            });
+        }
+    }
+    out
+}
+fn opts() -> ReadOpts {
+    ReadOpts {
+        propagation: jazz::db::Propagation::LocalOnly,
+        ..ReadOpts::default()
+    }
+}
+fn apply_complete_event(rows: &mut BTreeSet<RowUuid>, event: SubscriptionEvent) {
+    match event {
+        SubscriptionEvent::Delta {
+            reset,
+            added,
+            updated,
+            removed,
+            terminal_operations,
+            ..
+        } => {
+            if reset {
+                rows.clear();
+            }
+            for row in removed {
+                rows.remove(&row.row_uuid);
+            }
+            for row in added.into_iter().chain(updated) {
+                rows.insert(row.row.row_uuid());
+            }
+            for op in terminal_operations {
+                assert!(
+                    op.path.is_empty(),
+                    "fixture queries have no nested terminal paths"
+                );
+                match op.edit {
+                    jazz::groove::ivm::TerminalEdit::Insert { value, .. }
+                    | jazz::groove::ivm::TerminalEdit::Update { value, .. } => {
+                        let value = op.root_descriptor.bind(&value).get_idx(0).unwrap();
+                        let id = match value {
+                            Value::Uuid(id) => id,
+                            Value::Nullable(Some(v)) => match *v {
+                                Value::Uuid(id) => id,
+                                _ => panic!("root key must be UUID"),
+                            },
+                            _ => panic!("root key must be UUID"),
+                        };
+                        rows.insert(RowUuid(id));
+                    }
+                    jazz::groove::ivm::TerminalEdit::Move { .. } => {}
+                    jazz::groove::ivm::TerminalEdit::Remove { .. } => {
+                        panic!("append-only fixture unexpectedly removed a root")
+                    }
+                }
+            }
+        }
+        SubscriptionEvent::Rejected { reason } => panic!("rejected: {reason:?}"),
+        SubscriptionEvent::Closed => panic!("unexpected close"),
+    }
+}
+
+pub fn run(root: &Path) {
+    assert_ne!(
+        storage_mode(),
+        "rocks",
+        "use all-memory to isolate CPU work"
+    );
+    let fixture: JsonValue =
+        serde_json::from_reader(fs::File::open(root.join("fixture.json")).unwrap()).unwrap();
+    let author = AuthorSubject::for_test_uuid(build_seed_plan(&Config::from_env()).ordinary_user.0);
+    let mut expected = fixture["expected"]
+        .as_object()
+        .unwrap()
+        .iter()
+        .map(|(t, ids)| {
+            (
+                t.clone(),
+                ids.as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|id| RowUuid(uuid::Uuid::parse_str(id.as_str().unwrap()).unwrap()))
+                    .collect::<BTreeSet<_>>(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    if std::env::var_os("JAZZ_HISTORY_GROUP_ONLY").is_some() {
+        expected.retain(|t, _| t == "group");
+    }
+    let fixture_cells = fixture["writes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|w| {
+            (
+                (
+                    w["table"].as_str().unwrap().to_owned(),
+                    RowUuid(uuid::Uuid::parse_str(w["id"].as_str().unwrap()).unwrap()),
+                ),
+                &w["cells"],
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let table_schema = schema();
+    for dataset in ["core-edge", "edge-client"] {
+        let mut bundles = read(&root.join(format!("{dataset}.jsonl")));
+        if std::env::var_os("JAZZ_HISTORY_GROUP_ONLY").is_some()
+            && std::env::var_os("JAZZ_HISTORY_ALL_BUNDLES").is_none()
+        {
+            bundles.retain(|b| b.versions.iter().all(|v| v.table() == "group"));
+        }
+        let unique = bundles
+            .iter()
+            .map(|b| b.tx.tx_id)
+            .collect::<BTreeSet<_>>()
+            .len();
+        for round in 0..std::env::var("JAZZ_HISTORY_ROUNDS")
+            .ok()
+            .map(|v| v.parse::<u64>().unwrap())
+            .unwrap_or(3)
+        {
+            for active in [false, true] {
+                if active && std::env::var_os("JAZZ_HISTORY_NO_ACTIVE").is_some() {
+                    continue;
+                }
+                if !active && std::env::var_os("JAZZ_HISTORY_ACTIVE_ONLY").is_some() {
+                    continue;
+                }
+                let dir = Rc::new(tempfile::tempdir().unwrap());
+                let db = block_on(Db::open_history_complete(DbConfig {
+                    schema: schema(),
+                    storage: open_receiver_storage(dir.path(), &schema()),
+                    identity: DbIdentity {
+                        node: node(70 + round),
+                        author: AuthorSubject::SYSTEM,
+                    },
+                    id_source: None,
+                }))
+                .unwrap();
+                let receiver = DbNode { _dir: dir, db };
+                let mut streams = Vec::new();
+                let prepare = Instant::now();
+                if active {
+                    for table in expected.keys().take(
+                        std::env::var("JAZZ_HISTORY_QUERY_LIMIT")
+                            .ok()
+                            .map(|v| v.parse::<usize>().unwrap())
+                            .unwrap_or(usize::MAX),
+                    ) {
+                        let q = receiver
+                            .db
+                            .prepare_query(&Query::from(table.as_str()))
+                            .unwrap();
+                        let stream =
+                            block_on(receiver.db.subscribe_for_identity(&q, opts(), author))
+                                .unwrap();
+                        streams.push((table.clone(), stream, BTreeSet::new()));
+                    }
+                }
+                if active {
+                    let mut initial = BTreeSet::new();
+                    for _ in 0..16 {
+                        block_on(receiver.db.refresh_after_benchmark_ingest()).unwrap();
+                        for (table, stream, rows) in &mut streams {
+                            while let Some(event) = stream.try_next_event() {
+                                if matches!(&event, SubscriptionEvent::Delta { reset: true, .. }) {
+                                    initial.insert(table.clone());
+                                }
+                                apply_complete_event(rows, event);
+                                assert!(rows.is_empty());
+                            }
+                        }
+                        if initial.len() == streams.len() {
+                            break;
+                        }
+                    }
+                    assert_eq!(
+                        initial.len(),
+                        streams.len(),
+                        "empty subscriptions must be initialized before ingest"
+                    );
+                }
+                let subscription_setup_ms = prepare.elapsed().as_secs_f64() * 1000.;
+                alloc_metrics::reset_and_start();
+                work_budget::start();
+                let t = Instant::now();
+                let installed = block_on(
+                    receiver
+                        .db
+                        .ingest_captured_reset_bundles_for_benchmark(&bundles),
+                )
+                .unwrap();
+                let ingest_ms = t.elapsed().as_secs_f64() * 1000.;
+                let allocations = alloc_metrics::stop();
+                let budget = work_budget::stop();
+                assert_eq!(installed, unique);
+                if let Some(path) = std::env::var_os("JAZZ_CUSTOMER_WORK_BUDGET") {
+                    fs::write(
+                        format!(
+                            "{}.{}.{round}.{active}.json",
+                            Path::new(&path).display(),
+                            dataset
+                        ),
+                        serde_json::to_vec(&budget).unwrap(),
+                    )
+                    .unwrap();
+                }
+                let t = Instant::now();
+                if active {
+                    for _ in 0..16 {
+                        let refreshed =
+                            block_on(receiver.db.refresh_after_benchmark_ingest()).unwrap();
+                        let ticked = block_on(receiver.db.tick()).unwrap();
+                        if std::env::var_os("JAZZ_HISTORY_DEBUG").is_some() {
+                            eprintln!("HISTORY_REFRESH changed={refreshed} tick={ticked:?}");
+                        }
+                        for (table, stream, rows) in &mut streams {
+                            while let Some(event) = stream.try_next_event() {
+                                if table == "group"
+                                    && std::env::var_os("JAZZ_HISTORY_DEBUG").is_some()
+                                {
+                                    if let SubscriptionEvent::Delta {
+                                        reset,
+                                        added,
+                                        updated,
+                                        removed,
+                                        terminal_operations,
+                                        publishable,
+                                        settled,
+                                        ..
+                                    } = &event
+                                    {
+                                        eprintln!(
+                                            "HISTORY_GROUP reset={reset} add={} update={} remove={} terminal={} publishable={publishable} settled={settled}",
+                                            added.len(),
+                                            updated.len(),
+                                            removed.len(),
+                                            terminal_operations.len()
+                                        );
+                                    }
+                                }
+                                apply_complete_event(rows, event);
+                            }
+                        }
+                        if streams
+                            .iter()
+                            .all(|(table, _, rows)| rows == &expected[table])
+                        {
+                            break;
+                        }
+                    }
+                    for (table, _, rows) in &streams {
+                        assert_eq!(rows, &expected[table], "active {table}");
+                    }
+                }
+                let delivery_ms = t.elapsed().as_secs_f64() * 1000.;
+                // First one-shot over installed state, then a second pass, both
+                // include query preparation and materialization at the facade.
+                let mut query_ms = Vec::new();
+                for _ in 0..2 {
+                    let t = Instant::now();
+                    let mut results = Vec::new();
+                    for table in expected.keys().take(
+                        std::env::var("JAZZ_HISTORY_QUERY_LIMIT")
+                            .ok()
+                            .map(|v| v.parse::<usize>().unwrap())
+                            .unwrap_or(usize::MAX),
+                    ) {
+                        let q = receiver
+                            .db
+                            .prepare_query(&Query::from(table.as_str()))
+                            .unwrap();
+                        let rows =
+                            block_on(receiver.db.all_for_identity(&q, opts(), author)).unwrap();
+                        let columns = &table_schema
+                            .tables
+                            .iter()
+                            .find(|t| &t.name == table)
+                            .unwrap()
+                            .columns;
+                        let fields = rows
+                            .iter()
+                            .map(|row| {
+                                (0..columns.len())
+                                    .map(|i| row.cell_at(i).unwrap())
+                                    .collect::<Vec<_>>()
+                            })
+                            .collect::<Vec<_>>();
+                        std::hint::black_box(&fields);
+                        results.push((table, rows, fields));
+                    }
+                    query_ms.push(t.elapsed().as_secs_f64() * 1000.);
+                    for (table, rows, fields) in results {
+                        let columns = &table_schema
+                            .tables
+                            .iter()
+                            .find(|t| &t.name == table)
+                            .unwrap()
+                            .columns;
+                        for (row, fields) in rows.iter().zip(fields) {
+                            for (column, value) in columns.iter().zip(fields) {
+                                assert_eq!(
+                                    serde_json::to_value(value).unwrap(),
+                                    fixture_cells[&(table.clone(), row.row_uuid())][column.name()]
+                                );
+                            }
+                        }
+                        assert_eq!(
+                            rows.iter().map(|r| r.row_uuid()).collect::<BTreeSet<_>>(),
+                            expected[table],
+                            "one-shot {table}"
+                        );
+                    }
+                }
+                println!(
+                    "{}",
+                    json!({"dataset":dataset,"round":round,"active":active,"unique_transactions":unique,"ingest_ms":ingest_ms,"subscription_setup_ms":subscription_setup_ms,"delivery_ms":delivery_ms,"query_ms":query_ms,"ingest_allocations":allocations.allocs,"ingest_allocation_bytes":allocations.bytes})
+                );
+            }
+        }
+    }
+}

--- a/crates/jazz-sim/benches/customer_cold_start/slim_memory.rs
+++ b/crates/jazz-sim/benches/customer_cold_start/slim_memory.rs
@@ -3,12 +3,14 @@ use super::*;
 use std::io::BufRead;
 use uuid::Uuid;
 
-type Encoded = Vec<(Vec<u8>, Vec<u8>)>;
+type Encoded = Vec<(Vec<u8>, Vec<u8>, jazz::tx::Fate)>;
 struct Store {
     rows: Vec<jazz::protocol::VersionRecord>,
     tables: BTreeMap<String, Vec<usize>>,
     keys: BTreeMap<(String, Uuid), usize>,
     transactions: Vec<Vec<u8>>,
+    history: BTreeMap<(String, Uuid, jazz::tx::TxId), usize>,
+    fates: BTreeMap<jazz::tx::TxId, jazz::tx::Fate>,
 }
 fn hex(value: &JsonValue) -> Vec<u8> {
     value
@@ -28,33 +30,72 @@ fn read(path: &Path) -> Encoded {
             assert_eq!(b["fate"], "Accepted");
             assert_eq!(b["versions"].as_array().unwrap().len(), 1);
             assert_eq!(b["versions"][0]["parents"], json!([]));
-            result.push((hex(&b["tx_hex"]), hex(&b["versions"][0]["wire_hex"])));
+            result.push((
+                hex(&b["tx_hex"]),
+                hex(&b["versions"][0]["wire_hex"]),
+                serde_json::from_value(b["fate"].clone()).unwrap(),
+            ));
         }
     }
     result
 }
 impl Store {
     fn ingest(input: &Encoded) -> Self {
+        let history_mode = std::env::var_os("JAZZ_SLIM_HISTORY").is_some();
         let mut s = Self {
             rows: Vec::new(),
             tables: BTreeMap::new(),
             keys: BTreeMap::new(),
             transactions: Vec::new(),
+            history: BTreeMap::new(),
+            fates: BTreeMap::new(),
         };
-        for (tx, bytes) in input {
-            let _: jazz::tx::Transaction = postcard::from_bytes(tx).unwrap();
+        let mut tx_ids = Vec::<jazz::tx::TxId>::new();
+        for (tx, bytes, fate) in input {
+            let decoded: jazz::tx::Transaction = postcard::from_bytes(tx).unwrap();
             let row: jazz::protocol::VersionRecord = postcard::from_bytes(bytes).unwrap();
             let key = (row.table().to_owned(), row.row_uuid().0);
-            if let Some(&i) = s.keys.get(&key) {
+            if history_mode {
+                // Explicit shallow-history contract; never silently approximate
+                // ancestor/deletion/exclusive semantics with timestamp ordering.
+                assert_eq!(decoded.kind, jazz::tx::TxKind::Mergeable);
+                assert!(row.parents().is_empty());
+                assert!(row.deletion().is_none());
+                if let Some(previous) = s.fates.insert(decoded.tx_id, fate.clone()) {
+                    assert_eq!(previous, *fate);
+                }
+                let history_key = (key.0.clone(), key.1, decoded.tx_id);
+                if let Some(&i) = s.history.get(&history_key) {
+                    assert_eq!(s.rows[i], row);
+                    assert_eq!(s.transactions[i], *tx);
+                    continue;
+                }
+                let i = s.rows.len();
+                s.history.insert(history_key, i);
+                if s.fates[&decoded.tx_id] == jazz::tx::Fate::Accepted {
+                    let wins = s.keys.get(&key).is_none_or(|&old| {
+                        decoded.tx_id.time.sort_key(decoded.tx_id.node)
+                            > tx_ids[old].time.sort_key(tx_ids[old].node)
+                    });
+                    if wins {
+                        s.keys.insert(key, i);
+                    }
+                }
+                tx_ids.push(decoded.tx_id);
+                s.rows.push(row);
+                s.transactions.push(tx.clone());
+            } else if let Some(&i) = s.keys.get(&key) {
                 assert_eq!(s.rows[i], row);
                 assert_eq!(s.transactions[i], *tx);
             } else {
                 let i = s.rows.len();
-                s.tables.entry(key.0.clone()).or_default().push(i);
                 s.keys.insert(key, i);
                 s.rows.push(row);
                 s.transactions.push(tx.clone());
             }
+        }
+        for ((table, _), &i) in &s.keys {
+            s.tables.entry(table.clone()).or_default().push(i);
         }
         s
     }
@@ -274,6 +315,16 @@ pub fn run(root: &Path) {
     let plan = Plan::new(&fixture);
     let ce = read(&root.join("core-edge.jsonl"));
     let ec = read(&root.join("edge-client.jsonl"));
+    if std::env::var_os("JAZZ_SLIM_HISTORY").is_some() {
+        let mut pending = vec![ce[0].clone()];
+        pending[0].2 = jazz::tx::Fate::Pending;
+        let probe = Store::ingest(&pending);
+        assert_eq!(probe.history.len(), 1);
+        assert!(
+            probe.keys.is_empty(),
+            "pending history must not become accepted current state"
+        );
+    }
     let core = Store::ingest(&ce); // preexisting Core state, outside load timing
     // Sensitivity: a principal with no membership must not receive protected
     // resource or child outputs. This would fail if the permission filter were
@@ -316,7 +367,7 @@ pub fn run(root: &Path) {
         plan.verify(&client, &client_result.0, &fixture);
         println!(
             "{}",
-            json!({"round":round,"allocation_requests":allocations.allocs,"allocation_bytes":allocations.bytes,"total_ms":total_ms,"core_query_ms":core_ms,"edge_ingest_ms":edge_ingest_ms,"edge_query_ms":edge_query_ms,"client_ingest_ms":client_ingest_ms,"client_query_ms":client_query_ms,"unique_rows":[core.rows.len(),edge.rows.len(),client.rows.len()],"operator_row_visits":[core_result.2,edge_result.2,client_result.2],"support_memberships":[core_result.1,edge_result.1,client_result.1],"output_fields":[core_result.3,edge_result.3,client_result.3]})
+            json!({"history_mode":std::env::var_os("JAZZ_SLIM_HISTORY").is_some(),"history_entries":[core.history.len(),edge.history.len(),client.history.len()],"fate_entries":[core.fates.len(),edge.fates.len(),client.fates.len()],"round":round,"allocation_requests":allocations.allocs,"allocation_bytes":allocations.bytes,"total_ms":total_ms,"core_query_ms":core_ms,"edge_ingest_ms":edge_ingest_ms,"edge_query_ms":edge_query_ms,"client_ingest_ms":client_ingest_ms,"client_query_ms":client_query_ms,"unique_rows":[core.rows.len(),edge.rows.len(),client.rows.len()],"operator_row_visits":[core_result.2,edge_result.2,client_result.2],"support_memberships":[core_result.1,edge_result.1,client_result.1],"output_fields":[core_result.3,edge_result.3,client_result.3]})
         );
     }
 }

--- a/crates/jazz/src/db.rs
+++ b/crates/jazz/src/db.rs
@@ -2633,6 +2633,28 @@ impl<S> Db<S>
 where
     S: OrderedKvStorage + ReopenableStorage + 'static,
 {
+    /// Testing-only direct bulk installer; excludes connection admission and
+    /// scope receipts for isolated benchmark measurements.
+    #[cfg(feature = "testing")]
+    pub async fn ingest_captured_reset_bundles_for_benchmark(
+        &self,
+        bundles: &[crate::protocol::VersionBundle],
+    ) -> Result<usize, Error> {
+        Ok(self
+            .node
+            .node()
+            .lock()
+            .await
+            .ingest_captured_reset_bundles_for_benchmark(bundles)
+            .await?)
+    }
+
+    /// Complete the ordinary facade refresh after direct benchmark ingestion.
+    #[cfg(feature = "testing")]
+    pub async fn refresh_after_benchmark_ingest(&self) -> Result<usize, Error> {
+        self.refresh_subscriptions().await
+    }
+
     /// Reserve local transaction-clock positions through `high_water` before a
     /// trusted native foreground host reuses a node identity.
     pub async fn reserve_minted_tx_time_after(&self, high_water: TxTime) -> Result<(), Error> {

--- a/crates/jazz/src/node/ingest/commit_bundles.rs
+++ b/crates/jazz/src/node/ingest/commit_bundles.rs
@@ -2,6 +2,24 @@ impl<S> NodeState<S>
 where
     S: OrderedKvStorage,
 {
+    /// Benchmark-only entry to the ordinary reset-bundle bulk ingestion path.
+    /// Inputs are predecoded trusted captures; this deliberately omits wire
+    /// admission and subscription scope bookkeeping to isolate installation.
+    #[cfg(feature = "testing")]
+    pub async fn ingest_captured_reset_bundles_for_benchmark(
+        &mut self,
+        bundles: &[crate::protocol::VersionBundle],
+    ) -> Result<usize, Error> {
+        let refs = bundles
+            .iter()
+            .map(crate::protocol::VersionBundle::as_ref)
+            .collect::<Vec<_>>();
+        Ok(self
+            .ingest_reset_view_bundle_refs_in_bulk(&refs, None)
+            .await?
+            .len())
+    }
+
     /// Ingest a commit unit as fate authority.
     pub async fn ingest_commit_unit(
         &mut self,

--- a/crates/jazz/src/node/ingest/commit_bundles.rs
+++ b/crates/jazz/src/node/ingest/commit_bundles.rs
@@ -1401,8 +1401,16 @@ where
         let applied = self.database.apply_batch(batch).await?;
         let persisted = applied.persist().await;
         self.database.finish_persistence(persisted)?;
-        self.rebuild_merge_heads_after_history_commit(&content_rows)
-            .await?;
+        // Counterfactual benchmark only: price the post-write history reread.
+        // This is not a supported ingestion mode or a proof of redundancy.
+        #[cfg(feature = "testing")]
+        let skip_head_rebuild = std::env::var_os("JAZZ_HISTORY_SKIP_HEAD_REBUILD").is_some();
+        #[cfg(not(feature = "testing"))]
+        let skip_head_rebuild = false;
+        if !skip_head_rebuild {
+            self.rebuild_merge_heads_after_history_commit(&content_rows)
+                .await?;
+        }
         if let Some(tx_time) = loaded_tx_ids.iter().map(|tx_id| tx_id.time).max() {
             self.persist_storage_consistency_marker_through(tx_time).await?;
         }

--- a/crates/jazz/src/node/query_eval/maintained_views.rs
+++ b/crates/jazz/src/node/query_eval/maintained_views.rs
@@ -1093,6 +1093,16 @@ where
             match local.subscription.try_recv() {
                 Ok(deltas) => {
                     local.initial_received = true;
+                    #[cfg(feature = "testing")]
+                    if local.result_table == "group"
+                        && std::env::var_os("JAZZ_HISTORY_DEBUG").is_some()
+                    {
+                        eprintln!(
+                            "HISTORY_GROUP_RUNTIME sinks={} terminal_sinks={}",
+                            deltas.sinks.len(),
+                            deltas.terminal_sinks.len()
+                        );
+                    }
                     if std::env::var_os("JAZZ_COVERED_INPUT_TRACE").is_some() {
                         eprintln!(
                             "JAZZ_COVERED_INPUT_TRACE stage=drain sinks={} terminals={}",

--- a/dev/benchmarks/sql-proxy/HISTORY_COST.md
+++ b/dev/benchmarks/sql-proxy/HISTORY_COST.md
@@ -1,0 +1,86 @@
+# Separating history installation from maintained query work
+
+This follow-up to SLIM_MEMORY.md isolates the ordinary Jazz reset-bundle bulk
+installer from transport, scope receipts and upstream query serving.
+
+## Engine control
+
+Set `JAZZ_CUSTOMER_HISTORY_COST` to the capture/fixture directory and
+`JAZZ_CUSTOMER_STORAGE=all-memory`. Captures are decoded before timing. For each
+of the two actual delivered datasets, create a fresh history-complete local
+Db, then compare:
+
+- No application subscriptions: install all bundles; query all 39 tables twice.
+- Active application subscriptions: initialize the 39 permissioned queries on
+  the empty database, install the same bundles, refresh and drain their results,
+  then query all 39 tables twice.
+
+Report subscription setup, bulk installation, result refresh/delivery and each
+one-shot pass separately. One-shot timings include preparation and materializing
+all application fields. Output IDs and fields are checked against the exported
+fixture after timing. Active streams must return the exact expected ID sets.
+The main installer is invoked through narrow `testing`-feature helpers; its
+production implementation is unchanged. Explicit facade refresh replaces the
+refresh normally invoked by inbound sync handling.
+
+The receiver is history-complete for this controlled local experiment, avoiding
+transport/authority-scope dependencies. The two dataset labels identify captured
+payloads (46,740 and 27,518 unique transactions); they are not claims that this
+control reproduces every behavior of a production Edge or Client. The smaller
+capture is treated as a closed fixture for these queries.
+
+The active case initially exposed #2892: pending terminal edits were lost on two
+evaluation continuation paths. Seven subscriptions passed; adding the eighth
+lost the group result. Preserving terminal edits and root ordering windows across
+those paths makes all 39 subscriptions pass for both datasets, in three rounds.
+These measurements include that candidate fix. It requires a focused regression
+and broader verification before release.
+
+## Engine result
+
+Optimized native, memory storage, three paired rounds in one process. Medians in
+milliseconds; these are controlled phase measurements, not a browser prediction.
+
+| Captured dataset    | Active queries | Setup | Install | Refresh/delivery | First read pass | Second read pass |
+| ------------------- | -------------: | ----: | ------: | ---------------: | --------------: | ---------------: |
+| 46,740 transactions |             No |     0 |   1,707 |                0 |           1,433 |            3,293 |
+| 46,740 transactions |            Yes | 1,002 |   3,414 |              624 |             717 |              706 |
+| 27,518 transactions |             No |     0 |   1,077 |                0 |           1,005 |            1,937 |
+| 27,518 transactions |            Yes | 1,015 |   2,414 |              610 |             547 |              522 |
+
+The larger no-active install ranged 1,583–1,807 ms; active install 3,244–3,540 ms.
+Do not interpret small differences as established wins. Active setup is on an
+empty database. Installer time includes ordinary internal table/index maintenance
+and any retained-query work it drives; it is not exclusively history logic.
+Refresh/delivery is additional facade work after installation.
+
+This rejects a history-only explanation of the overhead: installation without
+application queries remains substantial, but maintained query work roughly doubles
+installation time and adds delivery work. Reads also remain costly. The slower
+second unretained one-shot pass is an unresolved observation, not evidence of a
+beneficial warm cache. Active retained queries make subsequent reads cheaper, but
+paid setup and incremental-maintenance costs must remain in the accounting.
+
+## Reference control
+
+`JAZZ_SLIM_HISTORY=1` adds a separate per-row/per-transaction history index,
+transaction-fate map and current-winner selection to the slim reference. It
+reads fate metadata from the capture, retains history independently of the
+current map and selects accepted candidates using transaction ordering.
+An untimed sensitivity check changes one transaction to Pending: its history
+entry must remain present while its accepted-current entry is absent.
+
+The reference explicitly rejects non-mergeable transactions, parents and
+deletions. It is a shallow-history control, not a general merge algorithm.
+All actual fixture versions are accepted and have no parents. Both modes retain
+actual encoded version records and transaction bytes, and evaluate identical
+permissioned queries with full output validation.
+
+## Reference result
+
+Three clean optimized rounds on the same source: flat median **269.019 ms**;
+explicit-history median **306.623 ms**. Edge-sized decode/install rises from
+112.651 to 136.761 ms; Client-sized decode/install from 66.403 to 79.571 ms.
+Query times remain roughly 30 ms per node. The reference adds approximately
+38 ms total for its explicit shallow-history bookkeeping. This does not price
+Jazz's general semantics or prove they can be replaced by this reference.

--- a/dev/benchmarks/sql-proxy/HISTORY_COST.md
+++ b/dev/benchmarks/sql-proxy/HISTORY_COST.md
@@ -84,3 +84,19 @@ explicit-history median **306.623 ms**. Edge-sized decode/install rises from
 Query times remain roughly 30 ms per node. The reference adds approximately
 38 ms total for its explicit shallow-history bookkeeping. This does not price
 Jazz's general semantics or prove they can be replaced by this reference.
+
+## Counterfactual: omit post-write merge-head rebuilding
+
+A `testing`-only flag, `JAZZ_HISTORY_SKIP_HEAD_REBUILD=1`, deliberately skips the
+post-write history reread. This is not a supported mode and does not prove it is
+safe to remove: #2883 explains the partial/out-of-order history obligations.
+The changed experiment premise is a fresh memory receiver without application
+subscriptions, rather than the earlier full-topology phase instrumentation.
+
+Six fresh processes in baseline/skip/skip/baseline/baseline/skip order all passed
+the shallow fixture's output checks. The median sum of the two measured install
+phases was 2,587 ms baseline versus 2,434 ms skipped (~6%). Individual sums ranged
+2,565–2,902 ms versus 2,179–2,458 ms, so the effect is noisy. Client-sized install
+medians were 992 versus 845 ms; Core-sized medians 1,595 versus 1,589 ms. Do not
+claim a precise universal speedup from this small experiment. Even this deliberate
+omission leaves seconds of installer work; it is not the structural unlock.

--- a/dev/benchmarks/sql-proxy/RESEARCH_SYNTHESIS.md
+++ b/dev/benchmarks/sql-proxy/RESEARCH_SYNTHESIS.md
@@ -1,0 +1,130 @@
+# Cold-load cost synthesis
+
+This report combines the synthetic SQL references (#2888/#2889), unchanged-engine
+memory topology (#2890), slim encoded-memory reference and work budgets (#2891),
+and isolated installation/read controls (#2894). It is a research result, not a
+claim that a replacement engine or release-ready optimization has been built.
+
+## Main conclusion
+
+Shallow history is inexpensive in the reference, but Jazz's implementation pays
+substantial costs both installing that history and evaluating/maintaining queries.
+The evidence does not support attributing the entire gap to history, durability,
+encoding, or any other single mechanism. Our strongest larger opportunity is to
+reduce how much maintained relational machinery a snapshot load invokes, while
+preserving the same permission and history semantics.
+
+## What was compared
+
+All workloads use anonymized relationships and permissions, 46,740 physical rows,
+39 queries and 27,518 visible output rows. The histories contain one accepted
+version per row and no parents. This deliberately prices shallow-history overhead;
+it does not price arbitrary conflict resolution or long ancestry chains.
+
+| Experiment                                              | Measured time | What it establishes                                                                       |
+| ------------------------------------------------------- | ------------: | ----------------------------------------------------------------------------------------- |
+| SQLite current-row queries                              |        ~31 ms | A specialized relational read floor; not sync                                             |
+| SQLite history queries                                  |        ~75 ms | Shallow history need not make reads intrinsically expensive                               |
+| PostgreSQL history queries                              |        ~57 ms | Same direction with another mature engine                                                 |
+| SQLite durable Core→Edge→Client proxy                   |        2.84 s | Real payload persistence, indexes and query work substantially raise the read-only cost   |
+| PostgreSQL durable topology proxy                       |        4.84 s | Engine choice/workload implementation matters; not a universal sync tax                   |
+| Actual Jazz, RocksDB everywhere                         |       12.65 s | Full existing native topology                                                             |
+| Actual Jazz, memory receivers                           |       11.51 s | Removing receiver disk persistence alone saves ~9%                                        |
+| Actual Jazz, memory everywhere                          |       11.21 s | ~11% improvement; generic storage/ingestion work remains                                  |
+| Slim encoded-memory topology reference                  |        269 ms | Specialized relationships and real encoded payloads, without general maintained execution |
+| Slim plus explicit shallow history/fate/current indexes |        307 ms | Adds ~38 ms; still not general Jazz merge semantics                                       |
+
+These are different controlled experiments with documented boundaries, not one
+perfectly interchangeable leaderboard. SQL query-only numbers exclude loading;
+SQL sync proxies include ingestion and statistics preparation. The slim proxy
+omits the full wire/receipt lifecycle and arbitrary maintained graphs. Exact IDs,
+application fields, payloads and the applicable permission checks are verified.
+See RESULTS.md, SYNC_RESULTS.md, MEMORY.md, SLIM_MEMORY.md and HISTORY_COST.md.
+
+## Separating installation from queries
+
+For 46,740 captured transactions, a fresh memory-backed Jazz receiver installs in
+1.71 s without application subscriptions. A first permissioned read pass then
+costs 1.43 s. With 39 subscriptions initialized on the empty receiver, installation
+costs 3.41 s and delivery another 0.62 s; initialization itself costs 1.00 s.
+Subsequent reads against those retained queries cost ~0.71 s. The smaller capture
+shows the same direction. These phase controls exclude wire admission and scope
+bookkeeping and use a history-complete receiver; do not add them as a prediction
+of production topology latency.
+
+The second unretained read pass is slower (~3.29 s). A profile/code walk found
+`flush_pending_binding_retractions`: a later snapshot may first propagate removal
+of a previous temporary query binding through the maintained graph. This is a
+concrete investigation lead, not yet an isolated explanation of the full slowdown.
+Stack truncation/async inlining means ancestor-selected sample percentages must
+not be presented as complete wall-clock phase shares.
+
+The active control also exposed a correctness bug (#2892/#2893). Two incremental
+evaluation continuation paths dropped pending terminal edits/order windows. Seven
+subscriptions passed, an eighth caused missing group output; preserving that state
+made all 39 pass on both datasets for three repetitions. The fix remains a draft
+pending a focused public-API regression and broader verification.
+
+## Work amplification
+
+The full engine requested ~109 million allocations/reallocations and 27.7 GB of
+cumulative allocation bytes, versus ~2.53 million and 363 MB in the earlier slim
+reference. These are churn counters, not peak memory or bytes copied.
+
+Only 83 storage batches were observed across receivers, with one main bulk install
+each. Nevertheless, the Client-sized ingest generated ~335,000 KV sets for 27,518
+rows: ~141,000 index writes, ~111,000 metadata writes and ~27,500 each for history,
+current and change records. The three nodes processed ~2.09 million projection
+inputs and requested ~799 MB of new projection output bytes. Client-side right
+join inputs exceeded 1.13 million. Batching is already present; reducing the amount
+of work inside a batch matters more than merely grouping API calls.
+
+In the isolated installer profile, ancestor-selected samples include ~35.5% batch
+application, ~19.6% persistence and ~11.1% persisted-history head recomputation.
+Nested functions overlap; these percentages are diagnostic, not independent costs
+to sum or a complete allocation of wall time. Even memory persistence includes
+owned-key/value manipulation, layout dispatch and B-tree operations.
+
+A deliberately incomplete counterfactual omitted the post-write head rebuild on
+fresh receivers. The median sum of both install phases fell from 2.587 s to 2.434 s
+in six rotated fresh processes (~6%, noisy). All shallow output checks still passed;
+this does not validate merge-head semantics for general history. Removing this
+entire pass plainly does not close most of the gap. See HISTORY_COST.md for ranges.
+
+## Derived theses and estimated effort
+
+Effort estimates below are engineering estimates for one focused engineer, not
+measured delivery promises. They exclude unrelated release work.
+
+| Direction                                                                             | Why it is plausible / likely bound                                                                                                                                                                                | Next decisive test                                                                                                                           | Estimated effort                                                                        |
+| ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Carry proven fresh-install facts through history/head maintenance                     | Avoid repeated lookup and decoding of data just inserted. Existing full-topology attribution priced post-write head rebuilding at ~0.50 s, so this alone cannot produce a multi-fold speedup.                     | Counterfactual omission, then equivalence tests for existing history, partial ancestry, fate changes and duplicates.                         | 1–2 days experiment; 3–7 days safe implementation/tests if the invariant is expressible |
+| Reduce generic index/metadata write amplification                                     | Hundreds of thousands of KV operations remain despite very few physical batches. Avoid construction/copying of unnecessary keys and values before reaching the backend.                                           | Per-family ablation and allocation attribution, preserving reopen/current/history and exact-match conflict checks.                           | 2–4 days diagnosis; 1–2 weeks for a bounded redesign                                    |
+| Make temporary query bindings cheap to dispose                                        | A read should not routinely pay a second relational evaluation merely to remove its own private parameters. Sharing with live bindings makes naive deletion unsafe.                                               | Compare snapshot-only queries with scoped binding state and explicit cleanup timing; verify other subscribers are unaffected.                | 2–3 days prototype; 1–2 weeks implementation and lifecycle tests                        |
+| Give snapshot execution a bulk path, retaining delta machinery for actual changes     | Most of this fixture is first hydration. The slim/SQL references show a large gap without changing shallow-history or permission outputs.                                                                         | Same lowered graph/operators, transient snapshot state versus fully arranged hydration; preserve complete support/negative-evidence outputs. | 3–5 days prototype; 2–4 weeks to integrate if successful                                |
+| Keep immutable encoded rows once and make internal relations carry compact references | Large intermediate volume, allocation churn and repeated metadata fanout remain. This differs from rejected universal reference counting (#2848): only long-lived/shared carriers should pay ownership machinery. | Account exact retained copies and replace one high-amplification carrier; measure full wall time, not allocations alone.                     | 3–5 days prototype; 2–4 weeks depending on lifetime and storage boundaries              |
+| Separate query-output materialization from authorization/support bookkeeping          | Full support closure may be needed, but repeated author/schema/version reconstruction and wide relational carriers are implementation choices.                                                                    | Attribute repeated metadata rows to specific lowered operators; prove output and supporting-version equivalence.                             | 2–4 days attribution; 1–3 weeks bounded lowering changes                                |
+| Delay downstream durability / use memory-first cache persistence                      | Architecturally coherent for resyncable data, but unchanged-engine memory comparison saved only ~9–11%. It is not the leading speed thesis now.                                                                   | Revisit only after CPU/write amplification falls; separately test local unsynced edits and crash recovery.                                   | 1 week prototype; several weeks production scheduling/recovery design                   |
+
+The first two are bounded incremental work. The middle directions attack execution
+and representation, where multi-fold improvement is plausible but unproven. None
+requires separate Core versus Client query semantics: a shared engine can choose
+snapshot or incremental execution based on operation lifetime and available state.
+Durability is an orthogonal role-dependent policy, not a reason to fork evaluators.
+
+## Recommended order
+
+First finish the continuation correctness regression. Then isolate temporary
+binding cleanup and the Client's metadata join fanout before changing another
+projection implementation. In parallel conceptually (not additional agents), design
+a bulk snapshot path using the same operators and exact supporting-row contract.
+Use fresh-process rotated timings, allocation/work budgets and the 27,518-row
+oracle to decide whether either deserves integration. Small head/index improvements
+are useful, but should not displace the larger execution experiment merely because
+they are easier to implement.
+
+No evidence currently justifies weakening permissions, dropping required witnesses,
+or removing history semantics to meet the cold-load target. The references suggest
+there is substantial implementation headroom first. A sub-second full topology is
+not established by any of these controls; the specialized reference is a direction
+and lower comparison point, not a promised Jazz result.


### PR DESCRIPTION
🤖 Separate history installation from query work using the same captured synthetic row versions as #2891.

The experiment compares fresh memory-backed databases with no application subscriptions against the same installation with all 39 permissioned queries already open. It measures setup, installation, refresh/delivery and two subsequent read passes separately; IDs and all application fields are verified. A companion slim-reference mode explicitly retains shallow history, transaction fates and current winners.

For 46,740 transactions, median installation is 1.71s without application subscriptions and 3.41s with them, plus 0.62s refresh/delivery. First reads over installed state cost 1.43s without retained queries versus 0.72s with them. The reference’s explicit shallow-history bookkeeping raises its total from 269ms to 307ms. These native controls support multiple sources of overhead, not a history-only explanation.

The active control exposed #2892; this PR is based on its draft candidate #2893. Three complete paired rounds pass with that fix. The experimental direct entry points require `testing`; transport admission and scope bookkeeping are deliberately excluded. The fixture has accepted, parentless, single-version histories, so this does not measure general conflict resolution. See `dev/benchmarks/sql-proxy/HISTORY_COST.md` for boundaries and full results.

Draft research artifact. Optimized benchmark compilation/execution and pre-commit clippy passed; this is not full CI-equivalent verification. Further profiling and alternate-approach experiments remain in progress.


The final research synthesis, including evidence boundaries, incremental and larger design theses, and estimated effort, is [RESEARCH_SYNTHESIS.md](https://github.com/garden-co/jazz/blob/ce21ea7ad5/dev/benchmarks/sql-proxy/RESEARCH_SYNTHESIS.md). A testing-only counterfactual that omits post-write head rebuilding reduced the median sum of both install phases by ~6%, with substantial variation; it is explicitly not a supported ingestion mode or a proof that the work is redundant. Temporary-binding cleanup is tracked in #2895; the correctness finding remains #2892/#2893. The focused benchmark compile gate passed on the final source tree.
