### PR TITLE
Trial prepared physical field accessors in Groove projections

### DIFF
--- a/crates/groove/src/records/mod.rs
+++ b/crates/groove/src/records/mod.rs
@@ -743,11 +743,132 @@ pub(crate) enum RawProjectionField {
     },
 }
 
+/// Physical access constants resolved once, rather than for every projected row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PreparedFieldAccessor {
+    minimum_len: usize,
+    exact_len: bool,
+    start: PreparedFieldOffset,
+    end: PreparedFieldOffset,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PreparedFieldOffset {
+    Constant(usize),
+    Slot(usize),
+    RecordEnd,
+}
+
+impl PreparedFieldOffset {
+    fn read(&self, record: &[u8]) -> Result<usize, Error> {
+        match *self {
+            Self::Constant(offset) => Ok(offset),
+            Self::Slot(slot) => Ok(read_u32_at(record, slot)? as usize),
+            Self::RecordEnd => Ok(record.len()),
+        }
+    }
+}
+
+impl PreparedFieldAccessor {
+    fn new(source: &RecordDescriptor, index: usize) -> Result<Self, Error> {
+        let layout = source
+            .layout
+            .fields
+            .get(index)
+            .ok_or(Error::FieldIndexOutOfBounds {
+                index,
+                len: source.fields.len(),
+            })?;
+        let fixed = source.fixed_size();
+        let count = source.variable_count();
+        let minimum_len = checked_add(fixed, count.saturating_sub(1) * 4)?;
+        let (start, end) = match *layout {
+            FieldLayout::Static { offset, width } => (
+                PreparedFieldOffset::Constant(offset),
+                PreparedFieldOffset::Constant(checked_add(offset, width)?),
+            ),
+            FieldLayout::Variable { variable_idx } => (
+                if variable_idx == 0 {
+                    PreparedFieldOffset::Constant(minimum_len)
+                } else {
+                    PreparedFieldOffset::Slot(fixed + (variable_idx - 1) * 4)
+                },
+                if variable_idx + 1 == count {
+                    PreparedFieldOffset::RecordEnd
+                } else {
+                    PreparedFieldOffset::Slot(fixed + variable_idx * 4)
+                },
+            ),
+        };
+        Ok(Self {
+            minimum_len,
+            exact_len: count == 0,
+            start,
+            end,
+        })
+    }
+
+    fn span(&self, record: &[u8]) -> Result<std::ops::Range<usize>, Error> {
+        if record.len() < self.minimum_len {
+            return Err(Error::UnexpectedEof);
+        }
+        if self.exact_len && record.len() != self.minimum_len {
+            return Err(Error::InvalidOffset);
+        }
+        let start = self.start.read(record)?;
+        let end = self.end.read(record)?;
+        if end < start || end > record.len() {
+            return Err(Error::InvalidOffset);
+        }
+        // A variable field must not point into the header or fixed-width fields.
+        if !matches!(self.end, PreparedFieldOffset::Constant(_)) && start < self.minimum_len {
+            return Err(Error::InvalidOffset);
+        }
+        Ok(start..end)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PreparedProjectionField {
+    Copy(PreparedFieldAccessor),
+    WrapNullable(PreparedFieldAccessor),
+    Nested(Vec<PreparedFieldAccessor>),
+    Encoded(Vec<u8>),
+    Evaluate,
+    Error(Error),
+}
+
+impl PreparedProjectionField {
+    fn new(source: &RecordDescriptor, field: RawProjectionField) -> Self {
+        match field {
+            RawProjectionField::Copy { source_idx } => {
+                PreparedFieldAccessor::new(source, source_idx)
+                    .map(Self::Copy)
+                    .unwrap_or_else(Self::Error)
+            }
+            RawProjectionField::WrapNullable { source_idx } => {
+                PreparedFieldAccessor::new(source, source_idx)
+                    .map(Self::WrapNullable)
+                    .unwrap_or_else(Self::Error)
+            }
+            RawProjectionField::Nested { path } => path
+                .iter()
+                .map(|(descriptor, index)| PreparedFieldAccessor::new(descriptor, *index))
+                .collect::<Result<Vec<_>, _>>()
+                .map(Self::Nested)
+                .unwrap_or_else(Self::Error),
+            RawProjectionField::Encoded { bytes } => Self::Encoded(bytes),
+            RawProjectionField::Evaluate => Self::Evaluate,
+            RawProjectionField::Error(error) => Self::Error(error),
+        }
+    }
+}
+
 /// Field plan with a once-proven byte-preserving case. Names and logical
 /// identities may differ; every physical field must occupy the same slot.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct PreparedProjection {
-    pub(crate) fields: Vec<RawProjectionField>,
+    pub(crate) fields: Vec<PreparedProjectionField>,
     pub(crate) reuses_input: bool,
 }
 
@@ -771,7 +892,10 @@ impl PreparedProjection {
                 })
             });
         Self {
-            fields,
+            fields: fields
+                .into_iter()
+                .map(|field| PreparedProjectionField::new(&source, field))
+                .collect(),
             reuses_input,
         }
     }
