### PR TITLE
bench: replay join arrangements against compact sorted batches

### DIFF
--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -46,3 +46,8 @@ harness = false
 [[bench]]
 name = "record_validation"
 harness = false
+
+[[bench]]
+name = "arrangement_replay"
+harness = false
+required-features = ["arrangement-replay"]

--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [features]
 default = []
 test = []
+arrangement-replay = []
 cold-settle-attribution = ["dep:tracing"]
 
 [dependencies]

--- a/crates/groove/benches/arrangement_replay.rs
+++ b/crates/groove/benches/arrangement_replay.rs
@@ -1,0 +1,7 @@
+#[global_allocator]
+static ALLOCATOR: jazz_benchmark_guard::Allocator = jazz_benchmark_guard::Allocator;
+
+fn main() {
+    println!("allocator={}", jazz_benchmark_guard::ALLOCATOR_NAME);
+    groove::replay_captured_arrangements();
+}

--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -24,6 +24,9 @@ use super::{
     record_projection::{resolve_field_name, resolve_field_ref},
 };
 
+#[cfg(feature = "arrangement-replay")]
+mod replay;
+
 pub(super) type JoinKey = SmallVec<[u8; 64]>;
 #[derive(Clone, Debug, Default)]
 struct JoinBucket {
@@ -600,6 +603,8 @@ impl ArrangementState {
         deltas: &[KeyedRecordDelta<'_>],
         update_mode: ArrangementUpdateMode,
     ) {
+        #[cfg(feature = "arrangement-replay")]
+        replay::capture_update(self, deltas, update_mode);
         match update_mode {
             ArrangementUpdateMode::Accumulate => {
                 let mut buckets = HashMap::<JoinKey, JoinBucket>::default();
@@ -739,6 +744,8 @@ fn append_join_deltas(
     side: JoinProbeSide,
     sign: i64,
 ) -> Result<(), IvmRuntimeError> {
+    #[cfg(feature = "arrangement-replay")]
+    replay::capture_probe(stored, delta_records);
     for delta in delta_records {
         if delta.delta.weight == 0 {
             continue;

--- a/crates/groove/src/ivm/runtime/join.rs
+++ b/crates/groove/src/ivm/runtime/join.rs
@@ -25,7 +25,7 @@ use super::{
 };
 
 #[cfg(feature = "arrangement-replay")]
-mod replay;
+pub(crate) mod replay;
 
 pub(super) type JoinKey = SmallVec<[u8; 64]>;
 #[derive(Clone, Debug, Default)]

--- a/crates/groove/src/ivm/runtime/join/replay.rs
+++ b/crates/groove/src/ivm/runtime/join/replay.rs
@@ -1,0 +1,329 @@
+//! Opt-in synthetic-workload capture. Never enabled in shipping builds.
+//! Internal replay is necessary to isolate container costs from key encoding,
+//! output encoding, graph scheduling and storage; it is not an end-to-end gate.
+use super::*;
+use serde::{Deserialize, Serialize};
+use std::io::{BufWriter, Write};
+use std::sync::{Mutex, OnceLock};
+
+#[derive(Serialize, Deserialize)]
+struct Row(Vec<u8>, Vec<u8>, i64);
+#[derive(Serialize, Deserialize)]
+struct Case {
+    before: Vec<Row>,
+    deltas: Vec<Row>,
+    replace: bool,
+    probes: Vec<Vec<u8>>,
+}
+fn rows(index: &JoinLookup<'_>) -> Vec<Row> {
+    let keys: HashSet<_> = match index {
+        JoinLookup::Index(index) => index.keys().cloned().collect(),
+        JoinLookup::Arrangement(a) => a.index.keys().chain(a.overlay.keys()).cloned().collect(),
+    };
+    keys.into_iter()
+        .flat_map(|key| {
+            index
+                .bucket(&key)
+                .into_iter()
+                .flat_map(|b| b.iter())
+                .map(|(r, w)| Row(key.to_vec(), r.to_vec(), *w))
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+fn enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    crate::ARRANGEMENT_CAPTURE_ACTIVE.load(std::sync::atomic::Ordering::Relaxed)
+        && *ENABLED.get_or_init(|| std::env::var_os("GROOVE_ARRANGEMENT_CAPTURE").is_some())
+}
+fn write(case: Case) {
+    static OUTPUT: OnceLock<Mutex<BufWriter<std::fs::File>>> = OnceLock::new();
+    let output = OUTPUT.get_or_init(|| {
+        Mutex::new(BufWriter::new(
+            std::fs::File::create(std::env::var_os("GROOVE_ARRANGEMENT_CAPTURE").unwrap()).unwrap(),
+        ))
+    });
+    let bytes = postcard::to_allocvec(&case).unwrap();
+    let mut output = output.lock().unwrap();
+    output
+        .write_all(&(bytes.len() as u64).to_le_bytes())
+        .unwrap();
+    output.write_all(&bytes).unwrap();
+    // Explicit flush: globals do not drop at process exit.
+    output.flush().unwrap();
+}
+pub(super) fn capture_update(
+    a: &ArrangementState,
+    deltas: &[KeyedRecordDelta<'_>],
+    mode: ArrangementUpdateMode,
+) {
+    if !enabled() || deltas.is_empty() {
+        return;
+    }
+    write(Case {
+        before: rows(&JoinLookup::Arrangement(a)),
+        deltas: deltas
+            .iter()
+            .map(|d| Row(d.key.to_vec(), d.delta.record.to_vec(), d.delta.weight))
+            .collect(),
+        replace: mode == ArrangementUpdateMode::Replace,
+        probes: Vec::new(),
+    });
+}
+pub(super) fn capture_probe(a: &JoinLookup<'_>, deltas: &[KeyedRecordDelta<'_>]) {
+    if !enabled() || deltas.is_empty() {
+        return;
+    }
+    write(Case {
+        before: rows(a),
+        deltas: Vec::new(),
+        replace: false,
+        probes: deltas
+            .iter()
+            .filter(|d| d.delta.weight != 0)
+            .map(|d| d.key.to_vec())
+            .collect(),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+    #[global_allocator]
+    static ALLOCATOR: jazz_benchmark_guard::Allocator = jazz_benchmark_guard::Allocator;
+    use std::io::{BufReader, Read};
+    #[derive(Clone)]
+    struct Sorted {
+        keys: Vec<JoinKey>,
+        offsets: Vec<usize>,
+        records: Vec<Bytes>,
+        weights: Vec<i64>,
+    }
+    impl Sorted {
+        fn build(mut rows: Vec<(JoinKey, Bytes, i64)>) -> Self {
+            rows.sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+            let mut merged: Vec<(JoinKey, Bytes, i64)> = Vec::with_capacity(rows.len());
+            for row in rows {
+                if let Some(last) = merged
+                    .last_mut()
+                    .filter(|last| last.0 == row.0 && last.1 == row.1)
+                {
+                    last.2 += row.2;
+                } else {
+                    merged.push(row);
+                }
+            }
+            let mut s = Self {
+                keys: Vec::new(),
+                offsets: Vec::new(),
+                records: Vec::new(),
+                weights: Vec::new(),
+            };
+            for (key, record, weight) in merged.into_iter().filter(|r| r.2 != 0) {
+                if s.keys.last() != Some(&key) {
+                    s.keys.push(key);
+                    s.offsets.push(s.records.len());
+                }
+                s.records.push(record);
+                s.weights.push(weight);
+            }
+            s.offsets.push(s.records.len());
+            s
+        }
+        fn probe(&self, key: &[u8]) -> impl Iterator<Item = (&Bytes, &i64)> {
+            let range = self
+                .keys
+                .binary_search_by(|k| k.as_slice().cmp(key))
+                .ok()
+                .map(|i| self.offsets[i]..self.offsets[i + 1])
+                .unwrap_or(0..0);
+            self.records[range.clone()]
+                .iter()
+                .zip(self.weights[range].iter())
+        }
+        fn all(&self) -> Vec<(JoinKey, Bytes, i64)> {
+            self.keys
+                .iter()
+                .enumerate()
+                .flat_map(|(i, k)| {
+                    (self.offsets[i]..self.offsets[i + 1])
+                        .map(move |j| (k.clone(), self.records[j].clone(), self.weights[j]))
+                })
+                .collect()
+        }
+    }
+    fn inputs(rows: &[Row]) -> (Vec<RecordDelta>, Vec<JoinKey>) {
+        (
+            rows.iter()
+                .map(|r| RecordDelta {
+                    record: Bytes::copy_from_slice(&r.1),
+                    weight: r.2,
+                })
+                .collect(),
+            rows.iter().map(|r| JoinKey::from_slice(&r.0)).collect(),
+        )
+    }
+    fn keyed<'a>(records: &'a [RecordDelta], keys: &[JoinKey]) -> Vec<KeyedRecordDelta<'a>> {
+        records
+            .iter()
+            .zip(keys)
+            .map(|(delta, key)| KeyedRecordDelta {
+                delta,
+                key: key.clone(),
+            })
+            .collect()
+    }
+    fn tuples(rows: &[Row]) -> Vec<(JoinKey, Bytes, i64)> {
+        rows.iter()
+            .map(|r| (JoinKey::from_slice(&r.0), Bytes::copy_from_slice(&r.1), r.2))
+            .collect()
+    }
+    fn canonical(a: &ArrangementState) -> Vec<(JoinKey, Bytes, i64)> {
+        let mut v = tuples(&rows(&JoinLookup::Arrangement(a)));
+        v.sort();
+        v
+    }
+    #[test]
+    fn sorted_batch_preserves_signed_weights_and_cancellation() {
+        // Container-level test: signed intermediate weights are not a public row API.
+        let row = |key: &'static [u8], record: &'static [u8], weight| {
+            (JoinKey::from_slice(key), Bytes::from_static(record), weight)
+        };
+        let a = Rc::new(Sorted::build(vec![
+            row(b"k", b"a", 2),
+            row(b"k", b"a", -1),
+            row(b"k", b"b", -3),
+        ]));
+        let snapshot = a.clone();
+        let mut changes = a.all();
+        changes.extend([row(b"k", b"a", -1), row(b"k", b"b", 3), row(b"z", b"c", 1)]);
+        let b = Sorted::build(changes);
+        assert_eq!(b.all(), vec![row(b"z", b"c", 1)]);
+        assert_eq!(
+            snapshot.all(),
+            vec![row(b"k", b"a", 1), row(b"k", b"b", -3)]
+        );
+        assert_eq!(b.probe(b"k").count(), 0);
+        assert_eq!(b.probe(b"missing").count(), 0);
+        assert_eq!(b.probe(b"z").count(), 1);
+    }
+    // This test deliberately targets the private representation: public queries
+    // cannot distinguish equivalent containers or isolate their operation costs.
+    #[test]
+    #[ignore = "manual synthetic arrangement capture replay; no production behavior change"]
+    fn replay_captured_arrangements() {
+        let path = std::env::var("GROOVE_ARRANGEMENT_REPLAY").expect("capture path");
+        let mut reader = BufReader::new(std::fs::File::open(path).unwrap());
+        let mut count = 0usize;
+        let mut times = [Duration::ZERO; 6];
+        let mut update_times = [Duration::ZERO; 4];
+        let mut total_rows = 0usize;
+        let (mut updates, mut replacements, mut probes) = (0usize, 0usize, 0usize);
+        loop {
+            let mut length = [0; 8];
+            match reader.read_exact(&mut length) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(e) => panic!("{e}"),
+            }
+            let mut bytes = vec![0; u64::from_le_bytes(length) as usize];
+            reader.read_exact(&mut bytes).unwrap();
+            let c: Case = postcard::from_bytes(&bytes).unwrap();
+            let (records, keys) = inputs(&c.before);
+            let before = keyed(&records, &keys);
+            let (records_d, keys_d) = inputs(&c.deltas);
+            let delta = keyed(&records_d, &keys_d);
+            let sorted_input = tuples(&c.before);
+            let start = Instant::now();
+            let mut baseline = ArrangementState {
+                index: Rc::new(build_join_delta_index(&before)),
+                overlay: Rc::default(),
+            };
+            times[0] += start.elapsed();
+            let start = Instant::now();
+            let mut sorted = Rc::new(Sorted::build(sorted_input));
+            times[1] += start.elapsed();
+            let snapshot = baseline.clone();
+            let sorted_snapshot = sorted.clone();
+            if !c.deltas.is_empty() {
+                let start = Instant::now();
+                baseline.apply_update(
+                    &delta,
+                    if c.replace {
+                        ArrangementUpdateMode::Replace
+                    } else {
+                        ArrangementUpdateMode::Accumulate
+                    },
+                );
+                let elapsed = start.elapsed();
+                times[2] += elapsed;
+                update_times[if c.replace { 0 } else { 2 }] += elapsed;
+                let updates = tuples(&c.deltas);
+                let start = Instant::now();
+                let mut merged = if c.replace { Vec::new() } else { sorted.all() };
+                merged.extend(updates);
+                sorted = Rc::new(Sorted::build(merged));
+                let elapsed = start.elapsed();
+                times[3] += elapsed;
+                update_times[if c.replace { 1 } else { 3 }] += elapsed;
+            }
+            let start = Instant::now();
+            for key in &c.probes {
+                if let Some(b) = baseline.bucket(key) {
+                    for pair in b.iter() {
+                        std::hint::black_box(pair);
+                    }
+                }
+            }
+            times[4] += start.elapsed();
+            let start = Instant::now();
+            for key in &c.probes {
+                for pair in sorted.probe(key) {
+                    std::hint::black_box(pair);
+                }
+            }
+            times[5] += start.elapsed();
+            for key in &c.probes {
+                let mut expected = baseline
+                    .bucket(key)
+                    .into_iter()
+                    .flat_map(|b| b.iter())
+                    .map(|(r, w)| (r.clone(), *w))
+                    .collect::<Vec<_>>();
+                expected.sort();
+                let actual = sorted
+                    .probe(key)
+                    .map(|(r, w)| (r.clone(), *w))
+                    .collect::<Vec<_>>();
+                assert_eq!(expected, actual, "probe case {count}");
+            }
+            assert_eq!(canonical(&baseline), sorted.all(), "case {count}");
+            assert_eq!(
+                canonical(&snapshot),
+                sorted_snapshot.all(),
+                "snapshot {count}"
+            );
+            updates += usize::from(!c.deltas.is_empty());
+            replacements += usize::from(c.replace);
+            probes += c.probes.len();
+            total_rows += c.before.len() + c.deltas.len();
+            count += 1;
+        }
+        println!(
+            "updates={updates} replacements={replacements} probes={probes} allocator={} cases={count} rows={total_rows} baseline_build={:?} sorted_build={:?} baseline_update={:?} sorted_update={:?} baseline_probe={:?} sorted_probe={:?}",
+            jazz_benchmark_guard::ALLOCATOR_NAME,
+            times[0],
+            times[1],
+            times[2],
+            times[3],
+            times[4],
+            times[5]
+        );
+        println!(
+            "replace baseline={:?} sorted={:?}; accumulate baseline={:?} sorted={:?}",
+            update_times[0], update_times[1], update_times[2], update_times[3]
+        );
+        assert!(count > 0);
+    }
+}

--- a/crates/groove/src/ivm/runtime/join/replay.rs
+++ b/crates/groove/src/ivm/runtime/join/replay.rs
@@ -86,13 +86,10 @@ pub(super) fn capture_probe(a: &JoinLookup<'_>, deltas: &[KeyedRecordDelta<'_>])
     });
 }
 
-#[cfg(test)]
-mod tests {
+mod engine {
     use super::*;
-    use std::time::{Duration, Instant};
-    #[global_allocator]
-    static ALLOCATOR: jazz_benchmark_guard::Allocator = jazz_benchmark_guard::Allocator;
     use std::io::{BufReader, Read};
+    use std::time::{Duration, Instant};
     #[derive(Clone)]
     struct Sorted {
         keys: Vec<JoinKey>,
@@ -210,9 +207,7 @@ mod tests {
     }
     // This test deliberately targets the private representation: public queries
     // cannot distinguish equivalent containers or isolate their operation costs.
-    #[test]
-    #[ignore = "manual synthetic arrangement capture replay; no production behavior change"]
-    fn replay_captured_arrangements() {
+    pub(super) fn run() {
         let path = std::env::var("GROOVE_ARRANGEMENT_REPLAY").expect("capture path");
         let mut reader = BufReader::new(std::fs::File::open(path).unwrap());
         let mut count = 0usize;
@@ -311,14 +306,8 @@ mod tests {
             count += 1;
         }
         println!(
-            "updates={updates} replacements={replacements} probes={probes} allocator={} cases={count} rows={total_rows} baseline_build={:?} sorted_build={:?} baseline_update={:?} sorted_update={:?} baseline_probe={:?} sorted_probe={:?}",
-            jazz_benchmark_guard::ALLOCATOR_NAME,
-            times[0],
-            times[1],
-            times[2],
-            times[3],
-            times[4],
-            times[5]
+            "updates={updates} replacements={replacements} probes={probes} cases={count} rows={total_rows} baseline_build={:?} sorted_build={:?} baseline_update={:?} sorted_update={:?} baseline_probe={:?} sorted_probe={:?}",
+            times[0], times[1], times[2], times[3], times[4], times[5]
         );
         println!(
             "replace baseline={:?} sorted={:?}; accumulate baseline={:?} sorted={:?}",
@@ -326,4 +315,8 @@ mod tests {
         );
         assert!(count > 0);
     }
+}
+
+pub(crate) fn run() {
+    engine::run();
 }

--- a/crates/groove/src/ivm/runtime/mod.rs
+++ b/crates/groove/src/ivm/runtime/mod.rs
@@ -48,7 +48,7 @@ use thiserror::Error;
 
 mod aggregate;
 pub(crate) mod evaluation_session;
-mod join;
+pub(crate) mod join;
 mod persist;
 mod recursion;
 mod state;

--- a/crates/groove/src/lib.rs
+++ b/crates/groove/src/lib.rs
@@ -29,3 +29,9 @@ pub use internment::Intern;
 #[cfg(feature = "arrangement-replay")]
 pub static ARRANGEMENT_CAPTURE_ACTIVE: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
+
+/// Run the opt-in arrangement replay benchmark from its captured input file.
+#[cfg(feature = "arrangement-replay")]
+pub fn replay_captured_arrangements() {
+    ivm::runtime::join::replay::run();
+}

--- a/crates/groove/src/lib.rs
+++ b/crates/groove/src/lib.rs
@@ -24,3 +24,8 @@ pub mod schema;
 pub mod storage;
 
 pub use internment::Intern;
+
+/// Diagnostic capture switch; only present in the opt-in replay build.
+#[cfg(feature = "arrangement-replay")]
+pub static ARRANGEMENT_CAPTURE_ACTIVE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);

--- a/crates/jazz-sim/Cargo.toml
+++ b/crates/jazz-sim/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [features]
+arrangement-replay = ["jazz/arrangement-replay"]
 default = []
 bench-alloc-metrics = []
 bench-perf-control = []

--- a/crates/jazz-sim/benches/customer_cold_start.rs
+++ b/crates/jazz-sim/benches/customer_cold_start.rs
@@ -1896,6 +1896,8 @@ fn run_connect_and_subscribe(
         jazz::cold_settle_attribution::reset();
         jazz::groove::cold_settle_attribution::reset();
     }
+    #[cfg(feature = "arrangement-replay")]
+    jazz::groove::ARRANGEMENT_CAPTURE_ACTIVE.store(true, std::sync::atomic::Ordering::Relaxed);
     work_budget::start();
     alloc_metrics::reset_and_start();
     #[cfg(feature = "bench-perf-control")]
@@ -2071,6 +2073,8 @@ fn run_connect_and_subscribe(
     let settle_ms = settle_start.elapsed().as_millis();
     #[cfg(feature = "bench-perf-control")]
     perf_control.command("disable");
+    #[cfg(feature = "arrangement-replay")]
+    jazz::groove::ARRANGEMENT_CAPTURE_ACTIVE.store(false, std::sync::atomic::Ordering::Relaxed);
     // Match the readiness boundary: later one-shot verification and storage
     // sizing are diagnostics, not work needed to make subscriptions usable.
     let alloc_snapshot = alloc_metrics::stop();

--- a/crates/jazz/Cargo.toml
+++ b/crates/jazz/Cargo.toml
@@ -7,6 +7,7 @@ autobenches = false
 autotests = true
 
 [features]
+arrangement-replay = ["groove/arrangement-replay"]
 # Jazz is the common semantic library. Process and target shells select
 # storage, transport, compression, and runtime capabilities explicitly.
 default = []

--- a/dev/benchmarks/sorted-arrangement-replay.md
+++ b/dev/benchmarks/sorted-arrangement-replay.md
@@ -1,0 +1,31 @@
+# Sorted arrangement replay experiment
+
+Research branch based on `f56e5f3b4982995f8c4c8b4ecd3817b1b9c37e38`.
+Separate from the release checkpoint and the unsuccessful prepared-accessor trial.
+
+## Changed premise
+
+The rejected #2864 changed construction of the same nested maps. This experiment
+compares those maps against sorted keys, bucket offsets, record references and
+weights. It initially changes no query execution or Jazz lowering.
+
+The opt-in `arrangement-replay` feature records actual arrangement updates and
+join probes during the native cold-load phase. Each case contains the complete
+visible input arrangement plus the update or probe keys. Capture overhead and
+serialization are excluded from replay timings; the capture run is not a
+performance receipt. The existing anonymized fixture is unchanged.
+
+Replay compares weighted contents after each update and keeps an old snapshot
+alive to check isolation. This deliberately forces a retained snapshot for every
+update; it does not establish the frequency of retained snapshots in production.
+Signed-weight cancellation has a separate internal container test.
+
+Build times reconstruct captured states for replay and must not be summed as
+actual end-to-end construction cost. Probe and update cases are observed calls;
+key extraction and joined-output encoding are excluded. The first sorted update
+implementation rebuilds the batch, explicitly exposing its copying cost.
+
+This capture currently covers ordinary join probes and arrangement updates. It
+does not capture every semijoin/antijoin lookup or the full arrangement lifetime.
+A favorable result would justify fuller integration and end-to-end measurement,
+not establish a product speedup on its own.

--- a/dev/benchmarks/sorted-arrangement-replay.md
+++ b/dev/benchmarks/sorted-arrangement-replay.md
@@ -29,3 +29,28 @@ This capture currently covers ordinary join probes and arrangement updates. It
 does not capture every semijoin/antijoin lookup or the full arrangement lifetime.
 A favorable result would justify fuller integration and end-to-end measurement,
 not establish a product speedup on its own.
+
+## Replay result
+
+Five uncontended runs, optimized native `perf` profile, mimalloc. All 3,649 cases
+passed weighted-content, exact-probe and preserved-snapshot comparisons. Captured
+calls include 2,923 updates (2,252 replacements) and 2,606,965 probe keys.
+
+| Operation                                      | Existing maps median | Sorted batch median |
+| ---------------------------------------------- | -------------------: | ------------------: |
+| Replace                                        |            585.34 ms |            71.79 ms |
+| Accumulate                                     |             85.33 ms |            17.68 ms |
+| Probe                                          |             24.73 ms |            26.87 ms |
+| Reconstruct captured before-state (diagnostic) |             33.16 ms |            20.55 ms |
+
+The update saving is approximately 581 ms; it is not an end-to-end saving.
+99.62% of update-batch key groups contain one record (990,417 of 994,176 groups).
+Incoming records average 386.5 bytes, versus 21.2-byte keys. This supports testing
+compact per-bucket storage that avoids full-record hashing while retaining cheap
+bucket-local incremental updates. It does not justify a claim of faster probes.
+
+External receipts: `permissioned-profile/arrangement-replay/` contains the exact
+binary, capture, source patch, five raw logs, timing JSON and cardinality script.
+The comparison always times maps before sorted batches within a case; a production
+trial should use alternating process-level before/after runs and full correctness
+gates before retention. The synthetic cancellation test also passes.

--- a/dev/benchmarks/sorted-arrangement-replay.md
+++ b/dev/benchmarks/sorted-arrangement-replay.md
@@ -54,3 +54,15 @@ binary, capture, source patch, five raw logs, timing JSON and cardinality script
 The comparison always times maps before sorted batches within a case; a production
 trial should use alternating process-level before/after runs and full correctness
 gates before retention. The synthetic cancellation test also passes.
+
+## Run the replay
+
+```sh
+GROOVE_ARRANGEMENT_REPLAY=/path/to/cases.bin cargo bench -p groove \
+  --bench arrangement_replay --profile perf \
+  --features arrangement-replay,jazz-benchmark-guard/mimalloc
+```
+
+The initial receipts used an equivalent manual test runner. The maintained entry
+point is an explicit opt-in benchmark, so it does not add an ignored test to the
+canonical correctness inventory.


### PR DESCRIPTION
🤖 Research only: compare Groove's current join buckets with compact sorted batches using operations captured from the existing anonymized cold-sync workload. This does not change production query execution and is not part of the release checkpoint.

The current representation maintains nested maps keyed by join key and full encoded record. The experiment stores sorted join keys, offsets, record references and signed weights. Capture is opt-in and limited to the cold-load phase; its timings are discarded.

Replay checks exact weighted contents and probe outputs, preserves prior snapshots, and includes a signed-weight cancellation case. For example, weights +2 and -1 leave +1; a later -1 removes that record while an earlier snapshot remains unchanged. Negative weights remain representable.

The initial capture contains 3,649 cases, 2,923 update calls and 2,606,965 probe keys. It passes equivalence checks. Five quiet allocator-matched runs show median replacement work falling from 585 ms to 72 ms, accumulation from 85 ms to 18 ms, and probes changing from 25 ms to 27 ms. This is approximately 581 ms of replay update savings, not a measured end-to-end improvement. Most update batches have singleton buckets, suggesting full-record hashing and per-bucket allocation deserve particular attention.

Limits: this is a container replay, not an end-to-end performance result. It reconstructs input states, forces a retained snapshot during updates, and excludes key extraction and output encoding. It does not capture every semijoin/antijoin lookup. The initial sorted update rebuilds its batch, deliberately exposing that cost. No wire, storage, permission or query semantics change.

See `dev/benchmarks/sorted-arrangement-replay.md` for the changed premise relative to rejected #2864 and #2869/#2872.

The replay now has a dedicated opt-in benchmark entry point and passes all captured equivalence checks there. The earlier CI lint failure from registering it as an ignored test is addressed. Earlier CI also reported a BandChat guest-invitation failure; that has not been attributed or repaired in this research branch. This draft is not presented as green for release.
