### PR TITLE
fix: wait for hydration temporal predecessors

### DIFF
--- a/.changeset/hydration-temporal-predecessors.md
+++ b/.changeset/hydration-temporal-predecessors.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Keep overlapping subscription hydration pending until earlier shared-node snapshots are installed, avoiding internal subscription failures while those dependencies resolve.

--- a/crates/groove/src/ivm/runtime/runtime_tick.rs
+++ b/crates/groove/src/ivm/runtime/runtime_tick.rs
@@ -1546,6 +1546,11 @@ impl<'a> EvaluationSession<'a> {
             if self.requests.has_pending() {
                 return Poll::Pending;
             }
+            if !self.work_queue.temporal_waiting.is_empty() {
+                // Earlier evaluations own the continuation until their shared
+                // nodes are installed and the temporal barriers are released.
+                return Poll::Pending;
+            }
             return Poll::Ready(Err(IvmRuntimeError::EvaluationBlocked));
         }
     }

--- a/crates/groove/tests/async_hydration_session.rs
+++ b/crates/groove/tests/async_hydration_session.rs
@@ -253,6 +253,39 @@ fn cancelling_cold_hydration_releases_a_later_shared_subscription() {
 }
 
 #[test]
+fn shared_hydrations_wait_for_the_predecessor_without_failing() {
+    let (storage, _) = TestStorage::controlled(&["albums"]);
+    let mut database = block_on(Database::new(schema(), storage)).unwrap();
+    let descriptor =
+        RecordDescriptor::new([("id", ColumnType::U64), ("title", ColumnType::String)]);
+    let source = |id| {
+        GraphBuilder::values(
+            descriptor.clone(),
+            [vec![Value::U64(id), Value::String("Album".into())]],
+        )
+        .unwrap()
+    };
+    // A large opening deliberately spans several owner turns. The second
+    // subscription shares a node whose private predecessor is not installed.
+    let waker = noop_waker();
+    let first = database
+        .subscribe_with_waker(
+            (0..256).map(|id| (format!("album_{id}"), source(id))),
+            Some(&waker),
+        )
+        .unwrap();
+    let second = database
+        .subscribe([("shared", source(0)), ("independent", source(256))])
+        .unwrap();
+    block_on(database.drive_progress()).unwrap();
+    let first_rows = block_on(database.next_multisink_subscription(&first)).unwrap();
+    assert_eq!(first_rows.sinks.len(), 256);
+    let second_rows = block_on(database.next_multisink_subscription(&second)).unwrap();
+    assert_eq!(second_rows.sinks["shared"].deltas.len(), 1);
+    assert_eq!(second_rows.sinks["independent"].deltas.len(), 1);
+}
+
+#[test]
 fn write_during_cold_subscription_hydration_is_delivered_exactly_once() {
     let (storage, control) = TestStorage::controlled(&["albums"]);
     let mut database = block_on(Database::new(schema(), storage)).unwrap();


### PR DESCRIPTION
🤖 Publishes the reviewed fix from #2745 in this repository for full integration CI, preserving the contributor's commits and adding its release note.

When a subscription opens while an earlier overlapping hydration is still installing its snapshot, storage can be ready while the shared query nodes are still waiting. Previously that legitimate wait failed with `EvaluationBlocked`. It now remains pending until the predecessor completes; work with neither storage requests nor a temporal dependency still fails as before.

For example, opening a large set of subscriptions and then another subscription sharing one source now delivers both outputs instead of failing the second opening. Independent review passed; all 29 hydration tests and a mutation removing the fix confirm the behavior. Combined CI is now green. No storage or wire format changes.