@@ -931,7 +1055,7 @@ impl RecordDescriptor {
         &self,
         source: &RecordDescriptor,
         source_record: &[u8],
-        fields: &[RawProjectionField],
+        fields: &[PreparedProjectionField],
         output: &mut BytesMut,
         mut evaluate: impl FnMut(usize, &mut BytesMut) -> Result<(), E>,
     ) -> Result<std::ops::Range<usize>, E> {
@@ -1130,31 +1254,31 @@ impl RecordDescriptor {
 }
 
 fn append_projected_field<E: From<Error>>(
-    source: &RecordDescriptor,
+    _source: &RecordDescriptor,
     record: &[u8],
-    field: &RawProjectionField,
+    field: &PreparedProjectionField,
     target_idx: usize,
     output: &mut BytesMut,
     evaluate: &mut impl FnMut(usize, &mut BytesMut) -> Result<(), E>,
 ) -> Result<(), E> {
     match field {
-        RawProjectionField::Copy { source_idx } => {
-            output.extend_from_slice(&record[source.field_span(record, *source_idx)?]);
+        PreparedProjectionField::Copy(accessor) => {
+            output.extend_from_slice(&record[accessor.span(record)?]);
         }
-        RawProjectionField::WrapNullable { source_idx } => {
+        PreparedProjectionField::WrapNullable(accessor) => {
             output.extend_from_slice(&[1]);
-            output.extend_from_slice(&record[source.field_span(record, *source_idx)?]);
+            output.extend_from_slice(&record[accessor.span(record)?]);
         }
-        RawProjectionField::Nested { path } => {
+        PreparedProjectionField::Nested(path) => {
             let mut bytes = record;
-            for (descriptor, index) in path {
-                bytes = &bytes[descriptor.field_span(bytes, *index)?];
+            for accessor in path {
+                bytes = &bytes[accessor.span(bytes)?];
             }
             output.extend_from_slice(bytes);
         }
-        RawProjectionField::Encoded { bytes } => output.extend_from_slice(bytes),
-        RawProjectionField::Evaluate => evaluate(target_idx, output)?,
-        RawProjectionField::Error(error) => return Err(error.clone().into()),
+        PreparedProjectionField::Encoded(bytes) => output.extend_from_slice(bytes),
+        PreparedProjectionField::Evaluate => evaluate(target_idx, output)?,
+        PreparedProjectionField::Error(error) => return Err(error.clone().into()),
     }
     Ok(())
 }

--- a/crates/groove/src/records/tests.rs
+++ b/crates/groove/src/records/tests.rs
@@ -2769,3 +2769,67 @@ fn compact_large_value_preserves_native_and_serde_encodings() {
         serde_json::json!({"Large": reference})
     );
 }
+
+// Internal byte-level oracle: public query results cannot distinguish malformed
+// offset boundaries. Keep the general decoder as the independent reference.
+#[test]
+fn prepared_field_accessors_match_general_spans_at_byte_boundaries() {
+    let cases = [
+        (
+            vec![ValueType::U64, ValueType::Bool],
+            vec![Value::U64(7), Value::Bool(true)],
+        ),
+        (
+            vec![
+                ValueType::String,
+                ValueType::U64,
+                ValueType::Bytes,
+                ValueType::String,
+            ],
+            vec![
+                Value::String("first".into()),
+                Value::U64(9),
+                Value::Bytes(vec![1, 2]),
+                Value::String("tail".into()),
+            ],
+        ),
+        (vec![ValueType::String], vec![Value::String(String::new())]),
+    ];
+    for (types, values) in cases {
+        let descriptor = descriptor(types);
+        let raw = descriptor.create(&values).unwrap();
+        for index in 0..values.len() {
+            let accessor = PreparedFieldAccessor::new(&descriptor, index).unwrap();
+            let check = |bytes: &[u8]| {
+                assert_eq!(
+                    accessor.span(bytes),
+                    descriptor.field_span(bytes, index),
+                    "field {index}, bytes {bytes:?}"
+                );
+            };
+            check(&raw);
+            for end in 0..raw.len() {
+                check(&raw[..end]);
+            }
+            let mut extended = raw.clone();
+            extended.push(0);
+            check(&extended);
+            for slot in 0..descriptor.variable_count().saturating_sub(1) {
+                for offset in [
+                    0,
+                    1,
+                    descriptor.fixed_size() as u32,
+                    raw.len() as u32,
+                    raw.len() as u32 + 1,
+                    u32::MAX,
+                ] {
+                    let mut invalid = raw.clone();
+                    let start = descriptor.fixed_size() + slot * 4;
+                    invalid[start..start + 4].copy_from_slice(&offset.to_le_bytes());
+                    check(&invalid);
+                }
+            }
+        }
+        assert!(PreparedFieldAccessor::new(&descriptor, values.len()).is_err());
+    }
+}

--- a/dev/benchmarks/prepared-record-accessors.md
+++ b/dev/benchmarks/prepared-record-accessors.md
@@ -16,5 +16,48 @@ field-span implementation across fixed/mixed/variable records, every truncation,
 extra trailing bytes and invalid offset-table entries. Existing projection tests
 cover nested fields, nullability, mixed evaluation and rollback.
 
-Alternating optimized native full-load measurements and scoped follow-up
-profiles are pending. No speedup or release readiness is claimed yet.
+Completed measurements are below. No speedup or release readiness is claimed.
+
+## Result: no established end-to-end improvement
+
+Five pairs, alternating execution order, optimized native, default member
+fixture, RocksDB Core/Edge/Client. Release gate paused at a partition boundary;
+no compilation overlapped measurements. Each run verified 27,518 expected rows.
+Times cover connect + subscribe + settle, excluding seed setup and subsequent
+one-shot verification/storage accounting.
+
+| Round  | Baseline ms | Candidate ms |
+| ------ | ----------: | -----------: |
+| 0      |       11216 |        11144 |
+| 1      |       11611 |        11519 |
+| 2      |       11174 |        11521 |
+| 3      |       11249 |        11239 |
+| 4      |       11160 |        11285 |
+| Median |       11216 |        11285 |
+
+Candidate median is 0.62% slower. Pair directions are mixed and ranges overlap;
+this does not establish either a useful gain or a robust regression. It is not
+recommended for the release candidate.
+
+Separate scoped 499Hz cpu-clock profile: projection 0.255 CPU-seconds (2.21%),
+fresh join-index construction 0.539s (4.69%), collect-by update 0.513s (4.46%),
+graph deduplication/addition 0.429s (3.73%). These are inclusive sampled paths,
+not additive exclusive buckets. The old baseline profiles suggested larger
+projection cost, but were not contemporaneous paired profiles; do not quote
+their difference as a precisely measured local speedup.
+
+Whole-process copy leaves remain 1.216s (10.57%), comparison leaves 0.657s
+(5.71%) and allocator clock paths 0.990s (8.60%). They are not entirely Groove
+and overlap inclusive caller costs. Host clocksource remains HPET. No hardware
+or allocator settings changed. The profile does not isolate a dominant single
+operator or justify another round of the rejected #2864 constructor.
+
+Mutation sensitivity: shift prepared constant offsets by one byte; the new
+oracle fails with span1..9 versus0..8. Restore source and rerun before claiming
+validation. Full-suite baseline candidate checks were757passed/2ignored.
+
+Provenance: baseline f56e5f3b49; candidate Rust source is4ce927fb4b. Candidate
+build began before commit, so its embedded dirty-source receipt is retained
+rather than rewritten; source was unchanged between build and commit. Binaries,
+build JSON, all10 receipts and profile are preserved outside target under
+`/home/ubuntu/jazz-debug-evidence/permissioned-profile/prepared-accessors/`.

--- a/dev/benchmarks/prepared-record-accessors.md
+++ b/dev/benchmarks/prepared-record-accessors.md
@@ -1,0 +1,20 @@
+# Prepared physical field accessor trial
+
+This tests an execution-only change on the existing lowered graphs: resolve
+fixed field ranges and variable offset-table slots while preparing a projection,
+then reuse those constants across input rows. The existing encoded layout and
+record validity checks are preserved. Nested fields prepare one accessor for
+each level; constant/evaluation errors remain lazy.
+
+Unlike #2797, this prepares physical span access, not just field names, types and
+nested descriptor paths. It does not repeat the rejected fresh-join constructor
+#2864. General descriptor field access outside prepared projections is unchanged.
+
+Initial validation: full Groove library suite passes (757 passed, 2 ignored).
+An internal byte-boundary oracle compares prepared spans with the general
+field-span implementation across fixed/mixed/variable records, every truncation,
+extra trailing bytes and invalid offset-table entries. Existing projection tests
+cover nested fields, nullability, mixed evaluation and rollback.
+
+Alternating optimized native full-load measurements and scoped follow-up
+profiles are pending. No speedup or release readiness is claimed yet.


### PR DESCRIPTION
🤖 Resolve physical field ranges and variable offset-table slots once when preparing a projection, instead of recalculating descriptor layout for every copied field in every row. This is a measured execution-engine trial on unchanged Jazz graphs.

Fixed, variable, nullable-wrapped and nested copies use prepared accessors. Record header/offset checks and lazy evaluation errors remain intact; no storage or wire encoding changes. This differs from #2797, which prepared logical mappings but retained general physical span lookup.

Full Groove library tests pass (757 passed, 2 ignored), including a byte-level oracle against the existing decoder across truncations and malformed offsets. Clippy and formatting pass. Alternating native full-load timings, scoped profiling, mutation sensitivity and independent review remain pending. No speedup or release readiness is claimed.

Result: five quiet alternating pairs gave11.216s baseline median versus11.285s candidate (+0.62%, overlapping ranges). No useful end-to-end gain established; do not include in release. All27,518 rows verified each run. A deliberate one-byte offset mutation fails the new oracle; restoration passes. Separate scoped profile puts raw projection at2.21% of CPU, with arrangement construction, collection state, setup and allocation/copying still distributed across the engine. Full results and evidence boundaries are in dev/benchmarks/prepared-record-accessors.md.
